### PR TITLE
Centralize new-method URI construction in buildNewMethodUri

### DIFF
--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -21,7 +21,7 @@ vi.mock('../browserQueries', () => ({
 }));
 
 import { Uri, FileSystemError, FilePermission, window, languages } from '../__mocks__/vscode';
-import { GemStoneFileSystemProvider } from '../gemstoneFileSystemProvider';
+import { GemStoneFileSystemProvider, buildNewMethodUri } from '../gemstoneFileSystemProvider';
 import { SessionManager } from '../sessionManager';
 import * as queries from '../browserQueries';
 import { BrowserQueryError } from '../browserQueries';
@@ -410,5 +410,63 @@ describe('GemStoneFileSystemProvider', () => {
         expect.anything(), 'Array', false, 'size', 0,
       );
     });
+  });
+});
+
+describe('buildNewMethodUri', () => {
+  it('uses the gemstone scheme', () => {
+    const uri = buildNewMethodUri(42, 'Globals', 'Array', false, 'accessing', 0);
+    expect(uri.scheme).toBe('gemstone');
+  });
+
+  it('uses the session id as the authority', () => {
+    const uri = buildNewMethodUri(42, 'Globals', 'Array', false, 'accessing', 0);
+    expect(uri.authority).toBe('42');
+  });
+
+  it('produces an instance-side path when the class side is not meta', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
+    const parts = uri.path.split('/');
+    expect(parts[3]).toBe('instance');
+  });
+
+  it('produces a class-side path when the class side is meta', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', true, 'accessing', 0);
+    const parts = uri.path.split('/');
+    expect(parts[3]).toBe('class');
+  });
+
+  it('URL-encodes the dictionary name', () => {
+    const uri = buildNewMethodUri(1, 'User Globals', 'Array', false, 'accessing', 0);
+    const parts = uri.path.split('/');
+    expect(parts[1]).toBe('User%20Globals');
+  });
+
+  it('URL-encodes the class name', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'My Class', false, 'accessing', 0);
+    const parts = uri.path.split('/');
+    expect(parts[2]).toBe('My%20Class');
+  });
+
+  it('URL-encodes the category name', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'as yet unclassified', 0);
+    const parts = uri.path.split('/');
+    expect(parts[4]).toBe('as%20yet%20unclassified');
+  });
+
+  it('places new-method as the final path segment', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
+    const parts = uri.path.split('/');
+    expect(parts[5]).toBe('new-method');
+  });
+
+  it('omits the env query parameter when the environment is the default', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
+    expect(uri.query).toBe('');
+  });
+
+  it('appends the env query parameter when a non-default environment is specified', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 2);
+    expect(uri.query).toBe('env=2');
   });
 });

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -102,6 +102,26 @@ function parseUri(uri: vscode.Uri): ParsedUri {
   throw vscode.FileSystemError.FileNotFound(uri);
 }
 
+export function buildNewMethodUri(
+  sessionId: number,
+  dictName: string,
+  className: string,
+  isMeta: boolean,
+  category: string,
+  environmentId: number,
+): vscode.Uri {
+  const side = isMeta ? 'class' : 'instance';
+  const envQuery = environmentId > 0 ? `?env=${environmentId}` : '';
+  return vscode.Uri.parse(
+    `gemstone://${sessionId}` +
+    `/${encodeURIComponent(dictName)}` +
+    `/${encodeURIComponent(className)}` +
+    `/${side}` +
+    `/${encodeURIComponent(category)}` +
+    `/new-method${envQuery}`,
+  );
+}
+
 // ── FileSystemProvider ────────────────────────────────────────
 
 export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -8,6 +8,7 @@ import {parseTopazDocument} from './topazFileIn';
 import * as queries from './browserQueries';
 import {GlobalsBrowser} from './globalsBrowser';
 import {ClassBrowser} from './classBrowser';
+import {buildNewMethodUri} from './gemstoneFileSystemProvider';
 
 /**
  * The webview HTML is a large template literal in getHtml(). Embedding JS directly
@@ -1263,17 +1264,9 @@ export class SystemBrowser {
     }
 
     const dictName = this.state.dictionaries[dictIndex - 1];
-    const side = this.state.isMeta ? 'class' : 'instance';
     const category = (this.state.selectedMethodCategory && this.state.selectedMethodCategory !== '** ALL METHODS **')
       ? this.state.selectedMethodCategory : 'as yet unclassified';
-    const uri = vscode.Uri.parse(
-      `gemstone://${this.session.id}` +
-      `/${encodeURIComponent(dictName)}` +
-      `/${encodeURIComponent(className)}` +
-      `/${side}` +
-      `/${encodeURIComponent(category)}` +
-      `/new-method`,
-    );
+    const uri = buildNewMethodUri(this.session.id, dictName, className, this.state.isMeta, category, this.state.selectedEnvId);
     const viewColumn = await this.getBrowserViewColumn();
     const doc = await vscode.workspace.openTextDocument(uri);
     vscode.window.showTextDocument(doc, { viewColumn, preview: true });


### PR DESCRIPTION
The URI was built inline in handleNewMethod with a raw template string, duplicating encoding logic already captured in parseUri and also omitting the ?env=N query parameter, causing new methods to always be created in environment 0 instead of the one selected in the system browser.

Screen capture showing the creation of different methods in different environments.
There are some pre-existing usability issues that I'll address in follow-up PRs:

https://github.com/user-attachments/assets/68122c98-2cf0-4292-8751-7226472afb08

