### PR TITLE
Don't close tabs on session actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ### Changed
 
-  - Use a modal dialog when asking whether to debug an error raised during Display It, Inspect It, or Execute It. This prevents workspaces from becoming stuck in the executing state if the prompt is not answered. 
+  - Use a modal dialog when asking whether to debug an error raised during Display It, Inspect It, or Execute It. This prevents workspaces from becoming stuck in the executing state if the prompt is not answered.
+  - Preserve open tabs across session actions (commit, abort or logout) to avoid altering the user’s workspace and to respect their tab selection.
 
 ### Fixed
 

--- a/client/src/__tests__/editorContextMenu.test.ts
+++ b/client/src/__tests__/editorContextMenu.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const pkgPath = path.resolve(__dirname, '..', '..', '..', 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+interface MenuItem {
+  command: string;
+  when: string;
+  group: string;
+}
+
+const editorContext: MenuItem[] = pkg.contributes.menus['editor/context'];
+
+function getMenuItem(command: string): MenuItem | undefined {
+  return editorContext.find((item) => item.command === command);
+}
+
+describe('editor/context menu', () => {
+  it('shows exactly six GemStone actions in the editor context menu', () => {
+    expect(editorContext).toHaveLength(6);
+  });
+
+  it('shows "Display It" only in gemstone documents when code execution is available', () => {
+    expect(getMenuItem('gemstone.displayIt')?.when)
+      .toBe('editorTextFocus && resourceScheme == gemstone && !gemstone.executing');
+  });
+
+  it('shows "Inspect It" only in gemstone documents when code execution is available', () => {
+    expect(getMenuItem('gemstone.inspectIt')?.when)
+      .toBe('editorTextFocus && resourceScheme == gemstone && !gemstone.executing');
+  });
+
+  it('shows "Execute It" only in gemstone documents when code execution is available', () => {
+    expect(getMenuItem('gemstone.executeIt')?.when)
+      .toBe('editorTextFocus && resourceScheme == gemstone && !gemstone.executing');
+  });
+
+  it('shows "Senders Of..." only in gemstone documents', () => {
+    expect(getMenuItem('gemstone.sendersOf')?.when)
+      .toBe('editorTextFocus && resourceScheme == gemstone');
+  });
+
+  it('shows "Implementors Of..." only in gemstone documents', () => {
+    expect(getMenuItem('gemstone.implementorsOf')?.when)
+      .toBe('editorTextFocus && resourceScheme == gemstone');
+  });
+
+  it('shows "Toggle Selector Breakpoint" only in gemstone documents', () => {
+    expect(getMenuItem('gemstone.toggleSelectorBreakpoint')?.when)
+      .toBe('editorTextFocus && resourceScheme == gemstone');
+  });
+});

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -333,64 +333,6 @@ describe('GemStoneFileSystemProvider', () => {
     });
   });
 
