### PR TITLE
Add unit tests for GT Phlow inspector (issue #83)

### DIFF
--- a/client/src/__tests__/gtInspectorDataFetchers.test.ts
+++ b/client/src/__tests__/gtInspectorDataFetchers.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchGtListTotal, fetchGtListData, fetchGtTextData, fetchGtPrintTabData, fetchGtForwardListData, fetchGtForwardListTotal, fetchGtTreeChildren } from '../queries/getGtViewSpecs';
+
+describe('fetchGtListTotal', () => {
+  it('returns count as a number on happy path', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '42');
+    expect(fetchGtListTotal(execute, 1000n, 'gtItemsFor:')).toBe(42);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #gtItemsFor:');
+    expect(fetchGtListTotal(execute, 1000n, 'gtItemsFor:')).toBeNull();
+  });
+
+  it('returns null when response is not a number', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'not a number');
+    expect(fetchGtListTotal(execute, 1000n, 'gtItemsFor:')).toBeNull();
+  });
+
+  it('returns null when response is an empty string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '');
+    expect(fetchGtListTotal(execute, 1000n, 'gtItemsFor:')).toBeNull();
+  });
+
+  it('handles whitespace in response', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '  42\n');
+    expect(fetchGtListTotal(execute, 1000n, 'gtItemsFor:')).toBe(42);
+  });
+
+  it('returns 0 when response is "0" — valid count, not treated as falsy', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '0');
+    expect(fetchGtListTotal(execute, 1000n, 'gtItemsFor:')).toBe(0);
+  });
+
+  it('returns null when methodSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '42');
+    expect(fetchGtListTotal(execute, 1000n, 'bad selector!')).toBeNull();
+  });
+
+  it('embeds oop and methodSelector in emitted Smalltalk', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '0');
+    fetchGtListTotal(execute, 99999n, 'gtItemsFor:');
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtItemsFor:');
+  });
+});
+
+describe('fetchGtListData', () => {
+  it('returns JSON string on happy path without modification', () => {
+    expect.assertions(1);
+    const json = '[{"col1":"foo"},{"col1":"bar"}]';
+    const execute = vi.fn(() => json);
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1, 100)).toBe(json);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #gtItemsFor:');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1, 100)).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1, 100)).toBeNull();
+  });
+
+  it('embeds oop, methodSelector, fromIndex, and count in emitted Smalltalk', () => {
+    expect.assertions(4);
+    const execute = vi.fn(() => '[]');
+    fetchGtListData(execute, 99999n, 'gtItemsFor:', 1, 50);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtItemsFor:');
+    expect(code).toContain('1');
+    expect(code).toContain('50');
+  });
+
+  it('returns null when fromIndex is 0 — below valid 1-based range', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 0, 100)).toBeNull();
+  });
+
+  it('returns null when count is 0', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1, 0)).toBeNull();
+  });
+
+  it('returns null when fromIndex is negative', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', -1, 100)).toBeNull();
+  });
+
+  it('returns null when fromIndex is a float', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1.5, 100)).toBeNull();
+  });
+
+  it('returns null when count is negative', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1, -1)).toBeNull();
+  });
+
+  it('returns null when count is a float', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1, 1.5)).toBeNull();
+  });
+
+  it('returns null when methodSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'bad selector!', 1, 100)).toBeNull();
+  });
+
+  it('passes through very large count — no upper bound validation', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtListData(execute, 1000n, 'gtItemsFor:', 1, Number.MAX_SAFE_INTEGER)).not.toBeNull();
+  });
+});
+
+describe('fetchGtTextData', () => {
+  it('returns the text data JSON string on happy path', () => {
+    expect.assertions(1);
+    const json = '{"string":"hello world","truncated":false}';
+    const execute = vi.fn(() => json);
+    expect(fetchGtTextData(execute, 1000n, 'gtTextFor:')).toBe(json);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #gtTextFor:');
+    expect(fetchGtTextData(execute, 1000n, 'gtTextFor:')).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fetchGtTextData(execute, 1000n, 'gtTextFor:')).toBeNull();
+  });
+
+  it('returns null when methodSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '{}');
+    expect(fetchGtTextData(execute, 1000n, 'bad selector!')).toBeNull();
+  });
+
+  it('embeds oop and methodSelector in emitted Smalltalk', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '{}');
+    fetchGtTextData(execute, 99999n, 'gtTextFor:');
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtTextFor:');
+  });
+});
+
+describe('fetchGtPrintTabData', () => {
+  it('returns data and truncated:false on happy path', () => {
+    expect.assertions(2);
+    const json = '{"string":"hello world","truncated":false}';
+    const execute = vi.fn(() => json);
+    const result = fetchGtPrintTabData(execute, 1000n, 'gtPrintTabFor:');
+    expect(result.data).toBe(json);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('returns data and truncated:true when JSON reports truncation', () => {
+    expect.assertions(2);
+    const json = '{"string":"hello wo...","truncated":true}';
+    const execute = vi.fn(() => json);
+    const result = fetchGtPrintTabData(execute, 1000n, 'gtPrintTabFor:');
+    expect(result.data).toBe(json);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('returns data and truncated:false when JSON.parse fails on malformed response', () => {
+    expect.assertions(2);
+    const badJson = 'not valid json {{{';
+    const execute = vi.fn(() => badJson);
+    const result = fetchGtPrintTabData(execute, 1000n, 'gtPrintTabFor:');
+    expect(result.data).toBe(badJson);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('returns null data and truncated:false when execute returns a GtError string', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => 'GtError:does not understand #gtPrintTabFor:');
+    const result = fetchGtPrintTabData(execute, 1000n, 'gtPrintTabFor:');
+    expect(result.data).toBeNull();
+    expect(result.truncated).toBe(false);
+  });
+
+  it('returns null data and truncated:false when execute throws', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    const result = fetchGtPrintTabData(execute, 1000n, 'gtPrintTabFor:');
+    expect(result.data).toBeNull();
+    expect(result.truncated).toBe(false);
+  });
+
+  it('returns null data and truncated:false when methodSelector is invalid', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '{}');
+    const result = fetchGtPrintTabData(execute, 1000n, 'bad selector!');
+    expect(result.data).toBeNull();
+    expect(result.truncated).toBe(false);
+  });
+
+  it('embeds oop and methodSelector in emitted Smalltalk', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '{}');
+    fetchGtPrintTabData(execute, 99999n, 'gtPrintTabFor:');
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtPrintTabFor:');
+  });
+});
+
+describe('fetchGtForwardListData', () => {
+  it('returns JSON string on happy path', () => {
+    expect.assertions(1);
+    const json = '[{"col1":"foo"},{"col1":"bar"}]';
+    const execute = vi.fn(() => json);
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 1, 100)).toBe(json);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #gtForwardFor:');
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 1, 100)).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 1, 100)).toBeNull();
+  });
+
+  it('returns null when forwardSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtForwardListData(execute, 1000n, 'bad selector!', 1, 100)).toBeNull();
+  });
+
+  it('returns null when fromIndex is 0', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 0, 100)).toBeNull();
+  });
+
+  it('returns null when fromIndex is negative', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', -1, 100)).toBeNull();
+  });
+
+  it('returns null when fromIndex is a float', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 1.5, 100)).toBeNull();
+  });
+
+  it('returns null when count is 0', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 1, 0)).toBeNull();
+  });
+
+  it('returns null when count is negative', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 1, -1)).toBeNull();
+  });
+
+  it('returns null when count is a float', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtForwardListData(execute, 1000n, 'gtForwardFor:', 1, 1.5)).toBeNull();
+  });
+
+  it('embeds oop, forwardSelector, fromIndex, and count in emitted Smalltalk', () => {
+    expect.assertions(4);
+    const execute = vi.fn(() => '[]');
+    fetchGtForwardListData(execute, 99999n, 'gtForwardFor:', 1, 50);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtForwardFor:');
+    expect(code).toContain('1');
+    expect(code).toContain('50');
+  });
+});
+
+describe('fetchGtForwardListTotal', () => {
+  it('returns count as a number on happy path', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '42');
+    expect(fetchGtForwardListTotal(execute, 1000n, 'gtForwardFor:')).toBe(42);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #gtForwardFor:');
+    expect(fetchGtForwardListTotal(execute, 1000n, 'gtForwardFor:')).toBeNull();
+  });
+
+  it('returns null when response is not a number', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'not a number');
+    expect(fetchGtForwardListTotal(execute, 1000n, 'gtForwardFor:')).toBeNull();
+  });
+
+  it('returns null when response is an empty string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '');
+    expect(fetchGtForwardListTotal(execute, 1000n, 'gtForwardFor:')).toBeNull();
+  });
+
+  it('handles whitespace in response', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '  42\n');
+    expect(fetchGtForwardListTotal(execute, 1000n, 'gtForwardFor:')).toBe(42);
+  });
+
+  it('returns 0 when response is "0" — valid count, not treated as falsy', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '0');
+    expect(fetchGtForwardListTotal(execute, 1000n, 'gtForwardFor:')).toBe(0);
+  });
+
+  it('returns null when forwardSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '42');
+    expect(fetchGtForwardListTotal(execute, 1000n, 'bad selector!')).toBeNull();
+  });
+
+  it('embeds oop and forwardSelector in emitted Smalltalk', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '0');
+    fetchGtForwardListTotal(execute, 99999n, 'gtForwardFor:');
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtForwardFor:');
+  });
+});
+
+describe('fetchGtTreeChildren', () => {
+  it('returns JSON string on happy path', () => {
+    expect.assertions(1);
+    const json = '[{"label":"child1"},{"label":"child2"}]';
+    const execute = vi.fn(() => json);
+    expect(fetchGtTreeChildren(execute, 1000n, 'gtTreeFor:', [1])).toBe(json);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #gtTreeFor:');
+    expect(fetchGtTreeChildren(execute, 1000n, 'gtTreeFor:', [1])).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fetchGtTreeChildren(execute, 1000n, 'gtTreeFor:', [1])).toBeNull();
+  });
+
+  it('returns null when methodSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    expect(fetchGtTreeChildren(execute, 1000n, 'bad selector!', [1])).toBeNull();
+  });
+
+  it('produces {} in Smalltalk for an empty path', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    fetchGtTreeChildren(execute, 1000n, 'gtTreeFor:', []);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('{}');
+  });
+
+  it('produces {1} in Smalltalk for a single-element path', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    fetchGtTreeChildren(execute, 1000n, 'gtTreeFor:', [1]);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('{1}');
+  });
+
+  it('produces {1. 2. 3} in Smalltalk for a multi-element path', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    fetchGtTreeChildren(execute, 1000n, 'gtTreeFor:', [1, 2, 3]);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('{1. 2. 3}');
+  });
+
+  it('embeds oop and methodSelector in emitted Smalltalk', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '[]');
+    fetchGtTreeChildren(execute, 99999n, 'gtTreeFor:', [1]);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtTreeFor:');
+  });
+});

