### PR TITLE
Fix hierarchy view crash on GemStone 3.6.8

### DIFF
--- a/client/src/queries/getClassHierarchy.ts
+++ b/client/src/queries/getClassHierarchy.ts
@@ -10,6 +10,12 @@ export interface ClassHierarchyEntry {
 export function getClassHierarchy(
   execute: QueryExecutor, className: string,
 ): ClassHierarchyEntry[] {
+  /**
+   * In the Smalltalk code below, allSuperclassesOf: returns root-first ([Object, Collection, ...]),
+   *  which is the order we want to render — Object at indent 0, the
+   *  immediate parent right above the selected class. The earlier
+   *  reverseDo: flipped it leaf-first and put Object at the deepest indent.
+   */
   const code = `| organizer class supers subs stream classDict sl |
 organizer := ClassOrganizer new.
 class := System myUserProfile symbolList objectNamed: #'${escapeString(className)}'.
@@ -22,10 +28,6 @@ sl do: [:dict |
     (v isBehavior and: [(classDict includesKey: v) not])
       ifTrue: [classDict at: v put: dict name]]].
 stream := WriteStream on: Unicode7 new.
-"allSuperclassesOf: returns root-first ([Object, Collection, ...]),
- which is the order we want to render — Object at indent 0, the
- immediate parent right above the selected class. The earlier
- reverseDo: flipped it leaf-first and put Object at the deepest indent."
 supers do: [:each |
   stream nextPutAll: (classDict at: each ifAbsent: ['']); tab;
     nextPutAll: each name; tab; nextPutAll: 'superclass'; lf].


### PR DESCRIPTION
Fix hierarchy view crash on GemStone 3.6.8

A development comment embedded in the Smalltalk source string contained
an em dash, triggering a compiler cursor bug (error 1001) in GemStone
3.6.8 that made the hierarchy view empty for those versions.

With the current changes, the view hierarchy was verified to work fine in versions: 
* 3.6.1
* 3.6.2
* 3.6.3
* 3.6.4
* 3.6.5
* 3.6.6
* 3.6.8
* 3.7.0
* 3.7.1
* 3.7.2
* 3.7.4.1
* 3.7.5