### PR TITLE
Show methods when switching environments

### DIFF
--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -1321,6 +1321,7 @@ describe('SystemBrowser', () => {
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadMethodCategories',
         items: ['** ALL METHODS **', 'Ruby'],
+        selected: '** ALL METHODS **',
       });
     });
 
@@ -1336,6 +1337,67 @@ describe('SystemBrowser', () => {
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadMethodCategories',
         items: ['** ALL METHODS **'],
+        selected: '** ALL METHODS **',
+      });
+    });
+
+    it('selects ** ALL METHODS ** when no category was selected before environment toggle', () => {
+      messageHandler({ command: 'selectDictionary', index: 1 });
+      messageHandler({ command: 'selectCategory', name: '** ALL CLASSES **' });
+      messageHandler({ command: 'selectClass', name: 'Array' });
+      vi.mocked(mockPanel.webview.postMessage).mockClear();
+
+      messageHandler({ command: 'toggleEnvironment', envId: 1 });
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'loadMethodCategories', selected: '** ALL METHODS **' }),
+      );
+    });
+
+    it('preserves selected method category when it exists in the target environment', () => {
+      vi.mocked(queries.getClassEnvironments).mockReturnValue([
+        { isMeta: false, envId: 0, category: 'Accessing', selectors: ['name', 'name:'] },
+        { isMeta: false, envId: 1, category: 'Accessing', selectors: ['rb_name'] }
+      ]);
+      messageHandler({ command: 'selectDictionary', index: 1 });
+      messageHandler({ command: 'selectCategory', name: '** ALL CLASSES **' });
+      messageHandler({ command: 'selectClass', name: 'Array' });
+      messageHandler({ command: 'selectMethodCategory', name: 'Accessing' });
+      vi.mocked(mockPanel.webview.postMessage).mockClear();
+
+      messageHandler({ command: 'toggleEnvironment', envId: 1 });
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'loadMethodCategories', selected: 'Accessing' }),
+      );
+    });
+
+    it('selects ** ALL METHODS ** when selected category does not exist in target environment', () => {
+      messageHandler({ command: 'selectDictionary', index: 1 });
+      messageHandler({ command: 'selectCategory', name: '** ALL CLASSES **' });
+      messageHandler({ command: 'selectClass', name: 'Array' });
+      messageHandler({ command: 'selectMethodCategory', name: 'Accessing' });
+      vi.mocked(mockPanel.webview.postMessage).mockClear();
+
+      messageHandler({ command: 'toggleEnvironment', envId: 1 });
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'loadMethodCategories', selected: '** ALL METHODS **' }),
+      );
+    });
+
+    it('loads methods for the auto-selected category on environment toggle', () => {
+      messageHandler({ command: 'selectDictionary', index: 1 });
+      messageHandler({ command: 'selectCategory', name: '** ALL CLASSES **' });
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      messageHandler({ command: 'selectClass', name: 'Array' });
+      vi.mocked(mockPanel.webview.postMessage).mockClear();
+
+      messageHandler({ command: 'toggleEnvironment', envId: 1 });
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
+        command: 'loadMethods',
+        items: ['rb_name'],
       });
     });
 

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -974,12 +974,25 @@ export class SystemBrowser {
   }
 
   private handleToggleEnvironment(envId: number): void {
+    const previousCategory = this.state.selectedMethodCategory;
     this.state.selectedEnvId = envId;
-    this.state.selectedMethodCategory = null;
     this.state.selectedMethod = null;
 
     if (this.state.selectedClass) {
-      this.loadMethodCategories();
+      const dictIndex = this.state.selectedDictIndex!;
+      const envData = this.getCachedEnvData(dictIndex, this.state.selectedClass);
+      const availableInNewEnv = new Set(
+        envData
+          .filter(e => e.isMeta === this.state.isMeta && e.envId === envId)
+          .map(e => e.category),
+      );
+      const categoryToSelect =
+        previousCategory !== null && availableInNewEnv.has(previousCategory)
+          ? previousCategory
+          : '** ALL METHODS **';
+      this.state.selectedMethodCategory = categoryToSelect;
+      this.loadMethodCategories(categoryToSelect);
+      this.handleSelectMethodCategory(categoryToSelect);
     }
   }
 


### PR DESCRIPTION
Previously, switching environments cleared the selected method category, leaving the method list empty. The user had to manually click a category again to see any methods.

https://github.com/user-attachments/assets/49160d53-4f79-4592-8df4-3327f42c6cd7

Now, switching environments automatically selects the most relevant category: the previously selected one if it exists in the new environment, or "** ALL METHODS **" otherwise. The method list is populated immediately.

https://github.com/user-attachments/assets/d6501ed9-d54c-40b9-927d-f2f4143fdf0a


