### PR TITLE
Fix VS Code tasks in OSX

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,13 @@
       "command": "npm run compile",
       "group": "build",
       "problemMatcher": ["$tsc"],
+      "osx": {
+        "options": {
+          "shell": {
+            "args": [ "-i" ]
+          }
+        }
+      },
       "windows": {
         "options": {
           "shell": {
@@ -23,6 +30,13 @@
       "isBackground": true,
       "group": "build",
       "problemMatcher": ["$tsc-watch"],
+      "osx": {
+        "options": {
+          "shell": {
+            "args": [ "-i" ]
+          }
+        }
+      },
       "windows": {
         "options": {
           "shell": {


### PR DESCRIPTION
The project relies on nvm to configure the Node.js version to use, but the scripts assumed node was on the PATH. This might not be true if the system only uses nodes via nvm, and does not have a default version installed.

By default, VS Code runs shells in non-interactive, non-login mode. This does not source ~/.zshrc and nvm never gets added to the path.

To fix this, tasks that depends on node were configured to use zsh terminals in interactive mode, where ~/.zshrc is sourced and nvm is available.