-  describe('closeTabsForSession', () => {
-    beforeEach(() => {
-      (window.tabGroups.all as unknown[]).length = 0;
-    });
-
-    it('closes tabs belonging to the given session', () => {
-      const tab1 = { input: { uri: Uri.parse('gemstone://1/Globals/Array/instance/accessing/size') } };
-      const tab2 = { input: { uri: Uri.parse('gemstone://1/UserGlobals/MyClass/instance/init/initialize') } };
-      (window.tabGroups.all as unknown[]).push({ tabs: [tab1, tab2] });
-
-      provider.closeTabsForSession(1);
-
-      expect(window.tabGroups.close).toHaveBeenCalledWith(tab1);
-      expect(window.tabGroups.close).toHaveBeenCalledWith(tab2);
-      expect(window.tabGroups.close).toHaveBeenCalledTimes(2);
-    });
-
-    it('does not close tabs belonging to a different session', () => {
-      const tab1 = { input: { uri: Uri.parse('gemstone://1/Globals/Array/instance/accessing/size') } };
-      const tab2 = { input: { uri: Uri.parse('gemstone://2/Globals/Array/instance/accessing/size') } };
-      (window.tabGroups.all as unknown[]).push({ tabs: [tab1, tab2] });
-
-      provider.closeTabsForSession(1);
-
-      expect(window.tabGroups.close).toHaveBeenCalledWith(tab1);
-      expect(window.tabGroups.close).not.toHaveBeenCalledWith(tab2);
-      expect(window.tabGroups.close).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not close non-gemstone tabs', () => {
-      const tab1 = { input: { uri: Uri.parse('file:///path/to/file.gs') } };
-      (window.tabGroups.all as unknown[]).push({ tabs: [tab1] });
-
-      provider.closeTabsForSession(1);
-
-      expect(window.tabGroups.close).not.toHaveBeenCalled();
-    });
-
-    it('handles tabs without a URI input gracefully', () => {
-      const tab1 = { input: undefined };
-      const tab2 = { input: {} };
-      (window.tabGroups.all as unknown[]).push({ tabs: [tab1, tab2] });
-
-      expect(() => provider.closeTabsForSession(1)).not.toThrow();
-      expect(window.tabGroups.close).not.toHaveBeenCalled();
-    });
-
-    it('searches across multiple tab groups', () => {
-      const tab1 = { input: { uri: Uri.parse('gemstone://1/Globals/Array/instance/accessing/size') } };
-      const tab2 = { input: { uri: Uri.parse('gemstone://1/UserGlobals/MyClass/instance/init/initialize') } };
-      (window.tabGroups.all as unknown[]).push({ tabs: [tab1] }, { tabs: [tab2] });
-
-      provider.closeTabsForSession(1);
-
-      expect(window.tabGroups.close).toHaveBeenCalledTimes(2);
-    });
-  });
-
   describe('workspace', () => {
     const workspaceUri = Uri.parse('gemstone://1/Workspace');
     const encode = (s: string) => new TextEncoder().encode(s);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -668,7 +668,6 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage(
             `Session ${item.activeSession.id}: Commit succeeded.`
           );
-          gemstoneFs.closeTabsForSession(item.activeSession.id);
           await exportManager.refreshSession(item.activeSession);
           SystemBrowser.refresh(item.activeSession.id);
         } else {
@@ -697,7 +696,6 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage(
             `Session ${item.activeSession.id}: Abort succeeded.`
           );
-          gemstoneFs.closeTabsForSession(item.activeSession.id);
           await exportManager.refreshSession(item.activeSession);
           SystemBrowser.refresh(item.activeSession.id);
         } else {
@@ -725,7 +723,6 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage('No GemStone session to log out of.');
         return;
       }
-      gemstoneFs.closeTabsForSession(session.id);
       exportManager.deleteSessionFiles(session);
       SystemBrowser.disposeForSession(session.id);
       GlobalsBrowser.disposeForSession(session.id);

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -283,21 +283,6 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     }
   }
 
-  /**
-   * Close all open editor tabs for a given session (scheme: gemstone, authority: sessionId).
-   */
-  closeTabsForSession(sessionId: number): void {
-    const auth = String(sessionId);
-    for (const group of vscode.window.tabGroups.all) {
-      for (const tab of group.tabs) {
-        const input = tab.input as { uri?: vscode.Uri } | undefined;
-        if (input?.uri?.scheme === 'gemstone' && input.uri.authority === auth) {
-          vscode.window.tabGroups.close(tab);
-        }
-      }
-    }
-  }
-
   createDirectory(): void {
     throw vscode.FileSystemError.NoPermissions('Cannot create directories');
   }

--- a/package.json
+++ b/package.json
@@ -911,32 +911,32 @@
       "editor/context": [
         {
           "command": "gemstone.displayIt",
-          "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing",
+          "when": "editorTextFocus && resourceScheme == gemstone && !gemstone.executing",
           "group": "1_modification@0"
         },
         {
           "command": "gemstone.inspectIt",
-          "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing",
+          "when": "editorTextFocus && resourceScheme == gemstone && !gemstone.executing",
           "group": "1_modification@1"
         },
         {
           "command": "gemstone.executeIt",
-          "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing",
+          "when": "editorTextFocus && resourceScheme == gemstone && !gemstone.executing",
           "group": "1_modification@2"
         },
         {
           "command": "gemstone.sendersOf",
-          "when": "editorTextFocus && gemstone.hasActiveSession",
+          "when": "editorTextFocus && resourceScheme == gemstone",
           "group": "2_navigation@0"
         },
         {
           "command": "gemstone.implementorsOf",
-          "when": "editorTextFocus && gemstone.hasActiveSession",
+          "when": "editorTextFocus && resourceScheme == gemstone",
           "group": "2_navigation@1"
         },
         {
           "command": "gemstone.toggleSelectorBreakpoint",
-          "when": "editorTextFocus && gemstone.hasActiveSession && resourceScheme == gemstone",
+          "when": "editorTextFocus && resourceScheme == gemstone",
           "group": "3_gemstoneBreakpoints@0"
         }
       ]


### PR DESCRIPTION
Previously, tabs were closed whenever a session was committed, aborted, or ended.

Preserve open tabs across session actions to avoid altering the user’s workspace and to respect their tab selection.

The workspace commands (Display It, etc) are always displayed. We already had code in place to display an error message when one is executed without a session.

Closes #77 