### PR TITLE
Fixes Jasper issue #66.  Hotkeys are now a new key chord combo 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,8 +234,8 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ### Added
 
-- **Find Class command** (`Cmd+; C` / `Ctrl+; C`) — quick-pick search across all classes in all dictionaries; selecting a class navigates the System Browser to it (or opens the class definition if no browser is open)
-- **Find Method command** (`Cmd+; M` / `Ctrl+; M`) — quick-pick search across all methods (instance and class side) of the currently selected class in the System Browser; if no class is selected, prompts for a class name; selecting a method navigates the browser and opens the method editor
+- **Find Class command** (`Cmd+K C` / `Ctrl+K C`) — quick-pick search across all classes in all dictionaries; selecting a class navigates the System Browser to it (or opens the class definition if no browser is open)
+- **Find Method command** (`Cmd+K M` / `Ctrl+K M`) — quick-pick search across all methods (instance and class side) of the currently selected class in the System Browser; if no class is selected, prompts for a class name; selecting a method navigates the browser and opens the method editor
 - **FileSystem provider logging** — `gemstone://` file operations (`stat`, `readFile`, `writeFile`) now log to the GemStone output channel, making it easier to diagnose save/compile issues; entries show the URI, read-only status, and success/failure of each operation
 - **Register local GemStone versions** — "Register Local Version…" button in the Versions view lets you point to an existing GemStone installation directory without downloading or extracting; registered versions appear alongside downloaded ones and can be used for databases and logins; "Unregister" removes the registration without deleting files
 - **Login editor version picker** — the login editor now shows a dropdown of available GemStone versions (from extracted installations and configured GCI library paths) instead of a free-text field

--- a/README.md
+++ b/README.md
@@ -143,15 +143,15 @@ With an active session, execute Smalltalk code from any editor:
 
 | Command | macOS | Windows/Linux | Description |
 |---------|-------|---------------|-------------|
-| Display It | Cmd+; D | Ctrl+; D | Evaluate selection and insert result inline |
-| Execute It | Cmd+; E | Ctrl+; E | Evaluate selection silently |
-| Inspect It | Cmd+; I | Ctrl+; I | Evaluate selection and show result in Inspector |
+| Display It | Cmd+K D | Ctrl+K D | Evaluate selection and insert result inline |
+| Execute It | Cmd+K E | Ctrl+K E | Evaluate selection silently |
+| Inspect It | Cmd+K I | Ctrl+K I | Evaluate selection and show result in Inspector |
 
 Long-running expressions show a progress notification with soft-break and hard-break options. The **GemStone Transcript** output channel captures transcript output from the session.
 
 ### System Browser
 
-Open with **Cmd+; B** (Ctrl+; B) or from a session's inline button. The browser provides a five-column layout:
+Open with **Cmd+K B** (Ctrl+K B) or from a session's inline button. The browser provides a five-column layout:
 
 - **Dictionaries** — your symbol list dictionaries
 - **Class Categories** — classes grouped by category