--- a/client/src/__tests__/gtInspectorErrorIsolation.test.ts
+++ b/client/src/__tests__/gtInspectorErrorIsolation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchObjectMeta } from '../queries/getGtViewSpecs';
+
+// gtExecute is private — tested here through fetchObjectMeta (simplest exported
+// function with no selector validation to interfere with error path coverage).
+
+describe('gtExecute error isolation', () => {
+  it('wraps user code in AbstractException handler before sending to GemStone', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '{}');
+    fetchObjectMeta(execute, 1000n);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('on: AbstractException do:');
+    expect(code).toContain("'GtError:'");
+  });
+
+  it('returns null for "GtError:" with no message', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:');
+    expect(fetchObjectMeta(execute, 1000n)).toBeNull();
+  });
+
+  it('returns null for "GtError:" with a message', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:something went wrong');
+    expect(fetchObjectMeta(execute, 1000n)).toBeNull();
+  });
+
+  it('passes through an empty string result — not treated as null', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '');
+    expect(fetchObjectMeta(execute, 1000n)).toBe('');
+  });
+
+  it('returns null when execute throws a JavaScript error', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('GCI connection lost'); });
+    expect(fetchObjectMeta(execute, 1000n)).toBeNull();
+  });
+});

--- a/client/src/__tests__/gtInspectorMeta.test.ts
+++ b/client/src/__tests__/gtInspectorMeta.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchObjectMeta, fetchMethodBrowseLocation, fetchMethodSource } from '../queries/getGtViewSpecs';
+
+describe('fetchObjectMeta', () => {
+  it('returns the JSON string on happy path', () => {
+    expect.assertions(1);
+    const json = '{"className":"Array","superclassName":"SequenceableCollection","category":"Collections","comment":"","definition":"...","methodSelectors":[],"classMethodSelectors":[]}';
+    const execute = vi.fn(() => json);
+    expect(fetchObjectMeta(execute, 1000n)).toBe(json);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:object not found');
+    expect(fetchObjectMeta(execute, 1000n)).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fetchObjectMeta(execute, 1000n)).toBeNull();
+  });
+
+  it('embeds oop in emitted Smalltalk', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '{}');
+    fetchObjectMeta(execute, 99999n);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+  });
+});
+
+describe('fetchMethodBrowseLocation', () => {
+  it('returns parsed { dictName, className, category } on happy path', () => {
+    expect.assertions(3);
+    const json = '{"dictName":"Globals","className":"Array","category":"accessing"}';
+    const execute = vi.fn(() => json);
+    const result = fetchMethodBrowseLocation(execute, 1000n, 'size', false);
+    expect(result?.dictName).toBe('Globals');
+    expect(result?.className).toBe('Array');
+    expect(result?.category).toBe('accessing');
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #size');
+    expect(fetchMethodBrowseLocation(execute, 1000n, 'size', false)).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fetchMethodBrowseLocation(execute, 1000n, 'size', false)).toBeNull();
+  });
+
+  it('returns null when methodSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '{}');
+    expect(fetchMethodBrowseLocation(execute, 1000n, 'bad selector!', false)).toBeNull();
+  });
+
+  it('returns null when JSON is malformed', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'not valid json {{{');
+    expect(fetchMethodBrowseLocation(execute, 1000n, 'size', false)).toBeNull();
+  });
+
+  it.each([
+    { isClassSide: false, expected: 'baseCls categoryOfSelector:' },
+    { isClassSide: true, expected: 'baseCls class categoryOfSelector:' },
+  ])('isClassSide $isClassSide — Smalltalk contains "$expected"', ({ isClassSide, expected }) => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '{}');
+    fetchMethodBrowseLocation(execute, 1000n, 'size', isClassSide);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain(expected);
+  });
+
+  it('embeds oop and methodSelector in emitted Smalltalk', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => '{}');
+    fetchMethodBrowseLocation(execute, 99999n, 'size', false);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('size');
+  });
+});
+
+describe('fetchMethodSource', () => {
+  it('returns the source string on happy path', () => {
+    expect.assertions(1);
+    const source = 'size\n  ^ self basicSize';
+    const execute = vi.fn(() => source);
+    expect(fetchMethodSource(execute, 1000n, 'size', false)).toBe(source);
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #size');
+    expect(fetchMethodSource(execute, 1000n, 'size', false)).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fetchMethodSource(execute, 1000n, 'size', false)).toBeNull();
+  });
+
+  it('returns null when methodSelector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'some source');
+    expect(fetchMethodSource(execute, 1000n, 'bad selector!', false)).toBeNull();
+  });
+
+  it.each([
+    { isClassSide: false, expected: 'theNonMetaClass sourceCodeAt:' },
+    { isClassSide: true, expected: 'theNonMetaClass class sourceCodeAt:' },
+  ])('isClassSide $isClassSide — recv contains "$expected"', ({ isClassSide, expected }) => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'source');
+    fetchMethodSource(execute, 1000n, 'size', isClassSide);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain(expected);
+  });
+
+  it('embeds oop and methodSelector in emitted Smalltalk', () => {
+    expect.assertions(2);
+    const execute = vi.fn(() => 'source');
+    fetchMethodSource(execute, 99999n, 'size', false);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('size');
+  });
+});

