### PR TITLE
Add live search filter to the System Browser columns

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,6 +23,9 @@ mcp-server/node_modules/**
 !node_modules/koffi/build/**
 
 client/src/**
+# listFilter.js is read at runtime via fs.readFileSync and injected into the webview as a <script> tag.
+# It must ship as a standalone file — it cannot be compiled into the bundle.
+!client/src/listFilter.js
 server/src/**
 mcp-server/src/**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Added
+
+- **Live search filter in the System Browser.** A filter box now sits above every column in the System Browser. As you type, matching entries are highlighted in bold at the matching portion — non-matching items remain visible. The first match is automatically focused so you can press **Enter** to select it without touching the mouse. Use **↑ / ↓** to move through matches (wrapping at both ends), and **Escape** to clear the filter and restore the full list. A **✕** button in the filter box and a **Clear all filters** button in the toolbar let you reset filters with the mouse. Filters survive column selections and automatically re-focus the first matching entry whenever a list is refreshed from the server.
+
 ## [1.5.7] - 2026-06-04
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,9 @@
     "vscode-languageclient": "^9.0.0"
   },
   "devDependencies": {
+    "@types/jsdom": "^28.0.3",
     "@types/vscode": "^1.85.0",
+    "jsdom": "^27.0.1",
     "vitest": "^4.0.18"
   }
 }

--- a/client/src/__tests__/listFilter.test.ts
+++ b/client/src/__tests__/listFilter.test.ts
@@ -1,0 +1,473 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Register the ListFilter custom element once by evaluating its source in jsdom.
+// We use new Function() (indirect eval) so the code runs in global scope where
+// customElements, document, and HTMLElement are all available from jsdom.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  const source = fs.readFileSync(path.resolve(__dirname, '../listFilter.js'), 'utf8');
+  // eslint-disable-next-line no-new-func
+  new Function(source)();
+});
+
+// ── Types ─────────────────────────────────────────────────────
+
+type ListFilterClass = {
+  new(): ListFilterInstance;
+  clearAllFilters(): void;
+};
+
+type ListFilterInstance = HTMLElement & {
+  applyFilter(): void;
+  clearFilter(): void;
+  matchQuery(text: string, query: string): { start: number; end: number; text: string } | null;
+  moveFocusedItemBy(offset: number): void;
+  matchedItems: HTMLElement[];
+  focusedIndex: number;
+  searchBox: HTMLInputElement;
+};
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function getListFilterClass(): ListFilterClass {
+  return customElements.get('list-filter') as unknown as ListFilterClass;
+}
+
+function makeList(id: string, items: string[]): HTMLDivElement {
+  const list = document.createElement('div');
+  list.id = id;
+  for (const value of items) {
+    const div = document.createElement('div');
+    div.className = 'item';
+    div.dataset.value = value;
+    div.textContent = value;
+    list.appendChild(div);
+  }
+  document.body.appendChild(list);
+  return list;
+}
+
+function makeFilter(listId: string): ListFilterInstance {
+  const el = document.createElement('list-filter');
+  el.setAttribute('for', listId);
+  document.body.appendChild(el);
+  return el as unknown as ListFilterInstance;
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe('ListFilter', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.getElementById('list-filter-styles')?.remove();
+  });
+
+  describe('matchQuery', () => {
+    let filter: ListFilterInstance;
+
+    beforeEach(() => {
+      makeList('items', []);
+      filter = makeFilter('items');
+    });
+
+    it('returns null when query is not found', () => {
+      expect(filter.matchQuery('Array', 'xyz')).toBeNull();
+    });
+
+    it('returns match with correct start and end for a substring match', () => {
+      // 'collection'.indexOf('lect') === 3
+      const result = filter.matchQuery('Collection', 'lect');
+      expect(result).toEqual({ start: 3, end: 7, text: 'Collection' });
+    });
+
+    it('matches at the start of the string', () => {
+      const result = filter.matchQuery('Array', 'arr');
+      expect(result).toEqual({ start: 0, end: 3, text: 'Array' });
+    });
+
+    it('matches at the end of the string', () => {
+      const result = filter.matchQuery('Object', 'ect');
+      expect(result).toEqual({ start: 3, end: 6, text: 'Object' });
+    });
+
+    it('matches regardless of the case of the text', () => {
+      // matchQuery lowercases the text before searching
+      expect(filter.matchQuery('Array', 'arr')).not.toBeNull();
+      expect(filter.matchQuery('ARRAY', 'arr')).not.toBeNull();
+    });
+
+    it('requires the query to be pre-lowercased (callers must normalize)', () => {
+      // applyFilter lowercases the query before calling matchQuery
+      expect(filter.matchQuery('Array', 'ARR')).toBeNull();
+    });
+
+    it('matches the first occurrence when the query appears multiple times', () => {
+      const result = filter.matchQuery('abcabc', 'bc');
+      expect(result).toEqual({ start: 1, end: 3, text: 'abcabc' });
+    });
+  });
+
+  describe('applyFilter with empty query', () => {
+    it('renders all items as plain text with no highlights', () => {
+      makeList('items', ['Array', 'Bag', 'Set']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = '';
+      filter.applyFilter();
+
+      const items = document.querySelectorAll('#items .item');
+      items.forEach(item => {
+        expect(item.querySelector('.match-highlight')).toBeNull();
+        expect(item.textContent).toBe((item as HTMLElement).dataset.value);
+      });
+    });
+
+    it('has no matchedItems when query is empty', () => {
+      makeList('items', ['Array', 'Bag']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = '';
+      filter.applyFilter();
+
+      expect(filter.matchedItems).toHaveLength(0);
+    });
+  });
+
+  describe('applyFilter with a query', () => {
+    it('adds matching items to matchedItems', () => {
+      makeList('items', ['Array', 'Bag', 'Barcode']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'Ba';
+      filter.applyFilter();
+
+      expect(filter.matchedItems).toHaveLength(2);
+    });
+
+    it('does not include non-matching items in matchedItems', () => {
+      makeList('items', ['Array', 'Bag', 'Set']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.applyFilter();
+
+      expect(filter.matchedItems).toHaveLength(1);
+      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Array');
+    });
+
+    it('adds a match-highlight span for the matched portion', () => {
+      makeList('items', ['Collection']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'lect';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item')!;
+      const highlight = item.querySelector('.match-highlight');
+      expect(highlight).not.toBeNull();
+      expect(highlight!.textContent).toBe('lect');
+    });
+
+    it('renders text before the match as a text node', () => {
+      makeList('items', ['Collection']);
+      const filter = makeFilter('items');
+
+      // 'lect' matches at index 3: "Col" is before the match
+      filter.searchBox.value = 'lect';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item')!;
+      expect(item.firstChild!.nodeType).toBe(Node.TEXT_NODE);
+      expect(item.firstChild!.textContent).toBe('Col');
+    });
+
+    it('renders text after the match as a text node', () => {
+      makeList('items', ['Collection']);
+      const filter = makeFilter('items');
+
+      // 'lect' at index 3, end index 7: "ion" remains after
+      filter.searchBox.value = 'lect';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item')!;
+      expect(item.lastChild!.nodeType).toBe(Node.TEXT_NODE);
+      expect(item.lastChild!.textContent).toBe('ion');
+    });
+
+    it('renders no text node before a match at position 0', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item')!;
+      expect(item.firstChild!.nodeName).toBe('SPAN');
+    });
+
+    it('renders no text node after a match at the end', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'ray';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item')!;
+      expect(item.lastChild!.nodeName).toBe('SPAN');
+    });
+
+    it('restores non-matching items to plain textContent', () => {
+      makeList('items', ['Array', 'Bag']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.applyFilter();
+
+      const items = document.querySelectorAll('#items .item');
+      const bag = Array.from(items).find(el => (el as HTMLElement).dataset.value === 'Bag')!;
+      expect(bag.textContent).toBe('Bag');
+      expect(bag.querySelector('.match-highlight')).toBeNull();
+    });
+
+    it('is case-insensitive', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'ARRAY';
+      filter.applyFilter();
+
+      expect(filter.matchedItems).toHaveLength(1);
+    });
+  });
+
+  describe('keyboard focus after applyFilter', () => {
+    it('sets focusedIndex to 0 when there are matches', () => {
+      makeList('items', ['Array', 'Bag']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.applyFilter();
+
+      expect(filter.focusedIndex).toBe(0);
+    });
+
+    it('adds keyboard-cursor class to the first matched item', () => {
+      makeList('items', ['Array', 'Bag', 'Barcode']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'ba';
+      filter.applyFilter();
+
+      expect(filter.matchedItems[0].classList.contains('keyboard-cursor')).toBe(true);
+    });
+
+    it('leaves focusedIndex at -1 when no items match', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'xyz';
+      filter.applyFilter();
+
+      expect(filter.focusedIndex).toBe(-1);
+    });
+  });
+
+  describe('moveFocusedItemBy', () => {
+    let filter: ListFilterInstance;
+
+    beforeEach(() => {
+      makeList('items', ['Array', 'Bag', 'Set']);
+      filter = makeFilter('items');
+      filter.searchBox.value = 'a';
+      filter.applyFilter(); // 'Array' and 'Bag' match; focusedIndex = 0
+    });
+
+    it('moves forward by 1', () => {
+      filter.moveFocusedItemBy(1);
+      expect(filter.focusedIndex).toBe(1);
+    });
+
+    it('wraps from the last item to the first on ArrowDown', () => {
+      filter.moveFocusedItemBy(1); // index 1
+      filter.moveFocusedItemBy(1); // would be 2, but only 2 items → wraps to 0
+      expect(filter.focusedIndex).toBe(0);
+    });
+
+    it('wraps from the first item to the last on ArrowUp', () => {
+      filter.moveFocusedItemBy(-1); // from 0 → last (index 1)
+      expect(filter.focusedIndex).toBe(filter.matchedItems.length - 1);
+    });
+
+    it('moves backward by 1 from a mid-list position', () => {
+      filter.moveFocusedItemBy(1); // index 1
+      filter.moveFocusedItemBy(-1); // back to 0
+      expect(filter.focusedIndex).toBe(0);
+    });
+  });
+
+  describe('clearFilter', () => {
+    it('clears the search box value', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.clearFilter();
+
+      expect(filter.searchBox.value).toBe('');
+    });
+
+    it('clears matchedItems', () => {
+      makeList('items', ['Array', 'Bag']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'a';
+      filter.applyFilter();
+      expect(filter.matchedItems.length).toBeGreaterThan(0);
+
+      filter.clearFilter();
+      expect(filter.matchedItems).toHaveLength(0);
+    });
+
+    it('restores items to plain text', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.applyFilter();
+      filter.clearFilter();
+
+      const item = document.querySelector('#items .item')!;
+      expect(item.querySelector('.match-highlight')).toBeNull();
+      expect(item.textContent).toBe('Array');
+    });
+  });
+
+  describe('clearAllFilters (static)', () => {
+    it('calls clearFilter on every list-filter element in the document', () => {
+      makeList('list-a', ['Alpha', 'Beta']);
+      makeList('list-b', ['One', 'Two']);
+      const filterA = makeFilter('list-a');
+      const filterB = makeFilter('list-b');
+
+      filterA.searchBox.value = 'al';
+      filterA.applyFilter();
+      filterB.searchBox.value = 'on';
+      filterB.applyFilter();
+
+      expect(filterA.matchedItems).toHaveLength(1);
+      expect(filterB.matchedItems).toHaveLength(1);
+
+      getListFilterClass().clearAllFilters();
+
+      expect(filterA.searchBox.value).toBe('');
+      expect(filterA.matchedItems).toHaveLength(0);
+      expect(filterB.searchBox.value).toBe('');
+      expect(filterB.matchedItems).toHaveLength(0);
+    });
+  });
+
+  describe('has-text CSS class', () => {
+    it('adds has-text class when query is non-empty', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.applyFilter();
+
+      expect(filter.classList.contains('has-text')).toBe(true);
+    });
+
+    it('removes has-text class when query is empty', () => {
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.applyFilter();
+      filter.clearFilter();
+
+      expect(filter.classList.contains('has-text')).toBe(false);
+    });
+  });
+
+  describe('refreshFilter hook', () => {
+    it('wires a refreshFilter function onto the list element when accessed', () => {
+      const list = makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      // Trigger list() by calling applyFilter
+      filter.applyFilter();
+
+      expect(typeof (list as HTMLElement & { refreshFilter?: unknown }).refreshFilter).toBe('function');
+    });
+
+    it('calling refreshFilter re-applies the current filter', () => {
+      // 'Barrage' contains 'arr' at index 1; 'Array' contains 'arr' at index 0
+      const list = makeList('items', ['Array', 'Bag', 'Barrage']) as HTMLDivElement & { refreshFilter?(): void };
+      const filter = makeFilter('items');
+
+      // First apply with 'arr' — Array and Barrage match, Bag does not
+      filter.searchBox.value = 'arr';
+      filter.applyFilter(); // wires refreshFilter onto the list element
+      expect(filter.matchedItems).toHaveLength(2);
+
+      // Change query and re-apply via refreshFilter
+      filter.searchBox.value = 'bag';
+      list.refreshFilter!();
+
+      expect(filter.matchedItems).toHaveLength(1);
+      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Bag');
+    });
+  });
+
+  describe('connectedCallback', () => {
+    it('renders an input and a clear button', () => {
+      makeList('items', []);
+      const filter = makeFilter('items');
+
+      expect(filter.querySelector('input')).not.toBeNull();
+      expect(filter.querySelector('.clear-btn')).not.toBeNull();
+    });
+
+    it('injects styles into the document head exactly once', () => {
+      makeList('a', []);
+      makeList('b', []);
+      makeFilter('a');
+      makeFilter('b');
+
+      expect(document.querySelectorAll('#list-filter-styles')).toHaveLength(1);
+    });
+  });
+
+  describe('input debounce', () => {
+    it('does not apply the filter immediately when typing', () => {
+      vi.useFakeTimers();
+      makeList('items', ['Array']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.searchBox.dispatchEvent(new Event('input'));
+
+      // matchedItems hasn't changed yet (debounce pending)
+      expect(filter.matchedItems).toHaveLength(0);
+
+      vi.useRealTimers();
+    });
+
+    it('applies the filter after 150 ms', () => {
+      vi.useFakeTimers();
+      makeList('items', ['Array', 'Bag']);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'arr';
+      filter.searchBox.dispatchEvent(new Event('input'));
+      vi.advanceTimersByTime(150);
+
+      expect(filter.matchedItems).toHaveLength(1);
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -192,6 +192,29 @@ describe('SystemBrowser', () => {
     (SystemBrowser as unknown as { lastActive: Map<number, unknown> }).lastActive = new Map();
   });
 
+  describe('webview HTML', () => {
+    beforeEach(() => {
+      SystemBrowser.show(session, exportManager);
+    });
+
+    it('includes a list-filter for each column list', () => {
+      const html = mockPanel.webview.html;
+      expect(html).toContain('list-filter for="list-dicts"');
+      expect(html).toContain('list-filter for="list-categories"');
+      expect(html).toContain('list-filter for="list-classes"');
+      expect(html).toContain('list-filter for="list-method-cats"');
+      expect(html).toContain('list-filter for="list-methods"');
+    });
+
+    it('includes a Clear filters button', () => {
+      expect(mockPanel.webview.html).toContain('clearFiltersBtn');
+    });
+
+    it('includes the inlined listFilter.js script tag', () => {
+      expect(mockPanel.webview.html).toMatch(/<script nonce="[^"]*"><\/script>/);
+    });
+  });
+
   describe('show', () => {
     it('creates a new panel with initial title Browser', () => {
       SystemBrowser.show(session, exportManager);

--- a/client/src/listFilter.js
+++ b/client/src/listFilter.js
@@ -1,0 +1,292 @@
+const listFilterTag = 'list-filter';
+
+/**
+ * A live search filter for any column list.
+ *
+ * Drop a <list-filter for="some-list-id"> tag for a list, and it becomes
+ * instantly filterable. As the user types, matching items get their matching
+ * portion highlighted in bold. Non-matching items remain visible but unhighlighted.
+ * The first match is automatically focused so the user can hit Enter to select it
+ * without reaching for the mouse. Arrow keys cycle through matches (wrapping at
+ * both ends), and Escape clears the filter and restores the full list.
+ *
+ * When the list is reloaded from the server, call clearFilter() or
+ * ListFilter.clearAllFilters() to reset the search box and show everything again.
+ */
+class ListFilter extends HTMLElement {
+
+    static clearAllFilters() {
+        document.querySelectorAll(listFilterTag).forEach(listFilter => listFilter.clearFilter());
+    } 
+    
+    constructor() {
+        super();
+        this.debounceTimer = null;
+        this.listElement = null;
+        this.searchBox = null;
+        this.initializeMatchedItems();
+    }
+
+    connectedCallback() {
+        this.injectStyles();
+        this.innerHTML = '<input type="text" placeholder="Filter…" autocomplete="off" spellcheck="false"><button class="clear-btn" tabindex="-1" title="Clear filter">✕</button>';
+        this.searchBox = this.querySelector('input');
+        this.searchBox.addEventListener('input', this.onQueryChanged.bind(this));
+        this.searchBox.addEventListener('keydown', this.onKeydown.bind(this));
+        this.querySelector('.clear-btn').addEventListener('click', this.onClearFilterClick.bind(this));
+    }
+
+
+    // Keyboard and input handling
+
+    onQueryChanged() {
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = setTimeout(() => this.applyFilter(), 150);
+    }
+
+    onKeydown(e) {
+        if (e.key === 'Escape') return this.clearFilter();
+        if (e.key === 'Enter') return this.clickFocusedItem();
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') this.onArrowKeyPressed(e);
+    }
+
+    onArrowKeyPressed(e) {
+        if (!this.matchedItems.length) return;
+        
+        e.preventDefault();
+        const offset = e.key === 'ArrowUp' ? -1 : 1;
+
+        this.removeKeyboardIndicatorFromFocusedItem();
+        this.moveFocusedItemBy(offset);
+        this.addKeyboardIndicatorToFocusedItem();
+    }
+
+    onClearFilterClick() {
+        this.clearFilter();
+        this.searchBox.focus();
+    }
+
+
+    // Filtering
+
+    query() {
+        return this.searchBox.value.trim();
+    }
+
+    clearFilter() {
+        this.searchBox.value = '';
+        this.applyFilter();
+    }
+
+    applyFilter() {
+        const query = this.query().toLowerCase();
+        this.toggleClearFilterButtonVisibility();
+        this.clearMatchedItems();
+
+        for (const item of this.listItems()) {
+            this.applyFilterToItem(item, query);
+        }
+
+        this.focusFirstMatchedItem();
+    }
+
+    applyFilterToItem(item, query) {
+        if (!item.dataset.value) return;
+
+        if (!query) {
+            return this.renderUnmatchedItem(item);
+        }
+
+        const match = this.matchQuery(item.dataset.value, query);
+        if (!match) {
+            return this.renderUnmatchedItem(item);
+        }
+
+        this.renderMatchedItem(item, match);
+    }
+
+    toggleClearFilterButtonVisibility() {
+        this.classList.toggle('has-text', this.query().length > 0);
+    }
+
+    clearMatchedItems() {
+        this.removeKeyboardIndicatorFromFocusedItem();
+        this.initializeMatchedItems();
+    }
+
+    initializeMatchedItems() {
+        this.matchedItems = [];
+        this.focusedIndex = -1;
+    }
+
+    matchQuery(text, query) {
+        const start = text.toLowerCase().indexOf(query);
+        
+        if (start === -1) return null;
+        
+        return {start, end: start + query.length, text};
+    }
+
+
+    // Matched item rendering
+
+    renderUnmatchedItem(item) {
+        item.textContent = item.dataset.value;
+    }
+
+    renderMatchedItem(item, match) {
+        item.textContent = '';
+
+        this.renderTextBeforeMatch(item, match);
+        this.renderHighlightedMatch(item, match);
+        this.renderTextAfterMatch(item, match);
+
+        this.matchedItems.push(item);
+    }
+
+    renderTextBeforeMatch(item, match) {
+        if (match.start <= 0) return;
+
+        item.appendChild(document.createTextNode(match.text.slice(0, match.start)));
+    }
+
+    renderHighlightedMatch(item, match) {
+        const highlight = document.createElement('span');
+
+        highlight.className = 'match-highlight';
+        highlight.textContent = match.text.slice(match.start, match.end);
+
+        item.appendChild(highlight);
+    }
+
+    renderTextAfterMatch(item, match) {
+        if (match.end >= match.text.length) return;
+
+        item.appendChild(document.createTextNode(match.text.slice(match.end)));
+    }
+
+
+    // Keyboard focus
+
+    clickFocusedItem() {
+        this.matchedItems[this.focusedIndex]?.click();
+        this.searchBox.focus();
+    }
+
+    focusFirstMatchedItem() {
+        if (this.matchedItems.length === 0) return;
+
+        this.focusedIndex = 0;
+        this.addKeyboardIndicatorToFocusedItem();
+    }
+
+    moveFocusedItemBy(offset) {
+        const desiredFocusedIndex = this.focusedIndex + offset;
+
+        this.focusedIndex = desiredFocusedIndex < 0
+            ? this.matchedItems.length - 1
+            : desiredFocusedIndex % this.matchedItems.length;
+    }
+
+    addKeyboardIndicatorToFocusedItem() {
+        this.matchedItems[this.focusedIndex].classList.add('keyboard-cursor');
+
+        this.scrollFocusedItemIntoView();
+    }
+
+    removeKeyboardIndicatorFromFocusedItem() {
+        this.matchedItems[this.focusedIndex]?.classList.remove('keyboard-cursor');
+    }
+    
+    scrollFocusedItemIntoView() {
+        this.matchedItems[this.focusedIndex].scrollIntoView({block: 'nearest'});
+    }
+
+
+    // List access
+
+    list() {
+        if (!this.listElement) {
+            // getElementById may return null if the list hasn't been added to the DOM yet.
+            // Callers must handle a null return gracefully.
+            this.listElement = document.getElementById(this.getAttribute('for'));
+            
+            if (this.listElement) {
+                this.listElement.refreshFilter = () => this.applyFilter();
+            }
+        }
+
+        return this.listElement;
+    }
+
+    listItems() {
+        return this.list()?.children || [];
+    }
+
+
+    // Style injection
+
+    injectStyles() {
+        const styleId = 'list-filter-styles';
+        
+        if (document.getElementById(styleId)) return;
+        
+        const style = document.createElement('style');
+        style.id = styleId;
+        style.textContent = `
+            list-filter {
+                position: relative;
+                padding: 3px 6px;
+                border-bottom: 1px solid var(--vscode-panel-border);
+                flex-shrink: 0;
+            }
+            list-filter input {
+                width: 100%;
+                background: var(--vscode-input-background);
+                color: var(--vscode-input-foreground);
+                border: 1px solid var(--vscode-input-border, transparent);
+                border-radius: 2px;
+                padding: 2px 20px 2px 4px;
+                font-family: var(--vscode-font-family);
+                font-size: var(--vscode-font-size);
+                outline: none;
+            }
+            list-filter input:focus {
+                border-color: var(--vscode-focusBorder);
+            }
+            list-filter .clear-btn {
+                position: absolute;
+                right: 9px;
+                top: 50%;
+                transform: translateY(-50%);
+                visibility: hidden;
+                background: none;
+                border: none;
+                padding: 0 2px;
+                cursor: pointer;
+                color: var(--vscode-descriptionForeground);
+                font-size: 14px;
+                line-height: 1;
+            }
+            list-filter .clear-btn:hover {
+                color: var(--vscode-foreground);
+            }
+            list-filter.has-text .clear-btn {
+                visibility: visible;
+            }
+            .match-highlight {
+                font-weight: bold;
+                color: var(--vscode-list-highlightForeground);
+            }
+            .item.keyboard-cursor {
+                outline: 1px solid var(--vscode-focusBorder);
+                outline-offset: -1px;
+            }
+        `;
+        
+        document.head.appendChild(style);
+    }
+
+}
+
+customElements.define(listFilterTag, ListFilter);

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -9,6 +9,17 @@ import * as queries from './browserQueries';
 import {GlobalsBrowser} from './globalsBrowser';
 import {ClassBrowser} from './classBrowser';
 
