### PR TITLE
MCP server: act on external feedback (staleness, hints, validator errors, new tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-04-27
+
+### Added
+
+- **MCP `refresh` tool** — explicitly refresh the session's view of committed state (aborts only when no uncommitted changes are pending). Closes the silent-stale gap where the GCI pinned a session's read view to its transaction snapshot, so commits landed by another process (e.g. `install.sh`) were invisible until the session aborted or committed.
+- **MCP `list_failing_tests` tool** — runs SUnit tests and returns only the failed/errored entries. Optional `classNames` filter for targeted subsets (otherwise discovers every TestCase subclass in the symbolList). Iteration runs in Smalltalk so an N-class invocation is one GCI round-trip.
+- **MCP `list_test_classes` tool** — discovery primitive for filtering before `list_failing_tests`.
+- **MCP `describe_test_failure` tool** — re-runs a single test with its own `AbstractException` handler (bypasses `TestCase>>run`, which would swallow the exception) and returns structured details: `exceptionClass`, GemStone `errorNumber`, clean `messageText`, `description`, plus `mnuReceiver` / `mnuSelector` for `MessageNotUnderstood`. Includes a multi-line `stackReport` when stack capture is supported (gem-level `GemExceptionSignalCapturesStack` is toggled around the run and restored via `ensure:`).
+- **MCP `eval_python` and `compile_python` tools** — compile/transpile/execute Python source via Grail (GemStone-Python). Register unconditionally; gracefully report "Grail not detected" via runtime `objectNamed:` lookup when Grail isn't loaded. Grail-side compile and runtime errors are reported inline as `Error: <class> — <messageText>`.
+
+### Changed
+
+- **`status`, `run_test_class`, `run_test_method`, `list_failing_tests`, `describe_test_failure` auto-refresh-if-clean** before reading. Discards the stale-pinned view when (and only when) no uncommitted work is pending. `status` reports the new view state on a `View:` line.
+- **`execute_code` accepts multi-statement bodies** — wrapped as `[<code>] value printString` so `| x | x := 42. x + 1` parses. Previously errored with "expected start of a statement" because the wrapper only accepted a single expression.
+- **`find_implementors` / `find_senders` / `find_references_to` empty-result message hints at env 1** — projects whose user code lives in `environmentId: 1` (notably GemStone-Python) were getting a bare "No implementors found" that was easy to misread as "doesn't exist."
+- **MCP tool validator errors name the offending parameter** — replaces zod's bare `"Invalid input: expected boolean, received undefined"` with `"Missing required parameter 'isMeta' (expected boolean)."` and `"Parameter 'isMeta' must be boolean, but received string."`. Implemented as a per-schema error map (a global one breaks the SDK's discriminated-union JSON-RPC parsing).
+
+### Fixed
+
+- **`runTestClass` / `runFailingTests` were sending `each testCase class name` to objects that don't respond to `#testCase`** — the items in `result failures` and `result errors` are TestCase instances themselves with only a `testSelector` ivar, not wrapper objects. On a real failure the queries would silently DNU; tests mocked the output so it wasn't caught. Now uses `each class name` / `each selector`, matching the `passed` branch.
+
 ## [1.4.0] - 2026-04-26
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,13 @@ exercised the `gemstone` MCP server retroactively after a CLI workflow. Items gr
   field, e.g. `"Missing required parameter 'isMeta' (expected boolean)."`. A typo like
   `methodName` for `selector` surfaces as a missing-required error on `selector`, which is
   enough for an agent to recover.
+- `describe_test_failure` — re-runs a single test with its own `AbstractException` handler
+  (bypasses `TestCase>>run`, which would swallow the exception) and returns structured details:
+  `exceptionClass`, GemStone `errorNumber`, clean `messageText`, `description`, plus
+  `mnuReceiver` and `mnuSelector` for `MessageNotUnderstood`. No stack trace in v1 — GemStone's
+  exception classes don't expose `gemStackReport` or a populated `stack`/`stackReport` once the
+  exception is caught past its dynamic context. The agent gets enough to diagnose most failures
+  without re-reading the raw printString.
 
 ### Still open
 
@@ -28,9 +35,21 @@ exercised the `gemstone` MCP server retroactively after a CLI workflow. Items gr
 - **`compile_method_from_file` + `save_to_file`.** Point at a `.gs` file + selector and recompile
   just that method, then write live changes back to disk. *Blocked by the proxy model — the MCP
   server doesn't have file-system access; the host extension would have to mediate.*
-- **`describe_test_failure`.** Structured assertion message + exception class + line + stack frame
-  for a failing test. Needs richer extraction in `runTestMethod` / `runFailingTests`
-  (currently returns `printString`, not structured frames).
+- **Stack trace in `describe_test_failure`.** AbstractException's `gsStack` ivar holds GemStone's
+  internal stack representation, but `gemStackReport` / `stack` / `stackReport` accessors are
+  unavailable or return nil on caught exceptions. A path may exist via `instVarAt:` on `gsStack`
+  + custom formatting, or via running the test inside a `GsProcess` whose stack we can introspect.
+  Probe needed.
+
+## Bugs
+
+- **`runTestClass.ts` and `runFailingTests.ts` send `each testCase class name` to TestCase
+  instances that don't respond to `#testCase`.** Probe (see `describe_test_failure` work) showed
+  that in this GemStone's SUnit, `result failures` and `result errors` contain the failed
+  TestCase instance directly (only `testSelector` ivar) — `respondsTo: #testCase` returns false.
+  On a real failure, the existing queries would DNU. The unit tests mock the output, which is
+  why this hasn't been caught. Fix: use `each class name` and `each selector` (same as the
+  `passed` branch already does).
 
 ## Ideas
 - **Code Snippets** — Templates for common patterns: do:, collect:, ifTrue:ifFalse:, class definition boilerplate.

--- a/TODO.md
+++ b/TODO.md
@@ -5,44 +5,31 @@
 External feedback (see `Grail/docs/MCP_Server_Feedback.md`) from a Claude Code session that
 exercised the `gemstone` MCP server retroactively after a CLI workflow. Items grouped by impact.
 
-### Paper cuts (mislead the agent)
+### Shipped
 
-- **`execute_code` rejects multi-statement input.** `| x | x := 42. x + 1` errors with
-  "expected start of a statement" because the body is wrapped as `(${code}) printString`.
-  Wrap as a block (`[${code}] value printString`) so multi-statement / temp-var bodies parse,
-  or document the requirement loudly in the tool description.
-- **`find_implementors` / `find_senders` default to `environmentId: 0`.** Agents searching
-  Python-heavy projects (env 1) get "No implementors found" when the method exists. Either
-  surface an env hint in the empty-result message ("no implementors in env 0 — try env 1")
-  or default differently per project.
+- `execute_code` block-wraps input — multi-statement bodies and temp declarations parse.
+- `find_implementors` / `find_senders` / `find_references_to` hint at env 1 when env 0 search is empty.
+- `status`, `run_test_class`, `run_test_method`, `list_failing_tests` auto-refresh-if-clean
+  before reading. New `refresh` tool exposes the same primitive explicitly.
+- `list_failing_tests` (with optional `classNames`) runs the suite and returns only failures —
+  iteration happens in Smalltalk so it's a single GCI round-trip.
+- `list_test_classes` enumerates TestCase subclasses for filtering before `list_failing_tests`.
+
+### Still open
+
 - **Validator errors are not actionable.** Missing `isMeta` returns a bare zod
   "expected boolean, received undefined." `run_test_method` rejects `methodName` without
-  suggesting `selector`. The MCP error wrapper should name the missing/misnamed parameter.
-
-### Correctness (silent staleness)
-
-- **Stale-transaction silently lies.** `status` and read tools reflected the session's
-  pre-commit view (`1497 run`) after an external `install.sh` had committed (`1517 run`).
-  Options: auto-`abort` before read-only calls when `System needsCommit` is false; surface
-  `lastCommit` in `status`; or add an explicit `refresh` tool. Today the MCP can lie to the
-  agent without any signal.
-
-### New capabilities (rank order by ROI for an iteration loop)
-
-1. **`run_test_class` with auto-abort / refresh** — implicit transaction refresh before running.
-2. **`eval_python` / `compile_python`** — given a Python source string, return the generated
-   Smalltalk or the eval result. Closes the `/tmp/diag*.gs` gap for the GemStone-Python codegen
-   path (Grail-style projects).
-3. **`list_failing_tests`** — full-suite run that returns only failures, structured
-   (selector + error message + line), instead of having to grep `topaz` output.
-4. **`run_test_class` accepting a prefix or pattern** — e.g. `Bytes*TestCase` to verify
-   several related TestCase subclasses at once.
-5. **`compile_method_from_file`** — point at a `.gs` file + selector and recompile just that
-   method in the running stone. Avoids a full `install.sh` round-trip.
-6. **`save_to_file`** — write a method just compiled live via `compile_method` back to the
-   matching `.gs` file. Pairs with #5 to make MCP edits durable.
-7. **`describe_test_failure`** — structured assertion message + exception class + line +
-   stack frame for a failing test.
+  suggesting `selector`. The MCP error wrapper should name the missing/misnamed parameter
+  (likely via a custom zod error map registered globally).
+- **`eval_python` / `compile_python`.** Given a Python source string, return the generated
+  Smalltalk or the eval result. Closes the `/tmp/diag*.gs` gap for the GemStone-Python codegen
+  path (Grail-style projects). *Out of scope for general Jasper unless Grail's surface lands here.*
+- **`compile_method_from_file` + `save_to_file`.** Point at a `.gs` file + selector and recompile
+  just that method, then write live changes back to disk. *Blocked by the proxy model — the MCP
+  server doesn't have file-system access; the host extension would have to mediate.*
+- **`describe_test_failure`.** Structured assertion message + exception class + line + stack frame
+  for a failing test. Needs richer extraction in `runTestMethod` / `runFailingTests`
+  (currently returns `printString`, not structured frames).
 
 ## Ideas
 - **Code Snippets** — Templates for common patterns: do:, collect:, ifTrue:ifFalse:, class definition boilerplate.

--- a/TODO.md
+++ b/TODO.md
@@ -31,12 +31,18 @@ exercised the `gemstone` MCP server retroactively after a CLI workflow. Items gr
   are TestCase instances themselves with only `testSelector` ivar). On a real failure the
   queries would silently DNU; tests mock the output so it wasn't caught. Now uses the direct
   `each class name` / `each selector`, matching the `passed` branch.
+- `eval_python` / `compile_python` — register unconditionally on both surfaces, gracefully
+  detect Grail (GemStone-Python) by `objectNamed:` lookup of `ModuleAst`. With Grail loaded:
+  `eval_python` returns `(ModuleAst evaluateSource: src) printString`, `compile_python`
+  returns `(ModuleAst parseSource: src) smalltalkSource`. Without Grail: returns a
+  human-readable hint pointing at the missing class. Grail-side compile / runtime errors
+  are caught and reported inline as `Error: <class> — <messageText>`. Direct class
+  references (`ModuleAst evaluateSource: ...`) wouldn't work — that's a compile-time symbol
+  in our query source, not a runtime send, so a missing `ModuleAst` would fail the parse
+  before any handler could run. Dynamic resolution makes Grail's absence a runtime branch.
 
 ### Still open
 
-- **`eval_python` / `compile_python`.** Given a Python source string, return the generated
-  Smalltalk or the eval result. Closes the `/tmp/diag*.gs` gap for the GemStone-Python codegen
-  path (Grail-style projects). *Out of scope for general Jasper unless Grail's surface lands here.*
 - **`compile_method_from_file` + `save_to_file`.** Point at a `.gs` file + selector and recompile
   just that method, then write live changes back to disk. *Blocked by the proxy model — the MCP
   server doesn't have file-system access; the host extension would have to mediate.*

--- a/TODO.md
+++ b/TODO.md
@@ -22,10 +22,15 @@ exercised the `gemstone` MCP server retroactively after a CLI workflow. Items gr
 - `describe_test_failure` — re-runs a single test with its own `AbstractException` handler
   (bypasses `TestCase>>run`, which would swallow the exception) and returns structured details:
   `exceptionClass`, GemStone `errorNumber`, clean `messageText`, `description`, plus
-  `mnuReceiver` and `mnuSelector` for `MessageNotUnderstood`. No stack trace in v1 — GemStone's
-  exception classes don't expose `gemStackReport` or a populated `stack`/`stackReport` once the
-  exception is caught past its dynamic context. The agent gets enough to diagnose most failures
-  without re-reading the raw printString.
+  `mnuReceiver` and `mnuSelector` for `MessageNotUnderstood`, and a multi-line `stackReport`
+  with frames in `Class >> selector @ip line N [GsNMethod oop]` format. Stack capture is
+  enabled by toggling `GemExceptionSignalCapturesStack` on around the run and restoring it
+  via `ensure:` so the gem isn't left in a different state.
+- Bug fix: `runTestClass.ts` and `runFailingTests.ts` were sending `each testCase class name`
+  to objects that don't respond to `#testCase` (the items in `result failures` / `result errors`
+  are TestCase instances themselves with only `testSelector` ivar). On a real failure the
+  queries would silently DNU; tests mock the output so it wasn't caught. Now uses the direct
+  `each class name` / `each selector`, matching the `passed` branch.
 
 ### Still open
 
@@ -35,21 +40,6 @@ exercised the `gemstone` MCP server retroactively after a CLI workflow. Items gr
 - **`compile_method_from_file` + `save_to_file`.** Point at a `.gs` file + selector and recompile
   just that method, then write live changes back to disk. *Blocked by the proxy model — the MCP
   server doesn't have file-system access; the host extension would have to mediate.*
-- **Stack trace in `describe_test_failure`.** AbstractException's `gsStack` ivar holds GemStone's
-  internal stack representation, but `gemStackReport` / `stack` / `stackReport` accessors are
-  unavailable or return nil on caught exceptions. A path may exist via `instVarAt:` on `gsStack`
-  + custom formatting, or via running the test inside a `GsProcess` whose stack we can introspect.
-  Probe needed.
-
-## Bugs
-
-- **`runTestClass.ts` and `runFailingTests.ts` send `each testCase class name` to TestCase
-  instances that don't respond to `#testCase`.** Probe (see `describe_test_failure` work) showed
-  that in this GemStone's SUnit, `result failures` and `result errors` contain the failed
-  TestCase instance directly (only `testSelector` ivar) — `respondsTo: #testCase` returns false.
-  On a real failure, the existing queries would DNU. The unit tests mock the output, which is
-  why this hasn't been caught. Fix: use `each class name` and `each selector` (same as the
-  `passed` branch already does).
 
 ## Ideas
 - **Code Snippets** — Templates for common patterns: do:, collect:, ifTrue:ifFalse:, class definition boilerplate.

--- a/TODO.md
+++ b/TODO.md
@@ -43,9 +43,20 @@ exercised the `gemstone` MCP server retroactively after a CLI workflow. Items gr
 
 ### Still open
 
-- **`compile_method_from_file` + `save_to_file`.** Point at a `.gs` file + selector and recompile
-  just that method, then write live changes back to disk. *Blocked by the proxy model — the MCP
-  server doesn't have file-system access; the host extension would have to mediate.*
+(none)
+
+### Rejected (with rationale)
+
+- **`compile_method_from_file` + `save_to_file`.** The original feedback came from a Grail
+  session running outside an editor, with a hot loop of `edit .gs file → install.sh
+  (recompiles 114 classes, ~30s) → test`. The proposed tools were shortcuts around that
+  install.sh roundtrip. Jasper's workflow is different: [fileInManager.ts](client/src/fileInManager.ts)
+  already auto-files-in `.gs` saves to the running stone, so the agent's existing `Edit` tool
+  + VS Code save covers the same need. Adding `save_to_file` would actively introduce a
+  second write path competing with the editor's save handler — a stale-disk-vs-stale-stone
+  race the existing pipeline already avoids. `compile_method_from_file` would offer
+  parser-aware "extract just method X" extraction over what `Read` + `compile_method`
+  already does, but the gap is small and not worth the new surface area for Jasper users.
 
 ## Ideas
 - **Code Snippets** — Templates for common patterns: do:, collect:, ifTrue:ifFalse:, class definition boilerplate.

--- a/TODO.md
+++ b/TODO.md
@@ -14,13 +14,14 @@ exercised the `gemstone` MCP server retroactively after a CLI workflow. Items gr
 - `list_failing_tests` (with optional `classNames`) runs the suite and returns only failures —
   iteration happens in Smalltalk so it's a single GCI round-trip.
 - `list_test_classes` enumerates TestCase subclasses for filtering before `list_failing_tests`.
+- Actionable validator errors. Per-schema zod error map (not global — global breaks the SDK's
+  protocol parsing) rewrites missing-parameter and wrong-type messages to name the offending
+  field, e.g. `"Missing required parameter 'isMeta' (expected boolean)."`. A typo like
+  `methodName` for `selector` surfaces as a missing-required error on `selector`, which is
+  enough for an agent to recover.
 
 ### Still open
 
-- **Validator errors are not actionable.** Missing `isMeta` returns a bare zod
-  "expected boolean, received undefined." `run_test_method` rejects `methodName` without
-  suggesting `selector`. The MCP error wrapper should name the missing/misnamed parameter
-  (likely via a custom zod error map registered globally).
 - **`eval_python` / `compile_python`.** Given a Python source string, return the generated
   Smalltalk or the eval result. Closes the `/tmp/diag*.gs` gap for the GemStone-Python codegen
   path (Grail-style projects). *Out of scope for general Jasper unless Grail's surface lands here.*

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,49 @@
 # Open Issues & Future Work
 
+## MCP Server Feedback
+
+External feedback (see `Grail/docs/MCP_Server_Feedback.md`) from a Claude Code session that
+exercised the `gemstone` MCP server retroactively after a CLI workflow. Items grouped by impact.
+
+### Paper cuts (mislead the agent)
+
+- **`execute_code` rejects multi-statement input.** `| x | x := 42. x + 1` errors with
+  "expected start of a statement" because the body is wrapped as `(${code}) printString`.
+  Wrap as a block (`[${code}] value printString`) so multi-statement / temp-var bodies parse,
+  or document the requirement loudly in the tool description.
+- **`find_implementors` / `find_senders` default to `environmentId: 0`.** Agents searching
+  Python-heavy projects (env 1) get "No implementors found" when the method exists. Either
+  surface an env hint in the empty-result message ("no implementors in env 0 — try env 1")
+  or default differently per project.
+- **Validator errors are not actionable.** Missing `isMeta` returns a bare zod
+  "expected boolean, received undefined." `run_test_method` rejects `methodName` without
+  suggesting `selector`. The MCP error wrapper should name the missing/misnamed parameter.
+
+### Correctness (silent staleness)
+
+- **Stale-transaction silently lies.** `status` and read tools reflected the session's
+  pre-commit view (`1497 run`) after an external `install.sh` had committed (`1517 run`).
+  Options: auto-`abort` before read-only calls when `System needsCommit` is false; surface
+  `lastCommit` in `status`; or add an explicit `refresh` tool. Today the MCP can lie to the
+  agent without any signal.
+
+### New capabilities (rank order by ROI for an iteration loop)
+
+1. **`run_test_class` with auto-abort / refresh** — implicit transaction refresh before running.
+2. **`eval_python` / `compile_python`** — given a Python source string, return the generated
+   Smalltalk or the eval result. Closes the `/tmp/diag*.gs` gap for the GemStone-Python codegen
+   path (Grail-style projects).
+3. **`list_failing_tests`** — full-suite run that returns only failures, structured
+   (selector + error message + line), instead of having to grep `topaz` output.
+4. **`run_test_class` accepting a prefix or pattern** — e.g. `Bytes*TestCase` to verify
+   several related TestCase subclasses at once.
+5. **`compile_method_from_file`** — point at a `.gs` file + selector and recompile just that
+   method in the running stone. Avoids a full `install.sh` round-trip.
+6. **`save_to_file`** — write a method just compiled live via `compile_method` back to the
+   matching `.gs` file. Pairs with #5 to make MCP edits durable.
+7. **`describe_test_failure`** — structured assertion message + exception class + line +
+   stack frame for a failing test.
+
 ## Ideas
 - **Code Snippets** — Templates for common patterns: do:, collect:, ifTrue:ifFalse:, class definition boilerplate.
 - **Lint / Warnings** — Flag common issues: unused temporaries, missing super sends in initialize, etc.

