### PR TITLE
Revert MCP auto-reconnect and session-init-script (keep AlmostOutOfStack)

### DIFF
--- a/mcp-server/src/__tests__/index.test.ts
+++ b/mcp-server/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { parseArgs, readInitScripts } from '../index';
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../index';
 
 describe('parseArgs', () => {
   const validArgs = [
@@ -63,57 +63,6 @@ describe('parseArgs', () => {
   it('throws on invalid transport value', () => {
     expect(() => parseArgs([...validArgs, '--transport', 'websocket']))
       .toThrow('Invalid --transport');
-  });
-
-  // The user's pain: after every gem crash they re-paste a multi-line
-  // `importlib grailDir: ... ; CPythonShim libraryPath: ...` block. Storing
-  // those as `--session-init-script <path>` lets the server replay them on
-  // every login (initial + reconnects).
-  describe('--session-init-script', () => {
-    it('returns undefined when no init script is given', () => {
-      const result = parseArgs(validArgs);
-      expect(result.sessionInitScripts).toBeUndefined();
-    });
-
-    it('captures a single --session-init-script path', () => {
-      const result = parseArgs([...validArgs, '--session-init-script', '/etc/init1.gs']);
-      expect(result.sessionInitScripts).toEqual(['/etc/init1.gs']);
-    });
-
-    // Order matters: scripts run in argv order at login time, so repeated
-    // flags must preserve that order rather than the last-wins shape the
-    // rest of the args use.
-    it('accepts repeated --session-init-script flags in order', () => {
-      const result = parseArgs([
-        ...validArgs,
-        '--session-init-script', '/etc/a.gs',
-        '--session-init-script', '/etc/b.gs',
-      ]);
-      expect(result.sessionInitScripts).toEqual(['/etc/a.gs', '/etc/b.gs']);
-    });
-  });
-
-  describe('readInitScripts', () => {
-    it('returns [] when no paths are given', () => {
-      expect(readInitScripts(undefined)).toEqual([]);
-      expect(readInitScripts([])).toEqual([]);
-    });
-
-    it('reads each path via the injected reader and returns contents in order', () => {
-      const reader = vi.fn((p: string) => `contents of ${p}`);
-      expect(readInitScripts(['/a', '/b'], reader)).toEqual(['contents of /a', 'contents of /b']);
-      expect(reader).toHaveBeenNthCalledWith(1, '/a');
-      expect(reader).toHaveBeenNthCalledWith(2, '/b');
-    });
-
-    // Fail loud: silently skipping a missing init script would put the
-    // session in a half-primed state without the user knowing why their
-    // Grail / CPythonShim setup didn't take.
-    it('throws a clear error if the file cannot be read', () => {
-      const reader = vi.fn(() => { throw new Error('ENOENT'); });
-      expect(() => readInitScripts(['/missing.gs'], reader))
-        .toThrow(/Cannot read session-init-script \/missing.gs: ENOENT/);
-    });
   });
 
   describe('proxy mode', () => {

--- a/mcp-server/src/__tests__/mcpSession.test.ts
+++ b/mcp-server/src/__tests__/mcpSession.test.ts
@@ -24,7 +24,7 @@ vi.mock('../../../client/src/gciConstants', () => ({
   OOP_ILLEGAL: 0x01n,
 }));
 
-import { McpSession, McpSessionConfig, SessionRestartedError, isDeadSessionError } from '../mcpSession';
+import { McpSession, McpSessionConfig } from '../mcpSession';
 import { GciLibrary } from '../../../client/src/gciLibrary';
 
 const noErr = {
@@ -170,137 +170,6 @@ describe('McpSession', () => {
 
       const session = new McpSession(makeConfig());
       expect(() => session.logout()).not.toThrow();
-    });
-  });
-
-  // The dead-session detector is deliberately liberal: a false positive
-  // costs one extra login (cheap) while a false negative would surface an
-  // unrecoverable error to the agent — exactly the failure mode we're
-  // fixing. fatal=1 is the canonical signal; the textual markers cover GCI
-  // surfaces that report transport death without setting fatal.
-  describe('isDeadSessionError', () => {
-    it('treats fatal=1 as dead', () => {
-      expect(isDeadSessionError({ ...noErr, fatal: 1, number: 4099 })).toBe(true);
-    });
-
-    it('detects the "invalid netConnection" marker', () => {
-      expect(isDeadSessionError({
-        ...noErr, number: 4099, message: 'lgc sendOutput: invalid netConnection',
-      })).toBe(true);
-    });
-
-    it('detects a "not logged in" marker', () => {
-      expect(isDeadSessionError({
-        ...noErr, number: 4007, message: 'session is not logged in',
-      })).toBe(true);
-    });
-
-    it('treats normal Smalltalk errors (DNU, ZeroDivide) as alive', () => {
-      expect(isDeadSessionError({
-        ...noErr, number: 2101, message: 'nil does not understand #foo',
-      })).toBe(false);
-    });
-  });
-
-  describe('auto-reconnect on dead session', () => {
-    // Round-1 feedback: today, "lgc sendOutput: invalid netConnection"
-    // surfaces as an opaque error and the user has to manually restart the
-    // server. After this change the session transparently relogins and the
-    // caller sees a SessionRestartedError they (or the agent) can retry.
-    it('transparently re-logins after a netConnection-invalid error and throws SessionRestartedError', () => {
-      const session = new McpSession(makeConfig());
-      // First call: dead-session error. Second call: would succeed but we
-      // expect throw before it ever runs.
-      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
-        data: '', bytesReturned: 0,
-        err: { ...noErr, number: 4099, message: 'lgc sendOutput: invalid netConnection' },
-      });
-
-      // Constructor already logged in once; the auto-reconnect should log in again.
-      expect(() => session.executeFetchString('whatever')).toThrow(SessionRestartedError);
-      expect(mockGci.GciTsLogin).toHaveBeenCalledTimes(2);
-    });
-
-    it('rethrows a plain Error when reconnect itself fails', () => {
-      const session = new McpSession(makeConfig());
-      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
-        data: '', bytesReturned: 0,
-        err: { ...noErr, fatal: 1, message: 'gem died' },
-      });
-      mockGci.GciTsLogin.mockReturnValueOnce({
-        session: null,
-        err: { ...noErr, number: 4065, message: 'stone unavailable' },
-      });
-
-      expect(() => session.executeFetchString('1 + 1')).toThrow(/reconnect failed/);
-    });
-
-    // Cached Utf8 class OOPs are valid only for the session that produced
-    // them. After a reconnect the new gem has different OOPs — we must
-    // re-resolve, not reuse the cached value.
-    it('clears the cached Utf8 OOP across a reconnect', () => {
-      const session = new McpSession(makeConfig());
-      // First call: succeeds, primes the cache.
-      session.executeFetchString('1 + 1');
-      // Second call: dead-session error → reconnect → throw.
-      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
-        data: '', bytesReturned: 0,
-        err: { ...noErr, fatal: 1, message: 'gem died' },
-      });
-      expect(() => session.executeFetchString('2 + 2')).toThrow(SessionRestartedError);
-      // Third call: must re-resolve Utf8 against the new session.
-      const beforeResolve = mockGci.GciTsResolveSymbol.mock.calls.length;
-      session.executeFetchString('3 + 3');
-      expect(mockGci.GciTsResolveSymbol.mock.calls.length).toBe(beforeResolve + 1);
-    });
-  });
-
-  describe('initScripts', () => {
-    // The user pain: every restart, they re-paste `importlib grailDir: ... ;
-    // CPythonShim libraryPath: ...`. The config-time init scripts replay
-    // that block automatically — once on initial login, once after every
-    // reconnect.
-    it('runs each init script after the initial login', () => {
-      new McpSession(makeConfig({
-        initScripts: ['importlib grailDir: /opt/grail', 'CPythonShim libraryPath: /opt/py'],
-      }));
-
-      const codes = mockGci.GciTsExecuteFetchBytes.mock.calls.map((c: unknown[]) => c[1]);
-      expect(codes).toContain('importlib grailDir: /opt/grail');
-      expect(codes).toContain('CPythonShim libraryPath: /opt/py');
-    });
-
-    it('runs the init scripts again after an auto-reconnect', () => {
-      const session = new McpSession(makeConfig({
-        initScripts: ['importlib grailDir: /opt/grail'],
-      }));
-      mockGci.GciTsExecuteFetchBytes.mockClear();
-
-      // Trigger a dead-session error → reconnect → init scripts replayed.
-      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
-        data: '', bytesReturned: 0,
-        err: { ...noErr, fatal: 1, message: 'gem died' },
-      });
-      expect(() => session.executeFetchString('1 + 1')).toThrow(SessionRestartedError);
-
-      const replayedScripts = mockGci.GciTsExecuteFetchBytes.mock.calls
-        .map((c: unknown[]) => c[1])
-        .filter((s: unknown) => s === 'importlib grailDir: /opt/grail');
-      expect(replayedScripts).toHaveLength(1);
-    });
-
-    // Fail loud: if an init script doesn't compile/run, login fails — better
-    // than letting the session run in a half-primed state and surprising the
-    // user later.
-    it('throws if an init script fails', () => {
-      mockGci.GciTsExecuteFetchBytes.mockReturnValueOnce({
-        data: '', bytesReturned: 0,
-        err: { ...noErr, number: 1001, message: 'compile error: bad selector' },
-      });
-
-      expect(() => new McpSession(makeConfig({
-        initScripts: ['this does not compile'],
-      }))).toThrow(/init script 1 failed: compile error/);
     });
   });
 });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -2,7 +2,6 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import express from 'express';
 import * as net from 'net';
