### PR TITLE
Fix Tonel method signature semantic tokens landing on wrong column

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -352,7 +352,7 @@ connection.languages.semanticTokens.on((params) => {
 
     const scopeRoot = analyzer.analyze(pr.ast);
     const regionTokens = collectSemanticTokens(
-      pr.ast, pr.tokens, lineOffset, scopeRoot,
+      pr.ast, pr.tokens, lineOffset, scopeRoot, pr.region.selectorColumnOffset ?? 0,
     );
     allTokens.push(...regionTokens);
   }

--- a/server/src/services/semanticTokens.ts
+++ b/server/src/services/semanticTokens.ts
@@ -48,6 +48,7 @@ export function collectSemanticTokens(
   tokens: Token[],
   lineOffset: number,
   scopeRoot: ScopeNode,
+  selectorColumnOffset: number = 0,
 ): RawSemanticToken[] {
   const result: RawSemanticToken[] = [];
   const analyzer = new ScopeAnalyzer();
@@ -60,7 +61,7 @@ export function collectSemanticTokens(
     if (length <= 0) return;
     result.push({
       line: range.start.line + lineOffset,
-      startChar: range.start.column,
+      startChar: range.start.line === 0 ? range.start.column + selectorColumnOffset : range.start.column,
       length,
       tokenType,
       modifiers,
@@ -81,8 +82,8 @@ export function collectSemanticTokens(
   // Convert an AST-local range to document-level for token lookup
   function toDocRange(range: SourceRange): SourceRange {
     return {
-      start: { ...range.start, line: range.start.line + lineOffset },
-      end: { ...range.end, line: range.end.line + lineOffset },
+      start: { ...range.start, line: range.start.line + lineOffset, column: range.start.line === 0 ? range.start.column + selectorColumnOffset : range.start.column },
+      end: { ...range.end, line: range.end.line + lineOffset, column: range.end.line === 0 ? range.end.column + selectorColumnOffset : range.end.column },
     };
   }
 
@@ -98,7 +99,7 @@ export function collectSemanticTokens(
     if (pattern.range.start.line === selectorEnd.line) {
       result.push({
         line: pattern.range.start.line + lineOffset,
-        startChar: pattern.range.start.column,
+        startChar: pattern.range.start.line === 0 ? pattern.range.start.column + selectorColumnOffset : pattern.range.start.column,
         length: pattern.selector.length,
         tokenType: 7,
         modifiers: MOD_DECLARATION,

--- a/server/src/tonel/tonelParser.ts
+++ b/server/src/tonel/tonelParser.ts
@@ -142,7 +142,7 @@ export function parseTonelDocument(text: string): TopazRegion[] {
     }
 
     const signatureLine = i;
-    const { className: sigClassName, isClassSide, selectorPattern } = sigMatch;
+    const { className: sigClassName, isClassSide, selectorPattern, selectorColumnOffset } = sigMatch;
     const className = sigClassName || headerClassName;
 
     // Find the matching ] via bracket counting
@@ -164,6 +164,7 @@ export function parseTonelDocument(text: string): TopazRegion[] {
       command: isClassSide ? 'classmethod' : 'method',
       annotationStartLine,
       closingBracketLine: closingLine,
+      selectorColumnOffset,
     });
 
     i = closingLine + 1;
@@ -181,15 +182,23 @@ function parseMethodSignature(line: string): {
   className: string;
   isClassSide: boolean;
   selectorPattern: string;
+  selectorColumnOffset: number;
 } | null {
   // Match: ClassName [class] >> selectorPattern [
   const match = line.match(/^(\w+)(\s+class)?\s*>>\s*(.+?)\s*\[\s*$/);
   if (!match) return null;
 
+  const selectorPattern = match[3].trim();
+  // Calculate the column where selectorPattern begins in the original line.
+  // This is needed so that semantic tokens on the selector line get correct document columns.
+  const prefixLen = match[1].length + (match[2] ?? '').length;
+  const selectorColumnOffset = line.indexOf(selectorPattern, prefixLen);
+
   return {
     className: match[1],
     isClassSide: !!match[2],
-    selectorPattern: match[3].trim(),
+    selectorPattern,
+    selectorColumnOffset: selectorColumnOffset >= 0 ? selectorColumnOffset : 0,
   };
 }
 

--- a/server/src/topaz/topazParser.ts
+++ b/server/src/topaz/topazParser.ts
@@ -27,6 +27,8 @@ export interface TopazRegion {
   annotationStartLine?: number;
   /** For Tonel methods: line of the closing ] bracket */
   closingBracketLine?: number;
+  /** For Tonel methods: column in the signature line where the selector starts */
+  selectorColumnOffset?: number;
 }
 
 /** Known Topaz commands that do NOT start Smalltalk blocks */

--- a/server/src/utils/documentManager.ts
+++ b/server/src/utils/documentManager.ts
@@ -58,7 +58,7 @@ export class DocumentManager {
       const regionTokens = lexer.tokenize();
 
       // Offset token positions to document-level coordinates
-      const offsetTokens = regionTokens.map((t) => offsetToken(t, region.startLine));
+      const offsetTokens = regionTokens.map((t) => offsetToken(t, region.startLine, region.selectorColumnOffset ?? 0));
       allTokens.push(...offsetTokens);
 
       if (region.kind === 'smalltalk-method') {
@@ -138,10 +138,10 @@ export class DocumentManager {
   }
 }
 
-function offsetToken(token: Token, lineOffset: number): Token {
+function offsetToken(token: Token, lineOffset: number, selectorColumnOffset: number = 0): Token {
   return {
     ...token,
-    range: offsetRange(token.range, lineOffset),
+    range: offsetRange(token.range, lineOffset, selectorColumnOffset),
   };
 }
 
@@ -152,10 +152,10 @@ function offsetError(error: ParseError, lineOffset: number): ParseError {
   };
 }
 
-function offsetRange(range: SourceRange, lineOffset: number): SourceRange {
+function offsetRange(range: SourceRange, lineOffset: number, selectorColumnOffset: number = 0): SourceRange {
   return createRange(
-    createPosition(range.start.offset, range.start.line + lineOffset, range.start.column),
-    createPosition(range.end.offset, range.end.line + lineOffset, range.end.column),
+    createPosition(range.start.offset, range.start.line + lineOffset, range.start.column + (range.start.line === 0 ? selectorColumnOffset : 0)),
+    createPosition(range.end.offset, range.end.line + lineOffset, range.end.column + (range.end.line === 0 ? selectorColumnOffset : 0)),
   );
 }
 


### PR DESCRIPTION
These are Claude-suggested edits to fix the syntax highlighting problem with GemStone (tonel) files. 

Word of caution.  After Claude fixed my VS code environment, I asked it to capture all the changes into a local checkout so I could send them to you. During the middle of that request, Claude seemed to ... get tired (for lack of a better word) ... and just stopped. I had to prompt it to continue gathering it's changes.  So whether all the changes were included, I really don't know.

Claude's comments: 

"The selectorPattern extracted from a Tonel method header (e.g.
'showOnSession: aGciSession packageService: monticelloPackageService')
starts at column 0 in methodText, but in the document it appears after
'ClassName [class] >> ' — at column 40–50 or so.

offsetToken only adjusted the line, not the column, so all semantic
tokens on the selector line were placed at the wrong document column.
They overlapped with the class name at the start of the line, causing it
to render in multiple colors.

Fix:
- parseMethodSignature now returns selectorColumnOffset (the column
  where the selector starts in the original signature line).
- TopazRegion carries the new optional field.
- offsetToken/offsetRange apply selectorColumnOffset to line-0 tokens.
- collectSemanticTokens accepts selectorColumnOffset and applies it in
  push(), toDocRange(), and the BinaryPattern direct push."
"