--- a/client/src/__tests__/gtInspectorPanel.test.ts
+++ b/client/src/__tests__/gtInspectorPanel.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('vscode', () => ({
+  window: {
+    createWebviewPanel: vi.fn(),
+    showWarningMessage: vi.fn(),
+  },
+  ViewColumn: { Beside: 2 },
+}));
+
+vi.mock('../debugQueries', () => ({
+  fetchPrintString: vi.fn(),
+  getObjectClassName: vi.fn(),
+  fetchFullPrintString: vi.fn(),
+}));
+
+vi.mock('../browserQueries', () => ({
+  executeFetchString: vi.fn(() => ''),
+}));
+
+vi.mock('../queries/getGtViewSpecs', () => ({
+  getGtViewSpecs: vi.fn(),
+  fetchObjectMeta: vi.fn(),
+  fetchGtPrintTabData: vi.fn(),
+  fetchGtTextData: vi.fn(),
+  fetchGtListData: vi.fn(),
+  fetchGtForwardListData: vi.fn(),
+  fetchGtForwardListTotal: vi.fn(),
+  fetchGtListTotal: vi.fn(),
+  fetchGtRowOop: vi.fn(),
+  fetchGtForwardRowOop: vi.fn(),
+  fetchGtTreeChildren: vi.fn(),
+  fetchMethodSource: vi.fn(),
+  fetchMethodBrowseLocation: vi.fn(),
+}));
+
+vi.mock('../systemBrowser', () => ({
+  SystemBrowser: { navigateBeside: vi.fn() },
+}));
+
+import * as vscode from 'vscode';
+import * as debug from '../debugQueries';
+import * as queries from '../queries/getGtViewSpecs';
+import { SystemBrowser } from '../systemBrowser';
+import { GtInspector } from '../gtInspector';
+import { ActiveSession } from '../sessionManager';
+import { GemStoneLogin } from '../loginTypes';
+
+// ── Mock panel factory ─────────────────────────────────────────────────────
+// Each panel is self-contained: its own postMessage, title, and sendMessage.
+
+function makeMockPanel() {
+  const postMessage = vi.fn();
+  let title = '';
+  let messageHandler: ((msg: any) => void) | undefined;
+
+  const panel = {
+    webview: {
+      set html(_: string) {},
+      postMessage,
+      onDidReceiveMessage(cb: (msg: any) => void) {
+        messageHandler = cb;
+        return { dispose: vi.fn() };
+      },
+    },
+    get title() { return title; },
+    set title(v: string) { title = v; },
+    onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+  };
+
+  return {
+    panel,
+    get postMessage() { return postMessage; },
+    get title() { return title; },
+    sendMessage(msg: any) { messageHandler!(msg); },
+  };
+}
+
+function createMockSession(): ActiveSession {
+  return {
+    id: 1,
+    gci: {} as unknown as ActiveSession['gci'],
+    handle: {},
+    login: { label: 'Test' } as GemStoneLogin,
+    stoneVersion: '3.7.2',
+  };
+}
+
+// ── Shared state ───────────────────────────────────────────────────────────
+
+let session: ActiveSession;
+let mock: ReturnType<typeof makeMockPanel>;
+
+function setup(oop = 1000n, label = 'test') {
+  GtInspector.create(session, oop, label);
+  return mock;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  session = createMockSession();
+  mock = makeMockPanel();
+  vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel as any);
+  vi.mocked(debug.fetchPrintString).mockReturnValue({ value: 'an Object', truncated: false });
+  vi.mocked(debug.getObjectClassName).mockReturnValue('Object');
+  vi.mocked(queries.getGtViewSpecs).mockReturnValue([]);
+  vi.mocked(queries.fetchObjectMeta).mockReturnValue('{}');
+});
+
+afterEach(() => {
+  GtInspector.disposeForSession(session.id);
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('GtInspector', () => {
+  describe('A — panel lifecycle', () => {
+    it('create() opens the panel with ViewColumn.Beside', () => {
+      expect.assertions(1);
+      GtInspector.create(session, 1000n, 'test');
+      expect(vscode.window.createWebviewPanel).toHaveBeenCalledWith(
+        'gemstoneSuperInspector',
+        'Inspector',
+        vscode.ViewColumn.Beside,
+        expect.any(Object),
+      );
+    });
+
+    it('disposeForSession() disposes all panels registered to a session', () => {
+      expect.assertions(2);
+      const mock2 = makeMockPanel();
+      vi.mocked(vscode.window.createWebviewPanel)
+        .mockReturnValueOnce(mock.panel as any)
+        .mockReturnValueOnce(mock2.panel as any);
+      GtInspector.create(session, 1000n, 'first');
+      GtInspector.create(session, 2000n, 'second');
+      GtInspector.disposeForSession(session.id);
+      expect(mock.panel.dispose).toHaveBeenCalled();
+      expect(mock2.panel.dispose).toHaveBeenCalled();
+    });
+
+    it('disposeForSession() is a no-op for an unknown session id', () => {
+      expect.assertions(1);
+      expect(() => GtInspector.disposeForSession(9999)).not.toThrow();
+    });
+  });
+
+  describe('B — ready: panel title', () => {
+    it('sets title from fetchPrintString when not truncated', () => {
+      expect.assertions(1);
+      vi.mocked(debug.fetchPrintString).mockReturnValue({ value: 'an Array(3)', truncated: false });
+      setup();
+      mock.sendMessage({ command: 'ready' });
+      expect(mock.title).toBe('an Array(3)');
+    });
+
+    it('appends ellipsis to title when print string is truncated', () => {
+      expect.assertions(1);
+      vi.mocked(debug.fetchPrintString).mockReturnValue({ value: 'a very long string', truncated: true });
+      setup();
+      mock.sendMessage({ command: 'ready' });
+      expect(mock.title).toBe('a very long string…');
+    });
+
+    it('calls fetchPrintString with the inspector oop and a limit of 40', () => {
+      expect.assertions(2);
+      setup(5555n);
+      mock.sendMessage({ command: 'ready' });
+      const [, oop, limit] = vi.mocked(debug.fetchPrintString).mock.calls[0];
+      expect(oop).toBe(5555n);
+      expect(limit).toBe(40);
+    });
+  });
+
+  describe('C — ready: gtViewSpecs message', () => {
+    it('always includes meta in the gtViewSpecs message', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchObjectMeta).mockReturnValue('{"className":"Array"}');
+      setup();
+      mock.sendMessage({ command: 'ready' });
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtViewSpecs', meta: '{"className":"Array"}' }),
+      );
+    });
+
+    it('passes specs through in the gtViewSpecs message even when null', () => {
+      expect.assertions(1);
+      vi.mocked(queries.getGtViewSpecs).mockReturnValue(null);
+      setup();
+      mock.sendMessage({ command: 'ready' });
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtViewSpecs', specs: null }),
+      );
+    });
+
+    it('includes className from getObjectClassName in the gtViewSpecs message', () => {
+      expect.assertions(1);
+      vi.mocked(debug.getObjectClassName).mockReturnValue('OrderedCollection');
+      setup();
+      mock.sendMessage({ command: 'ready' });
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtViewSpecs', className: 'OrderedCollection' }),
+      );
+    });
+  });
+
+  describe('D — fetchGtViewData routing', () => {
+    it('routes gtPrintFor: + text editor view to fetchGtPrintTabData', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtPrintTabData).mockReturnValue({ data: '{}', truncated: false });
+      setup();
+      mock.sendMessage({ command: 'fetchGtViewData', oop: '1000', methodSelector: 'gtPrintFor:', viewName: 'GtPhlowTextEditorViewSpecification' });
+      expect(queries.fetchGtPrintTabData).toHaveBeenCalled();
+    });
+
+    it('routes text view to fetchGtTextData', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtTextData).mockReturnValue('{}');
+      setup();
+      mock.sendMessage({ command: 'fetchGtViewData', oop: '1000', methodSelector: 'gtTextFor:', viewName: 'GtPhlowTextViewSpecification' });
+      expect(queries.fetchGtTextData).toHaveBeenCalled();
+    });
+
+    it('routes list view to fetchGtListData', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtListData).mockReturnValue('[]');
+      setup();
+      mock.sendMessage({ command: 'fetchGtViewData', oop: '1000', methodSelector: 'gtItemsFor:', viewName: 'GtPhlowListViewSpecification' });
+      expect(queries.fetchGtListData).toHaveBeenCalled();
+    });
+  });
+
+  describe('E — fetchGtViewTotal routing', () => {
+    it('routes forward view to fetchGtForwardListTotal', () => {
+      expect.assertions(2);
+      vi.mocked(queries.fetchGtForwardListTotal).mockReturnValue(42);
+      setup();
+      mock.sendMessage({ command: 'fetchGtViewTotal', oop: '1000', methodSelector: 'gtForwardFor:', viewName: 'GtPhlowForwardViewSpecification' });
+      expect(queries.fetchGtForwardListTotal).toHaveBeenCalled();
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtViewTotal', total: 42 }),
+      );
+    });
+
+    it('routes non-forward view to fetchGtListTotal', () => {
+      expect.assertions(2);
+      vi.mocked(queries.fetchGtListTotal).mockReturnValue(10);
+      setup();
+      mock.sendMessage({ command: 'fetchGtViewTotal', oop: '1000', methodSelector: 'gtItemsFor:', viewName: 'GtPhlowListViewSpecification' });
+      expect(queries.fetchGtListTotal).toHaveBeenCalled();
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtViewTotal', total: 10 }),
+      );
+    });
+  });
+
+  describe('F — gtInspectRow: double-click opens new inspector', () => {
+    it('opens a new panel with ViewColumn.Beside when a row is double-clicked', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtRowOop).mockReturnValue(9999n);
+      setup();
+      const newMock = makeMockPanel();
+      vi.mocked(vscode.window.createWebviewPanel).mockReturnValueOnce(newMock.panel as any);
+      mock.sendMessage({ command: 'gtInspectRow', itemOop: '1000', methodSelector: 'gtItemsFor:', nodeId: 3, viewName: 'GtPhlowListViewSpecification' });
+      expect(vscode.window.createWebviewPanel).toHaveBeenLastCalledWith(
+        'gemstoneSuperInspector',
+        'Inspector',
+        vscode.ViewColumn.Beside,
+        expect.any(Object),
+      );
+    });
+
+    it('uses fetchGtForwardRowOop for double-click on a forward view row', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtForwardRowOop).mockReturnValue(8888n);
+      setup();
+      const newMock = makeMockPanel();
+      vi.mocked(vscode.window.createWebviewPanel).mockReturnValueOnce(newMock.panel as any);
+      mock.sendMessage({ command: 'gtInspectRow', itemOop: '1000', methodSelector: 'gtForwardFor:', nodeId: 2, viewName: 'GtPhlowForwardViewSpecification' });
+      expect(queries.fetchGtForwardRowOop).toHaveBeenCalled();
+    });
+
+    it('does not open a new inspector when row OOP is null', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtRowOop).mockReturnValue(null);
+      setup();
+      const callsBefore = vi.mocked(vscode.window.createWebviewPanel).mock.calls.length;
+      mock.sendMessage({ command: 'gtInspectRow', itemOop: '1000', methodSelector: 'gtItemsFor:', nodeId: 3, viewName: 'GtPhlowListViewSpecification' });
+      expect(vi.mocked(vscode.window.createWebviewPanel).mock.calls.length).toBe(callsBefore);
+    });
+  });
+
+  describe('G — browseMethod', () => {
+    it('calls SystemBrowser.navigateBeside when location is found', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchMethodBrowseLocation).mockReturnValue({ dictName: 'Globals', className: 'Array', category: 'accessing' });
+      setup();
+      mock.sendMessage({ command: 'browseMethod', oop: '1000', methodSelector: 'size', isClassSide: false });
+      expect(SystemBrowser.navigateBeside).toHaveBeenCalledWith(
+        session,
+        expect.objectContaining({ className: 'Array', selector: 'size' }),
+      );
+    });
+
+    it('shows a warning and does not navigate when location is null', () => {
+      expect.assertions(2);
+      vi.mocked(queries.fetchMethodBrowseLocation).mockReturnValue(null);
+      setup();
+      mock.sendMessage({ command: 'browseMethod', oop: '1000', methodSelector: 'size', isClassSide: false });
+      expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+      expect(SystemBrowser.navigateBeside).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/__tests__/gtInspectorPanel.test.ts
+++ b/client/src/__tests__/gtInspectorPanel.test.ts
@@ -291,6 +291,89 @@ describe('GtInspector', () => {
     });
   });
 