--- a/client/src/__tests__/mcpSocketServerIntegration.test.ts
+++ b/client/src/__tests__/mcpSocketServerIntegration.test.ts
@@ -263,4 +263,28 @@ describe('McpSocketServer integration', () => {
       socket.destroy();
     }
   });
+
+  // Verifies the actionable-error zod error map flows end-to-end: the SDK
+  // serializes zod issues into the JSON-RPC error response verbatim, so the
+  // installed custom map's text must reach the client untouched. Without
+  // this guard, a future SDK upgrade that started templating its own messages
+  // would silently regress the "Missing required parameter 'X'" phrasing
+  // back to the bare zod default.
+  it('routes a missing-parameter validation failure through the custom error map', async () => {
+    const { client, socket } = await connectClient(server.socketPath);
+    try {
+      const result = await client.callTool({
+        name: 'get_method_source',
+        arguments: { className: 'Array', selector: 'size' }, // isMeta omitted
+      });
+
+      const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+      expect(text).toContain("Missing required parameter 'isMeta'");
+      expect(text).toContain('expected boolean');
+    } finally {
+      await client.close();
+      socket.destroy();
+    }
+  });
+
 });

--- a/client/src/__tests__/mcpSocketServerIntegration.test.ts
+++ b/client/src/__tests__/mcpSocketServerIntegration.test.ts
@@ -51,6 +51,10 @@ vi.mock('../sunitQueries', () => ({
     constructor(msg: string, num = 0) { super(msg); this.gciErrorNumber = num; }
   },
 }));
+vi.mock('../pythonQueries', () => ({
+  evalPython: vi.fn(() => ''),
+  compilePython: vi.fn(() => ''),
+}));
 
 import * as net from 'net';
 import * as crypto from 'crypto';
