### PR TITLE
Open workspaces as regular editable files

### DIFF
--- a/client/src/__tests__/editorContextMenu.test.ts
+++ b/client/src/__tests__/editorContextMenu.test.ts
@@ -22,33 +22,33 @@ describe('editor/context menu', () => {
     expect(editorContext).toHaveLength(6);
   });
 
-  it('shows "Display It" only in gemstone documents when code execution is available', () => {
+  it('shows "Display It" in gemstone documents when code execution is available', () => {
     expect(getMenuItem('gemstone.displayIt')?.when)
-      .toBe('editorTextFocus && resourceScheme == gemstone && !gemstone.executing');
+      .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing`);
   });
 
-  it('shows "Inspect It" only in gemstone documents when code execution is available', () => {
+  it('shows "Inspect It" in gemstone documents when code execution is available', () => {
     expect(getMenuItem('gemstone.inspectIt')?.when)
-      .toBe('editorTextFocus && resourceScheme == gemstone && !gemstone.executing');
+      .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing`);
   });
 
-  it('shows "Execute It" only in gemstone documents when code execution is available', () => {
+  it('shows "Execute It" in gemstone documents when code execution is available', () => {
     expect(getMenuItem('gemstone.executeIt')?.when)
-      .toBe('editorTextFocus && resourceScheme == gemstone && !gemstone.executing');
+      .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing`);
   });
 
-  it('shows "Senders Of..." only in gemstone documents', () => {
+  it('shows "Senders Of..." in gemstone documents', () => {
     expect(getMenuItem('gemstone.sendersOf')?.when)
-      .toBe('editorTextFocus && resourceScheme == gemstone');
+      .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk`);
   });
 
-  it('shows "Implementors Of..." only in gemstone documents', () => {
+  it('shows "Implementors Of..." in gemstone documents', () => {
     expect(getMenuItem('gemstone.implementorsOf')?.when)
-      .toBe('editorTextFocus && resourceScheme == gemstone');
+      .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk`);
   });
 
-  it('shows "Toggle Selector Breakpoint" only in gemstone documents', () => {
+  it('shows "Toggle Selector Breakpoint" in gemstone documents', () => {
     expect(getMenuItem('gemstone.toggleSelectorBreakpoint')?.when)
-      .toBe('editorTextFocus && resourceScheme == gemstone');
+      .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk`);
   });
 });

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -21,7 +21,7 @@ vi.mock('../browserQueries', () => ({
 }));
 
 import { Uri, FileSystemError, FilePermission, window, languages } from '../__mocks__/vscode';
-import { GemStoneFileSystemProvider, WORKSPACE_TEMPLATE } from '../gemstoneFileSystemProvider';
+import { GemStoneFileSystemProvider } from '../gemstoneFileSystemProvider';
 import { SessionManager } from '../sessionManager';
 import * as queries from '../browserQueries';
 import { BrowserQueryError } from '../browserQueries';
@@ -365,52 +365,6 @@ describe('GemStoneFileSystemProvider', () => {
       expect(() => {
         provider.writeFile(uri, encode('bad code'), { create: false, overwrite: true });
       }).toThrow('Unexpected internal error');
-    });
-  });
-
-  describe('workspace', () => {
-    const workspaceUri = Uri.parse('gemstone://1/Workspace');
-    const encode = (s: string) => new TextEncoder().encode(s);
-
-    it('stat returns writable without checking canClassBeWritten', () => {
-      const stat = provider.stat(workspaceUri);
-      expect(stat.permissions).toBeUndefined();
-      expect(queries.canClassBeWritten).not.toHaveBeenCalled();
-    });
-
-    it('readFile returns workspace template on first read', () => {
-      const content = new TextDecoder().decode(provider.readFile(workspaceUri));
-      expect(content).toBe(WORKSPACE_TEMPLATE);
-    });
-
-    it('readFile returns saved content after writeFile', () => {
-      const edited = '"Workspace"\n3 + 4';
-      provider.writeFile(workspaceUri, encode(edited), { create: false, overwrite: true });
-      const content = new TextDecoder().decode(provider.readFile(workspaceUri));
-      expect(content).toBe(edited);
-    });
-
-    it('writeFile does not call any GemStone queries', () => {
-      provider.writeFile(workspaceUri, encode('anything'), { create: false, overwrite: true });
-      expect(queries.compileMethod).not.toHaveBeenCalled();
-      expect(queries.compileClassDefinition).not.toHaveBeenCalled();
-      expect(queries.setClassComment).not.toHaveBeenCalled();
-    });
-
-    it('workspace content is per-session', () => {
-      const session2 = makeSession(2);
-      const mgr = {
-        getSessions: vi.fn(() => [makeSession(1), session2]),
-        getSession: vi.fn((id: number) => id === 2 ? session2 : makeSession(1)),
-      } as unknown as SessionManager;
-      const p = new GemStoneFileSystemProvider(mgr);
-
-      const uri1 = Uri.parse('gemstone://1/Workspace');
-      const uri2 = Uri.parse('gemstone://2/Workspace');
-      p.writeFile(uri1, encode('session 1 content'), { create: false, overwrite: true });
-
-      expect(new TextDecoder().decode(p.readFile(uri1))).toBe('session 1 content');
-      expect(new TextDecoder().decode(p.readFile(uri2))).toBe(WORKSPACE_TEMPLATE);
     });
   });
 

