### PR TITLE
Fix search filter lost on column repopulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Fixed
+
+- **Search filter is re-applied after column repopulation even if never previously used.** When the server reloads a column's items (e.g. selecting a dictionary loads its class list), any active search query is now correctly re-applied to the new entries. Previously this failed silently if the user had not yet typed anything in the filter box before the first reload.
+
 ## [1.6.0] - 2026-06-08
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@types/jsdom": "^28.0.3",
     "@types/vscode": "^1.85.0",
+    "css.escape": "^1.5.1",
     "jsdom": "^27.4.0",
     "vitest": "^4.0.18"
   }

--- a/client/src/__tests__/listFilter.test.ts
+++ b/client/src/__tests__/listFilter.test.ts
@@ -18,6 +18,7 @@ beforeAll(() => {
 type ListFilterClass = {
   new(): ListFilterInstance;
   clearAllFilters(): void;
+  refreshFilterOf(listElement: HTMLElement): void;
 };
 
 type ListFilterInstance = HTMLElement & {
@@ -392,33 +393,108 @@ describe('ListFilter', () => {
     });
   });
 
-  describe('refreshFilter hook', () => {
-    it('wires a refreshFilter function onto the list element when accessed', () => {
-      const list = makeList('items', ['Array']);
+  describe('refreshFilterOf', () => {
+    it('applies the current filter to the given list element', () => {
+      const list = makeList('items', ['Array', 'Bag', 'Barrage']);
       const filter = makeFilter('items');
+      filter.searchBox.value = 'arr';
 
-      // Trigger list() by calling applyFilter
-      filter.applyFilter();
+      getListFilterClass().refreshFilterOf(list);
 
-      expect(typeof (list as HTMLElement & { refreshFilter?: unknown }).refreshFilter).toBe('function');
+      expect(filter.matchedItems).toHaveLength(2);
+      expect(filter.matchedItems.map(el => (el as HTMLElement).dataset.value)).toEqual(['Array', 'Barrage']);
     });
 
-    it('calling refreshFilter re-applies the current filter', () => {
-      // 'Barrage' contains 'arr' at index 1; 'Array' contains 'arr' at index 0
-      const list = makeList('items', ['Array', 'Bag', 'Barrage']) as HTMLDivElement & { refreshFilter?(): void };
+    it('picks up a changed query when called after searchBox value changes', () => {
+      const list = makeList('items', ['Array', 'Bag', 'Barrage']);
       const filter = makeFilter('items');
-
-      // First apply with 'arr' — Array and Barrage match, Bag does not
       filter.searchBox.value = 'arr';
-      filter.applyFilter(); // wires refreshFilter onto the list element
+      filter.applyFilter();
       expect(filter.matchedItems).toHaveLength(2);
 
-      // Change query and re-apply via refreshFilter
       filter.searchBox.value = 'bag';
-      list.refreshFilter!();
+      getListFilterClass().refreshFilterOf(list);
 
       expect(filter.matchedItems).toHaveLength(1);
       expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Bag');
+    });
+
+    it('re-applies the active filter against new children after list repopulation', () => {
+      const list = makeList('items', ['OldClass']);
+      const filter = makeFilter('items');
+      filter.searchBox.value = 'arr';
+      filter.applyFilter(); // user has an active query
+
+      // Server repopulates the list — replace contents using makeList's schema
+      list.innerHTML = '';
+      makeList('items-tmp', ['Array', 'Bag', 'Barrage'])
+        .querySelectorAll('.item')
+        .forEach(el => list.appendChild(el));
+
+      getListFilterClass().refreshFilterOf(list);
+
+      expect(filter.matchedItems).toHaveLength(2);
+      expect(filter.matchedItems.map(el => (el as HTMLElement).dataset.value)).toEqual(['Array', 'Barrage']);
+    });
+
+    it('does nothing when no filter is associated with the list element', () => {
+      const list = makeList('unfiltered-list', ['Array', 'Bag']);
+      const before = list.innerHTML;
+
+      getListFilterClass().refreshFilterOf(list);
+
+      expect(list.innerHTML).toBe(before);
+    });
+
+    it('does nothing when the list element has no id', () => {
+      const list = document.createElement('div');
+      const before = list.innerHTML;
+
+      getListFilterClass().refreshFilterOf(list);
+
+      expect(list.innerHTML).toBe(before);
+    });
+
+    it('throws when more than one filter is defined for the same list', () => {
+      const list = makeList('items', ['Array', 'Bag']);
+      makeFilter('items');
+      makeFilter('items');
+
+      expect(() => getListFilterClass().refreshFilterOf(list)).toThrow('Found 2 list-filter elements for #items — only one filter per list is supported.');
+    });
+
+    it('finds the filter when the list id contains a double quote', () => {
+      const list = makeList('list"items', ['Array', 'Bag']);
+      const filter = makeFilter('list"items');
+      filter.searchBox.value = 'arr';
+
+      getListFilterClass().refreshFilterOf(list);
+
+      expect(filter.matchedItems).toHaveLength(1);
+      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Array');
+    });
+  });
+
+  describe('list() lazy loading', () => {
+    it('does nothing when the list element is not yet in the DOM', () => {
+      const filter = makeFilter('items');
+      filter.searchBox.value = 'arr';
+
+      filter.applyFilter();
+
+      expect(filter.matchedItems).toHaveLength(0);
+    });
+
+    it('applies the filter once the list is added to the DOM after a failed lookup', () => {
+      const filter = makeFilter('items');
+      filter.searchBox.value = 'arr';
+      filter.applyFilter(); // list not in DOM yet — no-op
+
+      makeList('items', ['Array', 'Bag']);
+      filter.applyFilter();
+
+      expect(filter.matchedItems).toHaveLength(1);
+      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Array');
     });
   });
 

--- a/client/src/__tests__/vitest.windowSetup.cjs
+++ b/client/src/__tests__/vitest.windowSetup.cjs
@@ -1,0 +1,16 @@
+// Vitest runs some tests in jsdom (a simulated browser) and others in plain Node.
+// This setup file runs before every test suite. The block below only applies to
+// jsdom environments — Node has no 'window', so we skip it there.
+if (typeof window !== 'undefined') {
+
+    // jsdom may not have a CSS object at all. Create it if missing, but leave
+    // any existing one intact (??= only assigns when the left side is null/undefined).
+    window.CSS ??= {};
+
+    // jsdom doesn't implement CSS.escape. Polyfill it using the 'css.escape' npm
+    // package, which matches the spec. Skip if it's already present — a future
+    // jsdom version may add native support, and we don't want to shadow it.
+    if (typeof window.CSS.escape === 'undefined') {
+        window.CSS.escape = require('css.escape');
+    }
+}

--- a/client/src/listFilter.js
+++ b/client/src/listFilter.js
@@ -17,8 +17,25 @@ class ListFilter extends HTMLElement {
 
     static clearAllFilters() {
         document.querySelectorAll(listFilterTag).forEach(listFilter => listFilter.clearFilter());
-    } 
-    
+    }
+
+    static refreshFilterOf(listElement) {
+        this.#filterFor(listElement)?.applyFilter();
+    }
+
+    static #filterFor(listElement) {
+        // An empty id would produce [for=""], matching any list-filter with a missing or blank
+        // 'for' attribute — a phantom match that would apply the filter to the wrong list.
+        if (!listElement.id) return undefined;
+
+        const filters = document.querySelectorAll(`${listFilterTag}[for="${CSS.escape(listElement.id)}"]`);
+        if (filters.length > 1) {
+            throw new Error(`Found ${filters.length} list-filter elements for #${listElement.id} — only one filter per list is supported.`);
+        }
+
+        return filters[0];
+    }
+
     constructor() {
         super();
         this.debounceTimer = null;
@@ -206,17 +223,9 @@ class ListFilter extends HTMLElement {
     // List access
 
     list() {
-        if (!this.listElement) {
-            // getElementById may return null if the list hasn't been added to the DOM yet.
-            // Callers must handle a null return gracefully.
-            this.listElement = document.getElementById(this.getAttribute('for'));
-            
-            if (this.listElement) {
-                this.listElement.refreshFilter = () => this.applyFilter();
-            }
-        }
-
-        return this.listElement;
+        // getElementById may return null if the list hasn't been added to the DOM yet.
+        // Callers must handle a null return gracefully.
+        return this.listElement ??= document.getElementById(this.getAttribute('for'));
     }
 
     listItems() {

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -1952,7 +1952,7 @@ export class SystemBrowser {
         listEl.appendChild(div);
       }
       
-      listEl.refreshFilter();
+      ListFilter.refreshFilterOf(listEl);
     }
 
     function selectItemInColumn(listEl, value) {

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     include: ['src/**/__tests__/**/*.test.ts'],
     exclude: ['src/__tests__/gci/**'],
+    setupFiles: ['src/__tests__/vitest.windowSetup.cjs']
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@types/jsdom": "^28.0.3",
         "@types/vscode": "^1.85.0",
+        "css.escape": "^1.5.1",
         "jsdom": "^27.4.0",
         "vitest": "^4.0.18"
       }
@@ -3319,6 +3320,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "5.3.7",


### PR DESCRIPTION
When the server loads new data into a column — for example, selecting a dictionary loads its classes — any active search query should be re-applied to the new items. This broke silently whenever the column reloaded before the user had ever typed in the filter box: the hook that triggers the re-apply only existed after first use.

The filter now finds its list independently of initialization order, so the active query is always re-applied correctly after a reload.