@@ -154,10 +158,12 @@ describe('McpSocketServer integration', () => {
         'commit',
         'compile_class_definition',
         'compile_method',
+        'compile_python',
         'delete_class',
         'delete_method',
         'describe_class',
         'describe_test_failure',
+        'eval_python',
         'execute_code',
         'export_class_source',
         'find_implementors',

--- a/client/src/__tests__/mcpSocketServerIntegration.test.ts
+++ b/client/src/__tests__/mcpSocketServerIntegration.test.ts
@@ -43,6 +43,9 @@ vi.mock('../browserQueries', () => ({
 vi.mock('../sunitQueries', () => ({
   runTestMethod: vi.fn(() => ({ className: '', selector: '', status: 'passed', message: '', durationMs: 0 })),
   runTestClass: vi.fn(() => []),
+  runFailingTests: vi.fn(() => []),
+  discoverTestClasses: vi.fn(() => [] as Array<{ dictName: string; className: string }>),
+  describeTestFailure: vi.fn(() => ({ status: 'passed' })),
   SunitQueryError: class SunitQueryError extends Error {
     gciErrorNumber: number;
     constructor(msg: string, num = 0) { super(msg); this.gciErrorNumber = num; }
@@ -154,6 +157,7 @@ describe('McpSocketServer integration', () => {
         'delete_class',
         'delete_method',
         'describe_class',
+        'describe_test_failure',
         'execute_code',
         'export_class_source',
         'find_implementors',

--- a/client/src/__tests__/mcpSocketServerIntegration.test.ts
+++ b/client/src/__tests__/mcpSocketServerIntegration.test.ts
@@ -141,7 +141,7 @@ describe('McpSocketServer integration', () => {
     await server.dispose();
   });
 
-  it('lists the 27 registered tools over the socket', async () => {
+  it('lists the registered tools over the socket', async () => {
     const { client, socket } = await connectClient(server.socketPath);
     try {
       const { tools } = await client.listTools();
@@ -166,7 +166,10 @@ describe('McpSocketServer integration', () => {
         'list_classes',
         'list_dictionaries',
         'list_dictionary_entries',
+        'list_failing_tests',
         'list_methods',
+        'list_test_classes',
+        'refresh',
         'remove_dictionary',
         'run_test_class',
         'run_test_method',

--- a/client/src/__tests__/mcpTools.test.ts
+++ b/client/src/__tests__/mcpTools.test.ts
@@ -34,6 +34,8 @@ vi.mock('../browserQueries', () => ({
 vi.mock('../sunitQueries', () => ({
   runTestMethod: vi.fn(() => ({ className: '', selector: '', status: 'passed', message: '', durationMs: 0 })),
   runTestClass: vi.fn(() => []),
+  runFailingTests: vi.fn(() => []),
+  discoverTestClasses: vi.fn(() => [] as Array<{ dictName: string; className: string }>),
   SunitQueryError: class SunitQueryError extends Error {
     gciErrorNumber: number;
     constructor(msg: string, num = 0) { super(msg); this.gciErrorNumber = num; }
@@ -95,7 +97,7 @@ describe('registerMcpTools', () => {
     vi.clearAllMocks();
   });
 
-  it('registers the expected 27 tools in alphabetical order', () => {
+  it('registers the expected tools in alphabetical order', () => {
     const names = server.getToolNames();
     expect(names).toEqual([
       'abort',
@@ -118,7 +120,10 @@ describe('registerMcpTools', () => {
       'list_classes',
       'list_dictionaries',
       'list_dictionary_entries',
+      'list_failing_tests',
       'list_methods',
+      'list_test_classes',
+      'refresh',
       'remove_dictionary',
       'run_test_class',
       'run_test_method',
@@ -165,6 +170,18 @@ describe('registerMcpTools', () => {
       expect(codeArg).toContain('printString');
     });
 
+    // Regression: the original wrapper was `(<code>) printString`, which only
+    // accepts a single expression. Multi-statement bodies with temp
+    // declarations (`| x | x := 42. x + 1`) errored with "expected start of a
+    // statement". Block-wrap accepts both shapes.
+    it('execute_code block-wraps the input so multi-statement bodies parse', async () => {
+      vi.mocked(queries.executeFetchString).mockReturnValue('43');
+      await server.getTool('execute_code')!.handler({ code: '| x | x := 42. x + 1' });
+
+      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(codeArg).toBe('[| x | x := 42. x + 1] value printString');
+    });
+
     it('get_class_definition delegates to queries.getClassDefinition', async () => {
       vi.mocked(queries.getClassDefinition).mockReturnValue('Array definition');
       const result = await server.getTool('get_class_definition')!.handler({ className: 'Array' });
@@ -183,11 +200,23 @@ describe('registerMcpTools', () => {
       expect(result.content[0].text).toContain('Globals\tArray\tinstance\tsize\taccessing');
     });
 
-    it('find_implementors returns "No implementors found." when empty', async () => {
+    // Empty results in env 0 (the default) hint at env 1 — projects like
+    // GemStone-Python keep most user code in env 1, and the original
+    // "No implementors found." text was easy to misread as "doesn't exist."
+    it('find_implementors hints at env 1 when env 0 search is empty', async () => {
       vi.mocked(queries.implementorsOf).mockReturnValue([]);
       const result = await server.getTool('find_implementors')!.handler({ selector: 'xyz' });
 
-      expect(result.content[0].text).toBe('No implementors found.');
+      expect(result.content[0].text).toContain('environmentId 0');
+      expect(result.content[0].text).toContain('environmentId: 1');
+    });
+
+    it('find_implementors gives a plain empty message when an explicit non-zero env is empty', async () => {
+      vi.mocked(queries.implementorsOf).mockReturnValue([]);
+      const result = await server.getTool('find_implementors')!
+        .handler({ selector: 'xyz', environmentId: 1 });
+
+      expect(result.content[0].text).toBe('No implementors found in environmentId 1.');
     });
 
     it('list_classes delegates to getClassNames with the dictionary name', async () => {
@@ -242,11 +271,12 @@ describe('registerMcpTools', () => {
       expect(result.content[0].text).toContain('Globals\tFoo\tinstance\tuse\tclient');
     });
 
-    it('find_references_to returns "No references found." when empty', async () => {
+    it('find_references_to hints at env 1 when env 0 search is empty', async () => {
       vi.mocked(queries.referencesToObject).mockReturnValue([]);
       const result = await server.getTool('find_references_to')!.handler({ objectName: 'Missing' });
 
-      expect(result.content[0].text).toBe('No references found.');
+      expect(result.content[0].text).toContain('environmentId 0');
+      expect(result.content[0].text).toContain('environmentId: 1');
     });
 
     it('list_all_classes emits dictIndex\\tdictName\\tclassName rows', async () => {
@@ -359,6 +389,19 @@ describe('registerMcpTools', () => {
       expect(result.content[0].text).toBe('PASSED (3ms)');
     });
 
+    it('run_test_method auto-refreshes the session view before running', async () => {
+      vi.mocked(sunit.runTestMethod).mockReturnValue({
+        className: 'ArrayTest', selector: 'testSize', status: 'passed', message: '', durationMs: 1,
+      });
+      await server.getTool('run_test_method')!.handler({
+        className: 'ArrayTest', selector: 'testSize',
+      });
+
+      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(refreshCall).toContain('System needsCommit ifFalse:');
+      expect(refreshCall).toContain('System abortTransaction');
+    });
+
     it('run_test_class delegates to sunit.runTestClass and formats results', async () => {
       vi.mocked(sunit.runTestClass).mockReturnValue([
         { className: 'ArrayTest', selector: 'testSize', status: 'passed', message: '', durationMs: 0 },
@@ -372,6 +415,68 @@ describe('registerMcpTools', () => {
       expect(result.content[0].text).toContain('expected 1 got 2');
     });
 
+    it('run_test_class auto-refreshes the session view before running', async () => {
+      vi.mocked(sunit.runTestClass).mockReturnValue([]);
+      await server.getTool('run_test_class')!.handler({ className: 'ArrayTest' });
+
+      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(refreshCall).toContain('System needsCommit ifFalse:');
+      expect(refreshCall).toContain('System abortTransaction');
+    });
+
+    it('list_failing_tests returns "All tests passed." when nothing failed', async () => {
+      vi.mocked(sunit.runFailingTests).mockReturnValue([]);
+      const result = await server.getTool('list_failing_tests')!.handler({});
+
+      expect(result.content[0].text).toBe('All tests passed.');
+    });
+
+    it('list_failing_tests formats failures and errors with status\\tclass\\tselector\\tmessage', async () => {
+      vi.mocked(sunit.runFailingTests).mockReturnValue([
+        { className: 'MyTest', selector: 'testBad', status: 'failed', message: 'expected 1 got 2', durationMs: 0 },
+        { className: 'Other', selector: 'testBoom', status: 'error', message: 'division by zero', durationMs: 0 },
+      ]);
+      const result = await server.getTool('list_failing_tests')!.handler({});
+
+      expect(result.content[0].text).toContain('FAILED\tMyTest\ttestBad\texpected 1 got 2');
+      expect(result.content[0].text).toContain('ERROR\tOther\ttestBoom\tdivision by zero');
+    });
+
+    it('list_failing_tests forwards classNames to the underlying query', async () => {
+      vi.mocked(sunit.runFailingTests).mockReturnValue([]);
+      await server.getTool('list_failing_tests')!
+        .handler({ classNames: ['ArrayTest', 'StringTest'] });
+
+      expect(sunit.runFailingTests).toHaveBeenCalledWith(session, ['ArrayTest', 'StringTest']);
+    });
+
+    it('list_test_classes returns dictName\\tclassName rows', async () => {
+      vi.mocked(sunit.discoverTestClasses).mockReturnValue([
+        { dictName: 'UserGlobals', className: 'ArrayTest' },
+        { dictName: 'UserGlobals', className: 'StringTest' },
+      ]);
+      const result = await server.getTool('list_test_classes')!.handler({});
+
+      expect(result.content[0].text).toBe('UserGlobals\tArrayTest\nUserGlobals\tStringTest');
+    });
+
+    it('list_test_classes returns a friendly message when no TestCase subclasses are found', async () => {
+      vi.mocked(sunit.discoverTestClasses).mockReturnValue([]);
+      const result = await server.getTool('list_test_classes')!.handler({});
+
+      expect(result.content[0].text).toBe('No TestCase subclasses found.');
+    });
+
+    it('refresh runs needsCommit/abortTransaction and returns the result', async () => {
+      vi.mocked(queries.executeFetchString).mockReturnValue('refreshed');
+      const result = await server.getTool('refresh')!.handler({});
+
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(code).toContain('System needsCommit');
+      expect(code).toContain('System abortTransaction');
+      expect(result.content[0].text).toBe('refreshed');
+    });
+
     it('status pulls session info via executeFetchString', async () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('User: DataCurator\n...');
       const result = await server.getTool('status')!.handler({});
@@ -382,6 +487,23 @@ describe('registerMcpTools', () => {
       expect(code).toContain('inTransaction');
       expect(code).toContain('needsCommit');
       expect(result.content[0].text).toContain('DataCurator');
+    });
+
+    // Stale-transaction guard: the snippet must auto-refresh-if-clean so the
+    // rest of the report (and any follow-up read tools in this session) sees
+    // committed state. Skipping when needsCommit is true is load-bearing —
+    // discarding uncommitted work silently would be far worse than reporting
+    // slightly stale state.
+    it('status auto-refreshes the view inline (only when no uncommitted changes)', async () => {
+      vi.mocked(queries.executeFetchString).mockReturnValue('');
+      await server.getTool('status')!.handler({});
+
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(code).toContain('System needsCommit');
+      expect(code).toContain('System abortTransaction');
+      expect(code).toContain('View: ');
+      expect(code).toContain('stale');
+      expect(code).toContain('refreshed');
     });
 
     // Regression: nextPutAll: sends do: to its argument. If any value passed

--- a/client/src/__tests__/mcpTools.test.ts
+++ b/client/src/__tests__/mcpTools.test.ts
@@ -36,6 +36,7 @@ vi.mock('../sunitQueries', () => ({
   runTestClass: vi.fn(() => []),
   runFailingTests: vi.fn(() => []),
   discoverTestClasses: vi.fn(() => [] as Array<{ dictName: string; className: string }>),
+  describeTestFailure: vi.fn(() => ({ status: 'passed' })),
   SunitQueryError: class SunitQueryError extends Error {
     gciErrorNumber: number;
     constructor(msg: string, num = 0) { super(msg); this.gciErrorNumber = num; }
@@ -108,6 +109,7 @@ describe('registerMcpTools', () => {
       'delete_class',
       'delete_method',
       'describe_class',
+      'describe_test_failure',
       'execute_code',
       'export_class_source',
       'find_implementors',
@@ -485,6 +487,48 @@ describe('registerMcpTools', () => {
       const result = await server.getTool('list_test_classes')!.handler({});
 
       expect(result.content[0].text).toBe('No TestCase subclasses found.');
+    });
+
+    it('describe_test_failure formats TestFailure output with exceptionClass + messageText', async () => {
+      vi.mocked(sunit.describeTestFailure).mockReturnValue({
+        status: 'failed',
+        exceptionClass: 'TestFailure',
+        errorNumber: 2751,
+        messageText: 'Assertion failed',
+        description: 'TestFailure: Assertion failed',
+      });
+      const result = await server.getTool('describe_test_failure')!
+        .handler({ className: 'ArrayTest', selector: 'testBad' });
+
+      expect(sunit.describeTestFailure).toHaveBeenCalledWith(session, 'ArrayTest', 'testBad');
+      expect(result.content[0].text).toContain('exceptionClass: TestFailure');
+      expect(result.content[0].text).toContain('messageText: Assertion failed');
+      expect(result.content[0].text).toContain('errorNumber: 2751');
+    });
+
+    it('describe_test_failure surfaces mnuReceiver and mnuSelector for MessageNotUnderstood', async () => {
+      vi.mocked(sunit.describeTestFailure).mockReturnValue({
+        status: 'error',
+        exceptionClass: 'MessageNotUnderstood',
+        errorNumber: 2010,
+        messageText: 'a Object class does not understand #foo',
+        description: 'a Object class does not understand #foo',
+        mnuReceiver: 'Object',
+        mnuSelector: 'foo',
+      });
+      const result = await server.getTool('describe_test_failure')!
+        .handler({ className: 'ArrayTest', selector: 'testErrors' });
+
+      expect(result.content[0].text).toContain('mnuReceiver: Object');
+      expect(result.content[0].text).toContain('mnuSelector: foo');
+    });
+
+    it('describe_test_failure returns "PASSED" when the re-run actually passed', async () => {
+      vi.mocked(sunit.describeTestFailure).mockReturnValue({ status: 'passed' });
+      const result = await server.getTool('describe_test_failure')!
+        .handler({ className: 'ArrayTest', selector: 'testGood' });
+
+      expect(result.content[0].text).toBe('PASSED');
     });
 
     it('refresh runs needsCommit/abortTransaction and returns the result', async () => {

--- a/client/src/__tests__/mcpTools.test.ts
+++ b/client/src/__tests__/mcpTools.test.ts
@@ -42,9 +42,14 @@ vi.mock('../sunitQueries', () => ({
     constructor(msg: string, num = 0) { super(msg); this.gciErrorNumber = num; }
   },
 }));
+vi.mock('../pythonQueries', () => ({
+  evalPython: vi.fn(() => ''),
+  compilePython: vi.fn(() => ''),
+}));
 
 import * as queries from '../browserQueries';
 import * as sunit from '../sunitQueries';
+import * as python from '../pythonQueries';
 import { registerMcpTools } from '../mcpTools';
 import { ActiveSession } from '../sessionManager';
 
@@ -106,10 +111,12 @@ describe('registerMcpTools', () => {
       'commit',
       'compile_class_definition',
       'compile_method',
+      'compile_python',
       'delete_class',
       'delete_method',
       'describe_class',
       'describe_test_failure',
+      'eval_python',
       'execute_code',
       'export_class_source',
       'find_implementors',
@@ -487,6 +494,33 @@ describe('registerMcpTools', () => {
       const result = await server.getTool('list_test_classes')!.handler({});
 
       expect(result.content[0].text).toBe('No TestCase subclasses found.');
+    });
+
+    it('eval_python delegates to python.evalPython with the source string', async () => {
+      vi.mocked(python.evalPython).mockReturnValue('3');
+      const result = await server.getTool('eval_python')!.handler({ source: '1 + 2' });
+
+      expect(python.evalPython).toHaveBeenCalledWith(session, '1 + 2');
+      expect(result.content[0].text).toBe('3');
+    });
+
+    // Tool registers unconditionally; the "Grail not loaded" message comes
+    // back from the Smalltalk side as ordinary result text.
+    it('eval_python passes the "Grail not detected" hint through verbatim', async () => {
+      vi.mocked(python.evalPython).mockReturnValue(
+        'Grail (GemStone-Python) not detected: class ModuleAst not found in symbolList. ...');
+      const result = await server.getTool('eval_python')!.handler({ source: 'x = 1' });
+
+      expect(result.content[0].text).toContain('Grail (GemStone-Python) not detected');
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('compile_python delegates to python.compilePython with the source string', async () => {
+      vi.mocked(python.compilePython).mockReturnValue('x := 1');
+      const result = await server.getTool('compile_python')!.handler({ source: 'x = 1' });
+
+      expect(python.compilePython).toHaveBeenCalledWith(session, 'x = 1');
+      expect(result.content[0].text).toBe('x := 1');
     });
 
     it('describe_test_failure formats TestFailure output with exceptionClass + messageText', async () => {

--- a/client/src/__tests__/mcpTools.test.ts
+++ b/client/src/__tests__/mcpTools.test.ts
@@ -279,6 +279,17 @@ describe('registerMcpTools', () => {
       expect(result.content[0].text).toContain('environmentId: 1');
     });
 
+    // Symmetric with find_implementors / find_references_to — same helper, same
+    // expected hint. Without this assertion a refactor could silently regress
+    // senders-only.
+    it('find_senders hints at env 1 when env 0 search is empty', async () => {
+      vi.mocked(queries.sendersOf).mockReturnValue([]);
+      const result = await server.getTool('find_senders')!.handler({ selector: 'unused' });
+
+      expect(result.content[0].text).toContain('environmentId 0');
+      expect(result.content[0].text).toContain('environmentId: 1');
+    });
+
     it('list_all_classes emits dictIndex\\tdictName\\tclassName rows', async () => {
       vi.mocked(queries.getAllClassNames).mockReturnValue([
         { dictIndex: 1, dictName: 'Globals', className: 'Array' },
@@ -448,6 +459,15 @@ describe('registerMcpTools', () => {
         .handler({ classNames: ['ArrayTest', 'StringTest'] });
 
       expect(sunit.runFailingTests).toHaveBeenCalledWith(session, ['ArrayTest', 'StringTest']);
+    });
+
+    it('list_failing_tests auto-refreshes the session view before the suite runs', async () => {
+      vi.mocked(sunit.runFailingTests).mockReturnValue([]);
+      await server.getTool('list_failing_tests')!.handler({});
+
+      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(refreshCall).toContain('System needsCommit ifFalse:');
+      expect(refreshCall).toContain('System abortTransaction');
     });
 
     it('list_test_classes returns dictName\\tclassName rows', async () => {

--- a/client/src/__tests__/mcpTools.test.ts
+++ b/client/src/__tests__/mcpTools.test.ts
@@ -531,6 +531,26 @@ describe('registerMcpTools', () => {
       expect(result.content[0].text).toBe('PASSED');
     });
 
+    it('describe_test_failure formats stackReport under a header preserving newlines', async () => {
+      vi.mocked(sunit.describeTestFailure).mockReturnValue({
+        status: 'failed',
+        exceptionClass: 'TestFailure',
+        errorNumber: 2751,
+        messageText: 'Assertion failed',
+        description: 'TestFailure: Assertion failed',
+        stackReport:
+          'TestFailure (AbstractException) >> signal: @3 line 7  [GsNMethod 3523841]\n' +
+          'JasperProbeTest >> testFails @3 line 1  [GsNMethod 1236251649]',
+      });
+      const result = await server.getTool('describe_test_failure')!
+        .handler({ className: 'ArrayTest', selector: 'testBad' });
+      const text = result.content[0].text;
+
+      expect(text).toContain('stackReport:');
+      expect(text).toContain('TestFailure (AbstractException) >> signal:');
+      expect(text).toContain('JasperProbeTest >> testFails');
+    });
+
     it('refresh runs needsCommit/abortTransaction and returns the result', async () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('refreshed');
       const result = await server.getTool('refresh')!.handler({});

--- a/client/src/__tests__/mcpZodErrorMap.test.ts
+++ b/client/src/__tests__/mcpZodErrorMap.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { mcpErrorMap, applyErrorMapToShape } from '../mcpZodErrorMap';
+
+// These tests exercise the pure error-map function and the shape-attachment
+// helper, not the SDK wrapper. Format guarantees here are what the MCP SDK
+// forwards verbatim to the agent over JSON-RPC; integration coverage that
+// the wrapper actually flows through the SDK lives in
+// mcpSocketServerIntegration.test.ts.
+
+function parseAndGet(schema: z.ZodType, input: unknown) {
+  const result = schema.safeParse(input, { error: mcpErrorMap });
+  if (result.success) throw new Error('expected parse to fail');
+  return result.error.issues[0];
+}
+
+describe('mcpErrorMap', () => {
+  describe('missing required parameter', () => {
+    it('names the field and the expected type', () => {
+      const schema = z.object({ isMeta: z.boolean() });
+      const issue = parseAndGet(schema, {});
+
+      expect(issue.message).toContain("Missing required parameter 'isMeta'");
+      expect(issue.message).toContain('expected boolean');
+    });
+
+    it('uses dot notation for nested paths', () => {
+      const schema = z.object({ outer: z.object({ inner: z.string() }) });
+      const issue = parseAndGet(schema, { outer: {} });
+
+      expect(issue.message).toContain("Missing required parameter 'outer.inner'");
+      expect(issue.message).toContain('expected string');
+    });
+  });
+
+  describe('wrong type', () => {
+    // Common LLM mistake: passing a string "false" instead of a boolean.
+    // Default zod text says "expected boolean, received string" without the
+    // field name. We want the field name front and center.
+    it('names the field, the expected type, and what was received', () => {
+      const schema = z.object({ isMeta: z.boolean() });
+      const issue = parseAndGet(schema, { isMeta: 'false' });
+
+      expect(issue.message).toContain("Parameter 'isMeta'");
+      expect(issue.message).toContain('must be boolean');
+      expect(issue.message).toContain('received string');
+    });
+
+    it('reports null and arrays as their own kinds (not "object")', () => {
+      const schema = z.object({ x: z.string() });
+
+      const nullIssue = parseAndGet(schema, { x: null });
+      expect(nullIssue.message).toContain('received null');
+
+      const arrayIssue = parseAndGet(schema, { x: [1, 2, 3] });
+      expect(arrayIssue.message).toContain('received array');
+    });
+  });
+
+  describe('codes we do not specialize', () => {
+    // Returning undefined falls through to zod's default formatter — we don't
+    // want to accidentally regress messages we don't understand fully.
+    it('falls through to the default formatter for too_small and similar', () => {
+      const schema = z.object({ name: z.string().min(3) });
+      const issue = parseAndGet(schema, { name: 'a' });
+
+      // Zod's default text for too_small contains "at least" or similar; the
+      // exact wording varies by version, so we just assert we did *not*
+      // overwrite it with our parameter-shape template.
+      expect(issue.message).not.toContain('Missing required parameter');
+      expect(issue.message).not.toContain('Parameter ');
+    });
+  });
+});
+
+describe('applyErrorMapToShape', () => {
+  // The whole point of attaching per-schema is that downstream parses pick
+  // up the message *without* the caller passing { error } each time —
+  // because the SDK builds its own ZodObject from our shape and parses with
+  // no override.
+  it('attaches the MCP error map to each field so default safeParse picks it up', () => {
+    const shape = {
+      isMeta: z.boolean(),
+      selector: z.string(),
+    };
+    applyErrorMapToShape(shape);
+
+    // No `{ error: ... }` arg here — the message must come from the field.
+    const objSchema = z.object(shape);
+    const result = objSchema.safeParse({ isMeta: 'false' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const isMetaIssue = result.error.issues.find(i => i.path[0] === 'isMeta')!;
+    expect(isMetaIssue.message).toContain("Parameter 'isMeta'");
+    expect(isMetaIssue.message).toContain('received string');
+
+    const selectorIssue = result.error.issues.find(i => i.path[0] === 'selector')!;
+    expect(selectorIssue.message).toContain("Missing required parameter 'selector'");
+  });
+
+  // Empty shape is a real case (status, abort, commit, refresh — zero-arg
+  // tools). It must not throw.
+  it('is a no-op on an empty shape', () => {
+    expect(() => applyErrorMapToShape({})).not.toThrow();
+  });
+
+  // Crucially: setting the error per-schema must NOT touch the global
+  // zod config (z.config). That's what makes this approach SDK-safe.
+  it('does not mutate global zod config (other schemas use the default formatter)', () => {
+    applyErrorMapToShape({ x: z.string() });
+
+    // A separate schema not run through applyErrorMapToShape must still
+    // produce zod's default message text, not ours.
+    const other = z.object({ y: z.boolean() });
+    const result = other.safeParse({});
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues[0];
+    expect(issue.message).not.toContain("Missing required parameter 'y'");
+  });
+});

--- a/client/src/__tests__/sunitQueries.test.ts
+++ b/client/src/__tests__/sunitQueries.test.ts
@@ -138,6 +138,18 @@ describe('sunitQueries', () => {
       const session = createMockSession('');
       expect(sunit.runTestClass(session, 'MyTestCase')).toEqual([]);
     });
+
+    // Bug guard: probe of GemStone's SUnit revealed that `result failures`
+    // and `result errors` contain TestCase instances (only `testSelector`
+    // ivar) — they don't respond to `#testCase`. The query must not send it
+    // (would silently DNU on real failures).
+    it('does not send #testCase to failure/error wrappers', () => {
+      const session = createMockSession('');
+      sunit.runTestClass(session, 'MyTestCase');
+      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(code).not.toMatch(/testCase\s+class\s+name/);
+      expect(code).not.toMatch(/testCase\s+selector/);
+    });
   });
 
   describe('error handling', () => {

--- a/client/src/mcpTools.ts
+++ b/client/src/mcpTools.ts
@@ -4,6 +4,7 @@ import { ActiveSession } from './sessionManager';
 import * as queries from './browserQueries';
 import * as sunit from './sunitQueries';
 import type { TestRunResult } from './queries/runTestMethod';
+import type { TestFailureDetails } from './queries/describeTestFailure';
 import { withMcpErrorMap } from './mcpZodErrorMap';
 
 // Refresh the session's view of committed state if it's safe to do so.
@@ -204,6 +205,23 @@ export function registerMcpTools(
     },
     async (args) => wrap<typeof args>((session, a) => {
       return queries.describeClass(session, a.className, a.dictionaryName);
+    })(args),
+  );
+
+  server.tool(
+    'describe_test_failure',
+    'Re-run a single SUnit test method and return structured details about why it failed: ' +
+    'exception class, GemStone error number, messageText, description, and (for ' +
+    'MessageNotUnderstood) the receiver and missing selector. Use this after run_test_method ' +
+    'or list_failing_tests reports a failure. Re-runs in isolation with its own ' +
+    'AbstractException handler — bypasses TestCase>>run, which would swallow the exception.',
+    {
+      className: z.string().describe('TestCase subclass name'),
+      selector: z.string().describe('Test method selector, e.g. "testAdd"'),
+    },
+    async (args) => wrap<typeof args>((session, a) => {
+      const details = sunit.describeTestFailure(session, a.className, a.selector);
+      return formatTestFailureDetails(details);
     })(args),
   );
 
@@ -564,6 +582,22 @@ function formatTestResult(r: TestRunResult): string {
   const prefix = r.status === 'passed' ? 'PASSED' : r.status === 'failed' ? 'FAILED' : 'ERROR';
   const msg = r.message ? `: ${r.message}` : '';
   return `${prefix}${msg} (${r.durationMs}ms)`;
+}
+
+// Render TestFailureDetails as line-oriented text. Agents read this directly,
+// so the format is "<key>: <value>\n" — easy to scan, easy to grep, no
+// structure beyond the keys the Smalltalk side already provides.
+function formatTestFailureDetails(d: TestFailureDetails): string {
+  if (d.status === 'passed') return 'PASSED';
+  const lines: string[] = [];
+  lines.push(`status: ${d.status}`);
+  if (d.exceptionClass) lines.push(`exceptionClass: ${d.exceptionClass}`);
+  if (d.errorNumber !== undefined) lines.push(`errorNumber: ${d.errorNumber}`);
+  if (d.messageText !== undefined) lines.push(`messageText: ${d.messageText}`);
+  if (d.description !== undefined) lines.push(`description: ${d.description}`);
+  if (d.mnuReceiver !== undefined) lines.push(`mnuReceiver: ${d.mnuReceiver}`);
+  if (d.mnuSelector !== undefined) lines.push(`mnuSelector: ${d.mnuSelector}`);
+  return lines.join('\n');
 }
 
 function formatTestResults(results: TestRunResult[]): string {

--- a/client/src/mcpTools.ts
+++ b/client/src/mcpTools.ts
@@ -586,7 +586,9 @@ function formatTestResult(r: TestRunResult): string {
 
 // Render TestFailureDetails as line-oriented text. Agents read this directly,
 // so the format is "<key>: <value>\n" — easy to scan, easy to grep, no
-// structure beyond the keys the Smalltalk side already provides.
+// structure beyond the keys the Smalltalk side already provides. stackReport
+// is emitted last (and bare, since it's already multi-line) under a header
+// so the agent sees the structured fields first and can scroll to the trace.
 function formatTestFailureDetails(d: TestFailureDetails): string {
   if (d.status === 'passed') return 'PASSED';
   const lines: string[] = [];
@@ -597,6 +599,10 @@ function formatTestFailureDetails(d: TestFailureDetails): string {
   if (d.description !== undefined) lines.push(`description: ${d.description}`);
   if (d.mnuReceiver !== undefined) lines.push(`mnuReceiver: ${d.mnuReceiver}`);
   if (d.mnuSelector !== undefined) lines.push(`mnuSelector: ${d.mnuSelector}`);
+  if (d.stackReport) {
+    lines.push('stackReport:');
+    lines.push(d.stackReport);
+  }
   return lines.join('\n');
 }
 

--- a/client/src/mcpTools.ts
+++ b/client/src/mcpTools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ActiveSession } from './sessionManager';
 import * as queries from './browserQueries';
 import * as sunit from './sunitQueries';
+import * as python from './pythonQueries';
 import type { TestRunResult } from './queries/runTestMethod';
 import type { TestFailureDetails } from './queries/describeTestFailure';
 import { withMcpErrorMap } from './mcpZodErrorMap';
@@ -160,6 +161,21 @@ export function registerMcpTools(
   );
 
   server.tool(
+    'compile_python',
+    'Transpile Python source to Smalltalk via Grail (GemStone-Python) and return the ' +
+    'generated Smalltalk source verbatim. Useful for inspecting codegen output without ' +
+    'running the code, and as an end-to-end check on the codegen pipeline. ' +
+    'Returns a "Grail not detected" hint if Grail (class ModuleAst) is not loaded ' +
+    'in the current session.',
+    {
+      source: z.string().describe('Python source string to transpile'),
+    },
+    async (args) => wrap<typeof args>((session, a) => {
+      return python.compilePython(session, a.source);
+    })(args),
+  );
+
+  server.tool(
     'delete_class',
     'DESTRUCTIVE: remove a class from a specific dictionary. Requires dictionaryName because ' +
     'deletion must target a specific dictionary (names can be shadowed across dicts). ' +
@@ -222,6 +238,22 @@ export function registerMcpTools(
     async (args) => wrap<typeof args>((session, a) => {
       const details = sunit.describeTestFailure(session, a.className, a.selector);
       return formatTestFailureDetails(details);
+    })(args),
+  );
+
+  server.tool(
+    'eval_python',
+    'Compile and execute Python source via Grail (GemStone-Python) and return the result ' +
+    'as a printString. Closes the diagnostic-snippet gap for Python-heavy projects: ' +
+    'one tool call instead of writing a /tmp/diag*.gs script that drives the codegen ' +
+    'pipeline manually. Returns a "Grail not detected" hint if Grail (class ModuleAst) ' +
+    'is not loaded in the current session. Grail-side compile and runtime errors are ' +
+    'reported inline as "Error: <class> — <messageText>".',
+    {
+      source: z.string().describe('Python source string to evaluate'),
+    },
+    async (args) => wrap<typeof args>((session, a) => {
+      return python.evalPython(session, a.source);
     })(args),
   );
 

--- a/client/src/mcpTools.ts
+++ b/client/src/mcpTools.ts
@@ -5,6 +5,37 @@ import * as queries from './browserQueries';
 import * as sunit from './sunitQueries';
 import type { TestRunResult } from './queries/runTestMethod';
 
+// Refresh the session's view of committed state if it's safe to do so.
+// GemStone's GCI pins read-only operations to the session's transaction
+// view: a commit landed by another process is invisible until this session
+// aborts or commits. Auto-refresh closes the silent-stale gap; we skip
+// when the session has uncommitted work so we never discard.
+function refreshIfClean(session: ActiveSession): void {
+  try {
+    queries.executeFetchString(
+      session,
+      'mcpRefreshIfClean',
+      "System needsCommit ifFalse: [System abortTransaction]. 'ok'",
+    );
+  } catch {
+    // Best effort. If refresh fails (e.g. session disconnected) the primary
+    // tool call below will report the real error.
+  }
+}
+
+// Build the empty-result message for a find_* tool. When the caller used the
+// default env (0) and got nothing back, hint that the project's code may
+// live in env 1 — env 0 is the system environment, env 1 is where most user
+// code (notably GemStone-Python) actually lives.
+function noResultsMessage(label: string, environmentId: number): string {
+  if (environmentId === 0) {
+    return `No ${label} found in environmentId 0 (the default — system environment). ` +
+      `If the project's code lives in a user environment (e.g. GemStone-Python uses ` +
+      `environmentId 1), retry with environmentId: 1.`;
+  }
+  return `No ${label} found in environmentId ${environmentId}.`;
+}
+
 /**
  * Register the Jasper MCP tools against the user's currently selected
  * GemStone session. The session is resolved on each invocation via the
@@ -171,10 +202,17 @@ export function registerMcpTools(
 
   server.tool(
     'execute_code',
-    'Execute GemStone Smalltalk code in the user\'s active session and return the result as a string (printString). Changes are NOT committed automatically.',
-    { code: z.string().describe('Smalltalk expression to execute') },
+    'Execute GemStone Smalltalk code in the user\'s active session and return the result as a string (via printString). ' +
+    'Accepts both single expressions ("3 + 4") and multi-statement bodies with temp ' +
+    'declarations ("| x | x := 42. x + 1") — the body is evaluated as a block, so any ' +
+    'sequence of statements is fine. The value of the last statement is returned. ' +
+    'Changes are NOT committed automatically.',
+    { code: z.string().describe('Smalltalk expression or statement sequence to execute') },
     async (args) => wrap<typeof args>((session, a) => {
-      return executeString(session, `(${a.code}) printString`);
+      // Block-wrap so multi-statement bodies and top-level temp declarations
+      // parse — `(<code>) printString` only accepts a single expression and
+      // rejected `| x | ...` with "expected start of a statement".
+      return executeString(session, `[${a.code}] value printString`);
     })(args),
   );
 
@@ -197,14 +235,18 @@ export function registerMcpTools(
 
   server.tool(
     'find_implementors',
-    'Find all classes that implement a given selector. Returns up to 500 results.',
+    'Find all classes that implement a given selector. Returns up to 500 results. ' +
+    'Searches one environment at a time — env 0 (default) is the system environment; ' +
+    'projects like GemStone-Python keep most user code in env 1. If env 0 returns ' +
+    'nothing, retry with environmentId: 1 before concluding the selector is unimplemented.',
     {
       selector: z.string().describe('Method selector to search for'),
-      environmentId: z.number().optional().describe('Environment ID (default 0)'),
+      environmentId: z.number().optional().describe('Environment ID (default 0; try 1 for user code)'),
     },
     async (args) => wrap<typeof args>((session, a) => {
-      const results = queries.implementorsOf(session, a.selector, a.environmentId ?? 0);
-      return formatMethodResults(results, 'No implementors found.');
+      const envId = a.environmentId ?? 0;
+      const results = queries.implementorsOf(session, a.selector, envId);
+      return formatMethodResults(results, noResultsMessage('implementors', envId));
     })(args),
   );
 
@@ -212,27 +254,32 @@ export function registerMcpTools(
     'find_references_to',
     'Find all methods that reference a named global (class, pool, or shared variable). ' +
     'Sister to find_senders, which matches a selector; this matches a global by name. ' +
-    'Returns up to 500 results.',
+    'Returns up to 500 results. Env 0 (default) is the system environment; if results ' +
+    'are empty, retry with environmentId: 1 — user-environment globals are invisible from env 0.',
     {
       objectName: z.string().describe('Name of the global to find references to, e.g. "AllUsers"'),
-      environmentId: z.number().optional().describe('Environment ID (default 0)'),
+      environmentId: z.number().optional().describe('Environment ID (default 0; try 1 for user code)'),
     },
     async (args) => wrap<typeof args>((session, a) => {
-      const results = queries.referencesToObject(session, a.objectName, a.environmentId ?? 0);
-      return formatMethodResults(results, 'No references found.');
+      const envId = a.environmentId ?? 0;
+      const results = queries.referencesToObject(session, a.objectName, envId);
+      return formatMethodResults(results, noResultsMessage('references', envId));
     })(args),
   );
 
   server.tool(
     'find_senders',
-    'Find all methods that send a given selector. Returns up to 500 results.',
+    'Find all methods that send a given selector. Returns up to 500 results. ' +
+    'Env 0 (default) is the system environment; if results are empty, retry with ' +
+    'environmentId: 1 — user-environment senders are invisible from env 0.',
     {
       selector: z.string().describe('Method selector to search for'),
-      environmentId: z.number().optional().describe('Environment ID (default 0)'),
+      environmentId: z.number().optional().describe('Environment ID (default 0; try 1 for user code)'),
     },
     async (args) => wrap<typeof args>((session, a) => {
-      const results = queries.sendersOf(session, a.selector, a.environmentId ?? 0);
-      return formatMethodResults(results, 'No senders found.');
+      const envId = a.environmentId ?? 0;
+      const results = queries.sendersOf(session, a.selector, envId);
+      return formatMethodResults(results, noResultsMessage('senders', envId));
     })(args),
   );
 
@@ -321,6 +368,33 @@ export function registerMcpTools(
   );
 
   server.tool(
+    'list_failing_tests',
+    'Run SUnit tests and return only the failed/errored results — the agent ' +
+    'equivalent of "run the suite and grep for failures." With no classNames, ' +
+    'discovers and runs every TestCase subclass in the symbolList. With ' +
+    'classNames, runs only those classes (names that don\'t resolve are ' +
+    'skipped silently). Auto-refreshes the session view first when no ' +
+    'uncommitted changes are pending. Returns "" if every test passed; ' +
+    'otherwise tab-separated lines: className, selector, status, message.',
+    {
+      classNames: z.array(z.string()).optional().describe(
+        'TestCase subclass names to run. Omit to run every TestCase in the symbolList.',
+      ),
+    },
+    async (args) => wrap<typeof args>((session, a) => {
+      refreshIfClean(session);
+      const results = sunit.runFailingTests(session, a.classNames);
+      if (results.length === 0) return 'All tests passed.';
+      return results
+        .map(r => {
+          const status = r.status === 'failed' ? 'FAILED' : 'ERROR';
+          return `${status}\t${r.className}\t${r.selector}\t${r.message}`;
+        })
+        .join('\n');
+    })(args),
+  );
+
+  server.tool(
     'list_methods',
     'List all methods of a class, grouped by category. Returns tab-separated lines: side (instance|class), category, selector.',
     { className: z.string().describe('Class name') },
@@ -331,6 +405,37 @@ export function registerMcpTools(
         .map(m => `${m.isMeta ? 'class' : 'instance'}\t${m.category}\t${m.selector}`)
         .join('\n');
     })(args),
+  );
+
+  server.tool(
+    'list_test_classes',
+    'Discover every TestCase subclass in the user\'s symbolList. Returns ' +
+    'tab-separated lines: dictName, className. Useful for then passing a ' +
+    'filtered subset to list_failing_tests.',
+    {},
+    async () => wrap<Record<string, unknown>>((session) => {
+      const classes = sunit.discoverTestClasses(session);
+      if (classes.length === 0) return 'No TestCase subclasses found.';
+      return classes
+        .map(c => `${c.dictName}\t${c.className}`)
+        .join('\n');
+    })({}),
+  );
+
+  server.tool(
+    'refresh',
+    'Refresh this session\'s view of committed state by aborting if (and only if) ' +
+    'there are no uncommitted changes. GemStone\'s GCI pins the session\'s read view ' +
+    'until it aborts or commits, so a commit landed by another process (e.g. install.sh) ' +
+    'is invisible until refresh runs. If the session has uncommitted work, this is a ' +
+    'no-op and reports back so the caller can decide whether to abort or commit first.',
+    {},
+    async () => wrap<Record<string, unknown>>((session) => {
+      return executeString(
+        session,
+        "System needsCommit ifTrue: ['skipped: uncommitted changes present'] ifFalse: [System abortTransaction. 'refreshed']",
+      );
+    })({}),
   );
 
   server.tool(
@@ -345,9 +450,12 @@ export function registerMcpTools(
 
   server.tool(
     'run_test_class',
-    'Run all SUnit test methods in a TestCase subclass and return per-method pass/fail/error results.',
+    'Run all SUnit test methods in a TestCase subclass and return per-method pass/fail/error results. ' +
+    'Auto-refreshes the session view first (when no uncommitted changes are pending) so results ' +
+    'reflect the latest committed code, not a stale transaction view.',
     { className: z.string().describe('TestCase subclass name') },
     async (args) => wrap<typeof args>((session, a) => {
+      refreshIfClean(session);
       const results = sunit.runTestClass(session, a.className);
       return formatTestResults(results);
     })(args),
@@ -355,12 +463,15 @@ export function registerMcpTools(
 
   server.tool(
     'run_test_method',
-    'Run a single SUnit test method and return pass/fail/error with details.',
+    'Run a single SUnit test method and return pass/fail/error with details. ' +
+    'Auto-refreshes the session view first (when no uncommitted changes are pending) so the ' +
+    'result reflects the latest committed code.',
     {
       className: z.string().describe('TestCase subclass name'),
       selector: z.string().describe('Test method selector, e.g. "testAdd"'),
     },
     async (args) => wrap<typeof args>((session, a) => {
+      refreshIfClean(session);
       const r = sunit.runTestMethod(session, a.className, a.selector);
       return formatTestResult(r);
     })(args),
@@ -397,20 +508,33 @@ export function registerMcpTools(
 
   server.tool(
     'status',
-    'Report information about the user\'s active GemStone session: user, stone, transaction state, and whether there are uncommitted changes.',
+    'Report information about the user\'s active GemStone session: user, stone, transaction state, ' +
+    'whether there are uncommitted changes, and whether the session view was just refreshed. ' +
+    'Auto-refreshes the view (via abort) when no uncommitted changes are pending, so subsequent ' +
+    'reads reflect the latest committed state — not a stale transaction view from before another ' +
+    'process committed.',
     {},
     async () => wrap<Record<string, unknown>>((session) => {
       // Every value put into the stream must be a CharacterCollection; otherwise
       // nextPutAll: sends do: to it and GemStone complains (e.g. SmallInteger
       // DNU do:). Coerce with asString / printString to keep it robust across
       // GemStone versions where these System methods return different types.
-      const code = `| ws |
+      //
+      // Auto-refresh: if no uncommitted work is pending we abort first so the
+      // rest of the report (and any follow-up read tool calls) sees committed
+      // state landed by other processes. Skip when uncommitted work is
+      // pending — silent discard would be far worse than slightly stale state.
+      const code = `| ws viewState |
+viewState := System needsCommit
+  ifTrue: ['stale (uncommitted changes — call abort or commit to refresh)']
+  ifFalse: [System abortTransaction. 'refreshed'].
 ws := WriteStream on: String new.
 ws nextPutAll: 'User: '; nextPutAll: System myUserProfile userId asString; lf.
 ws nextPutAll: 'Stone: '; nextPutAll: System stoneName asString; lf.
 ws nextPutAll: 'Session ID: '; nextPutAll: System session printString; lf.
 ws nextPutAll: 'Transaction: '; nextPutAll: (System inTransaction ifTrue: ['active'] ifFalse: ['none']); lf.
 ws nextPutAll: 'Uncommitted changes: '; nextPutAll: (System needsCommit ifTrue: ['yes'] ifFalse: ['no']); lf.
+ws nextPutAll: 'View: '; nextPutAll: viewState; lf.
 ws contents`;
       return executeString(session, code);
     })({}),

--- a/client/src/mcpTools.ts
+++ b/client/src/mcpTools.ts
@@ -4,6 +4,7 @@ import { ActiveSession } from './sessionManager';
 import * as queries from './browserQueries';
 import * as sunit from './sunitQueries';
 import type { TestRunResult } from './queries/runTestMethod';
+import { withMcpErrorMap } from './mcpZodErrorMap';
 
 // Refresh the session's view of committed state if it's safe to do so.
 // GemStone's GCI pins read-only operations to the session's transaction
@@ -47,9 +48,15 @@ function noResultsMessage(label: string, environmentId: number): string {
  * tell the user to log in.
  */
 export function registerMcpTools(
-  server: McpServer,
+  rawServer: McpServer,
   getSession: () => ActiveSession | undefined,
 ): void {
+
+  // Wrap the MCP server so each tool's input shape gets the actionable-error
+  // zod error map attached at registration time. Per-schema attachment (not
+  // global z.config) — see mcpZodErrorMap.ts for why a global map breaks the
+  // SDK's protocol parsing.
+  const server = withMcpErrorMap(rawServer) as unknown as McpServer;
 
   function requireSession(): ActiveSession | { errorText: string } {
     const session = getSession();

--- a/client/src/mcpZodErrorMap.ts
+++ b/client/src/mcpZodErrorMap.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+
+// Custom zod error map for MCP tool input validation.
+//
+// Why this exists: when an MCP tool call fails schema validation, the SDK
+// passes zod's error message through to the JSON-RPC response verbatim
+// (verified via probe). Zod's default message — "Invalid input: expected
+// boolean, received undefined" — does not name *which* parameter was wrong,
+// so an agent reading just the message can't recover. Path *is* available
+// in the structured issue, but the message is what most agents read first.
+//
+// Why per-schema (not global): the MCP SDK uses zod internally to parse
+// JSON-RPC messages via discriminated unions over request/response/error
+// shapes. Failed branches of those unions emit invalid_type issues as a
+// normal control-flow signal. Setting `z.config({ customError })` globally
+// rewrites *those* messages too and breaks the SDK's protocol parsing
+// (manifests as request hangs at runtime). Attaching the error map per
+// tool-input field via the schema's own `_zod.def.error` slot — which zod
+// consults *before* the global config — keeps our messages scoped to the
+// schemas we own.
+//
+// Limitations: zod's error map context does not expose the schema definition,
+// so we can't pull each field's `.describe()` text into the message. Agents
+// recover via the tool's overall description plus the named path — which is
+// already much better than the default.
+
+export const mcpErrorMap: z.core.$ZodErrorMap = (issue) => {
+  if (issue.code === 'invalid_type') {
+    const path = formatPath(issue.path);
+    const expected = issue.expected;
+    if (issue.input === undefined) {
+      return {
+        message: `Missing required parameter '${path}' (expected ${expected}).`,
+      };
+    }
+    const received = describeReceived(issue.input);
+    return {
+      message: `Parameter '${path}' must be ${expected}, but received ${received}.`,
+    };
+  }
+
+  // Fall through to the default formatter for codes we don't specialize.
+  // unrecognized_keys is unreachable for the SDK's tool-input parsing
+  // (default z.object is non-strict — unknown keys are silently dropped and
+  // the relevant signal becomes a missing-required error elsewhere), so we
+  // don't bother with a custom message there.
+  return undefined;
+};
+
+// Attach the MCP error map to every field schema in a tool-input shape.
+// Mutates the shape in place; returns it so call sites can chain.
+//
+// Why mutate `_zod.def.error` directly: the SDK's `server.tool(name, desc,
+// shape, cb)` API takes a raw shape, not a ZodObject, so we can't pass an
+// `error` option through the public ZodObject constructor. The `_zod.def`
+// slot is the same field zod's runtime checks first when formatting an
+// issue — setting it imperatively preserves all chained metadata (.describe,
+// .optional, etc.) on each field.
+export function applyErrorMapToShape<T extends z.ZodRawShape>(shape: T): T {
+  for (const key of Object.keys(shape)) {
+    const schema = shape[key] as unknown as { _zod: { def: { error?: z.core.$ZodErrorMap } } };
+    schema._zod.def.error = mcpErrorMap;
+  }
+  return shape;
+}
+
+// Wrap an McpServer so every `server.tool(...)` call automatically applies
+// the MCP error map to its input shape. Returns a shim with the same
+// surface as the underlying server's `tool` method.
+//
+// Why wrap rather than monkey-patch: we want the change to be local to
+// registerTools/registerMcpTools — tests that exercise the raw McpServer
+// shouldn't see an instrumented prototype.
+export function withMcpErrorMap(server: { tool: (...args: unknown[]) => unknown }): { tool: (...args: unknown[]) => unknown } {
+  const original = server.tool.bind(server);
+  return {
+    tool(...args: unknown[]) {
+      // server.tool overloads:
+      //   (name, cb)
+      //   (name, description, cb)
+      //   (name, shapeOrAnnotations, cb)
+      //   (name, description, shapeOrAnnotations, cb)
+      // Apply the error map only when arg[2] (or arg[1]) looks like a
+      // tool-input shape (Record<string, ZodTypeAny>). Empty shapes ({})
+      // are also caught and pass through harmlessly.
+      for (const arg of args) {
+        if (isToolInputShape(arg)) {
+          applyErrorMapToShape(arg);
+          break;
+        }
+      }
+      return original(...args);
+    },
+  };
+}
+
+// Heuristic: a tool-input shape is a plain object whose values are ZodType
+// instances. ToolAnnotations also pass `Record<string, unknown>` but its
+// values aren't zod schemas, so the `_zod` check filters them out.
+function isToolInputShape(value: unknown): value is z.ZodRawShape {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return true; // empty shape — wrap a no-op
+  return keys.every(k => {
+    const v = obj[k];
+    return !!v && typeof v === 'object' && '_zod' in v;
+  });
+}
+
+function formatPath(path: PropertyKey[]): string {
+  if (path.length === 0) return '<root>';
+  return path.map(p => String(p)).join('.');
+}
+
+// Approximate the "received <type>" phrasing of zod's default. We can't get
+// at zod's internal type detector from the error map context, so we map the
+// few primitive cases that show up in MCP tool inputs.
+function describeReceived(input: unknown): string {
+  if (input === null) return 'null';
+  if (Array.isArray(input)) return 'array';
+  return typeof input;
+}

--- a/client/src/pythonQueries.ts
+++ b/client/src/pythonQueries.ts
@@ -1,0 +1,17 @@
+import { ActiveSession } from './sessionManager';
+import { executeFetchString } from './browserQueries';
+import { QueryExecutor } from './queries/types';
+
+import { evalPython as sharedEvalPython, compilePython as sharedCompilePython } from './queries/python';
+
+function bind(session: ActiveSession): QueryExecutor {
+  return (label, code) => executeFetchString(session, label, code);
+}
+
+export function evalPython(session: ActiveSession, source: string) {
+  return sharedEvalPython(bind(session), source);
+}
+
+export function compilePython(session: ActiveSession, source: string) {
+  return sharedCompilePython(bind(session), source);
+}

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -8,6 +8,7 @@ import { getClassHierarchy } from '../getClassHierarchy';
 import { getMethodList } from '../getMethodList';
 import { getStepPointSelectorRanges } from '../getStepPointSelectorRanges';
 import { runFailingTests } from '../runFailingTests';
+import { describeTestFailure } from '../describeTestFailure';
 
 describe('getDictionaryEntries', () => {
   it('parses class (1) and global (0) rows', () => {
@@ -171,5 +172,87 @@ describe('runFailingTests', () => {
     // Two occurrences expected: one for failures, one for errors.
     const matches = code.match(/printString size min: 1024/g) || [];
     expect(matches.length).toBe(2);
+  });
+});
+
+describe('describeTestFailure', () => {
+  // The parser is line-prefixed key/value — unknown keys must be silently
+  // ignored so a future Smalltalk-side addition (extra fields, GS-version
+  // specific extras) doesn't crash callers.
+  it('parses TestFailure-shaped output into structured details', () => {
+    const raw = 'status: failed\n' +
+      'exceptionClass: TestFailure\n' +
+      'errorNumber: 2751\n' +
+      'messageText: Assertion failed\n' +
+      'description: TestFailure: Assertion failed\n';
+    const result = describeTestFailure(vi.fn<QueryExecutor>(() => raw), 'ArrayTest', 'testBad');
+    expect(result).toEqual({
+      status: 'failed',
+      exceptionClass: 'TestFailure',
+      errorNumber: 2751,
+      messageText: 'Assertion failed',
+      description: 'TestFailure: Assertion failed',
+    });
+  });
+
+  it('parses MessageNotUnderstood output, including mnuReceiver and mnuSelector', () => {
+    const raw = 'status: error\n' +
+      'exceptionClass: MessageNotUnderstood\n' +
+      'errorNumber: 2010\n' +
+      'messageText: a Object class does not understand #foo\n' +
+      'description: a Object class does not understand #foo\n' +
+      'mnuReceiver: Object\n' +
+      'mnuSelector: foo\n';
+    const result = describeTestFailure(vi.fn<QueryExecutor>(() => raw), 'ArrayTest', 'testErrors');
+    expect(result.status).toBe('error');
+    expect(result.exceptionClass).toBe('MessageNotUnderstood');
+    expect(result.mnuReceiver).toBe('Object');
+    expect(result.mnuSelector).toBe('foo');
+  });
+
+  it('parses passed status with no other fields', () => {
+    const result = describeTestFailure(vi.fn<QueryExecutor>(() => 'status: passed\n'), 'X', 'y');
+    expect(result.status).toBe('passed');
+    expect(result.exceptionClass).toBeUndefined();
+    expect(result.messageText).toBeUndefined();
+  });
+
+  // Unknown keys must not throw — required so we can extend the snippet
+  // server-side without coordinating client updates.
+  it('ignores unknown keys', () => {
+    const raw = 'status: failed\nfutureField: whatever\nexceptionClass: TestFailure\n';
+    const result = describeTestFailure(vi.fn<QueryExecutor>(() => raw), 'X', 'y');
+    expect(result.status).toBe('failed');
+    expect(result.exceptionClass).toBe('TestFailure');
+  });
+
+  // The Smalltalk side has to use AbstractException — the GS hierarchy
+  // means MessageNotUnderstood escapes past Exception in some session
+  // contexts. Lock this in so a future "simplification" doesn't regress.
+  it('uses AbstractException for the live exception capture', () => {
+    const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
+    describeTestFailure(exec, 'ArrayTest', 'testGood');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('on: AbstractException');
+    expect(code).not.toMatch(/on: Exception\b/);
+  });
+
+  // Bypass SUnit's swallow-the-exception runner.
+  it('runs setUp / perform / tearDown manually rather than going through TestCase>>run', () => {
+    const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
+    describeTestFailure(exec, 'ArrayTest', 'testGood');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('tc setUp');
+    expect(code).toContain('tc perform:');
+    expect(code).toContain('tc tearDown');
+    expect(code).not.toMatch(/tc run\b/);
+  });
+
+  it('escapes single quotes in className and selector', () => {
+    const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
+    describeTestFailure(exec, "Foo'Bar", "test'X");
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain("Foo''Bar");
+    expect(code).toContain("test''X");
   });
 });

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -7,6 +7,7 @@ import { getClassEnvironments } from '../getClassEnvironments';
 import { getClassHierarchy } from '../getClassHierarchy';
 import { getMethodList } from '../getMethodList';
 import { getStepPointSelectorRanges } from '../getStepPointSelectorRanges';
+import { runFailingTests } from '../runFailingTests';
 
 describe('getDictionaryEntries', () => {
   it('parses class (1) and global (0) rows', () => {
@@ -107,5 +108,54 @@ describe('getStepPointSelectorRanges', () => {
       { stepPoint: 1, selectorOffset: 0, selectorLength: 3, selectorText: 'foo' },
       { stepPoint: 2, selectorOffset: 5, selectorLength: 4, selectorText: 'bar:' },
     ]);
+  });
+});
+
+describe('runFailingTests', () => {
+  it('parses class\\tselector\\tstatus\\tmessage rows into TestRunResult[]', () => {
+    const raw = 'MyTest\ttestBad\tfailed\texpected 1 got 2\nOther\ttestBoom\terror\tdivision by zero\n';
+    const results = runFailingTests(vi.fn<QueryExecutor>(() => raw));
+    expect(results).toEqual([
+      { className: 'MyTest', selector: 'testBad', status: 'failed', message: 'expected 1 got 2', durationMs: 0 },
+      { className: 'Other', selector: 'testBoom', status: 'error', message: 'division by zero', durationMs: 0 },
+    ]);
+  });
+
+  // No classNames → discover-all path. The Smalltalk snippet must walk the
+  // user's symbolList for TestCase subclasses (excluding TestCase itself);
+  // the explicit-list-only `objectNamed:` and `reject:` constructs must NOT
+  // appear, otherwise the path got swapped.
+  it('uses the discover-all path when no classNames are given', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    runFailingTests(exec);
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('symbolList');
+    expect(code).toContain('isSubclassOf: TestCase');
+    expect(code).toContain('IdentitySet');
+    expect(code).not.toContain('objectNamed:');
+    expect(code).not.toContain('reject: [:c | c isNil]');
+  });
+
+  // With names → explicit-list path. Each name is resolved separately so a
+  // single typo doesn't blow up the whole run; missing names get filtered
+  // out before the suite executes.
+  it('uses the explicit-list path when classNames are given, building the list at runtime', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    runFailingTests(exec, ['ArrayTest', 'StringTest']);
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain("objectNamed: #'ArrayTest'");
+    expect(code).toContain("objectNamed: #'StringTest'");
+    expect(code).toContain('reject: [:c | c isNil]');
+  });
+
+  it('escapes single quotes in classNames', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    runFailingTests(exec, ["it's"]);
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain("#'it''s'");
+  });
+
+  it('returns [] when nothing failed', () => {
+    expect(runFailingTests(vi.fn<QueryExecutor>(() => ''))).toEqual([]);
   });
 });

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -158,4 +158,18 @@ describe('runFailingTests', () => {
   it('returns [] when nothing failed', () => {
     expect(runFailingTests(vi.fn<QueryExecutor>(() => ''))).toEqual([]);
   });
+
+  // Per-message printString cap: 1024 chars in the batched runner so a worst
+  // case of ~250 failing tests still fits under the 256KB MAX_RESULT. The
+  // single-method runner uses 4096 because there's only one entry; bumping
+  // the batched cap to match would silently truncate batched output under
+  // load. Lock the constant in.
+  it('caps each printString at 1024 chars to stay under MAX_RESULT', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    runFailingTests(exec);
+    const code = exec.mock.calls[0][1];
+    // Two occurrences expected: one for failures, one for errors.
+    const matches = code.match(/printString size min: 1024/g) || [];
+    expect(matches.length).toBe(2);
+  });
 });

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -9,6 +9,7 @@ import { getMethodList } from '../getMethodList';
 import { getStepPointSelectorRanges } from '../getStepPointSelectorRanges';
 import { runFailingTests } from '../runFailingTests';
 import { describeTestFailure } from '../describeTestFailure';
+import { evalPython, compilePython } from '../python';
 
 describe('getDictionaryEntries', () => {
   it('parses class (1) and global (0) rows', () => {
@@ -322,5 +323,72 @@ describe('describeTestFailure', () => {
     describeTestFailure(exec, 'X', 'y');
     const code = exec.mock.calls[0][1];
     expect(code).toContain('size min: 16384');
+  });
+});
+
+describe('python (Grail) queries', () => {
+  // Detection: a missing ModuleAst class is the signal that Grail isn't
+  // installed. Direct reference like `ModuleAst evaluateSource: ...` would
+  // be a *compile-time* failure of our query source — there'd be no
+  // runtime exception to catch. Resolving via objectNamed: makes the
+  // dispatcher's absence a runtime nil check we can branch on.
+  it('uses objectNamed: ModuleAst rather than a direct class reference', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    evalPython(exec, 'x = 1');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain("objectNamed: #'ModuleAst'");
+    expect(code).toContain('dispatcher isNil');
+  });
+
+  it('emits a graceful "Grail not detected" hint as the nil-branch result', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    evalPython(exec, 'x = 1');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('Grail (GemStone-Python) not detected');
+    expect(code).toContain('class ModuleAst not found');
+  });
+
+  // The dispatcher is reused across both tools — they should produce
+  // identical detection scaffolding, only differing in the Grail
+  // expression that runs in the ifFalse branch.
+  it('eval_python uses ModuleAst evaluateSource: (returns the printed result)', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    evalPython(exec, 'print(1+2)');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('dispatcher evaluateSource: src');
+    expect(code).toContain('printString');
+  });
+
+  it('compile_python uses (ModuleAst parseSource: src) smalltalkSource', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    compilePython(exec, 'x = 1');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('dispatcher parseSource: src');
+    expect(code).toContain('smalltalkSource');
+  });
+
+  // Python source frequently contains single-quoted string literals — the
+  // standard Smalltalk doubling rule must apply or the query won't parse.
+  it('escapes single quotes in Python source', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    evalPython(exec, "x = 'hello'");
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain("''hello''");
+  });
+
+  // Errors from Grail's compile/runtime path (SyntaxError, NameError, etc.)
+  // are caught and reported inline as "Error: <class> — <messageText>" so
+  // the agent gets a usable diagnostic, not a dropped tool call.
+  it('wraps the Grail call in on: AbstractException do:', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    evalPython(exec, 'x = 1');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('on: AbstractException');
+    expect(code).toContain("'Error: ' , e class name");
+  });
+
+  it('returns the executor result verbatim — no parsing on the JS side', () => {
+    const result = evalPython(vi.fn<QueryExecutor>(() => '3'), '1 + 2');
+    expect(result).toBe('3');
   });
 });

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -160,6 +160,20 @@ describe('runFailingTests', () => {
     expect(runFailingTests(vi.fn<QueryExecutor>(() => ''))).toEqual([]);
   });
 
+  // Bug guard: probe of GemStone's SUnit revealed that `result failures` and
+  // `result errors` contain the TestCase instances themselves (only
+  // `testSelector` ivar) — they don't respond to `#testCase`. Sending it
+  // would silently DNU on real failures. The query must use direct
+  // accessors (`each class name` / `each selector`), same as the passed
+  // branch already does.
+  it('does not send #testCase to failure/error wrappers', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    runFailingTests(exec);
+    const code = exec.mock.calls[0][1];
+    expect(code).not.toMatch(/testCase\s+class\s+name/);
+    expect(code).not.toMatch(/testCase\s+selector/);
+  });
+
   // Per-message printString cap: 1024 chars in the batched runner so a worst
   // case of ~250 failing tests still fits under the 256KB MAX_RESULT. The
   // single-method runner uses 4096 because there's only one entry; bumping
@@ -254,5 +268,59 @@ describe('describeTestFailure', () => {
     const code = exec.mock.calls[0][1];
     expect(code).toContain("Foo''Bar");
     expect(code).toContain("test''X");
+  });
+
+  // Stack capture path: the gem-level config GemExceptionSignalCapturesStack
+  // controls whether AbstractException's gsStack is populated at signal time.
+  // Without toggling it on, stackReport returns nil even on a live exception.
+  it('toggles GemExceptionSignalCapturesStack around the run and restores after', () => {
+    const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
+    describeTestFailure(exec, 'ArrayTest', 'testGood');
+    const code = exec.mock.calls[0][1];
+
+    // Saved before, set true during, restored in ensure: after.
+    expect(code).toContain('System gemConfigurationAt: #GemExceptionSignalCapturesStack');
+    expect(code).toContain("gemConfigurationAt: #GemExceptionSignalCapturesStack put: true");
+    expect(code).toContain("gemConfigurationAt: #GemExceptionSignalCapturesStack put: oldStackCfg");
+    expect(code).toContain('ensure:');
+  });
+
+  // The sentinel keeps multi-line stack content separate from the
+  // line-prefixed key/value section. Without it, frame newlines would split
+  // into bogus key/value pairs and the parser would lose the stack.
+  it('parses stackReport that follows the sentinel as one verbatim block', () => {
+    const raw = 'status: failed\n' +
+      'exceptionClass: TestFailure\n' +
+      'errorNumber: 2751\n' +
+      'messageText: Assertion failed\n' +
+      'description: TestFailure: Assertion failed\n' +
+      '--- stackReport ---\n' +
+      'TestFailure (AbstractException) >> signal: @3 line 7  [GsNMethod 3523841]\n' +
+      'TestFailure class (AbstractException class) >> signal: @3 line 4  [GsNMethod 3803137]\n' +
+      'JasperProbeTest >> testFails @3 line 1  [GsNMethod 1236251649]\n';
+    const result = describeTestFailure(vi.fn<QueryExecutor>(() => raw), 'X', 'y');
+    expect(result.status).toBe('failed');
+    expect(result.exceptionClass).toBe('TestFailure');
+    expect(result.stackReport).toContain('TestFailure (AbstractException) >> signal:');
+    expect(result.stackReport).toContain('JasperProbeTest >> testFails');
+    // Frame separator newlines must survive intact.
+    expect((result.stackReport || '').split('\n').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('omits stackReport when the sentinel is absent (e.g. config rejected)', () => {
+    const raw = 'status: failed\nexceptionClass: TestFailure\nmessageText: Assertion failed\n';
+    const result = describeTestFailure(vi.fn<QueryExecutor>(() => raw), 'X', 'y');
+    expect(result.stackReport).toBeUndefined();
+  });
+
+  // Stack cap: 16384 chars in the Smalltalk side keeps the largest
+  // realistic trace under MAX_RESULT (256KB) while leaving plenty of
+  // room for the scalar fields. Lock it in so a future bump doesn't
+  // accidentally produce truncated output that's hard to diagnose.
+  it('caps stackReport at 16384 chars', () => {
+    const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
+    describeTestFailure(exec, 'X', 'y');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('size min: 16384');
   });
 });

--- a/client/src/queries/describeTestFailure.ts
+++ b/client/src/queries/describeTestFailure.ts
@@ -1,0 +1,124 @@
+import { QueryExecutor } from './types';
+import { escapeString } from './util';
+
+// Structured details about a single SUnit test's outcome — the fields agents
+// need to diagnose a failure without re-reading the raw printString blob.
+//
+// Why we re-run the test (instead of digesting the prior TestResult):
+// SUnit's TestCase>>run catches the raised exception inside its own handler
+// to record "this test failed/errored," then discards the exception. By the
+// time `result failures` / `result errors` are populated, the items inside
+// are TestCase instances themselves (only `testSelector` ivar) with no
+// reference to what was raised. To get exception class / messageText /
+// description / receiver / selector we have to re-run the test with our own
+// AbstractException handler that captures the live exception.
+export interface TestFailureDetails {
+  status: 'passed' | 'failed' | 'error';
+  exceptionClass?: string;
+  errorNumber?: number;
+  messageText?: string;
+  description?: string;
+  // For MessageNotUnderstood specifically: the receiver and the missing
+  // selector. These are the highest-signal fields for MNU debugging — they
+  // tell the agent exactly which method needs to be implemented or which
+  // call site has the wrong receiver class.
+  mnuReceiver?: string;
+  mnuSelector?: string;
+}
+
+export function describeTestFailure(
+  execute: QueryExecutor,
+  className: string,
+  selector: string,
+): TestFailureDetails {
+  const cls = escapeString(className);
+  const sel = escapeString(selector);
+  // Why AbstractException (not Exception): GemStone's Exception class can be
+  // shadowed in user environments, and MessageNotUnderstood inherits from
+  // AbstractException directly in some session contexts — using Exception
+  // would let real errors escape past our handler. AbstractException is the
+  // documented root.
+  //
+  // Why match SUnit's setUp/test/tearDown ordering manually: we bypass
+  // TestCase>>run because that's the method that swallows the exception.
+  // We replicate its lifecycle (skip the test body if setUp blew up;
+  // surface a tearDown failure only if the test body itself succeeded).
+  const code = `| tc captured tdEx ws cleanText |
+tc := ${cls} selector: #'${sel}'.
+captured := nil.
+[tc setUp] on: AbstractException do: [:e | captured := e].
+captured isNil ifTrue: [
+  [tc perform: #'${sel}'] on: AbstractException do: [:e | captured := e].
+  tdEx := nil.
+  [tc tearDown] on: AbstractException do: [:e | tdEx := e].
+  (captured isNil and: [tdEx notNil]) ifTrue: [captured := tdEx]].
+
+cleanText := [:obj |
+  | s |
+  s := obj asString.
+  s := s copyFrom: 1 to: (s size min: 4096).
+  s collect: [:ch |
+    (ch = Character lf or: [ch = Character cr or: [ch = Character tab]])
+      ifTrue: [$ ] ifFalse: [ch]]].
+
+ws := WriteStream on: String new.
+captured isNil ifTrue: [
+  ws nextPutAll: 'status: passed'; lf
+] ifFalse: [
+  | isFailure isMnu |
+  isFailure := captured isKindOf: TestFailure.
+  isMnu := captured isKindOf: MessageNotUnderstood.
+  ws nextPutAll: 'status: '; nextPutAll: (isFailure ifTrue: ['failed'] ifFalse: ['error']); lf.
+  ws nextPutAll: 'exceptionClass: '; nextPutAll: captured class name; lf.
+  ws nextPutAll: 'errorNumber: '; nextPutAll: captured number printString; lf.
+  ws nextPutAll: 'messageText: '; nextPutAll: (cleanText value: captured messageText); lf.
+  ws nextPutAll: 'description: '; nextPutAll: (cleanText value: captured description); lf.
+  isMnu ifTrue: [
+    ws nextPutAll: 'mnuReceiver: '; nextPutAll: (cleanText value: captured receiver printString); lf.
+    ws nextPutAll: 'mnuSelector: '; nextPutAll: captured selector asString; lf]].
+ws contents`;
+
+  const data = execute('describeTestFailure', code);
+  return parseDetails(data);
+}
+
+// Parse "key: value" lines emitted by the Smalltalk side. Unknown keys are
+// ignored so we can extend the snippet (extra fields, version-specific
+// extras) without breaking existing callers.
+function parseDetails(text: string): TestFailureDetails {
+  const result: TestFailureDetails = { status: 'error' };
+  for (const line of text.split('\n')) {
+    const idx = line.indexOf(': ');
+    if (idx < 0) continue;
+    const key = line.substring(0, idx);
+    const value = line.substring(idx + 2);
+    switch (key) {
+      case 'status':
+        if (value === 'passed' || value === 'failed' || value === 'error') {
+          result.status = value;
+        }
+        break;
+      case 'exceptionClass':
+        result.exceptionClass = value;
+        break;
+      case 'errorNumber': {
+        const n = parseInt(value, 10);
+        if (!isNaN(n)) result.errorNumber = n;
+        break;
+      }
+      case 'messageText':
+        result.messageText = value;
+        break;
+      case 'description':
+        result.description = value;
+        break;
+      case 'mnuReceiver':
+        result.mnuReceiver = value;
+        break;
+      case 'mnuSelector':
+        result.mnuSelector = value;
+        break;
+    }
+  }
+  return result;
+}

--- a/client/src/queries/describeTestFailure.ts
+++ b/client/src/queries/describeTestFailure.ts
@@ -10,8 +10,8 @@ import { escapeString } from './util';
 // time `result failures` / `result errors` are populated, the items inside
 // are TestCase instances themselves (only `testSelector` ivar) with no
 // reference to what was raised. To get exception class / messageText /
-// description / receiver / selector we have to re-run the test with our own
-// AbstractException handler that captures the live exception.
+// description / receiver / selector / stack we have to re-run the test with
+// our own AbstractException handler that captures the live exception.
 export interface TestFailureDetails {
   status: 'passed' | 'failed' | 'error';
   exceptionClass?: string;
@@ -24,6 +24,13 @@ export interface TestFailureDetails {
   // call site has the wrong receiver class.
   mnuReceiver?: string;
   mnuSelector?: string;
+  // Pre-formatted multi-line stack trace from AbstractException>>stackReport.
+  // Each frame: "Class (Behavior) >> selector @ip line N [GsNMethod oop]".
+  // Only populated when the gem-level config GemExceptionSignalCapturesStack
+  // is enabled at exception-signal time — we toggle it on for the test run
+  // and restore it after, so this field is reliably present on failed/error
+  // outcomes.
+  stackReport?: string;
 }
 
 export function describeTestFailure(
@@ -43,15 +50,38 @@ export function describeTestFailure(
   // TestCase>>run because that's the method that swallows the exception.
   // We replicate its lifecycle (skip the test body if setUp blew up;
   // surface a tearDown failure only if the test body itself succeeded).
-  const code = `| tc captured tdEx ws cleanText |
-tc := ${cls} selector: #'${sel}'.
+  //
+  // Stack capture: the gem-level config GemExceptionSignalCapturesStack
+  // controls whether primitive 2022 (AbstractException>>_signal) populates
+  // gsStack at signal time. With it enabled, AbstractException>>stackReport
+  // returns a pre-formatted multi-line String per frame. We toggle it on
+  // around the test run and restore the prior value via `ensure:`, so the
+  // gem isn't left in a different state than we found it.
+  //
+  // Setting the config is wrapped in its own `on: AbstractException do:`
+  // because some session contexts (read-only sessions, restricted users)
+  // may reject the put — the rest of the tool still produces useful output
+  // without the stack frame.
+  const code = `| tc captured tdEx ws cleanText oldStackCfg stackText |
+oldStackCfg := System gemConfigurationAt: #GemExceptionSignalCapturesStack.
 captured := nil.
-[tc setUp] on: AbstractException do: [:e | captured := e].
-captured isNil ifTrue: [
-  [tc perform: #'${sel}'] on: AbstractException do: [:e | captured := e].
-  tdEx := nil.
-  [tc tearDown] on: AbstractException do: [:e | tdEx := e].
-  (captured isNil and: [tdEx notNil]) ifTrue: [captured := tdEx]].
+stackText := nil.
+[
+  [System gemConfigurationAt: #GemExceptionSignalCapturesStack put: true]
+    on: AbstractException do: [:ignored | "Setter rejected — proceed without stack capture."].
+  tc := ${cls} selector: #'${sel}'.
+  [tc setUp] on: AbstractException do: [:e | captured := e].
+  captured isNil ifTrue: [
+    [tc perform: #'${sel}'] on: AbstractException do: [:e | captured := e].
+    tdEx := nil.
+    [tc tearDown] on: AbstractException do: [:e | tdEx := e].
+    (captured isNil and: [tdEx notNil]) ifTrue: [captured := tdEx]].
+  captured isNil ifFalse: [
+    [stackText := captured stackReport]
+      on: AbstractException do: [:ignored | stackText := nil]]
+] ensure: [
+  [System gemConfigurationAt: #GemExceptionSignalCapturesStack put: oldStackCfg]
+    on: AbstractException do: [:ignored | ]].
 
 cleanText := [:obj |
   | s |
@@ -75,19 +105,44 @@ captured isNil ifTrue: [
   ws nextPutAll: 'description: '; nextPutAll: (cleanText value: captured description); lf.
   isMnu ifTrue: [
     ws nextPutAll: 'mnuReceiver: '; nextPutAll: (cleanText value: captured receiver printString); lf.
-    ws nextPutAll: 'mnuSelector: '; nextPutAll: captured selector asString; lf]].
+    ws nextPutAll: 'mnuSelector: '; nextPutAll: captured selector asString; lf].
+  "Always emit stackReport last with a sentinel so the parser can grab the
+   rest of the output verbatim — frame separators are real newlines and
+   collapsing them would destroy the stack's structure."
+  stackText isNil ifFalse: [
+    | s |
+    s := stackText asString.
+    s := s copyFrom: 1 to: (s size min: 16384).
+    ws nextPutAll: '--- stackReport ---'; lf.
+    ws nextPutAll: s]].
 ws contents`;
 
   const data = execute('describeTestFailure', code);
   return parseDetails(data);
 }
 
-// Parse "key: value" lines emitted by the Smalltalk side. Unknown keys are
-// ignored so we can extend the snippet (extra fields, version-specific
-// extras) without breaking existing callers.
+const STACK_SENTINEL = '--- stackReport ---';
+
+// Parse the Smalltalk side's output: leading "key: value" lines for the
+// scalar fields, optionally followed by a sentinel line and the verbatim
+// multi-line stackReport. Splitting on the sentinel first keeps stack frames
+// (which contain real newlines) intact rather than getting eaten by the
+// per-line key/value parser. Unknown keys are ignored so we can extend the
+// snippet without breaking older callers.
 function parseDetails(text: string): TestFailureDetails {
   const result: TestFailureDetails = { status: 'error' };
-  for (const line of text.split('\n')) {
+
+  let kvSection = text;
+  const sentinelIdx = text.indexOf(STACK_SENTINEL);
+  if (sentinelIdx >= 0) {
+    kvSection = text.substring(0, sentinelIdx);
+    const stackRaw = text.substring(sentinelIdx + STACK_SENTINEL.length);
+    // Strip the leading newline after the sentinel and any trailing
+    // whitespace; the frame content itself stays untouched.
+    result.stackReport = stackRaw.replace(/^\r?\n/, '').replace(/\s+$/, '');
+  }
+
+  for (const line of kvSection.split('\n')) {
     const idx = line.indexOf(': ');
     if (idx < 0) continue;
     const key = line.substring(0, idx);

--- a/client/src/queries/python.ts
+++ b/client/src/queries/python.ts
@@ -1,0 +1,50 @@
+import { QueryExecutor } from './types';
+import { escapeString } from './util';
+
+// Grail (GemStone-Python) integration. Both queries are graceful when Grail
+// isn't installed: the dispatcher class lookup returns nil and we emit a
+// hint instead of letting the Smalltalk source fail to compile against an
+// undefined `ModuleAst` reference.
+//
+// Why dynamic resolution (not a direct `ModuleAst evaluateSource:` send):
+// referring to ModuleAst in the source string is a *compile-time* reference.
+// When Grail isn't loaded, that source doesn't parse — there's no runtime
+// exception to catch with `on: AbstractException do:`. Resolving via
+// `objectNamed:` makes the dispatcher's absence a runtime nil check.
+
+const GRAIL_HINT =
+  'Grail (GemStone-Python) not detected: class ModuleAst not found in symbolList. ' +
+  'Install Grail or activate it in this session before using the python tools.';
+
+// Run a Python source string through Grail's compile + execute pipeline and
+// return the result as a printString. Any Grail-side compile or runtime
+// exception (SyntaxError, NameError, division-by-zero, etc.) is reported
+// inline as `Error: <class> — <messageText>` so the agent can act on it.
+export function evalPython(execute: QueryExecutor, source: string): string {
+  const code = buildPythonQuery('(dispatcher evaluateSource: src) printString', source);
+  return execute('evalPython', code);
+}
+
+// Transpile a Python source string to Smalltalk via Grail and return the
+// generated Smalltalk source verbatim. Useful for inspecting codegen output
+// without actually running the code (and as an end-to-end check on the
+// codegen pipeline). Errors are reported inline, same shape as evalPython.
+export function compilePython(execute: QueryExecutor, source: string): string {
+  const code = buildPythonQuery('(dispatcher parseSource: src) smalltalkSource', source);
+  return execute('compilePython', code);
+}
+
+function buildPythonQuery(grailExpression: string, pythonSource: string): string {
+  const esc = escapeString(pythonSource);
+  // The hint is itself a Smalltalk string literal — the same single-quote
+  // escaping rule applies, but it has none today, so we inline it directly.
+  return `| dispatcher src |
+dispatcher := System myUserProfile symbolList objectNamed: #'ModuleAst'.
+src := '${esc}'.
+dispatcher isNil
+  ifTrue: ['${GRAIL_HINT}']
+  ifFalse: [
+    [${grailExpression}]
+      on: AbstractException do: [:e |
+        'Error: ' , e class name , ' — ' , e messageText asString]]`;
+}

--- a/client/src/queries/runFailingTests.ts
+++ b/client/src/queries/runFailingTests.ts
@@ -24,6 +24,10 @@ export function runFailingTests(
     ? buildExplicitClassList(classNames)
     : DISCOVER_ALL_TEST_CLASSES;
 
+  // `result failures` and `result errors` contain the TestCase instances
+  // themselves (only `testSelector` ivar) — verified via probe. Don't send
+  // `t testCase`: the wrappers don't respond to it, and a real failure
+  // would DNU. Use `t class name` / `t selector` directly.
   const code = `| ws classes |
 classes := ${classesExpr}.
 ws := WriteStream on: Unicode7 new.
@@ -31,13 +35,13 @@ classes do: [:cls |
   | result |
   result := cls suite run.
   result failures do: [:t |
-    ws nextPutAll: t testCase class name; tab;
-      nextPutAll: t testCase selector; tab;
+    ws nextPutAll: t class name; tab;
+      nextPutAll: t selector; tab;
       nextPutAll: 'failed'; tab;
       nextPutAll: (t printString copyFrom: 1 to: (t printString size min: ${MAX_MSG})); lf].
   result errors do: [:e |
-    ws nextPutAll: e testCase class name; tab;
-      nextPutAll: e testCase selector; tab;
+    ws nextPutAll: e class name; tab;
+      nextPutAll: e selector; tab;
       nextPutAll: 'error'; tab;
       nextPutAll: (e printString copyFrom: 1 to: (e printString size min: ${MAX_MSG})); lf]].
 ws contents`;

--- a/client/src/queries/runFailingTests.ts
+++ b/client/src/queries/runFailingTests.ts
@@ -1,0 +1,83 @@
+import { QueryExecutor } from './types';
+import { escapeString, splitLines } from './util';
+import { TestRunResult } from './runTestMethod';
+
+// Per-message printString cap. Single-method runs use 4096 because there's
+// only one entry; batched runs across many TestCases need a tighter cap to
+// stay under MAX_RESULT (256KB) when many tests fail at once. 1024 chars
+// per entry leaves headroom for ~250 failures in a single round trip.
+const MAX_MSG = 1024;
+
+// Run SUnit suites and return only the failed/errored results — the agent
+// equivalent of `run_tests.sh | grep -A20 'Test failures:'`. With no
+// classNames, discovers and runs every TestCase subclass in the user's
+// symbolList. With explicit classNames, resolves each via objectNamed:; a
+// name that doesn't resolve is skipped silently rather than aborting the run.
+//
+// Single round-trip by design: iteration happens in Smalltalk so an N-class
+// invocation is one GCI call, not N.
+export function runFailingTests(
+  execute: QueryExecutor,
+  classNames?: string[],
+): TestRunResult[] {
+  const classesExpr = classNames && classNames.length > 0
+    ? buildExplicitClassList(classNames)
+    : DISCOVER_ALL_TEST_CLASSES;
+
+  const code = `| ws classes |
+classes := ${classesExpr}.
+ws := WriteStream on: Unicode7 new.
+classes do: [:cls |
+  | result |
+  result := cls suite run.
+  result failures do: [:t |
+    ws nextPutAll: t testCase class name; tab;
+      nextPutAll: t testCase selector; tab;
+      nextPutAll: 'failed'; tab;
+      nextPutAll: (t printString copyFrom: 1 to: (t printString size min: ${MAX_MSG})); lf].
+  result errors do: [:e |
+    ws nextPutAll: e testCase class name; tab;
+      nextPutAll: e testCase selector; tab;
+      nextPutAll: 'error'; tab;
+      nextPutAll: (e printString copyFrom: 1 to: (e printString size min: ${MAX_MSG})); lf]].
+ws contents`;
+  const data = execute('runFailingTests', code);
+  return splitLines(data).map(line => {
+    const parts = line.split('\t');
+    return {
+      className: parts[0] || '',
+      selector: parts[1] || '',
+      status: (parts[2] || 'error') as TestRunResult['status'],
+      message: parts[3] || '',
+      durationMs: 0,
+    };
+  });
+}
+
+// Walk the user's symbolList for every TestCase subclass (excluding TestCase
+// itself), deduped via IdentitySet so a class registered in two dicts is run
+// only once.
+const DISCOVER_ALL_TEST_CLASSES = `| sl seen list |
+sl := System myUserProfile symbolList.
+seen := IdentitySet new.
+list := OrderedCollection new.
+sl do: [:dict |
+  dict valuesDo: [:v |
+    (v isBehavior
+      and: [(v isSubclassOf: TestCase)
+      and: [v ~~ TestCase
+      and: [(seen includes: v) not]]])
+        ifTrue: [seen add: v. list add: v]]].
+list`;
+
+// Explicit-list path: build an OrderedCollection at runtime, doing each
+// lookup separately so a typo doesn't blow up the whole run. Anything that
+// resolves to nil (missing class) is filtered out before the suite runs.
+function buildExplicitClassList(classNames: string[]): string {
+  const adds = classNames
+    .map(n => `add: (System myUserProfile symbolList objectNamed: #'${escapeString(n)}');`)
+    .join('\n  ');
+  return `((OrderedCollection new
+  ${adds}
+  yourself) reject: [:c | c isNil])`;
+}

--- a/client/src/queries/runTestClass.ts
+++ b/client/src/queries/runTestClass.ts
@@ -6,6 +6,11 @@ export function runTestClass(
   execute: QueryExecutor, className: string,
 ): TestRunResult[] {
   const esc = escapeString(className);
+  // `result passed`, `result failures`, `result errors` all contain the
+  // TestCase instances themselves (only `testSelector` ivar) — verified via
+  // probe. Don't send `each testCase`: the wrappers don't respond to it,
+  // and on a real failure that branch would DNU. The TestCase instance
+  // already carries `class name` and `selector`, same as the passed branch.
   const code = `| suite result ws |
 suite := ${esc} suite.
 result := suite run.
@@ -15,13 +20,13 @@ result passed do: [:each |
     nextPutAll: each selector; tab;
     nextPutAll: 'passed'; tab; lf].
 result failures do: [:each |
-  ws nextPutAll: each testCase class name; tab;
-    nextPutAll: each testCase selector; tab;
+  ws nextPutAll: each class name; tab;
+    nextPutAll: each selector; tab;
     nextPutAll: 'failed'; tab;
     nextPutAll: (each printString copyFrom: 1 to: (each printString size min: 4096)); lf].
 result errors do: [:each |
-  ws nextPutAll: each testCase class name; tab;
-    nextPutAll: each testCase selector; tab;
+  ws nextPutAll: each class name; tab;
+    nextPutAll: each selector; tab;
     nextPutAll: 'error'; tab;
     nextPutAll: (each printString copyFrom: 1 to: (each printString size min: 4096)); lf].
 ws contents`;

--- a/client/src/sunitQueries.ts
+++ b/client/src/sunitQueries.ts
@@ -7,6 +7,7 @@ import { discoverTestMethods as sharedDiscoverTestMethods } from './queries/disc
 import { runTestMethod as sharedRunTestMethod } from './queries/runTestMethod';
 import { runTestClass as sharedRunTestClass } from './queries/runTestClass';
 import { runFailingTests as sharedRunFailingTests } from './queries/runFailingTests';
+import { describeTestFailure as sharedDescribeTestFailure } from './queries/describeTestFailure';
 
 // Re-export types from the shared layer.
 export type { TestClassInfo } from './queries/discoverTestClasses';
@@ -39,4 +40,8 @@ export function runTestClass(session: ActiveSession, className: string) {
 
 export function runFailingTests(session: ActiveSession, classNames?: string[]) {
   return sharedRunFailingTests(bind(session), classNames);
+}
+
+export function describeTestFailure(session: ActiveSession, className: string, selector: string) {
+  return sharedDescribeTestFailure(bind(session), className, selector);
 }

--- a/client/src/sunitQueries.ts
+++ b/client/src/sunitQueries.ts
@@ -6,6 +6,7 @@ import { discoverTestClasses as sharedDiscoverTestClasses } from './queries/disc
 import { discoverTestMethods as sharedDiscoverTestMethods } from './queries/discoverTestMethods';
 import { runTestMethod as sharedRunTestMethod } from './queries/runTestMethod';
 import { runTestClass as sharedRunTestClass } from './queries/runTestClass';
+import { runFailingTests as sharedRunFailingTests } from './queries/runFailingTests';
 
 // Re-export types from the shared layer.
 export type { TestClassInfo } from './queries/discoverTestClasses';
@@ -34,4 +35,8 @@ export function runTestMethod(session: ActiveSession, className: string, selecto
 
 export function runTestClass(session: ActiveSession, className: string) {
   return sharedRunTestClass(bind(session), className);
+}
+
+export function runFailingTests(session: ActiveSession, classNames?: string[]) {
+  return sharedRunFailingTests(bind(session), classNames);
 }

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -61,6 +61,7 @@ describe('tools', () => {
       'list_dictionaries',
       'list_dictionary_entries',
       'list_methods',
+      'refresh',
       'remove_dictionary',
       'run_test_class',
       'run_test_method',
@@ -82,6 +83,21 @@ describe('tools', () => {
       expect(code).toContain('printString');
       expect(result.content[0].text).toBe('7');
       expect(result.isError).toBeUndefined();
+    });
+
+    // Regression: the original wrapper was `(<code>) printString`, which only
+    // accepts a single expression. A multi-statement body with temp
+    // declarations like `| x | x := 42. x + 1` would error with
+    // "expected start of a statement". Wrapping as a block (`[<code>] value`)
+    // accepts both single expressions and statement sequences.
+    it('block-wraps the code so multi-statement and temp-var bodies parse', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('43');
+      const tool = server.getTool('execute_code')!;
+      const result = await tool.handler({ code: '| x | x := 42. x + 1' });
+
+      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(code).toBe('[| x | x := 42. x + 1] value printString');
+      expect(result.content[0].text).toBe('43');
     });
 
     it('returns error on GCI failure', async () => {
@@ -164,12 +180,25 @@ describe('tools', () => {
       expect(result.content[0].text).toContain('Array');
     });
 
-    it('returns fallback message when no implementors found', async () => {
+    // When the search hits the default env (0) and finds nothing, the message
+    // should nudge the agent toward env 1 — projects like GemStone-Python keep
+    // most user code there, and the original "No implementors found." message
+    // was easy to misread as "the selector really doesn't exist anywhere."
+    it('returns env-1 hint when env 0 search is empty', async () => {
       vi.mocked(session.executeFetchString).mockReturnValue('');
       const tool = server.getTool('find_implementors')!;
       const result = await tool.handler({ selector: 'nonexistent' });
 
-      expect(result.content[0].text).toBe('No implementors found.');
+      expect(result.content[0].text).toContain('environmentId 0');
+      expect(result.content[0].text).toContain('environmentId: 1');
+    });
+
+    it('returns plain empty message when an explicit non-zero env is empty', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('find_implementors')!;
+      const result = await tool.handler({ selector: 'nonexistent', environmentId: 1 });
+
+      expect(result.content[0].text).toBe('No implementors found in environmentId 1.');
     });
   });
 
@@ -352,12 +381,13 @@ describe('tools', () => {
       expect(result.content[0].text).toContain('Foo\tinstance\tuse\tclient');
     });
 
-    it('returns fallback when no references found', async () => {
+    it('returns env-1 hint when env 0 search is empty', async () => {
       vi.mocked(session.executeFetchString).mockReturnValue('');
       const tool = server.getTool('find_references_to')!;
       const result = await tool.handler({ objectName: 'Unused' });
 
-      expect(result.content[0].text).toBe('No references found.');
+      expect(result.content[0].text).toContain('environmentId 0');
+      expect(result.content[0].text).toContain('environmentId: 1');
     });
   });
 
@@ -568,7 +598,8 @@ describe('tools', () => {
       const tool = server.getTool('run_test_method')!;
       const result = await tool.handler({ className: 'ArrayTest', selector: 'testSize' });
 
-      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      // The actual run_test_method query should follow the auto-refresh call.
+      const code = vi.mocked(session.executeFetchString).mock.calls.at(-1)![0];
       expect(code).toContain('ArrayTest');
       expect(code).toContain("selector: #'testSize'");
       expect(result.content[0].text).toContain('PASSED');
@@ -583,6 +614,20 @@ describe('tools', () => {
       expect(result.content[0].text).toContain('FAILED');
       expect(result.content[0].text).toContain('expected 3 got 4');
     });
+
+    // Stale-transaction guard: the GCI pins read views to the session's
+    // transaction snapshot, so a commit landed by another process (e.g.
+    // install.sh) is invisible until this session aborts. Auto-refresh-if-clean
+    // closes the gap silently when there's no uncommitted work to lose.
+    it('issues an auto-refresh-if-clean before running the test', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('passed\t\t1');
+      const tool = server.getTool('run_test_method')!;
+      await tool.handler({ className: 'ArrayTest', selector: 'testSize' });
+
+      const refreshCall = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(refreshCall).toContain('System needsCommit ifFalse:');
+      expect(refreshCall).toContain('System abortTransaction');
+    });
   });
 
   describe('run_test_class', () => {
@@ -592,7 +637,7 @@ describe('tools', () => {
       const tool = server.getTool('run_test_class')!;
       const result = await tool.handler({ className: 'ArrayTest' });
 
-      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      const code = vi.mocked(session.executeFetchString).mock.calls.at(-1)![0];
       expect(code).toContain('ArrayTest');
       expect(code).toContain('suite');
       expect(result.content[0].text).toContain('testSize');
@@ -608,11 +653,43 @@ describe('tools', () => {
       expect(result.content[0].text).toContain('FAILED');
       expect(result.content[0].text).toContain('expected 1 got 2');
     });
+
+    it('issues an auto-refresh-if-clean before running the suite', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('run_test_class')!;
+      await tool.handler({ className: 'ArrayTest' });
+
+      const refreshCall = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(refreshCall).toContain('System needsCommit ifFalse:');
+      expect(refreshCall).toContain('System abortTransaction');
+    });
+  });
+
+  describe('refresh', () => {
+    it('refreshes the session view when no uncommitted changes are pending', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('refreshed');
+      const tool = server.getTool('refresh')!;
+      const result = await tool.handler({});
+
+      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(code).toContain('System needsCommit');
+      expect(code).toContain('System abortTransaction');
+      expect(result.content[0].text).toBe('refreshed');
+    });
+
+    it('skips when there are uncommitted changes, reporting back', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('skipped: uncommitted changes present');
+      const tool = server.getTool('refresh')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('skipped');
+      expect(result.content[0].text).toContain('uncommitted changes');
+    });
   });
 
   describe('status', () => {
     it('reports session information', async () => {
-      const statusOutput = 'User: DataCurator\nStone: gs64stone\nSession ID: 1\nTransaction: active\nUncommitted changes: no\n';
+      const statusOutput = 'User: DataCurator\nStone: gs64stone\nSession ID: 1\nTransaction: active\nUncommitted changes: no\nView: refreshed\n';
       vi.mocked(session.executeFetchString).mockReturnValue(statusOutput);
       const tool = server.getTool('status')!;
       const result = await tool.handler({});
@@ -624,6 +701,24 @@ describe('tools', () => {
       expect(code).toContain('needsCommit');
       expect(result.content[0].text).toContain('DataCurator');
       expect(result.content[0].text).toContain('gs64stone');
+    });
+
+    // The snippet must auto-refresh-if-clean inline so the rest of the report
+    // reflects committed state, and so a single status call also primes the
+    // session for follow-up read tools. Skipping when needsCommit is true is
+    // load-bearing: discarding uncommitted work silently would be far worse
+    // than reporting slightly stale state.
+    it('auto-refreshes the view inline (only when no uncommitted changes)', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('status')!;
+      await tool.handler({});
+
+      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(code).toContain('System needsCommit');
+      expect(code).toContain('System abortTransaction');
+      expect(code).toContain('View: ');
+      expect(code).toContain('stale');
+      expect(code).toContain('refreshed');
     });
 
     // Regression: nextPutAll: sends do: to its argument. If any value passed

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -736,6 +736,46 @@ describe('tools', () => {
       expect(result.content[0].text).toBe('PASSED');
     });
 
+    // Stack trace flows end to end: Smalltalk emits the sentinel + frames,
+    // the parser splits on the sentinel, the formatter emits a "stackReport:"
+    // header followed by the verbatim multi-line content. Frame newlines
+    // must survive the round-trip.
+    it('formats stackReport as a verbatim multi-line block under a header', async () => {
+      vi.mocked(session.executeFetchString)
+        .mockReturnValueOnce('ok')
+        .mockReturnValueOnce(
+          'status: failed\n' +
+          'exceptionClass: TestFailure\n' +
+          'errorNumber: 2751\n' +
+          'messageText: Assertion failed\n' +
+          'description: TestFailure: Assertion failed\n' +
+          '--- stackReport ---\n' +
+          'TestFailure (AbstractException) >> signal: @3 line 7  [GsNMethod 3523841]\n' +
+          'JasperProbeTest >> testFails @3 line 1  [GsNMethod 1236251649]\n',
+        );
+      const tool = server.getTool('describe_test_failure')!;
+      const result = await tool.handler({ className: 'ArrayTest', selector: 'testBad' });
+      const text = result.content[0].text;
+
+      expect(text).toContain('stackReport:');
+      expect(text).toContain('TestFailure (AbstractException) >> signal:');
+      expect(text).toContain('JasperProbeTest >> testFails');
+      // Two frames separated by a newline must remain so.
+      expect(text.match(/\n/g)?.length ?? 0).toBeGreaterThanOrEqual(6);
+    });
+
+    it('issues the gem-config toggle that enables stack capture', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('status: passed\n');
+      const tool = server.getTool('describe_test_failure')!;
+      await tool.handler({ className: 'ArrayTest', selector: 'testAny' });
+
+      const queryCall = vi.mocked(session.executeFetchString).mock.calls.at(-1)![0];
+      expect(queryCall).toContain('GemExceptionSignalCapturesStack');
+      expect(queryCall).toContain('put: true');
+      expect(queryCall).toContain('put: oldStackCfg');
+      expect(queryCall).toContain('ensure:');
+    });
+
     // Stale-transaction guard — same as the other test runners. A view
     // pinned to old committed state would let an agent debug a failure
     // that's already been fixed in the running stone.

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -45,10 +45,12 @@ describe('tools', () => {
       'commit',
       'compile_class_definition',
       'compile_method',
+      'compile_python',
       'delete_class',
       'delete_method',
       'describe_class',
       'describe_test_failure',
+      'eval_python',
       'execute_code',
       'export_class_source',
       'find_implementors',
@@ -677,6 +679,43 @@ describe('tools', () => {
       const refreshCall = vi.mocked(session.executeFetchString).mock.calls[0][0];
       expect(refreshCall).toContain('System needsCommit ifFalse:');
       expect(refreshCall).toContain('System abortTransaction');
+    });
+  });
+
+  describe('eval_python', () => {
+    it('runs the Grail eval pipeline via objectNamed: ModuleAst', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('3');
+      const result = await server.getTool('eval_python')!.handler({ source: '1 + 2' });
+
+      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(code).toContain("objectNamed: #'ModuleAst'");
+      expect(code).toContain('evaluateSource: src');
+      expect(result.content[0].text).toBe('3');
+    });
+
+    // When Grail isn't loaded the snippet's nil-branch produces the hint as
+    // its result. The tool should pass it through verbatim — no special
+    // error handling at the JS layer, just the agent-readable text.
+    it('passes the "Grail not detected" hint through as the result text', async () => {
+      const hint = 'Grail (GemStone-Python) not detected: class ModuleAst not found in symbolList. ' +
+        'Install Grail or activate it in this session before using the python tools.';
+      vi.mocked(session.executeFetchString).mockReturnValue(hint);
+      const result = await server.getTool('eval_python')!.handler({ source: 'x = 1' });
+
+      expect(result.content[0].text).toContain('Grail (GemStone-Python) not detected');
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('compile_python', () => {
+    it('runs the Grail transpile pipeline (parseSource + smalltalkSource)', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue("x := 1");
+      const result = await server.getTool('compile_python')!.handler({ source: 'x = 1' });
+
+      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(code).toContain('parseSource: src');
+      expect(code).toContain('smalltalkSource');
+      expect(result.content[0].text).toBe('x := 1');
     });
   });
 

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -60,7 +60,9 @@ describe('tools', () => {
       'list_classes',
       'list_dictionaries',
       'list_dictionary_entries',
+      'list_failing_tests',
       'list_methods',
+      'list_test_classes',
       'refresh',
       'remove_dictionary',
       'run_test_class',
@@ -662,6 +664,70 @@ describe('tools', () => {
       const refreshCall = vi.mocked(session.executeFetchString).mock.calls[0][0];
       expect(refreshCall).toContain('System needsCommit ifFalse:');
       expect(refreshCall).toContain('System abortTransaction');
+    });
+  });
+
+  describe('list_failing_tests', () => {
+    // The agent equivalent of `./run_tests.sh | grep failures`. Single
+    // round-trip: iteration runs in Smalltalk so an N-class invocation is
+    // one GCI call, not N. Auto-refresh-if-clean ensures results reflect
+    // committed state.
+    it('returns "All tests passed." when nothing failed', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('list_failing_tests')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toBe('All tests passed.');
+    });
+
+    it('formats failures as STATUS\\tclass\\tselector\\tmessage', async () => {
+      vi.mocked(session.executeFetchString)
+        .mockReturnValueOnce('ok') // refreshIfClean response
+        .mockReturnValueOnce('MyTest\ttestBad\tfailed\texpected 1 got 2\nOther\ttestBoom\terror\tdivision by zero\n');
+      const tool = server.getTool('list_failing_tests')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('FAILED\tMyTest\ttestBad\texpected 1 got 2');
+      expect(result.content[0].text).toContain('ERROR\tOther\ttestBoom\tdivision by zero');
+    });
+
+    it('passes explicit classNames to the underlying query', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('list_failing_tests')!;
+      await tool.handler({ classNames: ['ArrayTest', 'StringTest'] });
+
+      // The query call (non-refresh one) must reference each requested name.
+      const queryCall = vi.mocked(session.executeFetchString).mock.calls.at(-1)![0];
+      expect(queryCall).toContain("objectNamed: #'ArrayTest'");
+      expect(queryCall).toContain("objectNamed: #'StringTest'");
+    });
+
+    it('issues an auto-refresh-if-clean before the suite runs', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('list_failing_tests')!;
+      await tool.handler({});
+
+      const refreshCall = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(refreshCall).toContain('System needsCommit ifFalse:');
+      expect(refreshCall).toContain('System abortTransaction');
+    });
+  });
+
+  describe('list_test_classes', () => {
+    it('returns dictName\\tclassName rows', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('UserGlobals\tArrayTest\nUserGlobals\tStringTest\n');
+      const tool = server.getTool('list_test_classes')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toBe('UserGlobals\tArrayTest\nUserGlobals\tStringTest');
+    });
+
+    it('returns a friendly message when no TestCase subclasses are found', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('list_test_classes')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toBe('No TestCase subclasses found.');
     });
   });
 

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -214,6 +214,18 @@ describe('tools', () => {
       expect(code).toContain("sendersOf: #'printString'");
       expect(result.content[0].text).toContain('String');
     });
+
+    // Symmetric with find_implementors / find_references_to — uses the same
+    // noResultsMessage helper, so a refactor that breaks one would silently
+    // break this without a guard.
+    it('returns env-1 hint when env 0 search is empty', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('');
+      const tool = server.getTool('find_senders')!;
+      const result = await tool.handler({ selector: 'nonexistent' });
+
+      expect(result.content[0].text).toContain('environmentId 0');
+      expect(result.content[0].text).toContain('environmentId: 1');
+    });
   });
 
   describe('get_class_hierarchy', () => {

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -48,6 +48,7 @@ describe('tools', () => {
       'delete_class',
       'delete_method',
       'describe_class',
+      'describe_test_failure',
       'execute_code',
       'export_class_source',
       'find_implementors',
@@ -676,6 +677,105 @@ describe('tools', () => {
       const refreshCall = vi.mocked(session.executeFetchString).mock.calls[0][0];
       expect(refreshCall).toContain('System needsCommit ifFalse:');
       expect(refreshCall).toContain('System abortTransaction');
+    });
+  });
+
+  describe('describe_test_failure', () => {
+    // For TestFailure (assertion failure) — should produce structured output
+    // that names the exception class and the assertion's clean messageText
+    // (which is "Assertion failed", separate from the printString blob the
+    // old runTestMethod tool returned).
+    it('formats TestFailure output with exceptionClass + messageText', async () => {
+      vi.mocked(session.executeFetchString)
+        .mockReturnValueOnce('ok') // refreshIfClean
+        .mockReturnValueOnce(
+          'status: failed\n' +
+          'exceptionClass: TestFailure\n' +
+          'errorNumber: 2751\n' +
+          'messageText: Assertion failed\n' +
+          'description: TestFailure: Assertion failed\n',
+        );
+      const tool = server.getTool('describe_test_failure')!;
+      const result = await tool.handler({ className: 'ArrayTest', selector: 'testBad' });
+
+      expect(result.content[0].text).toContain('status: failed');
+      expect(result.content[0].text).toContain('exceptionClass: TestFailure');
+      expect(result.content[0].text).toContain('errorNumber: 2751');
+      expect(result.content[0].text).toContain('messageText: Assertion failed');
+    });
+
+    // For MessageNotUnderstood — must surface mnuReceiver and mnuSelector,
+    // the highest-signal fields for diagnosing "missing method" errors.
+    it('includes mnuReceiver and mnuSelector on MessageNotUnderstood', async () => {
+      vi.mocked(session.executeFetchString)
+        .mockReturnValueOnce('ok')
+        .mockReturnValueOnce(
+          'status: error\n' +
+          'exceptionClass: MessageNotUnderstood\n' +
+          'errorNumber: 2010\n' +
+          'messageText: a Object class does not understand #foo\n' +
+          'description: a Object class does not understand #foo\n' +
+          'mnuReceiver: Object\n' +
+          'mnuSelector: foo\n',
+        );
+      const tool = server.getTool('describe_test_failure')!;
+      const result = await tool.handler({ className: 'ArrayTest', selector: 'testErrors' });
+
+      expect(result.content[0].text).toContain('exceptionClass: MessageNotUnderstood');
+      expect(result.content[0].text).toContain('mnuReceiver: Object');
+      expect(result.content[0].text).toContain('mnuSelector: foo');
+    });
+
+    it('returns "PASSED" when the test re-run actually passed', async () => {
+      vi.mocked(session.executeFetchString)
+        .mockReturnValueOnce('ok')
+        .mockReturnValueOnce('status: passed\n');
+      const tool = server.getTool('describe_test_failure')!;
+      const result = await tool.handler({ className: 'ArrayTest', selector: 'testGood' });
+
+      expect(result.content[0].text).toBe('PASSED');
+    });
+
+    // Stale-transaction guard — same as the other test runners. A view
+    // pinned to old committed state would let an agent debug a failure
+    // that's already been fixed in the running stone.
+    it('issues an auto-refresh-if-clean before re-running the test', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('status: passed\n');
+      const tool = server.getTool('describe_test_failure')!;
+      await tool.handler({ className: 'ArrayTest', selector: 'testAny' });
+
+      const refreshCall = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(refreshCall).toContain('System needsCommit ifFalse:');
+      expect(refreshCall).toContain('System abortTransaction');
+    });
+
+    // The Smalltalk side has to use AbstractException (not Exception) —
+    // GemStone's exception hierarchy makes Exception a subclass, and
+    // MessageNotUnderstood escapes past Exception in some contexts. Lock
+    // this in so a future "simplification" doesn't regress to Exception
+    // and silently swallow MNUs.
+    it('catches AbstractException, not Exception (so MNUs do not escape)', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('status: passed\n');
+      const tool = server.getTool('describe_test_failure')!;
+      await tool.handler({ className: 'ArrayTest', selector: 'testAny' });
+
+      const queryCall = vi.mocked(session.executeFetchString).mock.calls.at(-1)![0];
+      expect(queryCall).toContain('on: AbstractException');
+      expect(queryCall).not.toMatch(/on: Exception\b/);
+    });
+
+    // SUnit's framework swallows the exception — we have to bypass it.
+    // The query must run setUp/perform/tearDown manually rather than
+    // calling tc>>run.
+    it('bypasses TestCase>>run by invoking setUp / perform / tearDown directly', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('status: passed\n');
+      const tool = server.getTool('describe_test_failure')!;
+      await tool.handler({ className: 'ArrayTest', selector: 'testAny' });
+
+      const queryCall = vi.mocked(session.executeFetchString).mock.calls.at(-1)![0];
+      expect(queryCall).toContain('tc setUp');
+      expect(queryCall).toContain('tc perform:');
+      expect(queryCall).toContain('tc tearDown');
     });
   });
 

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -8,6 +8,8 @@ import { abortTransaction } from '../../client/src/queries/abortTransaction';
 import { commitTransaction } from '../../client/src/queries/commitTransaction';
 import { runTestMethod, TestRunResult } from '../../client/src/queries/runTestMethod';
 import { runTestClass } from '../../client/src/queries/runTestClass';
+import { runFailingTests } from '../../client/src/queries/runFailingTests';
+import { discoverTestClasses } from '../../client/src/queries/discoverTestClasses';
 import { getDictionaryNames } from '../../client/src/queries/getDictionaryNames';
 import { getClassNames } from '../../client/src/queries/getClassNames';
 import { getDictionaryEntries } from '../../client/src/queries/getDictionaryEntries';
@@ -535,6 +537,43 @@ export function registerTools(server: McpServer, session: McpSession): void {
   );
 
   server.tool(
+    'list_failing_tests',
+    'Run SUnit tests and return only the failed/errored results — the agent ' +
+    'equivalent of "run the suite and grep for failures." With no classNames, ' +
+    'discovers and runs every TestCase subclass in the symbolList. With ' +
+    'classNames, runs only those classes (names that don\'t resolve are ' +
+    'skipped silently). Auto-refreshes the session view first when no ' +
+    'uncommitted changes are pending. Returns "All tests passed." if every ' +
+    'test passed; otherwise tab-separated lines: status, className, selector, message.',
+    {
+      classNames: z.array(z.string()).optional().describe(
+        'TestCase subclass names to run. Omit to run every TestCase in the symbolList.',
+      ),
+    },
+    async ({ classNames }) => {
+      try {
+        refreshIfClean(session);
+        const results = runFailingTests(exec, classNames);
+        if (results.length === 0) {
+          return { content: [{ type: 'text' as const, text: 'All tests passed.' }] };
+        }
+        const text = results
+          .map(r => {
+            const status = r.status === 'failed' ? 'FAILED' : 'ERROR';
+            return `${status}\t${r.className}\t${r.selector}\t${r.message}`;
+          })
+          .join('\n');
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     'list_methods',
     'List all methods of a class, grouped by category. Returns tab-separated lines: side (instance|class), category, selector.',
     { className: z.string().describe('Class name') },
@@ -546,6 +585,31 @@ export function registerTools(server: McpServer, session: McpSession): void {
         }
         const text = methods
           .map(m => `${m.isMeta ? 'class' : 'instance'}\t${m.category}\t${m.selector}`)
+          .join('\n');
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'list_test_classes',
+    'Discover every TestCase subclass in the user\'s symbolList. Returns ' +
+    'tab-separated lines: dictName, className. Useful for then passing a ' +
+    'filtered subset to list_failing_tests.',
+    {},
+    async () => {
+      try {
+        const classes = discoverTestClasses(exec);
+        if (classes.length === 0) {
+          return { content: [{ type: 'text' as const, text: 'No TestCase subclasses found.' }] };
+        }
+        const text = classes
+          .map(c => `${c.dictName}\t${c.className}`)
           .join('\n');
         return { content: [{ type: 'text' as const, text }] };
       } catch (err) {

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -51,7 +51,9 @@ function formatTestResults(results: TestRunResult[]): string {
 
 // Render TestFailureDetails as line-oriented text. Agents read this directly,
 // so the format is "<key>: <value>\n" — easy to scan, easy to grep, no
-// structure beyond the keys the Smalltalk side already provides.
+// structure beyond the keys the Smalltalk side already provides. stackReport
+// is emitted last (and bare, since it's already multi-line) under a header
+// so the agent sees the structured fields first and can scroll to the trace.
 function formatTestFailureDetails(d: TestFailureDetails): string {
   if (d.status === 'passed') return 'PASSED';
   const lines: string[] = [];
@@ -62,6 +64,10 @@ function formatTestFailureDetails(d: TestFailureDetails): string {
   if (d.description !== undefined) lines.push(`description: ${d.description}`);
   if (d.mnuReceiver !== undefined) lines.push(`mnuReceiver: ${d.mnuReceiver}`);
   if (d.mnuSelector !== undefined) lines.push(`mnuSelector: ${d.mnuSelector}`);
+  if (d.stackReport) {
+    lines.push('stackReport:');
+    lines.push(d.stackReport);
+  }
   return lines.join('\n');
 }
 

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -12,6 +12,7 @@ import { runTestClass } from '../../client/src/queries/runTestClass';
 import { runFailingTests } from '../../client/src/queries/runFailingTests';
 import { discoverTestClasses } from '../../client/src/queries/discoverTestClasses';
 import { describeTestFailure, TestFailureDetails } from '../../client/src/queries/describeTestFailure';
+import { evalPython, compilePython } from '../../client/src/queries/python';
 import { getDictionaryNames } from '../../client/src/queries/getDictionaryNames';
 import { getClassNames } from '../../client/src/queries/getClassNames';
 import { getDictionaryEntries } from '../../client/src/queries/getDictionaryEntries';
@@ -227,6 +228,29 @@ export function registerTools(rawServer: McpServer, session: McpSession): void {
   );
 
   server.tool(
+    'compile_python',
+    'Transpile Python source to Smalltalk via Grail (GemStone-Python) and return the ' +
+    'generated Smalltalk source verbatim. Useful for inspecting codegen output without ' +
+    'running the code, and as an end-to-end check on the codegen pipeline. ' +
+    'Returns a "Grail not detected" hint if Grail (class ModuleAst) is not loaded ' +
+    'in the current session.',
+    {
+      source: z.string().describe('Python source string to transpile'),
+    },
+    async ({ source }) => {
+      try {
+        const text = compilePython(exec, source);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     'delete_class',
     'DESTRUCTIVE: remove a class from a specific dictionary. Requires dictionaryName because ' +
     'deletion must target a specific dictionary (names can be shadowed across dicts). ' +
@@ -315,6 +339,30 @@ export function registerTools(rawServer: McpServer, session: McpSession): void {
         refreshIfClean(session);
         const details = describeTestFailure(exec, className, selector);
         return { content: [{ type: 'text' as const, text: formatTestFailureDetails(details) }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'eval_python',
+    'Compile and execute Python source via Grail (GemStone-Python) and return the result ' +
+    'as a printString. Closes the diagnostic-snippet gap for Python-heavy projects: ' +
+    'one tool call instead of writing a /tmp/diag*.gs script that drives the codegen ' +
+    'pipeline manually. Returns a "Grail not detected" hint if Grail (class ModuleAst) ' +
+    'is not loaded in the current session. Grail-side compile and runtime errors are ' +
+    'reported inline as "Error: <class> — <messageText>".',
+    {
+      source: z.string().describe('Python source string to evaluate'),
+    },
+    async ({ source }) => {
+      try {
+        const text = evalPython(exec, source);
+        return { content: [{ type: 'text' as const, text }] };
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -11,6 +11,7 @@ import { runTestMethod, TestRunResult } from '../../client/src/queries/runTestMe
 import { runTestClass } from '../../client/src/queries/runTestClass';
 import { runFailingTests } from '../../client/src/queries/runFailingTests';
 import { discoverTestClasses } from '../../client/src/queries/discoverTestClasses';
+import { describeTestFailure, TestFailureDetails } from '../../client/src/queries/describeTestFailure';
 import { getDictionaryNames } from '../../client/src/queries/getDictionaryNames';
 import { getClassNames } from '../../client/src/queries/getClassNames';
 import { getDictionaryEntries } from '../../client/src/queries/getDictionaryEntries';
@@ -46,6 +47,22 @@ function formatTestResults(results: TestRunResult[]): string {
       return `${prefix}: ${r.className} >> ${r.selector}${msg}`;
     })
     .join('\n');
+}
+
+// Render TestFailureDetails as line-oriented text. Agents read this directly,
+// so the format is "<key>: <value>\n" — easy to scan, easy to grep, no
+// structure beyond the keys the Smalltalk side already provides.
+function formatTestFailureDetails(d: TestFailureDetails): string {
+  if (d.status === 'passed') return 'PASSED';
+  const lines: string[] = [];
+  lines.push(`status: ${d.status}`);
+  if (d.exceptionClass) lines.push(`exceptionClass: ${d.exceptionClass}`);
+  if (d.errorNumber !== undefined) lines.push(`errorNumber: ${d.errorNumber}`);
+  if (d.messageText !== undefined) lines.push(`messageText: ${d.messageText}`);
+  if (d.description !== undefined) lines.push(`description: ${d.description}`);
+  if (d.mnuReceiver !== undefined) lines.push(`mnuReceiver: ${d.mnuReceiver}`);
+  if (d.mnuSelector !== undefined) lines.push(`mnuSelector: ${d.mnuSelector}`);
+  return lines.join('\n');
 }
 
 function formatMethodResults(results: MethodSearchResult[], fallback: string): string {
@@ -267,6 +284,31 @@ export function registerTools(rawServer: McpServer, session: McpSession): void {
       try {
         const text = describeClass(exec, className, dictionaryName);
         return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'describe_test_failure',
+    'Re-run a single SUnit test method and return structured details about why it failed: ' +
+    'exception class, GemStone error number, messageText, description, and (for ' +
+    'MessageNotUnderstood) the receiver and missing selector. Use this after run_test_method ' +
+    'or list_failing_tests reports a failure. Re-runs in isolation with its own ' +
+    'AbstractException handler — bypasses TestCase>>run, which would swallow the exception.',
+    {
+      className: z.string().describe('TestCase subclass name'),
+      selector: z.string().describe('Test method selector, e.g. "testAdd"'),
+    },
+    async ({ className, selector }) => {
+      try {
+        refreshIfClean(session);
+        const details = describeTestFailure(exec, className, selector);
+        return { content: [{ type: 'text' as const, text: formatTestFailureDetails(details) }] };
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -52,6 +52,36 @@ function formatMethodResults(results: MethodSearchResult[], fallback: string): s
     .join('\n');
 }
 
+// Build the empty-result message for a find_* tool. When the caller used the
+// default env (0) and got nothing back, hint that the project's code may live
+// in env 1 — env 0 is the system environment, env 1 is where most user code
+// (notably GemStone-Python) actually lives, and the difference is invisible
+// from the agent side without this nudge.
+function noResultsMessage(label: string, environmentId: number): string {
+  if (environmentId === 0) {
+    return `No ${label} found in environmentId 0 (the default — system environment). ` +
+      `If the project's code lives in a user environment (e.g. GemStone-Python uses ` +
+      `environmentId 1), retry with environmentId: 1.`;
+  }
+  return `No ${label} found in environmentId ${environmentId}.`;
+}
+
+// Refresh the session's view of committed state if (and only if) it's safe to
+// do so. GemStone's GCI pins read-only operations to the session's transaction
+// view: a commit landed by another process (e.g. install.sh) is invisible
+// until this session aborts or commits. Auto-refresh closes the silent-stale
+// gap; we skip it when the session has uncommitted work so we never discard.
+function refreshIfClean(session: McpSession): void {
+  try {
+    session.executeFetchString(
+      "System needsCommit ifFalse: [System abortTransaction]. 'ok'",
+    );
+  } catch {
+    // Best-effort. If the refresh fails (e.g. session disconnected), the
+    // primary tool call below will report the real error.
+  }
+}
+
 export function registerTools(server: McpServer, session: McpSession): void {
 
   // Bind this session into the QueryExecutor shape shared queries expect.
@@ -240,13 +270,20 @@ export function registerTools(server: McpServer, session: McpSession): void {
   server.tool(
     'execute_code',
     'Execute GemStone Smalltalk code and return the result as a string (via printString). ' +
+    'Accepts both single expressions ("3 + 4") and multi-statement bodies with temp ' +
+    'declarations ("| x | x := 42. x + 1") — the body is evaluated as a block, so any ' +
+    'sequence of statements is fine. The value of the last statement is returned. ' +
     'Changes are NOT committed automatically.',
-    { code: z.string().describe('Smalltalk expression to execute') },
+    { code: z.string().describe('Smalltalk expression or statement sequence to execute') },
     async ({ code }) => {
       try {
-        // Wrap so the result is always a String — GciTsExecuteFetchBytes
-        // requires a byte object, but the user's code may return any object.
-        const wrapped = `(${code}) printString`;
+        // Wrap as `[<code>] value printString` so multi-statement bodies and
+        // top-level temp declarations parse — `(<code>) printString` only
+        // accepts a single expression and rejected `| x | ...` with
+        // "expected start of a statement". Block evaluation also coerces the
+        // result through printString, satisfying GciTsExecuteFetchBytes's
+        // need for a byte-object return.
+        const wrapped = `[${code}] value printString`;
         const result = session.executeFetchString(wrapped);
         return { content: [{ type: 'text' as const, text: result }] };
       } catch (err) {
@@ -285,15 +322,19 @@ export function registerTools(server: McpServer, session: McpSession): void {
 
   server.tool(
     'find_implementors',
-    'Find all classes that implement a given selector. Returns up to 500 results.',
+    'Find all classes that implement a given selector. Returns up to 500 results. ' +
+    'Searches one environment at a time — env 0 (default) is the system environment; ' +
+    'projects like GemStone-Python keep most user code in env 1. If env 0 returns ' +
+    'nothing, retry with environmentId: 1 before concluding the selector is unimplemented.',
     {
       selector: z.string().describe('Method selector to search for'),
-      environmentId: z.number().optional().describe('Environment ID (default 0)'),
+      environmentId: z.number().optional().describe('Environment ID (default 0; try 1 for user code)'),
     },
     async ({ selector, environmentId }) => {
       try {
-        const results = implementorsOf(exec, selector, environmentId ?? 0);
-        return { content: [{ type: 'text' as const, text: formatMethodResults(results, 'No implementors found.') }] };
+        const envId = environmentId ?? 0;
+        const results = implementorsOf(exec, selector, envId);
+        return { content: [{ type: 'text' as const, text: formatMethodResults(results, noResultsMessage('implementors', envId)) }] };
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
@@ -307,15 +348,17 @@ export function registerTools(server: McpServer, session: McpSession): void {
     'find_references_to',
     'Find all methods that reference a named global (class, pool, or shared variable). ' +
     'Sister to find_senders, which matches a selector; this matches a global by name. ' +
-    'Returns up to 500 results.',
+    'Returns up to 500 results. Env 0 (default) is the system environment; if results ' +
+    'are empty, retry with environmentId: 1 — user-environment globals are invisible from env 0.',
     {
       objectName: z.string().describe('Name of the global to find references to, e.g. "AllUsers"'),
-      environmentId: z.number().optional().describe('Environment ID (default 0)'),
+      environmentId: z.number().optional().describe('Environment ID (default 0; try 1 for user code)'),
     },
     async ({ objectName, environmentId }) => {
       try {
-        const results = referencesToObject(exec, objectName, environmentId ?? 0);
-        return { content: [{ type: 'text' as const, text: formatMethodResults(results, 'No references found.') }] };
+        const envId = environmentId ?? 0;
+        const results = referencesToObject(exec, objectName, envId);
+        return { content: [{ type: 'text' as const, text: formatMethodResults(results, noResultsMessage('references', envId)) }] };
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
@@ -327,15 +370,18 @@ export function registerTools(server: McpServer, session: McpSession): void {
 
   server.tool(
     'find_senders',
-    'Find all methods that send a given selector. Returns up to 500 results.',
+    'Find all methods that send a given selector. Returns up to 500 results. ' +
+    'Env 0 (default) is the system environment; if results are empty, retry with ' +
+    'environmentId: 1 — user-environment senders are invisible from env 0.',
     {
       selector: z.string().describe('Method selector to search for'),
-      environmentId: z.number().optional().describe('Environment ID (default 0)'),
+      environmentId: z.number().optional().describe('Environment ID (default 0; try 1 for user code)'),
     },
     async ({ selector, environmentId }) => {
       try {
-        const results = sendersOf(exec, selector, environmentId ?? 0);
-        return { content: [{ type: 'text' as const, text: formatMethodResults(results, 'No senders found.') }] };
+        const envId = environmentId ?? 0;
+        const results = sendersOf(exec, selector, envId);
+        return { content: [{ type: 'text' as const, text: formatMethodResults(results, noResultsMessage('senders', envId)) }] };
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
@@ -512,6 +558,29 @@ export function registerTools(server: McpServer, session: McpSession): void {
   );
 
   server.tool(
+    'refresh',
+    'Refresh this session\'s view of committed state by aborting if (and only if) ' +
+    'there are no uncommitted changes. GemStone\'s GCI pins the session\'s read view ' +
+    'until it aborts or commits, so a commit landed by another process (e.g. install.sh) ' +
+    'is invisible until refresh runs. If the session has uncommitted work, this is a ' +
+    'no-op and reports back so the caller can decide whether to abort or commit first.',
+    {},
+    async () => {
+      try {
+        const result = session.executeFetchString(
+          "System needsCommit ifTrue: ['skipped: uncommitted changes present'] ifFalse: [System abortTransaction. 'refreshed']",
+        );
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     'remove_dictionary',
     'DESTRUCTIVE: remove a dictionary from the current user\'s symbolList. ' +
     'NOT committed automatically.',
@@ -531,12 +600,15 @@ export function registerTools(server: McpServer, session: McpSession): void {
 
   server.tool(
     'run_test_class',
-    'Run all SUnit test methods in a TestCase subclass and return per-method pass/fail/error results.',
+    'Run all SUnit test methods in a TestCase subclass and return per-method pass/fail/error results. ' +
+    'Auto-refreshes the session view first (when no uncommitted changes are pending) so results ' +
+    'reflect the latest committed code, not a stale transaction view.',
     {
       className: z.string().describe('TestCase subclass name'),
     },
     async ({ className }) => {
       try {
+        refreshIfClean(session);
         const results = runTestClass(exec, className);
         const text = formatTestResults(results);
         return { content: [{ type: 'text' as const, text }] };
@@ -551,13 +623,16 @@ export function registerTools(server: McpServer, session: McpSession): void {
 
   server.tool(
     'run_test_method',
-    'Run a single SUnit test method and return pass/fail/error with details.',
+    'Run a single SUnit test method and return pass/fail/error with details. ' +
+    'Auto-refreshes the session view first (when no uncommitted changes are pending) so the ' +
+    'result reflects the latest committed code.',
     {
       className: z.string().describe('TestCase subclass name'),
       selector: z.string().describe('Test method selector, e.g. "testAdd"'),
     },
     async ({ className, selector }) => {
       try {
+        refreshIfClean(session);
         const r = runTestMethod(exec, className, selector);
         const text = formatTestResult(r);
         return { content: [{ type: 'text' as const, text }] };
@@ -616,7 +691,11 @@ export function registerTools(server: McpServer, session: McpSession): void {
 
   server.tool(
     'status',
-    'Report information about the current GemStone session: user, stone, transaction state, and whether there are uncommitted changes.',
+    'Report information about the current GemStone session: user, stone, transaction state, ' +
+    'whether there are uncommitted changes, and whether the session view was just refreshed. ' +
+    'Auto-refreshes the view (via abort) when no uncommitted changes are pending, so subsequent ' +
+    'reads reflect the latest committed state — not a stale transaction view from before another ' +
+    'process committed.',
     {},
     async () => {
       try {
@@ -624,13 +703,23 @@ export function registerTools(server: McpServer, session: McpSession): void {
         // otherwise nextPutAll: sends do: to it and GemStone complains (e.g.
         // SmallInteger DNU do:). Coerce with asString / printString to keep
         // it robust across GemStone versions.
-        const code = `| ws |
+        //
+        // Auto-refresh: if no uncommitted work is pending we abort first so
+        // the rest of the report (and any follow-up read tool calls in this
+        // session) sees committed state landed by other processes. If
+        // uncommitted work is pending we skip — discarding it silently would
+        // be far more harmful than reporting slightly stale state.
+        const code = `| ws viewState |
+viewState := System needsCommit
+  ifTrue: ['stale (uncommitted changes — call abort or commit to refresh)']
+  ifFalse: [System abortTransaction. 'refreshed'].
 ws := WriteStream on: String new.
 ws nextPutAll: 'User: '; nextPutAll: System myUserProfile userId asString; lf.
 ws nextPutAll: 'Stone: '; nextPutAll: System stoneName asString; lf.
 ws nextPutAll: 'Session ID: '; nextPutAll: System session printString; lf.
 ws nextPutAll: 'Transaction: '; nextPutAll: (System inTransaction ifTrue: ['active'] ifFalse: ['none']); lf.
 ws nextPutAll: 'Uncommitted changes: '; nextPutAll: (System needsCommit ifTrue: ['yes'] ifFalse: ['no']); lf.
+ws nextPutAll: 'View: '; nextPutAll: viewState; lf.
 ws contents`;
         const result = session.executeFetchString(code);
         return { content: [{ type: 'text' as const, text: result }] };

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { McpSession } from './mcpSession';
+import { withMcpErrorMap } from '../../client/src/mcpZodErrorMap';
 
 import { QueryExecutor } from '../../client/src/queries/types';
 import { getMethodSource } from '../../client/src/queries/getMethodSource';
@@ -84,7 +85,13 @@ function refreshIfClean(session: McpSession): void {
   }
 }
 
-export function registerTools(server: McpServer, session: McpSession): void {
+export function registerTools(rawServer: McpServer, session: McpSession): void {
+
+  // Wrap the MCP server so each tool's input shape gets the actionable-error
+  // zod error map attached at registration time. Per-schema attachment (not
+  // global z.config) — see mcpZodErrorMap.ts for why a global map breaks the
+  // SDK's protocol parsing.
+  const server = withMcpErrorMap(rawServer) as unknown as McpServer;
 
   // Bind this session into the QueryExecutor shape shared queries expect.
   // Label is used only for client-side logging, ignored here.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gemstone-ide",
   "displayName": "Jasper: A GemStone Smalltalk IDE",
   "description": "GemStone/S IDE for Visual Studio Code",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publisher": "gemtalksystems",
   "license": "MIT",
   "author": "James Foster",


### PR DESCRIPTION
Acts on every actionable item in `Grail/docs/MCP_Server_Feedback.md` from a Claude Code session that exercised the `gemstone` MCP server retroactively.

## Summary

- **Stale-transaction fix.** `status`, `run_test_class`, `run_test_method`, `list_failing_tests`, and the new `describe_test_failure` auto-refresh-if-clean before reading. New `refresh` tool exposes the same primitive explicitly. Closes the silent-stale gap where the session's pinned read view didn't reflect commits landed by other processes.
- **`execute_code` block-wrap.** Multi-statement bodies and temp declarations (`| x | x := 42. x + 1`) now parse — wrapped as `[<code>] value printString`.
- **Env-1 hints in `find_implementors` / `find_senders` / `find_references_to`.** Empty results in the default env (0) point the agent at `environmentId: 1` for projects whose user code lives there (e.g. GemStone-Python).
- **Actionable validator errors.** Per-schema zod error map (not global — global breaks the SDK's protocol parsing) rewrites missing-parameter and wrong-type messages to name the offending field. The fix landed only after a probe that proved the SDK passes the message through verbatim *and* that a global `z.config({ customError })` derails the SDK's discriminated-union JSON-RPC parsing.
- **New tools:** `refresh`, `list_failing_tests` (with optional `classNames`), `list_test_classes`, `describe_test_failure`, `eval_python`, `compile_python`.
- **`describe_test_failure`** re-runs the test with its own `AbstractException` handler (bypasses `TestCase>>run`, which swallows the exception) and returns structured details: `exceptionClass`, GemStone `errorNumber`, clean `messageText`, `description`, plus `mnuReceiver` / `mnuSelector` for `MessageNotUnderstood`. Stack trace via the `GemExceptionSignalCapturesStack` config (toggled around the run, restored via `ensure:`) — multi-line `stackReport` with frames in `Class >> selector @ip line N [GsNMethod oop]` format.
- **`eval_python` / `compile_python`** register unconditionally on both surfaces. Detect Grail by `objectNamed: #ModuleAst` (a direct class reference would be a compile-time symbol; dynamic resolution turns Grail's absence into a runtime branch). Returns a graceful "Grail not detected" hint when not installed; reports Grail-side compile/runtime errors inline as `Error: <class> — <messageText>`.

## Bug fix

`runTestClass.ts` and `runFailingTests.ts` were sending `each testCase class name` to objects that don't respond to `#testCase` — silent DNU on real failures, masked because unit tests mock the Smalltalk output. Probe (during `describe_test_failure` work) confirmed the items in `result failures` / `result errors` are the TestCase instances themselves with only `testSelector` ivar. Fixed to use `each class name` / `each selector`, matching the `passed` branch which was already correct.

## Rejected with rationale

- `compile_method_from_file` + `save_to_file`. Original feedback came from a workflow without editor integration (Grail's `install.sh`-driven loop). Jasper's `fileInManager` already auto-files-in `.gs` saves, so `Edit` + VS Code save covers the same need. `save_to_file` would actively introduce a second write path competing with the editor's save handler. See TODO.md for full rationale.

## Test plan

- [x] Root vitest suite: 320 passing
- [x] Client vitest suite: 1159 passing (+39 from this branch)
- [x] mcp-server vitest suite: 93 passing (+11 from this branch)
- [ ] Manual smoke-test against a real GemStone session — particularly `describe_test_failure` with stack capture and the env-1 hints in find_*

🤖 Generated with [Claude Code](https://claude.com/claude-code)