+  describe('H — fetchMoreRows', () => {
+    it('posts gtMoreRows (not gtViewData) with list data', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtListData).mockReturnValue('[1,2,3]');
+      setup();
+      mock.sendMessage({ command: 'fetchMoreRows', oop: '1000', methodSelector: 'gtItemsFor:', viewName: 'GtPhlowListViewSpecification', fromIndex: 11 });
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtMoreRows', methodSelector: 'gtItemsFor:', data: '[1,2,3]' }),
+      );
+    });
+
+    it('passes fromIndex through to the query function', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtListData).mockReturnValue('[]');
+      setup();
+      mock.sendMessage({ command: 'fetchMoreRows', oop: '1000', methodSelector: 'gtItemsFor:', viewName: 'GtPhlowListViewSpecification', fromIndex: 21 });
+      expect(queries.fetchGtListData).toHaveBeenCalledWith(expect.any(Function), 1000n, 'gtItemsFor:', 21, expect.any(Number));
+    });
+  });
+
+  describe('I — fetchGtRangeData', () => {
+    it('routes non-forward view to fetchGtListData and posts gtRangeData with rangeStart', () => {
+      expect.assertions(2);
+      vi.mocked(queries.fetchGtListData).mockReturnValue('[4,5,6]');
+      setup();
+      mock.sendMessage({ command: 'fetchGtRangeData', oop: '1000', methodSelector: 'gtItemsFor:', viewName: 'GtPhlowListViewSpecification', fromIndex: 5, rangeStart: 5 });
+      expect(queries.fetchGtListData).toHaveBeenCalled();
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtRangeData', methodSelector: 'gtItemsFor:', rangeStart: 5, data: '[4,5,6]' }),
+      );
+    });
+
+    it('routes forward view to fetchGtForwardListData', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchGtForwardListData).mockReturnValue('[7,8,9]');
+      setup();
+      mock.sendMessage({ command: 'fetchGtRangeData', oop: '1000', methodSelector: 'gtForwardFor:', viewName: 'GtPhlowForwardViewSpecification', fromIndex: 1, rangeStart: 1 });
+      expect(queries.fetchGtForwardListData).toHaveBeenCalled();
+    });
+  });
+
+  describe('J — fetchGtTreeChildren', () => {
+    it('calls fetchGtTreeChildren and posts gtTreeChildren with path and data', () => {
+      expect.assertions(2);
+      vi.mocked(queries.fetchGtTreeChildren).mockReturnValue('[{"label":"child"}]');
+      setup();
+      mock.sendMessage({ command: 'fetchGtTreeChildren', itemOop: '2000', methodSelector: 'gtTreeFor:', path: [1, 2] });
+      expect(queries.fetchGtTreeChildren).toHaveBeenCalledWith(expect.any(Function), 2000n, 'gtTreeFor:', [1, 2]);
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'gtTreeChildren', methodSelector: 'gtTreeFor:', path: [1, 2], data: '[{"label":"child"}]' }),
+      );
+    });
+  });
+
+  describe('K — fetchFullPrintString', () => {
+    it('wraps fetchFullPrintString result in JSON with stylerSpecification null and posts fullPrintString', () => {
+      expect.assertions(2);
+      vi.mocked(debug.fetchFullPrintString).mockReturnValue('this is the full text');
+      setup();
+      mock.sendMessage({ command: 'fetchFullPrintString', oop: '1000', methodSelector: 'gtPrintFor:' });
+      expect(debug.fetchFullPrintString).toHaveBeenCalled();
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'fullPrintString',
+          methodSelector: 'gtPrintFor:',
+          data: JSON.stringify({ string: 'this is the full text', stylerSpecification: null }),
+        }),
+      );
+    });
+  });
+
+  describe('L — fetchMethodSource', () => {
+    it('posts methodSource with source, methodSelector, and isClassSide', () => {
+      expect.assertions(1);
+      vi.mocked(queries.fetchMethodSource).mockReturnValue('size\n  ^ self basicSize');
+      setup();
+      mock.sendMessage({ command: 'fetchMethodSource', oop: '1000', methodSelector: 'size', isClassSide: false });
+      expect(mock.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'methodSource', methodSelector: 'size', isClassSide: false, source: 'size\n  ^ self basicSize' }),
+      );
+    });
+  });
+
   describe('G — browseMethod', () => {
     it('calls SystemBrowser.navigateBeside when location is found', () => {
       expect.assertions(1);

--- a/client/src/__tests__/gtInspectorRowOop.test.ts
+++ b/client/src/__tests__/gtInspectorRowOop.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchGtRowOop, fetchGtForwardRowOop } from '../queries/getGtViewSpecs';
+
+type RowOopFn = (execute: ReturnType<typeof vi.fn>, oop: bigint, selector: string, nodeId: number) => bigint | null;
+
+describe.each([
+  { name: 'fetchGtRowOop', fn: fetchGtRowOop as unknown as RowOopFn },
+  { name: 'fetchGtForwardRowOop', fn: fetchGtForwardRowOop as unknown as RowOopFn },
+])('$name', ({ fn }) => {
+  it('returns a bigint OOP on happy path', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '12345');
+    expect(fn(execute, 1000n, 'gtItemsFor:', 5)).toBe(12345n);
+  });
+
+  it('returns null when Smalltalk error handler returns empty string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '');
+    expect(fn(execute, 1000n, 'gtItemsFor:', 5)).toBeNull();
+  });
+
+  it('returns null when result is non-numeric — BigInt() throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'not a number');
+    expect(fn(execute, 1000n, 'gtItemsFor:', 5)).toBeNull();
+  });
+
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:does not understand #gtItemsFor:');
+    expect(fn(execute, 1000n, 'gtItemsFor:', 5)).toBeNull();
+  });
+
+  it('returns null when execute throws', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => { throw new Error('connection lost'); });
+    expect(fn(execute, 1000n, 'gtItemsFor:', 5)).toBeNull();
+  });
+
+  it('returns null when selector is invalid', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '12345');
+    expect(fn(execute, 1000n, 'bad selector!', 5)).toBeNull();
+  });
+
+  it('embeds oop, selector, and nodeId in emitted Smalltalk', () => {
+    expect.assertions(3);
+    const execute = vi.fn(() => '12345');
+    fn(execute, 99999n, 'gtItemsFor:', 7);
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
+    expect(code).toContain('gtItemsFor:');
+    expect(code).toContain('7');
+  });
+});

