### PR TITLE
Don’t reload stale methods on class navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 ### Fixed
 
 - **Databases panel running/stopped indicators are now tied to the correct version.** With two versions installed (e.g. 3.6.2 and 3.7.5) that share a stone/NetLDI name, starting one stone lit up the Stone/NetLDI nodes under *both* versions — and trying to stop the wrong one failed with an incompatible-version error. `ProcessManager.isStoneRunning` / `isNetldiRunning` now match the gslist process version against the database's configured version (`versionsMatch`, prefix-tolerant so a gslist `3.7.4` still matches a `3.7.4.3` install), so each database reflects only its own running processes. The same version guard is applied to the delete / replace-extent safety checks.
+- Ensure the method list is refreshed correctly when navigating between classes, preventing methods from a previously selected class from being shown.
 
 ## [1.5.3] - 2026-05-31
 

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -1664,11 +1664,11 @@ describe('SystemBrowser', () => {
       );
     });
 
-    it('posts loadMethodCategories with no selected method', () => {
+    it('clears the method list', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       SystemBrowser.navigateToClass(session.id, 'UserGlobals', 'Array');
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ command: 'loadMethods', selected: null }),
+        { command: 'loadMethods', items: [], selected: null },
       );
     });
 

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -783,7 +783,7 @@ export class SystemBrowser {
     });
     this.panel.webview.postMessage({
       command: 'loadMethods',
-      items: this.state.methods,
+      items: [],
       selected: null,
     });
   }


### PR DESCRIPTION
When browsing a class’s methods and navigating to a different class, the method list continued to display methods from the previously selected class.

This bug was caused by sending a stale method list from the system browser to the view when the new class was selected.

It was fixed by preventing stale method lists from being sent to the view. The view already clears its method list when the method category is refreshed, so no additional handling is required at the view level.

The following capture shows the new behavior: a class's methods are browsed and then the user navigates to another class. It shows that the previous class's methods are no longer displayed.

https://github.com/user-attachments/assets/954ce789-e88a-4259-96a5-73fe33437c62

