### PR TITLE
Make the MCP server resilient to dead gems and stack blowups

### DIFF
--- a/client/src/__tests__/mcpTools.test.ts
+++ b/client/src/__tests__/mcpTools.test.ts
@@ -188,7 +188,27 @@ describe('registerMcpTools', () => {
       await server.getTool('execute_code')!.handler({ code: '| x | x := 42. x + 1' });
 
       const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
-      expect(codeArg).toBe('[| x | x := 42. x + 1] value printString');
+      expect(codeArg).toContain('[| x | x := 42. x + 1] value printString');
+    });
+
+    // Stack-blowup guard: user code recursing past the stack limit (e.g.
+    // dataclass self-reference) used to take the gem down. AlmostOutOfStack
+    // is signaled with ~30 frames of headroom — a minimal handler unwinds
+    // cleanly and returns a string the agent can read.
+    it('execute_code wraps user code with an AlmostOutOfStack handler', async () => {
+      vi.mocked(queries.executeFetchString).mockReturnValue('ok');
+      await server.getTool('execute_code')!.handler({ code: '1 + 1' });
+
+      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(codeArg).toContain('on: AlmostOutOfStack');
+    });
+
+    it('execute_code wraps user code with an AbstractException handler', async () => {
+      vi.mocked(queries.executeFetchString).mockReturnValue('ok');
+      await server.getTool('execute_code')!.handler({ code: '1 + 1' });
+
+      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      expect(codeArg).toContain('on: AbstractException');
     });
 
     it('get_class_definition delegates to queries.getClassDefinition', async () => {

--- a/client/src/mcpTools.ts
+++ b/client/src/mcpTools.ts
@@ -4,6 +4,7 @@ import { ActiveSession } from './sessionManager';
 import * as queries from './browserQueries';
 import * as sunit from './sunitQueries';
 import * as python from './pythonQueries';
+import { wrapExecuteCode } from './queries/executeCode';
 import type { TestRunResult } from './queries/runTestMethod';
 import type { TestFailureDetails } from './queries/describeTestFailure';
 import { withMcpErrorMap } from './mcpZodErrorMap';
@@ -275,10 +276,10 @@ export function registerMcpTools(
     'Changes are NOT committed automatically.',
     { code: z.string().describe('Smalltalk expression or statement sequence to execute') },
     async (args) => wrap<typeof args>((session, a) => {
-      // Block-wrap so multi-statement bodies and top-level temp declarations
-      // parse — `(<code>) printString` only accepts a single expression and
-      // rejected `| x | ...` with "expected start of a statement".
-      return executeString(session, `[${a.code}] value printString`);
+      // See queries/executeCode.ts. Block-wraps multi-statement bodies and
+      // guards against AlmostOutOfStack / AbstractException so a runaway
+      // block returns a clean error string instead of taking the gem down.
+      return executeString(session, wrapExecuteCode(a.code));
     })(args),
   );
 

--- a/client/src/queries/__tests__/executeCode.test.ts
+++ b/client/src/queries/__tests__/executeCode.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { wrapExecuteCode } from '../executeCode';
+
+describe('wrapExecuteCode', () => {
+  // The block wrap is what lets `| x | x := 42. x + 1` and other
+  // statement-sequence bodies parse — `(<code>) printString` only accepts a
+  // single expression. The full block + `value printString` pattern remains.
+  it('block-wraps the user code and sends printString', () => {
+    const out = wrapExecuteCode('3 + 4');
+    expect(out).toContain('[3 + 4] value printString');
+  });
+
+  it('block-wraps multi-statement bodies with temp declarations', () => {
+    const out = wrapExecuteCode('| x | x := 42. x + 1');
+    expect(out).toContain('[| x | x := 42. x + 1] value printString');
+  });
+
+  // GemStone signals AlmostOutOfStack with ~30 frames of headroom before a
+  // hard stack overflow. We must catch it with a *minimal* handler (no
+  // stream construction, no concatenation) because the handler itself runs
+  // with very little stack room. This guard pins both the catch and the
+  // minimal-handler shape so a future "improvement" can't quietly inflate it.
+  it('catches AlmostOutOfStack with a fixed-literal handler', () => {
+    const out = wrapExecuteCode('1');
+    expect(out).toContain('on: AlmostOutOfStack');
+    expect(out).toContain("'Error: AlmostOutOfStack");
+    // No WriteStream / no concatenation inside the AlmostOutOfStack arm.
+    const stackArm = out.match(/on: AlmostOutOfStack do: \[(.*?)\]/s)?.[1] ?? '';
+    expect(stackArm).not.toContain('WriteStream');
+    expect(stackArm).not.toContain(',');
+  });
+
+  // AbstractException is the outer net for everything else (DNU, ZeroDivide,
+  // SyntaxError). It has stack room available so it can build the richer
+  // error string the agent normally sees.
+  it('catches AbstractException with a class+messageText handler', () => {
+    const out = wrapExecuteCode('1');
+    expect(out).toContain('on: AbstractException');
+    expect(out).toContain('e class name asString');
+    expect(out).toContain('e messageText asString');
+  });
+
+  // The handlers nest as `[[code] on: AlmostOutOfStack ...] on: AbstractException ...`
+  // — AlmostOutOfStack is innermost so it intercepts before the more general
+  // AbstractException handler (AlmostOutOfStack IS an AbstractException).
+  it('nests AlmostOutOfStack inside AbstractException so the cheaper handler runs first', () => {
+    const out = wrapExecuteCode('1');
+    const stackIdx = out.indexOf('on: AlmostOutOfStack');
+    const exIdx = out.indexOf('on: AbstractException');
+    expect(stackIdx).toBeGreaterThan(-1);
+    expect(exIdx).toBeGreaterThan(-1);
+    expect(stackIdx).toBeLessThan(exIdx);
+  });
+});

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -526,6 +526,24 @@ describe('python (Grail) queries', () => {
     expect(code).toContain("''hello''");
   });
 
+  // Stack-blowup guard: dataclass self-references and other recursive code
+  // paths used to take the gem down. GemStone signals AlmostOutOfStack with
+  // ~30 frames of headroom — the handler must be minimal because it runs
+  // with very little stack room, so it just returns a fixed string literal.
+  // It's nested *inside* the AbstractException wrapper so the cheap handler
+  // intercepts before the rich-error path can fail under low stack.
+  it('wraps the Grail call in an inner on: AlmostOutOfStack do:', () => {
+    const exec = vi.fn<QueryExecutor>(() => '');
+    evalPython(exec, 'x = 1');
+    const code = exec.mock.calls[0][1];
+    expect(code).toContain('on: AlmostOutOfStack');
+    expect(code).toContain("'Error: AlmostOutOfStack");
+    // AlmostOutOfStack must appear *before* AbstractException in the source
+    // (innermost handler) so the minimal handler runs first.
+    expect(code.indexOf('on: AlmostOutOfStack'))
+      .toBeLessThan(code.indexOf('on: AbstractException'));
+  });
+
   // Errors from Grail's compile/runtime path (SyntaxError, NameError, etc.)
   // are caught and reported inline as "Error: <class> — <messageText>" so
   // the agent gets a usable diagnostic, not a dropped tool call.

--- a/client/src/queries/executeCode.ts
+++ b/client/src/queries/executeCode.ts
@@ -1,0 +1,20 @@
+// Wrap arbitrary user code (Smalltalk expression or statement sequence) so a
+// runaway block doesn't take the gem down.
+//
+// Two guard layers:
+//   - `on: AlmostOutOfStack` runs first (innermost) because GemStone signals
+//     it *before* the stack hard-fails — gives us a chance to unwind cleanly
+//     with very little stack room remaining. Handler must be minimal (no
+//     stream construction, no concatenation): just return a fixed literal.
+//   - `on: AbstractException` is the outer net for everything else
+//     (DNU, ZeroDivide, runtime errors) — these have stack room to build a
+//     proper error string.
+//
+// Both handlers return a String, matching the printString result the caller
+// expects, so the wrapper is shape-stable across success/error.
+
+export function wrapExecuteCode(code: string): string {
+  return `[[[${code}] value printString]
+  on: AlmostOutOfStack do: [:e | 'Error: AlmostOutOfStack — user code exhausted the call stack']]
+  on: AbstractException do: [:e | 'Error: ', e class name asString, ' — ', e messageText asString]`;
+}

--- a/client/src/queries/python.ts
+++ b/client/src/queries/python.ts
@@ -39,6 +39,14 @@ function buildPythonQuery(grailExpression: string, pythonSource: string): string
   // The hint is itself a Smalltalk string literal — the same single-quote
   // escaping rule applies, but it has none today, so we inline it directly.
   //
+  // Stack-guard layering: an inner `on: AlmostOutOfStack` wraps the Grail
+  // call. GemStone signals AlmostOutOfStack *before* the stack hard-fails
+  // (about 30 frames of headroom), and the handler must be cheap because
+  // it runs with very little stack room — so it just returns a fixed
+  // literal, no WriteStream / no concatenation. The outer
+  // `on: AbstractException` catches everything else (DNU, ZeroDivide,
+  // SyntaxError) and builds the rich error string the agent normally sees.
+  //
   // The encoding model GemStone wants us to use:
   //
   //   Unicode7 / Unicode16 / Unicode32 are *internal storage* formats with
@@ -70,7 +78,8 @@ src := '${esc}'.
 result := dispatcher isNil
   ifTrue: ['${GRAIL_HINT}']
   ifFalse: [
-    [${grailExpression}]
+    [[${grailExpression}]
+       on: AlmostOutOfStack do: [:e | 'Error: AlmostOutOfStack — user code exhausted the call stack']]
       on: AbstractException do: [:e |
         | ws |
         ws := WriteStream on: Unicode7 new.

--- a/mcp-server/src/__tests__/index.test.ts
+++ b/mcp-server/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseArgs } from '../index';
+import { describe, it, expect, vi } from 'vitest';
+import { parseArgs, readInitScripts } from '../index';
 
 describe('parseArgs', () => {
   const validArgs = [
@@ -63,6 +63,57 @@ describe('parseArgs', () => {
   it('throws on invalid transport value', () => {
     expect(() => parseArgs([...validArgs, '--transport', 'websocket']))
       .toThrow('Invalid --transport');
+  });
+
+  // The user's pain: after every gem crash they re-paste a multi-line
+  // `importlib grailDir: ... ; CPythonShim libraryPath: ...` block. Storing
+  // those as `--session-init-script <path>` lets the server replay them on
+  // every login (initial + reconnects).
+  describe('--session-init-script', () => {
+    it('returns undefined when no init script is given', () => {
+      const result = parseArgs(validArgs);
+      expect(result.sessionInitScripts).toBeUndefined();
+    });
+
+    it('captures a single --session-init-script path', () => {
+      const result = parseArgs([...validArgs, '--session-init-script', '/etc/init1.gs']);
+      expect(result.sessionInitScripts).toEqual(['/etc/init1.gs']);
+    });
+
+    // Order matters: scripts run in argv order at login time, so repeated
+    // flags must preserve that order rather than the last-wins shape the
+    // rest of the args use.
+    it('accepts repeated --session-init-script flags in order', () => {
+      const result = parseArgs([
+        ...validArgs,
+        '--session-init-script', '/etc/a.gs',
+        '--session-init-script', '/etc/b.gs',
+      ]);
+      expect(result.sessionInitScripts).toEqual(['/etc/a.gs', '/etc/b.gs']);
+    });
+  });
+
+  describe('readInitScripts', () => {
+    it('returns [] when no paths are given', () => {
+      expect(readInitScripts(undefined)).toEqual([]);
+      expect(readInitScripts([])).toEqual([]);
+    });
+
+    it('reads each path via the injected reader and returns contents in order', () => {
+      const reader = vi.fn((p: string) => `contents of ${p}`);
+      expect(readInitScripts(['/a', '/b'], reader)).toEqual(['contents of /a', 'contents of /b']);
+      expect(reader).toHaveBeenNthCalledWith(1, '/a');
+      expect(reader).toHaveBeenNthCalledWith(2, '/b');
+    });
+
+    // Fail loud: silently skipping a missing init script would put the
+    // session in a half-primed state without the user knowing why their
+    // Grail / CPythonShim setup didn't take.
+    it('throws a clear error if the file cannot be read', () => {
+      const reader = vi.fn(() => { throw new Error('ENOENT'); });
+      expect(() => readInitScripts(['/missing.gs'], reader))
+        .toThrow(/Cannot read session-init-script \/missing.gs: ENOENT/);
+    });
   });
 
   describe('proxy mode', () => {

--- a/mcp-server/src/__tests__/mcpSession.test.ts
+++ b/mcp-server/src/__tests__/mcpSession.test.ts
@@ -24,7 +24,7 @@ vi.mock('../../../client/src/gciConstants', () => ({
   OOP_ILLEGAL: 0x01n,
 }));
 
-import { McpSession, McpSessionConfig } from '../mcpSession';
+import { McpSession, McpSessionConfig, SessionRestartedError, isDeadSessionError } from '../mcpSession';
 import { GciLibrary } from '../../../client/src/gciLibrary';
 
 const noErr = {
@@ -170,6 +170,137 @@ describe('McpSession', () => {
 
       const session = new McpSession(makeConfig());
       expect(() => session.logout()).not.toThrow();
+    });
+  });
+
+  // The dead-session detector is deliberately liberal: a false positive
+  // costs one extra login (cheap) while a false negative would surface an
+  // unrecoverable error to the agent — exactly the failure mode we're
+  // fixing. fatal=1 is the canonical signal; the textual markers cover GCI
+  // surfaces that report transport death without setting fatal.
+  describe('isDeadSessionError', () => {
+    it('treats fatal=1 as dead', () => {
+      expect(isDeadSessionError({ ...noErr, fatal: 1, number: 4099 })).toBe(true);
+    });
+
+    it('detects the "invalid netConnection" marker', () => {
+      expect(isDeadSessionError({
+        ...noErr, number: 4099, message: 'lgc sendOutput: invalid netConnection',
+      })).toBe(true);
+    });
+
+    it('detects a "not logged in" marker', () => {
+      expect(isDeadSessionError({
+        ...noErr, number: 4007, message: 'session is not logged in',
+      })).toBe(true);
+    });
+
+    it('treats normal Smalltalk errors (DNU, ZeroDivide) as alive', () => {
+      expect(isDeadSessionError({
+        ...noErr, number: 2101, message: 'nil does not understand #foo',
+      })).toBe(false);
+    });
+  });
+
+  describe('auto-reconnect on dead session', () => {
+    // Round-1 feedback: today, "lgc sendOutput: invalid netConnection"
+    // surfaces as an opaque error and the user has to manually restart the
+    // server. After this change the session transparently relogins and the
+    // caller sees a SessionRestartedError they (or the agent) can retry.
+    it('transparently re-logins after a netConnection-invalid error and throws SessionRestartedError', () => {
+      const session = new McpSession(makeConfig());
+      // First call: dead-session error. Second call: would succeed but we
+      // expect throw before it ever runs.
+      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
+        data: '', bytesReturned: 0,
+        err: { ...noErr, number: 4099, message: 'lgc sendOutput: invalid netConnection' },
+      });
+
+      // Constructor already logged in once; the auto-reconnect should log in again.
+      expect(() => session.executeFetchString('whatever')).toThrow(SessionRestartedError);
+      expect(mockGci.GciTsLogin).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows a plain Error when reconnect itself fails', () => {
+      const session = new McpSession(makeConfig());
+      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
+        data: '', bytesReturned: 0,
+        err: { ...noErr, fatal: 1, message: 'gem died' },
+      });
+      mockGci.GciTsLogin.mockReturnValueOnce({
+        session: null,
+        err: { ...noErr, number: 4065, message: 'stone unavailable' },
+      });
+
+      expect(() => session.executeFetchString('1 + 1')).toThrow(/reconnect failed/);
+    });
+
+    // Cached Utf8 class OOPs are valid only for the session that produced
+    // them. After a reconnect the new gem has different OOPs — we must
+    // re-resolve, not reuse the cached value.
+    it('clears the cached Utf8 OOP across a reconnect', () => {
+      const session = new McpSession(makeConfig());
+      // First call: succeeds, primes the cache.
+      session.executeFetchString('1 + 1');
+      // Second call: dead-session error → reconnect → throw.
+      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
+        data: '', bytesReturned: 0,
+        err: { ...noErr, fatal: 1, message: 'gem died' },
+      });
+      expect(() => session.executeFetchString('2 + 2')).toThrow(SessionRestartedError);
+      // Third call: must re-resolve Utf8 against the new session.
+      const beforeResolve = mockGci.GciTsResolveSymbol.mock.calls.length;
+      session.executeFetchString('3 + 3');
+      expect(mockGci.GciTsResolveSymbol.mock.calls.length).toBe(beforeResolve + 1);
+    });
+  });
+
+  describe('initScripts', () => {
+    // The user pain: every restart, they re-paste `importlib grailDir: ... ;
+    // CPythonShim libraryPath: ...`. The config-time init scripts replay
+    // that block automatically — once on initial login, once after every
+    // reconnect.
+    it('runs each init script after the initial login', () => {
+      new McpSession(makeConfig({
+        initScripts: ['importlib grailDir: /opt/grail', 'CPythonShim libraryPath: /opt/py'],
+      }));
+
+      const codes = mockGci.GciTsExecuteFetchBytes.mock.calls.map((c: unknown[]) => c[1]);
+      expect(codes).toContain('importlib grailDir: /opt/grail');
+      expect(codes).toContain('CPythonShim libraryPath: /opt/py');
+    });
+
+    it('runs the init scripts again after an auto-reconnect', () => {
+      const session = new McpSession(makeConfig({
+        initScripts: ['importlib grailDir: /opt/grail'],
+      }));
+      mockGci.GciTsExecuteFetchBytes.mockClear();
+
+      // Trigger a dead-session error → reconnect → init scripts replayed.
+      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
+        data: '', bytesReturned: 0,
+        err: { ...noErr, fatal: 1, message: 'gem died' },
+      });
+      expect(() => session.executeFetchString('1 + 1')).toThrow(SessionRestartedError);
+
+      const replayedScripts = mockGci.GciTsExecuteFetchBytes.mock.calls
+        .map((c: unknown[]) => c[1])
+        .filter((s: unknown) => s === 'importlib grailDir: /opt/grail');
+      expect(replayedScripts).toHaveLength(1);
+    });
+
+    // Fail loud: if an init script doesn't compile/run, login fails — better
+    // than letting the session run in a half-primed state and surprising the
+    // user later.
+    it('throws if an init script fails', () => {
+      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
+        data: '', bytesReturned: 0,
+        err: { ...noErr, number: 1001, message: 'compile error: bad selector' },
+      });
+
+      expect(() => new McpSession(makeConfig({
+        initScripts: ['this does not compile'],
+      }))).toThrow(/init script 1 failed: compile error/);
     });
   });
 });

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -101,8 +101,33 @@ describe('tools', () => {
       const result = await tool.handler({ code: '| x | x := 42. x + 1' });
 
       const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
-      expect(code).toBe('[| x | x := 42. x + 1] value printString');
+      expect(code).toContain('[| x | x := 42. x + 1] value printString');
       expect(result.content[0].text).toBe('43');
+    });
+
+    // Stack-blowup guard: a runaway recursion in user code (e.g. dataclass
+    // self-reference) shouldn't take the gem down. AlmostOutOfStack fires
+    // before the hard overflow with ~30 frames of headroom; we catch it
+    // with a minimal handler so the result is a clean string.
+    it('wraps user code in an AlmostOutOfStack handler', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('ok');
+      const tool = server.getTool('execute_code')!;
+      await tool.handler({ code: '3 + 4' });
+
+      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(code).toContain('on: AlmostOutOfStack');
+      expect(code).toContain('AlmostOutOfStack');
+    });
+
+    // Non-stack errors (DNU, ZeroDivide, etc.) still need to come back as a
+    // diagnostic string rather than crashing the call.
+    it('wraps user code in an AbstractException handler too', async () => {
+      vi.mocked(session.executeFetchString).mockReturnValue('ok');
+      const tool = server.getTool('execute_code')!;
+      await tool.handler({ code: '3 + 4' });
+
+      const code = vi.mocked(session.executeFetchString).mock.calls[0][0];
+      expect(code).toContain('on: AbstractException');
     });
 
     it('returns error on GCI failure', async () => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import express from 'express';
 import * as net from 'net';
+import * as fs from 'fs';
 import { McpSession, McpSessionConfig } from './mcpSession';
 import { registerTools } from './tools';
 
@@ -19,14 +20,27 @@ export interface CliArgs {
   gemstone?: string;
   gemstoneGlobalDir?: string;
   hostUser?: string;
+  /**
+   * Paths to Smalltalk source files replayed after every login (including
+   * reconnects from a dead gem). Repeat `--session-init-script <path>` to
+   * register multiple — they run in argument order.
+   */
+  sessionInitScripts?: string[];
 }
 
 export function parseArgs(argv: string[]): CliArgs {
   const args = argv.slice(2);
   const result: Record<string, string> = {};
+  const sessionInitScripts: string[] = [];
   for (let i = 0; i < args.length - 1; i += 2) {
     const key = args[i].replace(/^--/, '');
-    result[key] = args[i + 1];
+    const value = args[i + 1];
+    // Multi-valued: repeat `--session-init-script` to register more than one.
+    if (key === 'session-init-script') {
+      sessionInitScripts.push(value);
+    } else {
+      result[key] = value;
+    }
   }
 
   // Proxy mode is inferred from --proxy-socket (transport=proxy is implicit).
@@ -61,7 +75,26 @@ export function parseArgs(argv: string[]): CliArgs {
     gemstone: result['gemstone'],
     gemstoneGlobalDir: result['gemstone-global-dir'],
     hostUser: result['host-user'],
+    sessionInitScripts: sessionInitScripts.length > 0 ? sessionInitScripts : undefined,
   };
+}
+
+// Read each --session-init-script path as the Smalltalk source we'll replay
+// after every login. Fail loud if the file is missing — silently skipping a
+// configured init script would defeat the purpose of having one. The reader
+// is injectable so tests don't need to fight Node's frozen-fs descriptors.
+export function readInitScripts(
+  paths: string[] | undefined,
+  read: (path: string) => string = (p) => fs.readFileSync(p, 'utf8'),
+): string[] {
+  if (!paths) return [];
+  return paths.map(p => {
+    try {
+      return read(p);
+    } catch (err) {
+      throw new Error(`Cannot read session-init-script ${p}: ${(err as Error).message}`);
+    }
+  });
 }
 
 export function createSessionConfig(args: CliArgs): McpSessionConfig {
@@ -76,6 +109,7 @@ export function createSessionConfig(args: CliArgs): McpSessionConfig {
     gsPassword: process.env.GS_PASSWORD || '',
     hostUser: args.hostUser,
     hostPassword: process.env.HOST_PASSWORD,
+    initScripts: readInitScripts(args.sessionInitScripts),
   };
 }
 

--- a/mcp-server/src/mcpSession.ts
+++ b/mcp-server/src/mcpSession.ts
@@ -1,4 +1,4 @@
-import { GciLibrary } from '../../client/src/gciLibrary';
+import { GciLibrary, GciError } from '../../client/src/gciLibrary';
 import { OOP_NIL, OOP_ILLEGAL } from '../../client/src/gciConstants';
 
 const MAX_RESULT = 256 * 1024;
@@ -11,6 +11,43 @@ export interface McpSessionConfig {
   gsPassword: string;
   hostUser?: string;
   hostPassword?: string;
+  /**
+   * Smalltalk source replayed after every login — including reconnects after
+   * the gem dies. Use for deterministic session setup (e.g. importlib
+   * grailDir:, CPythonShim libraryPath:) that the user otherwise has to
+   * re-paste manually after every crash.
+   */
+  initScripts?: string[];
+}
+
+/**
+ * Thrown when an in-flight call detected a dead session, transparently
+ * relogged in, and replayed the configured init scripts. The caller (or the
+ * agent reading the tool error) should retry the request — any per-session
+ * state set up beyond the init scripts is gone.
+ */
+export class SessionRestartedError extends Error {
+  readonly previousStateLost = true;
+  constructor(public readonly underlying: string) {
+    super(
+      `session died, restarted: ${underlying}. ` +
+      'Previous session state was lost; init scripts were replayed. ' +
+      'Retry your request.',
+    );
+    this.name = 'SessionRestartedError';
+  }
+}
+
+// Detect a GCI error that means the gem is gone — broken pipe, fatal error,
+// or one of the textual markers GCI surfaces when the netConnection is dead.
+// We're deliberately liberal: false positives just trigger a fresh login,
+// which is cheap relative to the alternative of surfacing an unrecoverable
+// error to the agent.
+const DEAD_SESSION_MARKERS = /netConnection|GemFatal|gem ?process|session ?not ?valid|not ?logged ?in/i;
+
+export function isDeadSessionError(err: GciError): boolean {
+  if (err.fatal !== 0) return true;
+  return DEAD_SESSION_MARKERS.test(err.message || '');
 }
 
 export class McpSession {
@@ -18,8 +55,16 @@ export class McpSession {
   private handle: unknown;
   private classUtf8Oop: bigint | undefined;
 
-  constructor(config: McpSessionConfig) {
+  constructor(private readonly config: McpSessionConfig) {
     this.gci = new GciLibrary(config.libraryPath);
+    this.login();
+  }
+
+  // Perform a fresh login and (re)run init scripts. Called from the
+  // constructor and from executeFetchString on a detected dead session.
+  // Throws on login failure; the caller decides how to surface that.
+  private login(): void {
+    const { config } = this;
     const result = this.gci.GciTsLogin(
       config.stoneNrs,
       config.hostUser || null,
@@ -34,9 +79,27 @@ export class McpSession {
       throw new Error(result.err.message || `Login failed (error ${result.err.number})`);
     }
     this.handle = result.session;
+    // Utf8 OOPs are session-scoped — invalidate the cache so the next call
+    // re-resolves against the new gem.
+    this.classUtf8Oop = undefined;
+    this.runInitScripts();
   }
 
-  private resolveClassUtf8(): bigint {
+  private runInitScripts(): void {
+    const scripts = this.config.initScripts ?? [];
+    for (let i = 0; i < scripts.length; i++) {
+      const script = scripts[i];
+      const oop = this.resolveClassUtf8OrThrow();
+      const { err } = this.gci.GciTsExecuteFetchBytes(
+        this.handle, script, -1, oop, OOP_ILLEGAL, OOP_NIL, MAX_RESULT,
+      );
+      if (err.number !== 0) {
+        throw new Error(`init script ${i + 1} failed: ${err.message || `GCI error ${err.number}`}`);
+      }
+    }
+  }
+
+  private resolveClassUtf8OrThrow(): bigint {
     if (this.classUtf8Oop !== undefined) return this.classUtf8Oop;
     const { result, err } = this.gci.GciTsResolveSymbol(this.handle, 'Utf8', OOP_NIL);
     if (err.number !== 0) {
@@ -47,20 +110,41 @@ export class McpSession {
   }
 
   executeFetchString(code: string): string {
-    const oopClassUtf8 = this.resolveClassUtf8();
-    const { data, err } = this.gci.GciTsExecuteFetchBytes(
-      this.handle,
-      code,
-      -1,
-      oopClassUtf8,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      MAX_RESULT,
-    );
-    if (err.number !== 0) {
-      throw new Error(err.message || `GCI error ${err.number}`);
+    // Lazy-resolve the Utf8 class OOP; cached across calls and cleared on
+    // reconnect. Surface dead-session errors from the resolve step the same
+    // way as from execute.
+    if (this.classUtf8Oop === undefined) {
+      const r = this.gci.GciTsResolveSymbol(this.handle, 'Utf8', OOP_NIL);
+      if (r.err.number !== 0 || r.err.fatal !== 0) this.handleErrOrReconnect(r.err);
+      this.classUtf8Oop = r.result;
     }
+    const { data, err } = this.gci.GciTsExecuteFetchBytes(
+      this.handle, code, -1, this.classUtf8Oop, OOP_ILLEGAL, OOP_NIL, MAX_RESULT,
+    );
+    // Check fatal in addition to number — a broken-pipe / dead-gem signal can
+    // arrive with fatal=1 and number=0 (transport-level failure, not a
+    // Smalltalk error). Skipping fatal here would mask the very condition we
+    // need to detect for auto-reconnect.
+    if (err.number !== 0 || err.fatal !== 0) this.handleErrOrReconnect(err);
     return data;
+  }
+
+  // Either throw a plain error for normal GCI failures (MNU, ZeroDivide,
+  // etc.) or, when the error indicates the gem is gone, transparently
+  // relog in and throw SessionRestartedError so the caller can retry.
+  private handleErrOrReconnect(err: GciError): never {
+    if (isDeadSessionError(err)) {
+      const original = err.message || `GCI error ${err.number}`;
+      try {
+        this.login();
+      } catch (loginErr) {
+        throw new Error(
+          `session died (${original}); reconnect failed: ${(loginErr as Error).message}`,
+        );
+      }
+      throw new SessionRestartedError(original);
+    }
+    throw new Error(err.message || `GCI error ${err.number}`);
   }
 
   logout(): void {

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -13,6 +13,7 @@ import { runFailingTests } from '../../client/src/queries/runFailingTests';
 import { discoverTestClasses } from '../../client/src/queries/discoverTestClasses';
 import { describeTestFailure, TestFailureDetails } from '../../client/src/queries/describeTestFailure';
 import { evalPython, compilePython } from '../../client/src/queries/python';
+import { wrapExecuteCode } from '../../client/src/queries/executeCode';
 import { getDictionaryNames } from '../../client/src/queries/getDictionaryNames';
 import { getClassNames } from '../../client/src/queries/getClassNames';
 import { getDictionaryEntries } from '../../client/src/queries/getDictionaryEntries';
@@ -394,13 +395,11 @@ export function registerTools(rawServer: McpServer, session: McpSession): void {
     { code: z.string().describe('Smalltalk expression or statement sequence to execute') },
     async ({ code }) => {
       try {
-        // Wrap as `[<code>] value printString` so multi-statement bodies and
-        // top-level temp declarations parse — `(<code>) printString` only
-        // accepts a single expression and rejected `| x | ...` with
-        // "expected start of a statement". Block evaluation also coerces the
-        // result through printString, satisfying GciTsExecuteFetchBytes's
-        // need for a byte-object return.
-        const wrapped = `[${code}] value printString`;
+        // Block-wrap so multi-statement bodies and top-level temp declarations
+        // parse, and guard with AlmostOutOfStack/AbstractException handlers so
+        // a runaway block returns a clean error instead of taking the gem
+        // down. See queries/executeCode.ts.
+        const wrapped = wrapExecuteCode(code);
         const result = session.executeFetchString(wrapped);
         return { content: [{ type: 'text' as const, text: result }] };
       } catch (err) {


### PR DESCRIPTION
## Summary

Three changes targeting the "gem died, restart everything by hand" pain reported against the MCP server.

- **#1 Auto-reconnect on a dead session.** `McpSession.executeFetchString` now detects a dead gem (GCI `fatal != 0` or textual markers like `invalid netConnection` / `not logged in`), transparently re-logs in, invalidates the cached `Utf8` OOP, and throws a new `SessionRestartedError`. The error message tells the agent that session state was lost and to retry — no more opaque `lgc sendOutput: invalid netConnection` surfacing through the tool layer.
- **#6 Replayable session init scripts.** New `--session-init-script <path>` CLI flag (repeatable). The contents of each file are stored on `McpSessionConfig` and replayed after every login — both initial and after auto-reconnects. Deterministic session setup (`importlib grailDir:`, `CPythonShim libraryPath:`, etc.) stops being the user's problem to re-paste after every crash. Init-script failures are loud rather than silent.
- **#3 AlmostOutOfStack guard on user code.** `execute_code` / `eval_python` / `compile_python` now wrap user code with an inner `on: AlmostOutOfStack do:` (minimal fixed-literal handler — must run with ~30 frames of headroom) and an outer `on: AbstractException do:` for the usual DNU / ZeroDivide / SyntaxError path. The shared wrapper lives in `client/src/queries/executeCode.ts` so the mcp-server and the in-extension MCP tool surface use the same code.

Skipped from the original feedback list: per-call timeout + worker isolation (#2), health probe (#5 — subsumed by #1), warm pool (#4). Those can come later if reconnect + init-script replay don't get us most of the way.

## Test plan

- [x] `npm run test:mcp` — 111 passing
- [x] `npm run test:client` — 1232 passing
- [x] `npm run test:server` — 320 passing
- [x] `npm run compile` — clean
- [ ] Manual smoke: kill the gem mid-call from another process, confirm the next MCP call returns `SessionRestartedError` and the call after that runs cleanly against the fresh session.
- [ ] Manual smoke: configure `--session-init-script` pointing at a file that sets `importlib grailDir:`, kill the gem, confirm the next call doesn't need the block to be re-pasted.
- [ ] Manual smoke: send a recursive Smalltalk block via `execute_code`, confirm it returns `Error: AlmostOutOfStack — user code exhausted the call stack` rather than killing the gem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)