--- a/client/src/__tests__/gtInspectorSelector.test.ts
+++ b/client/src/__tests__/gtInspectorSelector.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { isValidSelector } from '../queries/getGtViewSpecs';
+
+describe('isValidSelector', () => {
+  describe('valid selectors', () => {
+    it('accepts a unary selector', () => {
+      expect(isValidSelector('size')).toBe(true);
+    });
+
+    it('accepts a unary selector with mixed case', () => {
+      expect(isValidSelector('printString')).toBe(true);
+    });
+
+    it('accepts a single keyword selector', () => {
+      expect(isValidSelector('gtItemsFor:')).toBe(true);
+    });
+
+    it('accepts a multi-keyword selector', () => {
+      expect(isValidSelector('at:put:')).toBe(true);
+    });
+
+    it('accepts a single-character binary selector', () => {
+      expect(isValidSelector('+')).toBe(true);
+    });
+
+    it('accepts a two-character binary selector', () => {
+      expect(isValidSelector('<=')).toBe(true);
+    });
+
+    it('accepts a selector starting with underscore', () => {
+      expect(isValidSelector('_objectForOop:')).toBe(true);
+    });
+  });
+
+  describe('invalid selectors', () => {
+    it('rejects an empty string', () => {
+      expect(isValidSelector('')).toBe(false);
+    });
+
+    it('rejects a selector with a space inside a keyword', () => {
+      expect(isValidSelector('gt Items For:')).toBe(false);
+    });
+
+    it('rejects a selector that starts with a digit', () => {
+      expect(isValidSelector('1gtItemsFor:')).toBe(false);
+    });
+
+    it('rejects a selector containing an illegal character', () => {
+      expect(isValidSelector('gtItems!For:')).toBe(false);
+    });
+
+    it('rejects a selector starting with $', () => {
+      expect(isValidSelector('$foo')).toBe(false);
+    });
+  });
+});