--- a/client/src/__tests__/openWorkspace.test.ts
+++ b/client/src/__tests__/openWorkspace.test.ts
@@ -4,47 +4,35 @@ vi.mock('vscode', () => import('../__mocks__/vscode'));
 vi.mock('../gciLog', () => ({ logInfo: vi.fn() }));
 
 import { workspace, window } from '../__mocks__/vscode';
-import { openWorkspace } from '../workspace';
-
-// openWorkspace imports vscode internally, so the mock is already wired up
+import {openWorkspace, WORKSPACE_TEMPLATE} from '../workspace';
 
 describe('openWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (workspace.textDocuments as unknown[]).length = 0;
   });
 
-  it('opens a gemstone://sessionId/Workspace document', async () => {
-    await openWorkspace(1);
+  it('opens a gemstone-smalltalk document', async () => {
+    await openWorkspace();
+    
     expect(workspace.openTextDocument).toHaveBeenCalledWith(
-      expect.objectContaining({ scheme: 'gemstone', authority: '1', path: '/Workspace' }),
+      { content: WORKSPACE_TEMPLATE, language: 'gemstone-smalltalk' },
     );
   });
 
   it('shows the document with preview disabled', async () => {
-    await openWorkspace(1);
+    await openWorkspace();
+    
     expect(window.showTextDocument).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ preview: false }),
     );
   });
 