-import * as fs from 'fs';
 import { McpSession, McpSessionConfig } from './mcpSession';
 import { registerTools } from './tools';
 
@@ -20,27 +19,14 @@ export interface CliArgs {
   gemstone?: string;
   gemstoneGlobalDir?: string;
   hostUser?: string;
-  /**
-   * Paths to Smalltalk source files replayed after every login (including
-   * reconnects from a dead gem). Repeat `--session-init-script <path>` to
-   * register multiple — they run in argument order.
-   */
-  sessionInitScripts?: string[];
 }
 
 export function parseArgs(argv: string[]): CliArgs {
   const args = argv.slice(2);
   const result: Record<string, string> = {};
-  const sessionInitScripts: string[] = [];
   for (let i = 0; i < args.length - 1; i += 2) {
     const key = args[i].replace(/^--/, '');
-    const value = args[i + 1];
-    // Multi-valued: repeat `--session-init-script` to register more than one.
-    if (key === 'session-init-script') {
-      sessionInitScripts.push(value);
-    } else {
-      result[key] = value;
-    }
+    result[key] = args[i + 1];
   }
 
   // Proxy mode is inferred from --proxy-socket (transport=proxy is implicit).
@@ -75,26 +61,7 @@ export function parseArgs(argv: string[]): CliArgs {
     gemstone: result['gemstone'],
     gemstoneGlobalDir: result['gemstone-global-dir'],
     hostUser: result['host-user'],
-    sessionInitScripts: sessionInitScripts.length > 0 ? sessionInitScripts : undefined,
   };
-}
-
-// Read each --session-init-script path as the Smalltalk source we'll replay
-// after every login. Fail loud if the file is missing — silently skipping a
-// configured init script would defeat the purpose of having one. The reader
-// is injectable so tests don't need to fight Node's frozen-fs descriptors.
-export function readInitScripts(
-  paths: string[] | undefined,
-  read: (path: string) => string = (p) => fs.readFileSync(p, 'utf8'),
-): string[] {
-  if (!paths) return [];
-  return paths.map(p => {
-    try {
-      return read(p);
-    } catch (err) {
-      throw new Error(`Cannot read session-init-script ${p}: ${(err as Error).message}`);
-    }
-  });
 }
 
 export function createSessionConfig(args: CliArgs): McpSessionConfig {
@@ -109,7 +76,6 @@ export function createSessionConfig(args: CliArgs): McpSessionConfig {
     gsPassword: process.env.GS_PASSWORD || '',
     hostUser: args.hostUser,
     hostPassword: process.env.HOST_PASSWORD,
-    initScripts: readInitScripts(args.sessionInitScripts),
   };
 }
 