--- a/client/src/__tests__/keybindings.test.ts
+++ b/client/src/__tests__/keybindings.test.ts
@@ -12,18 +12,18 @@ const keybindings: Array<{
 }> = pkg.contributes.keybindings;
 
 describe('keybindings', () => {
-  it('should all use the ctrl+; chord prefix (Windows/Linux)', () => {
+  it('should all use the ctrl+k chord prefix (Windows/Linux)', () => {
     for (const kb of keybindings) {
       expect(kb.key, `${kb.command} has unexpected key: "${kb.key}"`).toMatch(
-        /^ctrl\+; [a-z]$/,
+        /^ctrl\+k [a-z]$/,
       );
     }
   });
 
-  it('should all use the cmd+; chord prefix (macOS)', () => {
+  it('should all use the cmd+k chord prefix (macOS)', () => {
     for (const kb of keybindings) {
       expect(kb.mac, `${kb.command} has unexpected mac key: "${kb.mac}"`).toMatch(
-        /^cmd\+; [a-z]$/,
+        /^cmd\+k [a-z]$/,
       );
     }
   });

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -114,7 +114,7 @@ function parseUri(uri: vscode.Uri): ParsedUri {
 
 const MOD_KEY = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
 export const WORKSPACE_TEMPLATE =
-  `"Workspace\nPlace cursor anywhere on a line with code\nand press [<${MOD_KEY}>+<;> followed by <D>]\n(note that this is a two-keypress chord) to display"\n6 * 7\n`;
+  `"Workspace\nPlace cursor anywhere on a line with code\nand press [<${MOD_KEY}>+<K> followed by <D>]\n(note that this is a two-keypress chord) to display"\n6 * 7\n`;
 
 export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
   private _onDidChangeFile = new vscode.EventEmitter<vscode.FileChangeEvent[]>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gemstone-ide",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gemstone-ide",
-      "version": "1.4.4",
+      "version": "1.5.0",
       "license": "MIT",
       "workspaces": [
         "client",

--- a/package.json
+++ b/package.json
@@ -971,38 +971,38 @@
     "keybindings": [
       {
         "command": "gemstone.displayIt",
-        "key": "ctrl+; d",
-        "mac": "cmd+; d",
+        "key": "ctrl+k d",
+        "mac": "cmd+k d",
         "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing"
       },
       {
         "command": "gemstone.executeIt",
-        "key": "ctrl+; e",
-        "mac": "cmd+; e",
+        "key": "ctrl+k e",
+        "mac": "cmd+k e",
         "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing"
       },
       {
         "command": "gemstone.inspectIt",
-        "key": "ctrl+; i",
-        "mac": "cmd+; i",
+        "key": "ctrl+k i",
+        "mac": "cmd+k i",
         "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing"
       },
       {
         "command": "gemstone.openBrowser",
-        "key": "ctrl+; b",
-        "mac": "cmd+; b",
+        "key": "ctrl+k b",
+        "mac": "cmd+k b",
         "when": "gemstone.hasActiveSession"
       },
       {
         "command": "gemstone.findClass",
-        "key": "ctrl+; c",
-        "mac": "cmd+; c",
+        "key": "ctrl+k c",
+        "mac": "cmd+k c",
         "when": "gemstone.hasActiveSession"
       },
       {
         "command": "gemstone.findMethod",
-        "key": "ctrl+; m",
-        "mac": "cmd+; m",
+        "key": "ctrl+k m",
+        "mac": "cmd+k m",
         "when": "gemstone.hasActiveSession"
       }
     ]


### PR DESCRIPTION
Changed the hot keys for D/E/I/B/C/M to <Ctrl/Cmd>+K <letter> per issue #66. 

npm run compile && npm test passed 

Note that gci test didn't pass but since this isn't in the area of gci, I'm submitting the pull request anyway. 

```
ewinger@uffda:/export/uffda1/users/ewinger/rowanStones/checkouts/gemstone37rowanv3_externals_st/Jasper$ GCI_LIBRARY_PATH=/uffda1/users/ewinger/jasperStones/GemStone64Bit3.7.5-x86_64.Linux/lib/libgcits-3.7.5-64.so npm run test:gci
...
 Test Files  15 failed | 5 passed (20)
      Tests  10 failed | 52 passed | 156 skipped (218)
   Start at  13:51:54
   Duration  3.61s (transform 264ms, setup 0ms, import 806ms, tests 616ms, environment 2ms)

Example failure. Others looked similar. 

 FAIL  src/__tests__/gci/gciLogin.test.ts > GciTsLogin / GciTsLogout > GciTsAbort / GciTsBegin / GciTsCommit / GciTsContinueWith > continueWith returns OOP_ILLEGAL with no active process
AssertionError: expected null not to be null
 ❯ src/__tests__/gci/gciLogin.test.ts:256:27
    254|         GEM_NRS, GS_USER, GS_PASSWORD, 0, 0,
    255|       );
    256|       expect(session).not.toBeNull();
       |                           ^
    257|
    258|       const OOP_NIL = 0x14n;
```