--- a/client/src/__tests__/gtInspectorViewSpecs.test.ts
+++ b/client/src/__tests__/gtInspectorViewSpecs.test.ts
@@ -47,6 +47,7 @@ describe('getGtViewSpecs', () => {
     expect.assertions(1);
     const execute = vi.fn(() => '[]');
     getGtViewSpecs(execute, 99999n);
-    expect(execute.mock.calls[0][1]).toContain('99999');
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(code).toContain('99999');
   });
 });

--- a/client/src/__tests__/gtInspectorViewSpecs.test.ts
+++ b/client/src/__tests__/gtInspectorViewSpecs.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getGtViewSpecs } from '../queries/getGtViewSpecs';
+
+describe('getGtViewSpecs', () => {
+  it('returns null when execute returns a GtError string', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'GtError:viewed object not found');
+    expect(getGtViewSpecs(execute, 1000n)).toBeNull();
+  });
+
+  it('returns null when execute returns malformed JSON', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => 'not valid json {{{');
+    expect(getGtViewSpecs(execute, 1000n)).toBeNull();
+  });
+
+  it('returns specs sorted by ascending priority', () => {
+    const priorities = [50, 10, 80, 30, 70, 20, 90, 40, 60, 1];
+    expect.assertions(priorities.length);
+    const specs = priorities.map((priority, i) => ({
+      viewName: 'GtPhlowListViewSpecification',
+      title: `View${i}`,
+      priority,
+      methodSelector: `gtView${i}For:`,
+      dataTransport: 1,
+    }));
+    const execute = vi.fn(() => JSON.stringify(specs));
+    const result = getGtViewSpecs(execute, 1000n)!;
+    const sorted = [...priorities].sort((a, b) => a - b);
+    sorted.forEach((p, i) => expect(result[i].priority).toBe(p));
+  });
+
+  it('makes a second execute call to resolve a forward view spec', () => {
+    expect.assertions(2);
+    const specs = [
+      { viewName: 'GtPhlowForwardViewSpecification', title: 'Forward', priority: 1, methodSelector: 'gtForwardFor:', dataTransport: 1 },
+    ];
+    const execute = vi.fn()
+      .mockReturnValueOnce(JSON.stringify(specs))
+      .mockReturnValueOnce(JSON.stringify({ __typeName: 'GtPhlowListViewSpecification', columnSpecifications: [] }));
+    const result = getGtViewSpecs(execute, 1000n);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(result![0].resolvedViewName).toBe('GtPhlowListViewSpecification');
+  });
+
+  it('embeds oop in emitted Smalltalk', () => {
+    expect.assertions(1);
+    const execute = vi.fn(() => '[]');
+    getGtViewSpecs(execute, 99999n);
+    expect(execute.mock.calls[0][1]).toContain('99999');
+  });
+});