--- a/mcp-server/src/mcpSession.ts
+++ b/mcp-server/src/mcpSession.ts
@@ -1,4 +1,4 @@
-import { GciLibrary, GciError } from '../../client/src/gciLibrary';
+import { GciLibrary } from '../../client/src/gciLibrary';
 import { OOP_NIL, OOP_ILLEGAL } from '../../client/src/gciConstants';
 
 const MAX_RESULT = 256 * 1024;
@@ -11,43 +11,6 @@ export interface McpSessionConfig {
   gsPassword: string;
   hostUser?: string;
   hostPassword?: string;
-  /**
-   * Smalltalk source replayed after every login — including reconnects after
-   * the gem dies. Use for deterministic session setup (e.g. importlib
-   * grailDir:, CPythonShim libraryPath:) that the user otherwise has to
-   * re-paste manually after every crash.
-   */
-  initScripts?: string[];
-}
-
-/**
- * Thrown when an in-flight call detected a dead session, transparently
- * relogged in, and replayed the configured init scripts. The caller (or the
- * agent reading the tool error) should retry the request — any per-session
- * state set up beyond the init scripts is gone.
- */
-export class SessionRestartedError extends Error {
-  readonly previousStateLost = true;
-  constructor(public readonly underlying: string) {
-    super(
-      `session died, restarted: ${underlying}. ` +
-      'Previous session state was lost; init scripts were replayed. ' +
-      'Retry your request.',
-    );
-    this.name = 'SessionRestartedError';
-  }
-}
-
-// Detect a GCI error that means the gem is gone — broken pipe, fatal error,
-// or one of the textual markers GCI surfaces when the netConnection is dead.
-// We're deliberately liberal: false positives just trigger a fresh login,
-// which is cheap relative to the alternative of surfacing an unrecoverable
-// error to the agent.
-const DEAD_SESSION_MARKERS = /netConnection|GemFatal|gem ?process|session ?not ?valid|not ?logged ?in/i;
-
-export function isDeadSessionError(err: GciError): boolean {
-  if (err.fatal !== 0) return true;
-  return DEAD_SESSION_MARKERS.test(err.message || '');
 }
 
 export class McpSession {
@@ -55,16 +18,8 @@ export class McpSession {
   private handle: unknown;
   private classUtf8Oop: bigint | undefined;
 
-  constructor(private readonly config: McpSessionConfig) {
+  constructor(config: McpSessionConfig) {
     this.gci = new GciLibrary(config.libraryPath);
-    this.login();
-  }
-
-  // Perform a fresh login and (re)run init scripts. Called from the
-  // constructor and from executeFetchString on a detected dead session.
-  // Throws on login failure; the caller decides how to surface that.
-  private login(): void {
-    const { config } = this;
     const result = this.gci.GciTsLogin(
       config.stoneNrs,
       config.hostUser || null,
@@ -79,27 +34,9 @@ export class McpSession {
       throw new Error(result.err.message || `Login failed (error ${result.err.number})`);
     }
     this.handle = result.session;
-    // Utf8 OOPs are session-scoped — invalidate the cache so the next call
-    // re-resolves against the new gem.
-    this.classUtf8Oop = undefined;
-    this.runInitScripts();
   }
 
-  private runInitScripts(): void {
-    const scripts = this.config.initScripts ?? [];
-    for (let i = 0; i < scripts.length; i++) {
-      const script = scripts[i];
-      const oop = this.resolveClassUtf8OrThrow();
-      const { err } = this.gci.GciTsExecuteFetchBytes(
-        this.handle, script, -1, oop, OOP_ILLEGAL, OOP_NIL, MAX_RESULT,
-      );
-      if (err.number !== 0) {
-        throw new Error(`init script ${i + 1} failed: ${err.message || `GCI error ${err.number}`}`);
-      }
-    }
-  }
-
-  private resolveClassUtf8OrThrow(): bigint {
+  private resolveClassUtf8(): bigint {
     if (this.classUtf8Oop !== undefined) return this.classUtf8Oop;
     const { result, err } = this.gci.GciTsResolveSymbol(this.handle, 'Utf8', OOP_NIL);
     if (err.number !== 0) {
@@ -110,41 +47,20 @@ export class McpSession {
   }
 
   executeFetchString(code: string): string {
-    // Lazy-resolve the Utf8 class OOP; cached across calls and cleared on
-    // reconnect. Surface dead-session errors from the resolve step the same
-    // way as from execute.
-    if (this.classUtf8Oop === undefined) {
-      const r = this.gci.GciTsResolveSymbol(this.handle, 'Utf8', OOP_NIL);
-      if (r.err.number !== 0 || r.err.fatal !== 0) this.handleErrOrReconnect(r.err);
-      this.classUtf8Oop = r.result;
-    }
+    const oopClassUtf8 = this.resolveClassUtf8();
     const { data, err } = this.gci.GciTsExecuteFetchBytes(
-      this.handle, code, -1, this.classUtf8Oop, OOP_ILLEGAL, OOP_NIL, MAX_RESULT,
+      this.handle,
+      code,
+      -1,
+      oopClassUtf8,
+      OOP_ILLEGAL,
+      OOP_NIL,
+      MAX_RESULT,
     );
-    // Check fatal in addition to number — a broken-pipe / dead-gem signal can
-    // arrive with fatal=1 and number=0 (transport-level failure, not a
-    // Smalltalk error). Skipping fatal here would mask the very condition we
-    // need to detect for auto-reconnect.
-    if (err.number !== 0 || err.fatal !== 0) this.handleErrOrReconnect(err);
-    return data;
-  }
-
-  // Either throw a plain error for normal GCI failures (MNU, ZeroDivide,
-  // etc.) or, when the error indicates the gem is gone, transparently
-  // relog in and throw SessionRestartedError so the caller can retry.
-  private handleErrOrReconnect(err: GciError): never {
-    if (isDeadSessionError(err)) {
-      const original = err.message || `GCI error ${err.number}`;
-      try {
-        this.login();
-      } catch (loginErr) {
-        throw new Error(
-          `session died (${original}); reconnect failed: ${(loginErr as Error).message}`,
-        );
-      }
-      throw new SessionRestartedError(original);
+    if (err.number !== 0) {
+      throw new Error(err.message || `GCI error ${err.number}`);
     }
-    throw new Error(err.message || `GCI error ${err.number}`);
+    return data;
   }
 
   logout(): void {


### PR DESCRIPTION
## Summary

[ad290c6](https://github.com/jgfoster/Jasper/commit/ad290c6c6f850c6ec5c7e69b9b9d76e0c055ab7a) bundled three changes; the auto-reconnect (#1) and session-init-script replay (#6) only apply to the standalone stdio/sse mode that real MCP clients (Claude Code, Claude Desktop) don't use — they connect via proxy mode, where the session lives in Jasper's extension host. Init-scripts as MCP-client-driven config also doesn't really fit: the client has no way to know what state to prime.

Ship-smallest-first: keep #3, the AlmostOutOfStack / AbstractException guard, which lives in the Smalltalk source the tools emit and therefore applies in both proxy and standalone mode. Watch whether disconnects drop with that alone before building proxy-mode reconnect.

This restores `mcp-server/src/mcpSession.ts`, `mcp-server/src/__tests__/mcpSession.test.ts`, `mcp-server/src/index.ts`, and `mcp-server/src/__tests__/index.test.ts` to their pre-ad290c6 state. #3 (`client/src/queries/executeCode.ts`, the python.ts inner handler, and the wire-up in both surfaces' tool dispatch) is untouched.

## Test plan

- [x] `npm run test:mcp` — 95 passing (down from 111; the 16 dropped tests cover the reverted #1/#6 behaviour)
- [x] `npm run test:client` — 1248 passing
- [x] `npm run test:server` — 320 passing
- [x] `npm run compile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)