+/**
+ * The webview HTML is a large template literal in getHtml(). Embedding JS directly
+ * inside that string is hard to work with and the file keeps growing. listFilter.js is kept as a
+ * standalone file so it gets proper IDE support and can be edited in isolation.
+ *
+ * We can't use a regular import because the webview needs the raw source text to
+ * inject into a <script> tag — not a compiled module.
+ * Reading the file at runtime is the simplest approach that works in both environments.
+ */
+const listFilterJs = fs.readFileSync(path.join(__dirname, '..', 'src', 'listFilter.js'), 'utf8');
+
 // ── Types ────────────────────────────────────────────────────
 
 interface BrowserState {
@@ -16,7 +27,7 @@ interface BrowserState {
   selectedDictIndex: number | null;       // 1-based
   classCategories: string[];
   selectedCategory: string | null;
-  classes: string[];
+  classes: string[];  
   selectedClass: string | null;
   isMeta: boolean;
   selectedEnvId: number;
@@ -1807,13 +1818,20 @@ export class SystemBrowser {
       font-size: 0.9em;
       display: none;
     }
+    .toolbar {
+         display: flex;
+    }
   </style>
+  <script nonce="${nonce}">${listFilterJs}</script>
 </head>
 <body>
   <div class="error-banner" id="errorBanner"></div>
   <div class="toolbar">
     <div class="toolbar-cell">
       <button id="refreshBtn" title="Refresh">&#x21bb; Refresh</button>
+    </div>
+    <div class="toolbar-cell">
+      <button id="clearFiltersBtn" title="Clear filters">✕ Clear filters</button>
     </div>
     <div class="toolbar-cell toolbar-mode">
       <span class="mode-toggle">
@@ -1828,14 +1846,17 @@ export class SystemBrowser {
   <div class="columns">
     <div class="column">
       <div class="column-header">Dictionaries</div>
+      <list-filter for="list-dicts"></list-filter>
       <div class="column-list" id="list-dicts"></div>
     </div>
     <div class="column" id="col-categories">
       <div class="column-header">Class Categories</div>
+      <list-filter for="list-categories"></list-filter>
       <div class="column-list" id="list-categories"></div>
     </div>
     <div class="column" id="col-classes">
       <div class="column-header">Classes</div>
+      <list-filter for="list-classes"></list-filter>
       <div class="column-list" id="list-classes"></div>
       <div class="column-footer">
         <label><input type="radio" name="side" value="instance" checked> Instance</label>
@@ -1852,11 +1873,13 @@ export class SystemBrowser {
     </div>
     <div class="column">
       <div class="column-header">Method Categories</div>
+      <list-filter for="list-method-cats"></list-filter>
       <div class="column-list" id="list-method-cats"></div>
       <div class="column-footer hidden" id="envFooter"></div>
     </div>
     <div class="column">
       <div class="column-header">Methods</div>
+      <list-filter for="list-methods"></list-filter>
       <div class="column-list" id="list-methods"></div>
     </div>
   </div>
@@ -1882,7 +1905,6 @@ export class SystemBrowser {
     const catBtn = document.getElementById('catBtn');
     const hierBtn = document.getElementById('hierBtn');
     const errorBanner = document.getElementById('errorBanner');
-
     // ── Populate a column with items ───────────────
     function populateColumn(listEl, items, virtualItems, draggable) {
       listEl.innerHTML = '';
@@ -1897,6 +1919,8 @@ export class SystemBrowser {
         }
         listEl.appendChild(div);
       }
+      
+      listEl.refreshFilter();
     }
 
     function selectItemInColumn(listEl, value) {
@@ -1933,9 +1957,7 @@ export class SystemBrowser {
     }
 
     setupClickHandler(cols.dicts, (name) => {
-      const idx = Array.from(cols.dicts.children).findIndex(
-        el => el.dataset.value === name
-      );
+      const idx = Array.from(cols.dicts.children).findIndex(el => el.dataset.value === name);
       vscode.postMessage({ command: 'selectDictionary', index: idx + 1 });
     });
 
@@ -1968,6 +1990,11 @@ export class SystemBrowser {
     // ── Refresh button ─────────────────────────────
     document.getElementById('refreshBtn').addEventListener('click', () => {
       vscode.postMessage({ command: 'refresh' });
+    });
+    
+    // ── Clear filters button ─────────────────────────────
+    document.getElementById('clearFiltersBtn').addEventListener('click', () => {
+      ListFilter.clearAllFilters();
     });
 
     // ── Category / Hierarchy toggle ─────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
         "vscode-languageclient": "^9.0.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^28.0.3",
         "@types/vscode": "^1.85.0",
+        "jsdom": "^27.0.1",
         "vitest": "^4.0.18"
       }
     },
@@ -51,6 +53,61 @@
         "@types/express": "^5.0.2",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",
@@ -260,6 +317,146 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1955,6 +2152,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.27.1.tgz",
+      "integrity": "sha512-NyfbU7cCMYYxzBT07eOv0/WR3L5j6vmza6sRlF2sDVCkNvsNaCcaFDGu0a4WqzE983tKuSk7YRTY2C+1krumMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
@@ -2013,6 +2256,13 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.120.0",
@@ -2572,6 +2822,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binaryextensions": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
@@ -3026,6 +3286,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -3037,6 +3311,56 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
@@ -3055,6 +3379,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -4092,6 +4423,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -4367,6 +4711,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4456,6 +4807,72 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -4965,6 +5382,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -5690,6 +6114,16 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -5962,6 +6396,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -6034,6 +6475,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/secretlint": {
@@ -6547,6 +7001,13 @@
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -6734,6 +7195,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
@@ -6764,6 +7245,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -7292,6 +7799,29 @@
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -7314,6 +7844,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -7354,6 +7898,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -7368,6 +7934,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xml2js": {
@@ -7393,6 +7969,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",


### PR DESCRIPTION
**Description**
Type in the filter box above any column to instantly highlight matching entries in bold. The first match is auto-focused — press Enter to select it without touching the mouse. Arrow keys cycle through matches (wrapping at both ends), and Escape restores the full list.

The filter lives in its own file (listFilter.js) so it can be dropped into any column with a single tag.

**Screen capture**
The recording shows the live search filter in action across all System Browser columns. A filter box sits above each column, and a "Clear all filters" button appears in the toolbar next to Refresh. As the user types, matching entries are highlighted in bold — the first match is auto-focused so it can be selected with Enter, no mouse needed.

Arrow keys cycle through matches and Escape restores the full list. The recording also shows that filters survive column selections and automatically re-focus the first match whenever a list is refreshed from the server.

https://github.com/user-attachments/assets/38284f24-f103-40a2-a440-77e74ed37269