-  it('does not open if workspace document is already open', async () => {
-    (workspace.textDocuments as unknown[]).push({
-      uri: { toString: () => 'gemstone://1/Workspace' },
-    });
-    await openWorkspace(1);
-    expect(workspace.openTextDocument).not.toHaveBeenCalled();
-    expect(window.showTextDocument).not.toHaveBeenCalled();
-  });
-
-  it('opens a new workspace for a different session', async () => {
-    (workspace.textDocuments as unknown[]).push({
-      uri: { toString: () => 'gemstone://1/Workspace' },
-    });
-    await openWorkspace(2);
-    expect(workspace.openTextDocument).toHaveBeenCalledWith(
-      expect.objectContaining({ authority: '2' }),
-    );
+  it('opens a new workspace document each time it is called', async () => {
+    await openWorkspace();
+    
+    await openWorkspace();
+    
+    expect(workspace.openTextDocument).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -238,6 +238,8 @@ export function activate(context: vscode.ExtensionContext) {
   // ── GCI-backed providers (Definition + Hover + Completion) ─
   const providerSelectors: vscode.DocumentFilter[] = [
     { scheme: 'gemstone', language: 'gemstone-smalltalk' },
+    { scheme: 'untitled', language: 'gemstone-smalltalk' },
+    { scheme: 'file', language: 'gemstone-smalltalk' },
     { scheme: 'file', language: 'gemstone-topaz' },
     { scheme: 'file', language: 'gemstone-tonel' },
   ];
@@ -650,7 +652,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage(`Login failed: ${msg}`);
         return;
       }
-      await openWorkspace(session.id);
+      await openWorkspace();
     }),
 
     vscode.commands.registerCommand('gemstone.sessionCommit', async (item: GemStoneSessionItem) => {

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -6,7 +6,6 @@ import { ExportManager } from './exportManager';
 import { logInfo } from './gciLog';
 
 // ── URI Structure ────────────────────────────────────────────
-// Workspace:  gemstone://{sessionId}/Workspace
 // Method:     gemstone://{sessionId}/{dictName}/{className}/{side}/{category}/{selector}
 // Definition: gemstone://{sessionId}/{dictName}/{className}/definition
 // Comment:    gemstone://{sessionId}/{dictName}/{className}/comment
@@ -55,12 +54,7 @@ interface ParsedNewMethodUri {
   environmentId: number;
 }
 
-interface ParsedWorkspaceUri {
-  kind: 'workspace';
-  sessionId: number;
-}
-
-type ParsedUri = ParsedMethodUri | ParsedDefinitionUri | ParsedCommentUri | ParsedNewClassUri | ParsedNewMethodUri | ParsedWorkspaceUri;
+type ParsedUri = ParsedMethodUri | ParsedDefinitionUri | ParsedCommentUri | ParsedNewClassUri | ParsedNewMethodUri;
 
 function parseUri(uri: vscode.Uri): ParsedUri {
   const sessionId = parseInt(uri.authority, 10);
@@ -71,9 +65,6 @@ function parseUri(uri: vscode.Uri): ParsedUri {
   const envMatch = uri.query?.match(/env=(\d+)/);
   const environmentId = envMatch ? parseInt(envMatch[1], 10) : 0;
 
-  if (parts.length === 2 && parts[1] === 'Workspace') {
-    return { kind: 'workspace', sessionId };
-  }
   if (parts.length === 3 && parts[2] === 'new-class') {
     const catMatch = uri.query?.match(/category=([^&]+)/);
     const category = catMatch ? decodeURIComponent(catMatch[1]) : undefined;
@@ -113,16 +104,11 @@ function parseUri(uri: vscode.Uri): ParsedUri {
 
 // ── FileSystemProvider ────────────────────────────────────────
 
-const MOD_KEY = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
-export const WORKSPACE_TEMPLATE =
-  `"Workspace\nPlace cursor anywhere on a line with code\nand press [<${MOD_KEY}>+<K> followed by <D>]\n(note that this is a two-keypress chord) to display"\n6 * 7\n`;
-
 export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
   private _onDidChangeFile = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
   readonly onDidChangeFile = this._onDidChangeFile.event;
 
   private diagnostics = vscode.languages.createDiagnosticCollection('gemstone-method');
-  private workspaceContents = new Map<number, Uint8Array>();
 
   constructor(
     private sessionManager: SessionManager,
@@ -142,8 +128,8 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
       size: 0,
     };
     const parsed = parseUri(uri);
-    // Workspaces and new documents are always writable — no existing class to check
-    if (parsed.kind === 'workspace' || parsed.kind === 'new-class' || parsed.kind === 'new-method') return stat;
+    // New documents are always writable — no existing class to check
+    if (parsed.kind === 'new-class' || parsed.kind === 'new-method') return stat;
     const session = this.sessionManager.getSession(parsed.sessionId);
     if (!session) return stat;
     try {
@@ -163,11 +149,6 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
 
   readFile(uri: vscode.Uri): Uint8Array {
     const parsed = parseUri(uri);
-
-    if (parsed.kind === 'workspace') {
-      return this.workspaceContents.get(parsed.sessionId)
-        ?? new TextEncoder().encode(WORKSPACE_TEMPLATE);
-    }
 
     if (parsed.kind === 'new-class') {
       const categoryLine = parsed.category ? `\n  category: '${parsed.category}'` : '';
@@ -216,13 +197,6 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
   ): void {
     logInfo(`[FS] writeFile ${uri.toString()} (${content.length} bytes)`);
     const parsed = parseUri(uri);
-
-    if (parsed.kind === 'workspace') {
-      this.workspaceContents.set(parsed.sessionId, content);
-      this._onDidChangeFile.fire([{ type: vscode.FileChangeType.Changed, uri }]);
-      return;
-    }
-
     const session = this.getSession(parsed.sessionId);
     const source = new TextDecoder().decode(content);
 

--- a/client/src/workspace.ts
+++ b/client/src/workspace.ts
@@ -1,20 +1,16 @@
 import * as vscode from 'vscode';
 import { logInfo } from './gciLog';
 
-export async function openWorkspace(sessionId: number): Promise<void> {
-  const uri = vscode.Uri.parse(`gemstone://${sessionId}/Workspace`);
-  const uriString = uri.toString();
-  logInfo(`[Workspace] opening ${uriString}`);
-  const alreadyOpen = vscode.workspace.textDocuments.some(
-    doc => doc.uri.toString() === uriString,
-  );
-  if (alreadyOpen) {
-    logInfo('[Workspace] already open, skipping');
-    return;
-  }
+const MOD_KEY = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
+
+export const WORKSPACE_TEMPLATE =
+    `"Workspace\nPlace cursor anywhere on a line with code\nand press [<${MOD_KEY}>+<K> followed by <D>]\n(note that this is a two-keypress chord) to display"\n6 * 7\n`;
+
+export async function openWorkspace(): Promise<void> {
+  logInfo('[Workspace] opening new workspace document');
   try {
-    const doc = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(doc, { preview: false });
+    const workspaceDocument = await vscode.workspace.openTextDocument({content: WORKSPACE_TEMPLATE, language: 'gemstone-smalltalk' });
+    await vscode.window.showTextDocument(workspaceDocument, { preview: false });
     logInfo('[Workspace] opened successfully');
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
           "GemStone (Smalltalk)",
           "Smalltalk"
         ],
+        "extensions": [
+          ".gst"
+        ],
         "mimeTypes": [
           "text/x-gemstone-smalltalk"
         ],
@@ -915,32 +918,32 @@
       "editor/context": [
         {
           "command": "gemstone.displayIt",
-          "when": "editorTextFocus && resourceScheme == gemstone && !gemstone.executing",
+          "when": "editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing",
           "group": "1_modification@0"
         },
         {
           "command": "gemstone.inspectIt",
-          "when": "editorTextFocus && resourceScheme == gemstone && !gemstone.executing",
+          "when": "editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing",
           "group": "1_modification@1"
         },
         {
           "command": "gemstone.executeIt",
-          "when": "editorTextFocus && resourceScheme == gemstone && !gemstone.executing",
+          "when": "editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing",
           "group": "1_modification@2"
         },
         {
           "command": "gemstone.sendersOf",
-          "when": "editorTextFocus && resourceScheme == gemstone",
+          "when": "editorTextFocus && resourceLangId == gemstone-smalltalk",
           "group": "2_navigation@0"
         },
         {
           "command": "gemstone.implementorsOf",
-          "when": "editorTextFocus && resourceScheme == gemstone",
+          "when": "editorTextFocus && resourceLangId == gemstone-smalltalk",
           "group": "2_navigation@1"
         },
         {
           "command": "gemstone.toggleSelectorBreakpoint",
-          "when": "editorTextFocus && resourceScheme == gemstone",
+          "when": "editorTextFocus && resourceLangId == gemstone-smalltalk",
           "group": "3_gemstoneBreakpoints@0"
         }
       ]


### PR DESCRIPTION
Workspace documents are now plain untitled gemstone-smalltalk files instead of virtual gemstone:// buffers, so users can save them to disk and track them in git. Saving as .gst gives automatic language recognition on reopen.

Context menus (Display It, Execute It, Inspect It, Senders, Implementors) and language features (hover, go-to-definition, completion) now work in any gemstone-smalltalk file, including saved workspace files.