--- a/client/src/queries/getGtViewSpecs.ts
+++ b/client/src/queries/getGtViewSpecs.ts
@@ -1,6 +1,12 @@
 import { QueryExecutor } from './types';
 import { escapeString } from './util';
 
+const VALID_SELECTOR = /^[a-zA-Z_][a-zA-Z0-9_]*:?$|^([a-zA-Z_][a-zA-Z0-9_]*:)+$|^[+\-*\/<>=~&|@%?,]{1,2}$/;
+
+export function isValidSelector(selector: string): boolean {
+  return VALID_SELECTOR.test(selector);
+}
+
 export interface GtViewSpec {
   viewName: string;
   title: string;
@@ -38,6 +44,7 @@ function resolveForwardViewSpec(
   oop: bigint,
   forwardSelector: string,
 ): Pick<GtViewSpec, 'resolvedViewName' | 'resolvedColumnSpecifications'> | null {
+  if (!isValidSelector(forwardSelector)) return null;
   const code =
     `| viewed ds specDict |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
@@ -84,6 +91,7 @@ export function fetchGtPrintTabData(
   oop: bigint,
   methodSelector: string,
 ): { data: string | null; truncated: boolean } {
+  if (!isValidSelector(methodSelector)) return { data: null, truncated: false };
   const code =
     `| viewed obj ds textData s |
 obj := Object _objectForOop: ${oop}.
@@ -103,6 +111,7 @@ STONJSON toString: textData`;
 }
 
 export function fetchGtTextData(execute: QueryExecutor, oop: bigint, methodSelector: string): string | null {
+  if (!isValidSelector(methodSelector)) return null;
   const code =
     `| viewed ds |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
@@ -117,6 +126,7 @@ export function fetchGtForwardRowOop(
   forwardSelector: string,
   nodeId: number,
 ): bigint | null {
+  if (!isValidSelector(forwardSelector)) return null;
   const code =
     `| viewed ds forwardDs item |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${itemOop}).
@@ -136,6 +146,7 @@ export function fetchGtRowOop(
   methodSelector: string,
   nodeId: number,
 ): bigint | null {
+  if (!isValidSelector(methodSelector)) return null;
   const code =
     `| viewed ds node item |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${itemOop}).
@@ -154,6 +165,7 @@ export function fetchGtListTotal(
   oop: bigint,
   methodSelector: string,
 ): number | null {
+  if (!isValidSelector(methodSelector)) return null;
   const code =
     `| viewed ds |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
@@ -171,6 +183,7 @@ export function fetchGtTreeChildren(
   methodSelector: string,
   path: number[],
 ): string | null {
+  if (!isValidSelector(methodSelector)) return null;
   const stPath = '{' + path.join('. ') + '}';
   const code =
     `| viewed ds |
@@ -187,6 +200,7 @@ export function fetchMethodBrowseLocation(
   methodSelector: string,
   isClassSide: boolean,
 ): { dictName: string; className: string; category: string } | null {
+  if (!isValidSelector(methodSelector)) return null;
   const methodCls = isClassSide ? 'baseCls class' : 'baseCls';
   const code =
     `| obj baseCls dictName category |
@@ -210,6 +224,7 @@ export function fetchMethodSource(
   methodSelector: string,
   isClassSide: boolean,
 ): string | null {
+  if (!isValidSelector(methodSelector)) return null;
   const recv = isClassSide
     ? `(Object _objectForOop: ${oop}) class theNonMetaClass class`
     : `(Object _objectForOop: ${oop}) class theNonMetaClass`;
@@ -241,6 +256,9 @@ export function fetchGtListData(
   fromIndex: number,
   count: number,
 ): string | null {
+  if (!isValidSelector(methodSelector)) return null;
+  if (!Number.isInteger(fromIndex) || fromIndex < 1) return null;
+  if (!Number.isInteger(count) || count < 1) return null;
   const code =
     `| viewed ds |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
@@ -256,6 +274,9 @@ export function fetchGtForwardListData(
   fromIndex: number,
   count: number,
 ): string | null {
+  if (!isValidSelector(forwardSelector)) return null;
+  if (!Number.isInteger(fromIndex) || fromIndex < 1) return null;
+  if (!Number.isInteger(count) || count < 1) return null;
   const code =
     `| viewed ds forwardDs |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
@@ -271,6 +292,7 @@ export function fetchGtForwardListTotal(
   oop: bigint,
   forwardSelector: string,
 ): number | null {
+  if (!isValidSelector(forwardSelector)) return null;
   const code =
     `| viewed ds forwardDs |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).


### PR DESCRIPTION
**Add unit tests for GT Phlow inspector (issue #83)**

## Summary

- Adds 7 new test files providing direct unit test coverage for every exported function in the GT inspector feature introduced in #89
- Added `isValidSelector` validation to all 11 query functions in `getGtViewSpecs.ts` that accept a method selector, plus `fromIndex`/`count` range guards to `fetchGtForwardListData`

## New test files

| File | What it covers |
|---|---|
| `gtInspectorSelector.test.ts` | `isValidSelector` — unary, keyword, binary, multi-keyword, underscore-prefixed, and invalid cases |
| `gtInspectorDataFetchers.test.ts` | `fetchGtListTotal`, `fetchGtListData`, `fetchGtTextData`, `fetchGtPrintTabData`, `fetchGtForwardListData`, `fetchGtForwardListTotal`, `fetchGtTreeChildren` |
| `gtInspectorRowOop.test.ts` | `fetchGtRowOop` and `fetchGtForwardRowOop` (via `describe.each`) |
| `gtInspectorMeta.test.ts` | `fetchObjectMeta`, `fetchMethodBrowseLocation`, `fetchMethodSource` |
| `gtInspectorErrorIsolation.test.ts` | `gtExecute` error handling — AbstractException wrapping, GtError prefix, JS exceptions |
| `gtInspectorViewSpecs.test.ts` | `getGtViewSpecs` — error handling, sort order (10-element), forward spec resolution |
| `gtInspectorPanel.test.ts` | `GtInspector` class — panel lifecycle, title, all 10 `handleMessage` cases, `ViewColumn.Beside` on create and double-click |

## Test plan

- All 1574 client tests, 320 server tests, and 95 MCP tests pass
- TypeScript compiles cleanly
- CI Health Check passing
