### PR TITLE
Use a modal dialog when asking users to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Changed
+
+  - Use a modal dialog when asking whether to debug an error raised during Display It, Inspect It, or Execute It. This prevents workspaces from becoming stuck in the executing state if the prompt is not answered. 
+
 ### Fixed
 
 - **Databases panel running/stopped indicators are now tied to the correct version.** With two versions installed (e.g. 3.6.2 and 3.7.5) that share a stone/NetLDI name, starting one stone lit up the Stone/NetLDI nodes under *both* versions — and trying to stop the wrong one failed with an incompatible-version error. `ProcessManager.isStoneRunning` / `isNetldiRunning` now match the gslist process version against the database's configured version (`versionsMatch`, prefix-tolerant so a gslist `3.7.4` still matches a `3.7.4.3` install), so each database reflects only its own running processes. The same version guard is applied to the delete / replace-extent safety checks.

--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -652,6 +652,107 @@ describe('CodeExecutor', () => {
     });
   });
 
+  // ── Debuggable error dialog must be modal ──────────────────
+  //
+  // When execution raises a DebuggableError, we prompt the user with a
+  // "Debug" / "Dismiss" choice. That prompt MUST be modal — a non-modal
+  // toast would be easy to miss and would let the stalled GemStone process
+  // linger unnoticed. These tests guard the `{ modal: true }` option.
+
+  describe('debuggable error dialog is modal', () => {
+    function debuggableGci() {
+      // Non-nil context (≠ OOP_NIL) makes fetchResultOop throw a DebuggableError.
+      return makeGci({
+        GciTsNbResult: vi.fn(() => ({
+          result: 0x01n,
+          err: {
+            number: 2003,
+            message: 'a UndefinedObject does not understand #foo',
+            context: 0x123n,
+          },
+        })),
+      });
+    }
+
+    /** The options object passed as the 2nd arg of the most recent showErrorMessage call. */
+    function lastErrorMessageOptions() {
+      const calls = vi.mocked(vscode.window.showErrorMessage).mock.calls;
+      return calls[calls.length - 1][1] as { modal?: boolean } | undefined;
+    }
+
+    it('shows a modal dialog when Execute It raises a DebuggableError', async () => {
+      gci = debuggableGci();
+      session = makeSession(gci);
+      executor = new CodeExecutor(makeSessionManager(session));
+
+      const editor = makeEditor('nil foo');
+      setActiveEditor(editor);
+
+      await executor.executeIt();
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalled();
+      expect(lastErrorMessageOptions()).toEqual({ modal: true });
+    });
+
+    it('offers Debug and Dismiss in the modal dialog on Execute It', async () => {
+      gci = debuggableGci();
+      session = makeSession(gci);
+      executor = new CodeExecutor(makeSessionManager(session));
+
+      const editor = makeEditor('nil foo');
+      setActiveEditor(editor);
+
+      await executor.executeIt();
+
+      const calls = vi.mocked(vscode.window.showErrorMessage).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall.slice(2)).toEqual(['Debug', 'Dismiss']);
+    });
+
+    it('shows a modal dialog when Inspect It raises a DebuggableError', async () => {
+      gci = debuggableGci();
+      session = makeSession(gci);
+      executor = new CodeExecutor(makeSessionManager(session));
+
+      const editor = makeEditor('nil foo');
+      setActiveEditor(editor);
+
+      const inspectorProvider = {
+        addRoot: vi.fn(),
+        findRootByLabel: vi.fn(),
+      };
+
+      await executor.inspectIt(
+        inspectorProvider as unknown as import('../inspectorTreeProvider').InspectorTreeProvider,
+      );
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalled();
+      expect(lastErrorMessageOptions()).toEqual({ modal: true });
+    });
+
+    it('offers Debug and Dismiss in the modal dialog on Inspect It', async () => {
+      gci = debuggableGci();
+      session = makeSession(gci);
+      executor = new CodeExecutor(makeSessionManager(session));
+
+      const editor = makeEditor('nil foo');
+      setActiveEditor(editor);
+
+      const inspectorProvider = {
+        addRoot: vi.fn(),
+        findRootByLabel: vi.fn(),
+      };
+
+      await executor.inspectIt(
+        inspectorProvider as unknown as import('../inspectorTreeProvider').InspectorTreeProvider,
+      );
+
+      const calls = vi.mocked(vscode.window.showErrorMessage).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall.slice(2)).toEqual(['Debug', 'Dismiss']);
+    });
+  });
+
   // ── Result polling: GciTsNbPoll (3.7+) vs GciTsSocket fallback (3.6.2) ──
 
   describe('result polling fallback for GemStone 3.6.2', () => {

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -188,7 +188,7 @@ export class CodeExecutor {
         // Try to show as inline diagnostic first; fall back to debug dialog
         this.showCompileError(editor, selection, code, codeOffset, msg);
         const choice = await vscode.window.showErrorMessage(
-          `GemStone error: ${msg}`, 'Debug', 'Dismiss',
+          `GemStone error: ${msg}`, { modal: true },'Debug', 'Dismiss',
         );
         if (choice === 'Debug') {
           vscode.debug.startDebugging(undefined, {
@@ -606,7 +606,7 @@ __t`;
 
       if (e instanceof DebuggableError) {
         const choice = await vscode.window.showErrorMessage(
-          `GemStone error: ${msg}`, 'Debug', 'Dismiss',
+          `GemStone error: ${msg}`, { modal: true },'Debug', 'Dismiss',
         );
         if (choice === 'Debug') {
           vscode.debug.startDebugging(undefined, {


### PR DESCRIPTION
Previously, the debug prompt was non-modal. While the prompt was open, the editor remained in the executing state, causing menu items to stay disabled until the user made a choice.

Make the prompt modal so users must explicitly choose whether to start debugging before interacting with the editor, preventing inconsistent UI state.

TODO: I'll remove the duplicated code to debug an expression in a follow-up pr.

Closes #68 

https://github.com/user-attachments/assets/d70f51b1-d7d3-4d98-b405-625b3e1d6bc6

