### PR TITLE
Remove dismiss from debug dialog

### DIFF
--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -655,7 +655,7 @@ describe('CodeExecutor', () => {
   // ── Debuggable error dialog must be modal ──────────────────
   //
   // When execution raises a DebuggableError, we prompt the user with a
-  // "Debug" / "Dismiss" choice. That prompt MUST be modal — a non-modal
+  // "Debug" choice. That prompt MUST be modal — a non-modal
   // toast would be easy to miss and would let the stalled GemStone process
   // linger unnoticed. These tests guard the `{ modal: true }` option.
 
@@ -694,7 +694,7 @@ describe('CodeExecutor', () => {
       expect(lastErrorMessageOptions()).toEqual({ modal: true });
     });
 
-    it('offers Debug and Dismiss in the modal dialog on Execute It', async () => {
+    it('offers Debug in the modal dialog on Execute It', async () => {
       gci = debuggableGci();
       session = makeSession(gci);
       executor = new CodeExecutor(makeSessionManager(session));
@@ -706,7 +706,7 @@ describe('CodeExecutor', () => {
 
       const calls = vi.mocked(vscode.window.showErrorMessage).mock.calls;
       const lastCall = calls[calls.length - 1];
-      expect(lastCall.slice(2)).toEqual(['Debug', 'Dismiss']);
+      expect(lastCall.slice(2)).toEqual(['Debug']);
     });
 
     it('shows a modal dialog when Inspect It raises a DebuggableError', async () => {
@@ -730,7 +730,7 @@ describe('CodeExecutor', () => {
       expect(lastErrorMessageOptions()).toEqual({ modal: true });
     });
 
-    it('offers Debug and Dismiss in the modal dialog on Inspect It', async () => {
+    it('offers Debug in the modal dialog on Inspect It', async () => {
       gci = debuggableGci();
       session = makeSession(gci);
       executor = new CodeExecutor(makeSessionManager(session));
@@ -749,7 +749,7 @@ describe('CodeExecutor', () => {
 
       const calls = vi.mocked(vscode.window.showErrorMessage).mock.calls;
       const lastCall = calls[calls.length - 1];
-      expect(lastCall.slice(2)).toEqual(['Debug', 'Dismiss']);
+      expect(lastCall.slice(2)).toEqual(['Debug']);
     });
   });
 

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -188,7 +188,7 @@ export class CodeExecutor {
         // Try to show as inline diagnostic first; fall back to debug dialog
         this.showCompileError(editor, selection, code, codeOffset, msg);
         const choice = await vscode.window.showErrorMessage(
-          `GemStone error: ${msg}`, { modal: true },'Debug', 'Dismiss',
+          `GemStone error: ${msg}`, { modal: true },'Debug'
         );
         if (choice === 'Debug') {
           vscode.debug.startDebugging(undefined, {
@@ -606,7 +606,7 @@ __t`;
 
       if (e instanceof DebuggableError) {
         const choice = await vscode.window.showErrorMessage(
-          `GemStone error: ${msg}`, { modal: true },'Debug', 'Dismiss',
+          `GemStone error: ${msg}`, { modal: true },'Debug'
         );
         if (choice === 'Debug') {
           vscode.debug.startDebugging(undefined, {

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -187,21 +187,7 @@ export class CodeExecutor {
       if (e instanceof DebuggableError) {
         // Try to show as inline diagnostic first; fall back to debug dialog
         this.showCompileError(editor, selection, code, codeOffset, msg);
-        const choice = await vscode.window.showErrorMessage(
-          `GemStone error: ${msg}`, { modal: true },'Debug'
-        );
-        if (choice === 'Debug') {
-          vscode.debug.startDebugging(undefined, {
-            type: 'gemstone',
-            name: 'GemStone Error',
-            request: 'attach',
-            sessionId: session.id,
-            gsProcess: e.context.toString(),
-            errorMessage: msg,
-          }, { suppressSaveBeforeStart: true });
-        } else {
-          try { session.gci.GciTsClearStack(session.handle, e.context); } catch { /* ignore */ }
-        }
+        await this.handleDebuggableError(session, e, msg);
       } else {
         this.showCompileError(editor, selection, code, codeOffset, msg);
       }
@@ -343,6 +329,24 @@ __t`;
         disposable.dispose();
       }
     });
+  }
+
+  private async handleDebuggableError(session: ActiveSession, e: DebuggableError, msg: string): Promise<void> {
+    const choice = await vscode.window.showErrorMessage(
+      `GemStone error: ${msg}`, { modal: true }, 'Debug'
+    );
+    if (choice === 'Debug') {
+      vscode.debug.startDebugging(undefined, {
+        type: 'gemstone',
+        name: 'GemStone Error',
+        request: 'attach',
+        sessionId: session.id,
+        gsProcess: e.context.toString(),
+        errorMessage: msg,
+      }, { suppressSaveBeforeStart: true });
+    } else {
+      try { session.gci.GciTsClearStack(session.handle, e.context); } catch { /* ignore */ }
+    }
   }
 
   /**
@@ -605,21 +609,7 @@ __t`;
       logError(session.id, msg);
 
       if (e instanceof DebuggableError) {
-        const choice = await vscode.window.showErrorMessage(
-          `GemStone error: ${msg}`, { modal: true },'Debug'
-        );
-        if (choice === 'Debug') {
-          vscode.debug.startDebugging(undefined, {
-            type: 'gemstone',
-            name: 'GemStone Error',
-            request: 'attach',
-            sessionId: session.id,
-            gsProcess: e.context.toString(),
-            errorMessage: msg,
-          }, { suppressSaveBeforeStart: true });
-        } else {
-          try { session.gci.GciTsClearStack(session.handle, e.context); } catch { /* ignore */ }
-        }
+        await this.handleDebuggableError(session, e, msg);
       } else {
         vscode.window.showErrorMessage(`GemStone execution error: ${msg}`);
       }


### PR DESCRIPTION
This PR removes the unused 'Dismiss' option from the debug dialog. The stock 'Cancel' item provided by VS Code has the same behavior.

This PR also unifies the way we handle DebuggableErrors so the code is not duplicated.