### PR TITLE
Add GT support docs, scripts, and files to Jasper. 

### DIFF
--- a/docs/gtSupport/Announcements.gs
+++ b/docs/gtSupport/Announcements.gs
@@ -1,0 +1,2166 @@
+! Class Declarations
+! Generated file, do not Edit
+
+doit
+(Error
+	subclass: 'WeakBlockUnsupported'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods WeakBlockUnsupported
+removeallclassmethods WeakBlockUnsupported
+
+doit
+(Object
+	subclass: 'Announcement'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		comment: 'This class is the superclass for events that someone might want to announce, such as a button click or an attribute change. Typically you create subclasses for your own events you want to announce.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods Announcement
+removeallclassmethods Announcement
+
+doit
+(Announcement
+	subclass: 'AnnouncementMockA'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'This is a simple test mock.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncementMockA
+removeallclassmethods AnnouncementMockA
+
+doit
+(Announcement
+	subclass: 'AnnouncementMockB'
+	instVarNames: #(parameter)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'This is a simple test mock';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncementMockB
+removeallclassmethods AnnouncementMockB
+
+doit
+(AnnouncementMockB
+	subclass: 'AnnouncementMockC'
+	instVarNames: #(announcingCounter)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'This is a simple test mock';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncementMockC
+removeallclassmethods AnnouncementMockC
+
+doit
+(Announcement
+	subclass: 'AnnouncementMockD'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncementMockD
+removeallclassmethods AnnouncementMockD
+
+doit
+(Announcement
+	subclass: 'GemToGemAnnouncement'
+	instVarNames: #(signalMessage sessionSerialNum)
+	classVars: #(RegisteredSessions Registry)
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GemToGemAnnouncement
+removeallclassmethods GemToGemAnnouncement
+
+doit
+(Object
+	subclass: 'AnnouncementSubscription'
+	instVarNames: #(announcer announcementClass subscriber action)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		comment: 'The subscription is a single entry in a SubscriptionRegistry.
+Several subscriptions by the same object is possible.
+
+I know how to make myself weak or strong, only use this capability if it can''t be determined at subscribe time though, as it uses become: (for thread-safety), which is quite slow.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncementSubscription
+removeallclassmethods AnnouncementSubscription
+
+doit
+(Object
+	subclass: 'Announcer'
+	instVarNames: #(registry deliveryErrorHandler)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		comment: 'The implementation uses a threadsafe subscription registry, in the sense that registering, unregistering, and announcing from an announcer at the same time in different threads should never cause failures.
+
+GemStone adds a "delivery error handler" to catch errors during delivery of announcements.
+The default handler invokes the default action for the exception.
+The ignore handler ignores the error and simply returns from the #deliver: method.
+The report to GCI handler bypasses any default action and immediately returns to the GCI.
+A developer can specify a customer block, as desired.
+Additionally, one can specify a custom handler around the #announce: message senf and automatically revert to the previous handler afterward.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods Announcer
+removeallclassmethods Announcer
+
+doit
+(Object
+	subclass: 'AnnouncerSubscriberMockA'
+	instVarNames: #(announcer)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'I am a mock class for testing in announcers';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncerSubscriberMockA
+removeallclassmethods AnnouncerSubscriberMockA
+
+doit
+(AnnouncerSubscriberMockA
+	subclass: 'AnnouncerSubscriberMockB'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'I am a mock class for testing in announcers';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncerSubscriberMockB
+removeallclassmethods AnnouncerSubscriberMockB
+
+doit
+(Object
+	subclass: 'MessageSend'
+	instVarNames: #(receiver selector arguments)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods MessageSend
+removeallclassmethods MessageSend
+
+doit
+(Object
+	subclass: 'SubscriptionRegistry'
+	instVarNames: #(subscriptions monitor)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		comment: 'The subscription registry is a threadsafe storage for the subscriptions to an Announcer.
+
+In Pharo, subscriptionsFor: protocol is not implemented.
+This is because Announcer does not provide public access to its registery for encapsulation reasons.
+(We do not want access to the announcer from action blocks to break encapsulation to other subscribers)';
+		immediateInvariant.
+true.
+%
+
+removeallmethods SubscriptionRegistry
+removeallclassmethods SubscriptionRegistry
+
+doit
+(Object
+	subclass: 'WeakAnnouncementSubscription'
+	instVarNames: #(receiver selector announcer announcementClass subscriber)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		comment: 'The subscription is a single entry in a SubscriptionRegistry.
+Several subscriptions by the same object is possible.
+
+This subscription references the receiver weakly. If the receiver is garbage collected, the subscription is automatically removed from the SubscriptionRegistry. A MessageSend is dynamically generated to make ephemeron finalization easier.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods WeakAnnouncementSubscription
+removeallclassmethods WeakAnnouncementSubscription
+
+doit
+(Object
+	subclass: 'WeakSubscriptionBuilder'
+	instVarNames: #(announcer)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods WeakSubscriptionBuilder
+removeallclassmethods WeakSubscriptionBuilder
+
+doit
+(Set
+	subclass: 'AnnouncementSet'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone';
+		comment: 'If you want to register the same action for multiple events, simply create an AnnouncementSet using a comma: 
+
+	Parent>>initialize 
+	    super initialize. 
+	    self session announcer on: AddChild, RemoveChild do: [:it | self changeChild: it child]
+	
+Motivation example: Often the UI is built after/independently from the model. You want to have the model raise fine-grained announcements to enable the layers on top, but sometimes it is easier in the UI to refresh everything whenever something happens.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncementSet
+removeallclassmethods AnnouncementSet
+
+doit
+(TestCase
+	subclass: 'AnnouncementSetTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'SUnit tests for announcement sets';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncementSetTest
+removeallclassmethods AnnouncementSetTest
+
+doit
+(TestCase
+	subclass: 'AnnouncerTest'
+	instVarNames: #(announcer)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'An AnnouncerTest is a test class used to test Announcer.
+
+Instance Variables
+	announcer:		<Announcer>  the announcer to test
+
+announcer
+	- the announcer that is tested
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AnnouncerTest
+removeallclassmethods AnnouncerTest
+
+doit
+(AnnouncerTest
+	subclass: 'WeakAnnouncerTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'Announcements-Core-GemStone-Test';
+		comment: 'SUnit tests for weak announcements';
+		immediateInvariant.
+true.
+%
+
+removeallmethods WeakAnnouncerTest
+removeallclassmethods WeakAnnouncerTest
+
+! Class implementation for 'Announcement'
+
+!		Class methods for 'Announcement'
+
+category: 'public'
+classmethod: Announcement
+, anAnnouncementClass
+	^ AnnouncementSet with: self with: anAnnouncementClass
+%
+
+category: 'public'
+classmethod: Announcement
+andSubclasses
+	^ AnnouncementSet withAll: self withAllSubclasses
+%
+
+category: 'converting'
+classmethod: Announcement
+asAnnouncement
+	^ self new
+%
+
+category: 'deprecated'
+classmethod: Announcement
+handles: anAnnouncement
+	^ self handlesAnnouncement: anAnnouncement
+%
+
+category: 'testing'
+classmethod: Announcement
+handlesAnnouncement: anAnnouncement
+	"The receiver acts as a filter to determine whether subscribers who used the receiver as signaling tag (event identifier class or symbol) should receive incoming announcement. In particular, registering to a superclass will receive the announcements from all subclasses."
+
+	^ anAnnouncement isKindOf: self
+%
+
+category: 'instance creation'
+classmethod: Announcement
+new
+
+	^super new
+		initialize;
+		yourself.
+%
+
+!		Instance methods for 'Announcement'
+
+category: 'converting'
+method: Announcement
+asAnnouncement
+	^ self
+%
+
+category: 'initialization'
+method: Announcement
+prepareForDelivery
+	"This method will be executed once before subscriptions delivery.
+	If nobody subscribed on me this method will not be called.
+	It allows to put some heavy initialization logic here. It will be executed only 
+	if there is interest on me"
+%
+
+! Class implementation for 'AnnouncementMockB'
+
+!		Class methods for 'AnnouncementMockB'
+
+category: 'instance creation'
+classmethod: AnnouncementMockB
+with: anObject
+	^self new 
+		parameter: anObject 
+%
+
+!		Instance methods for 'AnnouncementMockB'
+
+category: 'accessing'
+method: AnnouncementMockB
+parameter
+	^ parameter
+%
+
+category: 'accessing'
+method: AnnouncementMockB
+parameter: anObject
+	parameter := anObject
+%
+
+! Class implementation for 'AnnouncementMockC'
+
+!		Instance methods for 'AnnouncementMockC'
+
+category: 'accessing'
+method: AnnouncementMockC
+announcingCounter
+	^ announcingCounter
+%
+
+category: 'initialization'
+method: AnnouncementMockC
+initialize
+	super initialize.
+	announcingCounter := 0
+%
+
+category: 'initialization'
+method: AnnouncementMockC
+prepareForDelivery
+
+	announcingCounter := announcingCounter + 1
+%
+
+! Class implementation for 'GemToGemAnnouncement'
+
+!		Class methods for 'GemToGemAnnouncement'
+
+category: 'accessing'
+classmethod: GemToGemAnnouncement
+announcer
+
+	| ann |
+	ann := SessionTemps current at: #GemToGemAnnouncement_Announcer otherwise: nil.
+	ann == nil 
+		ifTrue: [
+			ann := Announcer new.
+			SessionTemps current at: #GemToGemAnnouncement_Announcer put: ann].
+	^ann
+%
+
+category: 'announcing'
+classmethod: GemToGemAnnouncement
+broadcast
+
+	self new broadcast
+%
+
+category: 'announcing'
+classmethod: GemToGemAnnouncement
+broadcastMessage: aString
+
+	(self new
+		signalMessage: aString;
+		yourself) broadcast
+%
+
+category: 'registration'
+classmethod: GemToGemAnnouncement
+cleanRegisteredSessions
+	(self registeredSessions select: [ :each | ((System descriptionOfSessionSerialNum: each) at: 1) == nil ])
+		do: [ :each | self registeredSessions remove: each ]
+%
+
+category: 'initialization'
+classmethod: GemToGemAnnouncement
+initialize
+	"self initialize"
+	
+	RegisteredSessions := RcIdentityBag new: 100.
+	Registry := Dictionary new.
+	self allSubclasses do: [:cl | cl initialize].
+%
+
+category: 'announcing'
+classmethod: GemToGemAnnouncement
+installStaticHandler
+  | handler |
+  self registeredSessions add: GsCurrentSession currentSession serialNumber.
+  handler := InterSessionSignal addDefaultHandler: [:ex |
+     GemToGemAnnouncement signal: ex sentInt 
+               message: ex sentMessage 
+	      sessionSerialNum: ex sendingSession .
+     System enableSignaledGemStoneSessionError .
+     ex resume
+  ].
+  SessionTemps current at: #GemToGemStaticException put: handler.
+  System enableSignaledGemStoneSessionError.
+%
+
+category: 'accessing'
+classmethod: GemToGemAnnouncement
+registeredSessions
+	
+	RegisteredSessions == nil ifTrue: [ RegisteredSessions := RcIdentityBag new: 100 ].
+	^RegisteredSessions
+%
+
+category: 'registration'
+classmethod: GemToGemAnnouncement
+registerForGemToGemSignalling
+
+	self registry at: self signalNumber put: self
+%
+
+category: 'accessing'
+classmethod: GemToGemAnnouncement
+registry
+
+	Registry == nil ifTrue: [ Registry := Dictionary new ].
+	^Registry
+%
+
+category: 'instance creation'
+classmethod: GemToGemAnnouncement
+signal: aSignal message: aString sessionSerialNum: aSerialNumber
+
+	| cl  |
+	cl := self registry at: aSignal ifAbsent: [ ^self ].
+	self announcer announce: (cl new
+		signalMessage: aString;
+		sessionSerialNum: aSerialNumber;
+		yourself)
+%
+
+category: 'constants'
+classmethod: GemToGemAnnouncement
+signalNumber
+
+	^0
+%
+
+category: 'testing'
+classmethod: GemToGemAnnouncement
+staticHandlerInstalled
+
+	^(SessionTemps current at: #GemToGemStaticException otherwise: nil) ~~ nil
+%
+
+category: 'announcing'
+classmethod: GemToGemAnnouncement
+uninstallStaticHandler
+
+  | handler |
+  self registeredSessions removeIfPresent: GsCurrentSession currentSession serialNumber.
+  handler := SessionTemps current at: #GemToGemStaticException otherwise: nil.
+  System disableSignaledGemStoneSessionError.
+  handler ifNotNil: [ Exception removeStaticException: handler ].
+%
+
+!		Instance methods for 'GemToGemAnnouncement'
+
+category: 'signalling'
+method: GemToGemAnnouncement
+broadcast
+
+	| badSerialNumbers |
+	badSerialNumbers := Array new.
+	self registeredSessions do: [:aSessionSerialNumber |
+		[System _sendSignal: self signalNumber toSess: aSessionSerialNumber withMessage: self signalMessage]
+			on: Error
+			do: [:ex | 
+				"Gem is no longer around or no longer listening"
+				badSerialNumbers add: aSessionSerialNumber.
+				ex return]].
+	self registeredSessions removeAll: badSerialNumbers
+%
+
+category: 'accessing'
+method: GemToGemAnnouncement
+registeredSessions
+
+	^self class registeredSessions
+%
+
+category: 'signalling'
+method: GemToGemAnnouncement
+replyToSenderWithSignal: aSignalNumber message: aString
+
+	System 
+		_sendSignal: aSignalNumber 
+		toSess: sessionSerialNum 
+		withMessage: aString
+%
+
+category: 'accessing'
+method: GemToGemAnnouncement
+sessionSerialNum
+
+	^sessionSerialNum
+%
+
+category: 'accessing'
+method: GemToGemAnnouncement
+sessionSerialNum: aSerialNumber
+
+	sessionSerialNum := aSerialNumber
+%
+
+category: 'accessing'
+method: GemToGemAnnouncement
+signalMessage
+
+	signalMessage == nil ifTrue: [ signalMessage := '' ].
+	^signalMessage
+%
+
+category: 'accessing'
+method: GemToGemAnnouncement
+signalMessage: aString
+
+	aString size > 1023 ifTrue: [self error: 'message too large for Gem to Gem Signalling'].
+	signalMessage := aString
+%
+
+category: 'accessing'
+method: GemToGemAnnouncement
+signalNumber
+
+	^self class signalNumber
+%
+
+! Class implementation for 'AnnouncementSubscription'
+
+!		Instance methods for 'AnnouncementSubscription'
+
+category: 'accessing'
+method: AnnouncementSubscription
+action
+
+	^ action
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+action: anObject
+
+	action := anObject
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+announcementClass
+
+	^ announcementClass
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+announcementClass: anObject
+
+	announcementClass := anObject
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+announcer
+
+	^ announcer
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+announcer: anAnnouncer
+	announcer := anAnnouncer
+%
+
+category: 'announcing'
+method: AnnouncementSubscription
+deliver: anAnnouncement
+	" deliver an announcement to receiver. In case of failure, it will be handled in separate process"
+
+	^ (self handlesAnnouncement: anAnnouncement ) ifTrue: [
+		[action cull: anAnnouncement cull: announcer] 
+"Pharo has:
+			on: UnhandledError fork: [:ex | ex pass ]]
+GemStone has:
+"			on: Error
+			do: announcer deliveryErrorHandler]
+%
+
+category: 'testing'
+method: AnnouncementSubscription
+handlesAnnouncement: anAnnouncement
+
+	^ announcementClass handlesAnnouncement: anAnnouncement
+%
+
+category: 'converting'
+method: AnnouncementSubscription
+makeStrong
+	"This subscription is already strong."
+
+	^self
+%
+
+category: 'converting'
+method: AnnouncementSubscription
+makeWeak
+	"Convert to a WeakAnnouncementSubscription."
+
+	| newSub |
+	(action isKindOf: BlockClosure) ifTrue: [WeakBlockUnsupported signal].
+	newSub := WeakAnnouncementSubscription
+		announcer: announcer
+		announcementClass: announcementClass
+		receiver: action receiver
+		selector: action selector.
+	^announcer
+		replace: self
+		with: newSub
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+subscriber
+	^ subscriber
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+subscriber: aSubscriber
+	subscriber := aSubscriber
+%
+
+category: 'accessing'
+method: AnnouncementSubscription
+valuable: aValuable
+	"Used when subscriber should be extracted from valuable object"
+	self action:  aValuable.
+	self subscriber: aValuable receiver.
+%
+
+! Class implementation for 'Announcer'
+
+!		Class methods for 'Announcer'
+
+category: 'instance creation'
+classmethod: Announcer
+new
+
+	^super new
+		initialize;
+		yourself.
+%
+
+!		Instance methods for 'Announcer'
+
+category: 'announce'
+method: Announcer
+announce: anAnnouncement
+
+	| announcement |
+	announcement := anAnnouncement asAnnouncement.	
+	registry ifNotNil: [
+		registry deliver: announcement
+		].
+	^ announcement
+%
+
+category: 'private'
+method: Announcer
+basicSubscribe: subscription
+	^ registry add: subscription
+%
+
+category: 'exception handling'
+method: Announcer
+defaultDeliveryErrors
+	self deliveryErrorHandler: [ :ex | ex defaultAction ]
+%
+
+category: 'exception handling'
+method: Announcer
+deliveryErrorHandler
+	"Answer the one argument block exception handler to be 
+	 used when delivering announcements encounters an error.
+	 The argument to the block will be the exception that
+	 was thrown (Error or a subclass of it)."
+
+	^ deliveryErrorHandler
+%
+
+category: 'exception handling'
+method: Announcer
+deliveryErrorHandler: aOneArgBlock
+	"Set the exception handler to be used when delivering
+	 announcements encounters an error.
+	 The argument to the block will be the exception that
+	 was thrown (Error or a subclass of it)."
+
+	deliveryErrorHandler := aOneArgBlock
+%
+
+category: 'exception handling'
+method: Announcer
+during: aBlock handleDeliveryErrorsUsing: anExceptionHandler
+	| savedHandler |
+	savedHandler := self deliveryErrorHandler.
+	self deliveryErrorHandler: anExceptionHandler.
+	^ aBlock
+		ensure: [ self deliveryErrorHandler: savedHandler ]
+%
+
+category: 'testing'
+method: Announcer
+handleSubscriberClass: eventClass
+	^ self subscriptions 
+		ifNil: [ false ]
+		ifNotNil: [:subscriptions | subscriptions handleSubscriberClass: eventClass]
+%
+
+category: 'testing'
+method: Announcer
+hasSubscriber: anObject
+
+	registry subscriptionsOf: anObject do: [:each | ^ true].
+	^ false
+%
+
+category: 'exception handling'
+method: Announcer
+ignoreDeliveryErrors
+	self deliveryErrorHandler: [ :ex | ex return ]
+%
+
+category: 'initialization'
+method: Announcer
+initialize
+	super initialize.
+	registry := SubscriptionRegistry new.
+	self defaultDeliveryErrors.
+%
+
+category: 'statistics'
+method: Announcer
+numberOfSubscriptions
+	^ registry numberOfSubscriptions
+%
+
+category: 'subscription'
+method: Announcer
+removeSubscription: subscription
+	"Remove the given subscription from the receiver"
+	
+	^ registry remove: subscription
+%
+
+category: 'private'
+method: Announcer
+replace: subscription with: newOne
+	^ registry replace: subscription with: newOne
+%
+
+category: 'exception handling'
+method: Announcer
+reportToGciOnDeliveryErrors
+	self deliveryErrorHandler: [ :ex | ex _signalGciError ]
+%
+
+category: 'accessing'
+method: Announcer
+subscriptions
+
+	^ registry
+%
+
+category: 'accessing'
+method: Announcer
+subscriptionsForClass: subscriberClass
+	"Return the list of subscription for a given class"
+	^ self subscriptions subscriptionsForClass: subscriberClass
+%
+
+category: 'subscription'
+method: Announcer
+unsubscribe: anObject
+	"Unsubscribe all subscriptions of anObject from the receiver"
+	
+	registry removeSubscriber: anObject
+%
+
+category: 'accessing'
+method: Announcer
+weak
+	"Return an object which allows the creation of weak subscriptions"
+
+	^WeakSubscriptionBuilder on: self
+%
+
+category: 'registration api'
+method: Announcer
+when: anAnnouncementClass do: aValuable
+	"Declare that when anAnnouncementClass is raised, aValuable is executed.  Pay attention that such method as well as #when:do: should not be used on weak announcer since the block holds the receiver and more strongly."
+	
+	aValuable hasReceiver ifFalse: [self error: 'Cannot determine aValuable''s subscriber. Use #when:do:for:, instead.'].
+	^ self when: anAnnouncementClass do: aValuable for: aValuable receiver
+%
+
+category: 'subscription'
+method: Announcer
+when: anAnnouncementClass do: aValuable for: aSubscriber
+	"Declare that when anAnnouncementClass is raised, aValuable is executed and define the subscriber."
+	
+	^ registry add: (
+		AnnouncementSubscription new 
+			announcer: self;
+			announcementClass: anAnnouncementClass;
+			valuable: aValuable;
+			subscriber: aSubscriber;
+			yourself)
+%
+
+category: 'registration api'
+method: Announcer
+when: anAnnouncementClass send: aSelector to: anObject
+	"Declare that when anAnnouncementClass is raised, anObject should receive the message aSelector.
+    When the message expects one argument (eg #fooAnnouncement:) the announcement is passed as argument.
+    When the message expects two arguments (eg #fooAnnouncement:announcer:) both the announcement and 
+    the announcer are passed as argument"
+
+	^ self
+		when: anAnnouncementClass
+		do: (MessageSend receiver: anObject selector: aSelector)
+%
+
+! Class implementation for 'AnnouncerSubscriberMockA'
+
+!		Instance methods for 'AnnouncerSubscriberMockA'
+
+category: 'accessing'
+method: AnnouncerSubscriberMockA
+announcer
+	^ announcer
+%
+
+category: 'accessing'
+method: AnnouncerSubscriberMockA
+announcer: anAnnouncer
+	announcer := anAnnouncer
+%
+
+category: 'events'
+method: AnnouncerSubscriberMockA
+registerEvents
+	self announcer when: AnnouncementMockA do: [ :evt | " something" ] for: self "GemStone can't identiy this block's receiver".
+%
+
+! Class implementation for 'MessageSend'
+
+!		Class methods for 'MessageSend'
+
+category: 'instance creation'
+classmethod: MessageSend
+message: aMessage to: anObject
+	^ self
+		receiver: anObject
+		selector: aMessage selector
+		arguments: aMessage arguments
+%
+
+category: 'instance creation'
+classmethod: MessageSend
+receiver: anObject selector: aSymbol
+	^ self receiver: anObject selector: aSymbol arguments: #()
+%
+
+category: 'instance creation'
+classmethod: MessageSend
+receiver: anObject selector: aSymbol argument: aParameter
+	^ self receiver: anObject selector: aSymbol arguments: (Array with: aParameter)
+%
+
+category: 'instance creation'
+classmethod: MessageSend
+receiver: anObject selector: aSymbol arguments: anArray
+	^ self new
+		receiver: anObject;
+		selector: aSymbol;
+		arguments: anArray
+%
+
+!		Instance methods for 'MessageSend'
+
+category: 'comparing'
+method: MessageSend
+= anObject
+	^ anObject species == self species 
+		and: [receiver == anObject receiver
+		and: [selector == anObject selector
+		and: [arguments = anObject arguments]]]
+%
+
+category: 'accessing'
+method: MessageSend
+arguments
+	^ arguments
+%
+
+category: 'accessing'
+method: MessageSend
+arguments: anArray
+	arguments := anArray
+%
+
+category: 'private'
+method: MessageSend
+collectArguments: anArgArray
+	"Private"
+
+	| staticArgs |
+	staticArgs := self arguments.
+	^ anArgArray size = staticArgs size
+		ifTrue: [ anArgArray ]
+		ifFalse: [ 
+			(staticArgs isEmpty
+				ifTrue: [ staticArgs := Array new: selector numArgs ]
+				ifFalse: [ staticArgs copy ])
+				replaceFrom: 1
+				to: (anArgArray size min: staticArgs size)
+				with: anArgArray
+				startingAt: 1 ]
+%
+
+category: 'evaluating'
+method: MessageSend
+cull: arg
+	^ selector numArgs = 0
+		ifTrue: [ self value ]
+		ifFalse: [ self value: arg ]
+%
+
+category: 'evaluating'
+method: MessageSend
+cull: arg1 cull: arg2
+	^ selector numArgs < 2
+		ifTrue: [ self cull: arg1 ]
+		ifFalse: [ self value: arg1 value: arg2 ]
+%
+
+category: 'evaluating'
+method: MessageSend
+cull: arg1 cull: arg2 cull: arg3
+	^ selector numArgs < 3
+		ifTrue: [ self cull: arg1 cull: arg2 ]
+		ifFalse: [ self value: arg1 value: arg2 value: arg3 ]
+%
+
+category: 'comparing'
+method: MessageSend
+hash
+	^ receiver hash bitXor: selector hash
+%
+
+category: 'testing'
+method: MessageSend
+hasReceiver
+
+	^true
+%
+
+category: 'testing'
+method: MessageSend
+isMessageSend
+	^true
+%
+
+category: 'testing'
+method: MessageSend
+isValid
+	^true
+%
+
+category: 'accessing'
+method: MessageSend
+message
+	^ Message selector: selector arguments: arguments
+%
+
+category: 'accessing'
+method: MessageSend
+numArgs
+	"Answer the number of arguments in this message"
+
+	^ arguments size
+%
+
+category: 'printing'
+method: MessageSend
+printOn: aStream
+	aStream
+		nextPutAll: self class name;
+		nextPut: $(;
+		print: selector;
+		nextPutAll: ' -> ';
+		print: receiver;
+		nextPut: $)
+%
+
+category: 'accessing'
+method: MessageSend
+receiver
+	^ receiver
+%
+
+category: 'accessing'
+method: MessageSend
+receiver: anObject
+	receiver := anObject
+%
+
+category: 'accessing'
+method: MessageSend
+selector
+	^ selector
+%
+
+category: 'accessing'
+method: MessageSend
+selector: aSymbol
+	selector := aSymbol
+%
+
+category: 'evaluating'
+method: MessageSend
+value
+	"Send the message and answer the return value"
+
+	arguments ifNil: [ ^ receiver perform: selector ].
+
+	^ receiver perform: selector withArguments: (self collectArguments: arguments)
+%
+
+category: 'evaluating'
+method: MessageSend
+value: anObject
+	^ receiver perform: selector with: anObject
+%
+
+category: 'evaluating'
+method: MessageSend
+value: anObject1 value: anObject2
+	^ receiver perform: selector with: anObject1 with: anObject2
+%
+
+category: 'evaluating'
+method: MessageSend
+value: anObject1 value: anObject2 value: anObject3
+	^ receiver
+		perform: selector
+		with: anObject1
+		with: anObject2
+		with: anObject3
+%
+
+category: 'evaluating'
+method: MessageSend
+valueWithArguments: anArray
+	^ receiver perform: selector withArguments: (self collectArguments: anArray)
+%
+
+category: 'evaluating'
+method: MessageSend
+valueWithEnoughArguments: anArray
+	"call the selector with enough arguments from arguments and anArray"
+
+	| args |
+	args := Array new: selector numArgs.
+	args
+		replaceFrom: 1
+		to: (arguments size min: args size)
+		with: arguments
+		startingAt: 1.
+	args size > arguments size
+		ifTrue: [ 
+			args
+				replaceFrom: arguments size + 1
+				to: (arguments size + anArray size min: args size)
+				with: anArray
+				startingAt: 1 ].
+	^ receiver perform: selector withArguments: args
+%
+
+! Class implementation for 'SubscriptionRegistry'
+
+!		Class methods for 'SubscriptionRegistry'
+
+category: 'instance creation'
+classmethod: SubscriptionRegistry
+new
+
+	^super new
+		initialize;
+		yourself.
+%
+
+!		Instance methods for 'SubscriptionRegistry'
+
+category: 'add/remove'
+method: SubscriptionRegistry
+add: subscription
+	^ self protected: [
+		subscriptions add: subscription  ]
+%
+
+category: 'announcing'
+method: SubscriptionRegistry
+deliver: anAnnouncement
+	|  interestedSubscriptions |
+	"using a copy, so subscribers can unsubscribe from announcer "
+	
+	subscriptions isEmpty ifTrue: [ ^ self ].
+	self protected: [ 
+		interestedSubscriptions := self subscriptionsHandling: anAnnouncement ].
+	interestedSubscriptions isEmpty ifTrue: [ ^self ].
+	
+	anAnnouncement prepareForDelivery.
+	self deliver: anAnnouncement to: interestedSubscriptions
+%
+
+category: 'private'
+method: SubscriptionRegistry
+deliver: anAnnouncement to: subs
+	^ self deliver: anAnnouncement to: subs startingAt: 1
+%
+
+category: 'private'
+method: SubscriptionRegistry
+deliver: anAnnouncement to: subs startingAt: startIndex
+	
+	startIndex to: subs size do: [ :index| | subscription |
+		subscription := subs at: index.
+		[ subscription deliver: anAnnouncement ] 
+			"Ensure delivery to remaining announcements"
+			ifCurtailed: [
+				self deliver: anAnnouncement to: subs startingAt: index + 1 ]]
+%
+
+category: 'testing'
+method: SubscriptionRegistry
+handleSubscriberClass: eventClass
+	"Return true if the receiver has a callback subscribed for the event class"
+
+	^ subscriptions anySatisfy: [ :sub | sub subscriber isKindOf: eventClass ]
+%
+
+category: 'initialization'
+method: SubscriptionRegistry
+initialize
+	monitor := Semaphore forMutualExclusion.
+	self reset
+%
+
+category: 'accessing'
+method: SubscriptionRegistry
+numberOfSubscriptions
+	^ subscriptions size
+%
+
+category: 'private'
+method: SubscriptionRegistry
+protected: aBlock
+	^ monitor critical: [ aBlock value ]
+%
+
+category: 'add/remove'
+method: SubscriptionRegistry
+remove: subscription
+	^ self protected: [
+		subscriptions remove: subscription ifAbsent: nil ]
+
+%
+
+category: 'add/remove'
+method: SubscriptionRegistry
+removeSubscriber: subscriber
+	
+	^ self protected: [
+		subscriptions removeAllSuchThat: [:subscription | subscription subscriber == subscriber ]]
+
+%
+
+category: 'add/remove'
+method: SubscriptionRegistry
+replace: subscription with: newOne
+
+	" Note that it will signal an error if subscription is not there "
+	self protected: [
+		subscriptions remove: subscription.
+		subscriptions add: newOne 
+	].
+	^ newOne
+%
+
+category: 'initialization'
+method: SubscriptionRegistry
+reset
+	"subscriber -> subscriptions"
+	
+	subscriptions := IdentitySet new
+	
+
+
+%
+
+category: 'accessing'
+method: SubscriptionRegistry
+subscriptions
+	^ subscriptions
+%
+
+category: 'accessing'
+method: SubscriptionRegistry
+subscriptionsForClass: subscriberClass
+	"Return the list of subscription for a given class"
+
+	^ Array
+		streamContents: [ :s | 
+			subscriptions
+				do: [ :each | 
+					(each subscriber isKindOf: subscriberClass)
+						ifTrue: [ s nextPut: each subscriber ] ] ]
+%
+
+category: 'accessing'
+method: SubscriptionRegistry
+subscriptionsHandling: anAnnouncement
+	^ Array streamContents: [ :s|
+			subscriptions do: [:each| 
+				(each handlesAnnouncement: anAnnouncement)
+					ifTrue: [ s nextPut: each ]]]
+%
+
+category: 'iterating'
+method: SubscriptionRegistry
+subscriptionsOf: aSubscriber do: aBlock
+	| copy |
+	
+	self protected: [ copy := subscriptions copy ].
+	
+	copy do: 
+		[:subscription | 
+			subscription subscriber == aSubscriber 
+				ifTrue: [ aBlock value: subscription ]	]
+%
+
+! Class implementation for 'WeakAnnouncementSubscription'
+
+!		Class methods for 'WeakAnnouncementSubscription'
+
+category: 'instance creation'
+classmethod: WeakAnnouncementSubscription
+announcer: anAnnouncer
+announcementClass: anAnnouncementClass
+receiver: anObject
+selector: aSelector
+
+	^self new
+		receiver: anObject;
+		selector: aSelector;
+		announcer: anAnnouncer;
+		announcementClass: anAnnouncementClass;
+		beEphemeron: true;
+		yourself
+%
+
+!		Instance methods for 'WeakAnnouncementSubscription'
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+action
+
+	^MessageSend
+		receiver: receiver
+		selector: selector
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+announcementClass
+
+	^announcementClass
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+announcementClass: anAnnouncementClass
+
+	announcementClass := anAnnouncementClass
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+announcer
+
+	^announcer
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+announcer: anAnnouncer
+
+	announcer := anAnnouncer
+%
+
+category: 'announcing'
+method: WeakAnnouncementSubscription
+deliver: anAnnouncement
+
+	^ (self handlesAnnouncement: anAnnouncement ) ifTrue: [
+		[self action cull: anAnnouncement cull: announcer] 
+"Pharo has:
+			on: UnhandledError fork: [:ex | ex pass ]]
+GemStone has:
+"			on: Error
+			do: announcer deliveryErrorHandler]
+%
+
+category: 'testing'
+method: WeakAnnouncementSubscription
+handlesAnnouncement: anAnnouncement
+
+	^ announcementClass handlesAnnouncement: anAnnouncement
+%
+
+category: 'converting'
+method: WeakAnnouncementSubscription
+makeStrong
+
+	| newSub |
+	newSub := AnnouncementSubscription new
+		announcer: announcer;
+		announcementClass: announcementClass;
+		valuable: self action;
+		subscriber: receiver;
+		yourself.
+	self beEphemeron: false.
+	^announcer
+		replace: self
+		with: newSub
+%
+
+category: 'converting'
+method: WeakAnnouncementSubscription
+makeWeak
+	"This subscription is already weak."
+
+	^self
+%
+
+category: 'finalizing'
+method: WeakAnnouncementSubscription
+mourn
+
+	announcer removeSubscription: self
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+receiver: anObject
+
+	receiver := anObject
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+selector: aSelector
+
+	selector := aSelector
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+subscriber
+
+	^receiver
+%
+
+category: 'accessing'
+method: WeakAnnouncementSubscription
+subscriber: anObject
+
+	receiver := anObject
+%
+
+! Class implementation for 'WeakSubscriptionBuilder'
+
+!		Class methods for 'WeakSubscriptionBuilder'
+
+category: 'instance creation'
+classmethod: WeakSubscriptionBuilder
+on: anAnnouncer
+
+	^super new
+		announcer: anAnnouncer;
+		yourself
+%
+
+!		Instance methods for 'WeakSubscriptionBuilder'
+
+category: 'accessing'
+method: WeakSubscriptionBuilder
+announcer: anAnnouncer
+
+	announcer := anAnnouncer
+%
+
+category: 'accessing'
+method: WeakSubscriptionBuilder
+weak
+	"This already handles the creation of weak registrations."
+
+	^self
+%
+
+category: 'registration'
+method: WeakSubscriptionBuilder
+when: anAnnouncementClass
+send: aSelector
+to: anObject
+
+	| subscription |
+	(anObject isKindOf: BlockClosure)
+		ifTrue: [WeakBlockUnsupported signal].
+	subscription := WeakAnnouncementSubscription
+		announcer: announcer
+		announcementClass: anAnnouncementClass
+		receiver: anObject
+		selector: aSelector.
+	^announcer basicSubscribe: subscription
+%
+
+! Class implementation for 'AnnouncementSet'
+
+!		Instance methods for 'AnnouncementSet'
+
+category: 'adding'
+method: AnnouncementSet
+, anAnnouncementClass
+	self add: anAnnouncementClass
+%
+
+category: 'deprecated'
+method: AnnouncementSet
+handles: anAnnouncement
+	^ self handlesAnnouncement: anAnnouncement
+%
+
+category: 'testing'
+method: AnnouncementSet
+handlesAnnouncement: anAnnouncement
+	"If any of the set handles the announcements, subscribers should receive it."
+	^ self anySatisfy: [ :each | each handlesAnnouncement: anAnnouncement ]
+%
+
+! Class implementation for 'AnnouncementSetTest'
+
+!		Instance methods for 'AnnouncementSetTest'
+
+category: 'tests'
+method: AnnouncementSetTest
+testIncludeOnlyOnce
+	| set |
+	set := AnnouncementMockA , AnnouncementMockB , AnnouncementMockA.
+	self assert: set size equals: 2
+%
+
+category: 'tests'
+method: AnnouncementSetTest
+testInstanceCreation
+	| set |
+	set := AnnouncementMockA , AnnouncementMockB.
+	self assert: set size equals: 2
+%
+
+! Class implementation for 'AnnouncerTest'
+
+!		Instance methods for 'AnnouncerTest'
+
+category: 'private'
+method: AnnouncerTest
+newAnnouncer
+	^ Announcer new
+%
+
+category: 'running'
+method: AnnouncerTest
+setUp
+	super setUp.
+	announcer := self newAnnouncer
+%
+
+category: 'tests - subscribers'
+method: AnnouncerTest
+testAccessingSubscribers
+	| subscribers |
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 0.
+	
+	announcer
+		when: AnnouncementMockA
+		do: [ "1" ]
+		for: self "GemStone can't identiy this block's receiver".
+	announcer
+		when: AnnouncementMockB
+		do: [ "2" ]
+		for: self "GemStone can't identiy this block's receiver".
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 2.
+	
+	subscribers do: [ :subscriber |	announcer unsubscribe: subscriber ].
+	
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 0.
+	
+%
+
+category: 'tests'
+method: AnnouncerTest
+testAnnounceClass
+	self assert: (announcer announce: AnnouncementMockA) class equals: AnnouncementMockA
+%
+
+category: 'tests'
+method: AnnouncerTest
+testAnnounceInstance
+	| instance |
+	instance := AnnouncementMockA new.
+	self assert: (announcer announce: instance) equals: instance
+%
+
+category: 'tests - subscribing'
+method: AnnouncerTest
+testAnnounceWorkWithinExceptionHandlerBlocks
+	|  found |
+	
+	announcer when: Announcement do: [ found := true ].
+	
+	[ "NotFound" Error signal ]
+		on: "NotFound" Error
+		do: [ announcer announce: Announcement new ].
+		
+	self assert: found
+%
+
+category: 'tests'
+method: AnnouncerTest
+testAnnouncingReentrant
+	"Test that it is safe to announce when handling announcement,
+	so announcer are reentrant"
+ 
+	| bool ok |
+
+	ok := bool := false.
+	announcer when: Announcement do: [
+		bool ifFalse: [
+			bool := true.
+			announcer announce:  Announcement new. ]
+		ifTrue: [ ok := true ] 
+	].
+
+	self should: [ announcer announce: Announcement new. ] notTakeMoreThan: (Duration seconds: 1).
+	self assert: ok
+
+%
+
+category: 'tests - subscribers'
+method: AnnouncerTest
+testHandleSubscriberClass
+	announcer
+		when: AnnouncementMockA
+		do: [  ]
+		for: self "GemStone can't identiy this block's receiver".
+	self assert: (announcer handleSubscriberClass: self class).
+	self deny: (announcer handleSubscriberClass: AnnouncementMockA).
+%
+
+category: 'tests'
+method: AnnouncerTest
+testIssue253
+	"unsubscribe during announcement ... hard to duplicate problem since we're using an IdentityDictionary 
+	 and collistionbucket density is a function of oop density"
+	
+	| block |
+	block := [ :ann | announcer unsubscribe: block ].
+	announcer
+		when: AnnouncementMockA
+			send: #value:
+			to: block;
+		when: AnnouncementMockB
+			send: #value:
+			to: block;
+		when: AnnouncementMockC
+			send: #value:
+			to: block;
+		when: AnnouncementMockD
+			send: #value:
+			to: block;
+		yourself.
+		
+	announcer announce: AnnouncementMockA.
+%
+
+category: 'tests'
+method: AnnouncerTest
+testNoArgBlock
+	"we are supposed to accept zero-argument blocks as actions "
+
+	| counter |
+	counter := nil.
+	announcer
+		when: AnnouncementMockA
+		do: [ counter := 1 ]
+		for: self "GemStone can't identiy this block's receiver".
+	announcer announce: AnnouncementMockA new.
+	self assert: counter equals: 1
+%
+
+category: 'tests'
+method: AnnouncerTest
+testPreparationAnnouncementDelivery
+	| announcement |
+	
+	announcer when: AnnouncementMockC send: #value: to: [ :ann | #firstBlock ].
+	announcer when: AnnouncementMockC send: #value: to: [ :ann | #lastBlock ].	
+		
+	announcement := AnnouncementMockC new.
+	announcer announce: announcement.
+	self assert: announcement announcingCounter equals: 1.
+	announcer announce: announcement.
+	self assert: announcement announcingCounter equals: 2.
+	announcement := announcer announce: AnnouncementMockC.
+	self assert: announcement announcingCounter equals: 1
+
+%
+
+category: 'tests'
+method: AnnouncerTest
+testPreparationAnnouncementDeliveryWhenNoSubscriptions
+
+	| instance |
+	announcer when: AnnouncementMockA send: #value: to: [ :ann | ].
+		
+	instance := announcer announce: AnnouncementMockC.
+	
+	self assert: instance announcingCounter equals: 0
+%
+
+category: 'tests - subscribing'
+method: AnnouncerTest
+testSubscribeBlock
+	| announcement instance |
+	announcer
+		when: AnnouncementMockA
+		do: [ :ann | announcement := ann ]
+		for: self "GemStone can't identiy this block's receiver".
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockA.
+	self assert: announcement equals: instance.
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockB.
+	self assert: announcement isNil
+%
+
+category: 'test - subscribers'
+method: AnnouncerTest
+testSubscribersForClass
+	| subscribers mockA mockB |
+	self assert: announcer numberOfSubscriptions equals: 0.
+	
+	mockA := AnnouncerSubscriberMockA new.
+	mockA announcer: announcer.
+	mockB := AnnouncerSubscriberMockB new.
+	mockB announcer: announcer.
+	mockA registerEvents.
+	mockB registerEvents.
+	
+	self assert: announcer numberOfSubscriptions > 0.
+	subscribers := announcer subscriptionsForClass: AnnouncerSubscriberMockA.
+	self assert: subscribers size equals: 2.
+	"AnnouncerSubscriberMockB inherits AnnouncerSubscriberMockA"
+	subscribers := announcer subscriptionsForClass: AnnouncerSubscriberMockB.
+	self assert: subscribers size equals: 1.
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 0.
+%
+
+category: 'tests - subscribing'
+method: AnnouncerTest
+testSubscribeSend
+	| announcement instance |
+	announcer when: AnnouncementMockA send: #value: to: [ :ann | announcement := ann ].
+		
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockA.
+	self assert: announcement equals: instance.
+	
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockB new.
+	self assert: announcement isNil
+%
+
+category: 'tests - subscribing'
+method: AnnouncerTest
+testSubscribeSet
+	| announcement instance |
+	announcer
+		when: AnnouncementMockA , AnnouncementMockC
+		do: [ :ann | announcement := ann ]
+		for: self "GemStone can't identiy this block's receiver".
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockA.
+	self assert: announcement equals: instance.
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockB.
+	self assert: announcement isNil.
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockC.
+	self assert: announcement equals: instance
+%
+
+category: 'tests - subscribing'
+method: AnnouncerTest
+testSubscribeSubclass
+	| announcement instance |
+	announcer
+		when: AnnouncementMockB
+		do: [ :ann | announcement := ann ]
+		for: self "GemStone can't identiy this block's receiver".
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockA.
+	self assert: announcement isNil.
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockB.
+	self assert: announcement equals: instance.
+	announcement := nil.
+	instance := announcer announce: AnnouncementMockC.
+	self assert: announcement equals: instance
+%
+
+category: 'tests'
+method: AnnouncerTest
+testTwoArgBlock
+	"we are supposed to accept two-argument blocks as actions "
+
+	| flag |
+	flag := false.
+	announcer
+		when: AnnouncementMockA
+		do: [ :ann :announcer2 | flag := announcer2 == announcer ].
+	announcer announce: AnnouncementMockA new.
+	self assert: flag
+%
+
+category: 'tests - unsubscribing'
+method: AnnouncerTest
+testUnsubscribeBlock
+	| announcement |
+	announcer
+		when: AnnouncementMockA
+		do: [ :ann | announcement := ann ]
+		for: self "GemStone can't identiy this block's receiver".
+	announcer unsubscribe: self.
+	announcement := nil.
+	announcer announce: AnnouncementMockA new.
+	self assert: announcement isNil
+%
+
+category: 'tests - unsubscribing'
+method: AnnouncerTest
+testUnsubscribeSend
+	| announcement receiver |
+	announcer when: AnnouncementMockA send: #value: to: (receiver := [ :ann | announcement := ann ]).
+	announcer unsubscribe: receiver.
+
+	announcement := nil.
+	announcer announce: AnnouncementMockA new.
+	self assert: announcement isNil
+%
+
+category: 'tests - unsubscribing'
+method: AnnouncerTest
+testUnsubscribeSet
+	| announcement |
+	announcer
+		when: AnnouncementMockA , AnnouncementMockB
+		do: [ :ann | announcement := ann ]
+		for: self "GemStone can't identiy this block's receiver".
+	announcer unsubscribe: self.
+	announcement := nil.
+	announcer announce: AnnouncementMockA new.
+	self assert: announcement isNil.
+	announcement := nil.
+	announcer announce: AnnouncementMockB new.
+	self assert: announcement isNil
+%
+
+! Class implementation for 'WeakAnnouncerTest'
+
+!		Instance methods for 'WeakAnnouncerTest'
+
+category: 'asserting'
+method: WeakAnnouncerTest
+assert: anObject
+identicalTo: bObject
+
+	^self assert: anObject == bObject
+%
+
+category: 'utilities'
+method: WeakAnnouncerTest
+maximumReclamation
+
+	System _generationScavenge_vmMarkSweep.
+	System _generationScavenge_vmMarkSweep.
+	(Delay forMilliseconds: 10) wait.
+%
+
+category: 'tests'
+method: WeakAnnouncerTest
+testMakeStrong
+
+	| counter collector forwarder subscription |
+	counter := 0.
+	collector := [ counter := counter + 1 ].
+	forwarder := MessageSend receiver: collector selector: #value.
+	subscription := announcer weak when: AnnouncementMockA send: #value to: forwarder.
+	
+	" shouldn't go away, we are still holding a reference to 'forwarder': "
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 1.
+	
+	"Shouldn't go away since we converted to a strong sub"
+	subscription := subscription makeStrong.
+	forwarder := nil.
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 2
+%
+
+category: 'tests'
+method: WeakAnnouncerTest
+testNoDeadWeakSubscriptions
+
+	self maximumReclamation.
+	self assert: (WeakAnnouncementSubscription allInstancesInMemory select: [ :sub | sub subscriber isNil ]) isEmpty.
+	self assert: (WeakAnnouncementSubscription allInstancesInMemory select: [ :sub | sub subscriber isNil ]) isEmpty
+%
+
+category: 'tests'
+method: WeakAnnouncerTest
+testWeakBlockUnsupported
+	"We support weak blocks though they aren't all that useful."
+
+	| counter |
+	counter := 0.
+	self
+		should: [announcer weak when: AnnouncementMockA send: #value to: []]
+		raise: WeakBlockUnsupported.
+	self
+		should: [(announcer when: AnnouncementMockA do: [ :ann | counter := counter + 1 ] for: self) makeWeak]
+		raise: WeakBlockUnsupported
+%
+
+category: 'tests'
+method: WeakAnnouncerTest
+testWeakDoubleAnnouncer
+
+	| a1 a2 o |
+	a1 := Announcer new.
+	a2 := Announcer new.
+	o := Object new.
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 0.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 0.
+	
+	a1 weak
+		when: Announcement
+		send: #abcdef
+		to: o.
+	a2 weak
+		when: Announcement
+		send: #abcdef
+		to: o.	
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 1.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 1.
+	
+	self maximumReclamation.
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 1.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 1.	
+
+	o := nil.
+	self maximumReclamation.
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 0.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 0.
+%
+
+category: 'tests'
+method: WeakAnnouncerTest
+testWeakObject
+
+	| counter collector forwarder |
+	counter := 0.
+	collector := [ counter := counter + 1 ].
+	forwarder := MessageSend receiver: collector selector: #value.
+	(announcer when: AnnouncementMockA send: #value to: forwarder) makeWeak.
+	
+	" shouldn't go away, we are still holding a reference to 'forwarder': "
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 1.
+	
+	" should go away as we let the only reference to 'forwarder' go: "
+	forwarder := nil.
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 1
+%
+
+category: 'tests'
+method: WeakAnnouncerTest
+testWeakSubscription
+
+	| obj subscription |
+	obj := Object new.
+	subscription := (announcer when: AnnouncementMockA send: #value to: obj) makeWeak.
+	self assert: obj identicalTo: subscription subscriber
+%
+
+! Class extensions for 'ExecBlock'
+
+!		Instance methods for 'ExecBlock'
+
+category: '*Announcements-Extensions-GemStone'
+method: ExecBlock
+hasReceiver
+	"Not all blocks record the receiver, so we need to know whether a block has done so."
+
+	^ (staticLink notNil and: [self selfOffsetInVC > 1])
+		or: [self _selfOffsetInSelf > 0]
+%
+
+category: '*Announcements-Extensions-GemStone'
+method: ExecBlock
+receiver
+
+	^self selfValue
+%
+
+! Class extensions for 'TestAsserter'
+
+!		Instance methods for 'TestAsserter'
+
+category: '*Announcements-Extensions-GemStone'
+method: TestAsserter
+should: aBlock notTakeMoreThan: aDuration
+	"Throw an exception if aBlock should take longer than aDuration to run.
+	 This is a toy implementation. It is should stop after the time limit.
+	 Instead, it just sees how long it took and complains if it was too long."
+
+	| msToRun actualDuration |
+	msToRun := Time millisecondsElapsedTime: aBlock.
+	actualDuration := Duration seconds: msToRun / 1000.
+	self assert: actualDuration <= aDuration
+		description: 'Block evaluation took more than the expected ', aDuration printString.
+	^ actualDuration
+%
+
+! Class Initialization
+
+run
+GemToGemAnnouncement initialize.
+true
+%

--- a/docs/gtSupport/README.md
+++ b/docs/gtSupport/README.md
@@ -1,0 +1,26 @@
+# GT Support for GemStone
+
+Loads GT remote inspection support into a plain-vanilla GemStone server.
+
+## Quick Start
+
+1. Start your stone and ensure a `.topazini` file is present in the current directory.
+2. Set `$GEMSTONE` to the GemStone product directory.
+3. Run:
+   ```
+   /path/to/gtSupport/load_gemstone_gt_support.sh
+   ```
+
+## Scripts
+
+- **`load_gemstone_gt_support.sh`** — loads the seven `.gs` files into a running stone. This is all you need.
+- **`update_gemstone_gt_support.sh`** — refreshes the `.gs` files from the feenk project checkouts in `$ROWAN_PROJECTS_HOME`. Run this when the feenk projects have been updated.
+
+## Updating the .gs Files
+
+Set `$ROWAN_PROJECTS_HOME` to the directory containing the four feenk project clones,
+pull the latest from each repo (see the comments in that script for the repo list),
+then run the update script:
+```
+./update_gemstone_gt_support.sh
+```

--- a/docs/gtSupport/RemoteServiceReplication.gs
+++ b/docs/gtSupport/RemoteServiceReplication.gs
@@ -1,0 +1,17542 @@
+! Class Declarations
+! Generated file, do not Edit
+
+doit
+(Announcement
+	subclass: 'RsrAnnouncement'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAnnouncement
+removeallclassmethods RsrAnnouncement
+
+doit
+(RsrAnnouncement
+	subclass: 'RsrConnectionStateAnnouncement'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectionStateAnnouncement
+removeallclassmethods RsrConnectionStateAnnouncement
+
+doit
+(RsrConnectionStateAnnouncement
+	subclass: 'RsrConnectionClosed'
+	instVarNames: #(connection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'This Announcement is used to signal that the specified Connection was closed.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectionClosed
+removeallclassmethods RsrConnectionClosed
+
+doit
+(Error
+	subclass: 'RsrError'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrError
+removeallclassmethods RsrError
+
+doit
+(RsrError
+	subclass: 'RsrAlreadyRegistered'
+	instVarNames: #(service intendedConnection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAlreadyRegistered
+removeallclassmethods RsrAlreadyRegistered
+
+doit
+(RsrError
+	subclass: 'RsrConnectionFailed'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectionFailed
+removeallclassmethods RsrConnectionFailed
+
+doit
+(RsrError
+	subclass: 'RsrHandshakeError'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrHandshakeError
+removeallclassmethods RsrHandshakeError
+
+doit
+(RsrHandshakeError
+	subclass: 'RsrProtocolVersionNegotiationFailed'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProtocolVersionNegotiationFailed
+removeallclassmethods RsrProtocolVersionNegotiationFailed
+
+doit
+(RsrHandshakeError
+	subclass: 'RsrTokenExchangeFailed'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenExchangeFailed
+removeallclassmethods RsrTokenExchangeFailed
+
+doit
+(RsrError
+	subclass: 'RsrNonresumableError'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNonresumableError
+removeallclassmethods RsrNonresumableError
+
+doit
+(RsrError
+	subclass: 'RsrOutOfRange'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrOutOfRange
+removeallclassmethods RsrOutOfRange
+
+doit
+(RsrError
+	subclass: 'RsrPromiseError'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPromiseError
+removeallclassmethods RsrPromiseError
+
+doit
+(RsrPromiseError
+	subclass: 'RsrAlreadyResolved'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAlreadyResolved
+removeallclassmethods RsrAlreadyResolved
+
+doit
+(RsrPromiseError
+	subclass: 'RsrBrokenPromise'
+	instVarNames: #(reason)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrBrokenPromise
+removeallclassmethods RsrBrokenPromise
+
+doit
+(RsrError
+	subclass: 'RsrRemoteError'
+	instVarNames: #(originalClassName stack)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemoteError
+removeallclassmethods RsrRemoteError
+
+doit
+(RsrError
+	subclass: 'RsrResumableError'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrResumableError
+removeallclassmethods RsrResumableError
+
+doit
+(RsrError
+	subclass: 'RsrServiceRejected'
+	instVarNames: #(reason)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServiceRejected
+removeallclassmethods RsrServiceRejected
+
+doit
+(RsrError
+	subclass: 'RsrSocketError'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketError
+removeallclassmethods RsrSocketError
+
+doit
+(RsrSocketError
+	subclass: 'RsrConnectFailed'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectFailed
+removeallclassmethods RsrConnectFailed
+
+doit
+(RsrSocketError
+	subclass: 'RsrInvalidBind'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInvalidBind
+removeallclassmethods RsrInvalidBind
+
+doit
+(RsrSocketError
+	subclass: 'RsrSocketClosed'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketClosed
+removeallclassmethods RsrSocketClosed
+
+doit
+(RsrError
+	subclass: 'RsrUnknownClass'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrUnknownClass
+removeallclassmethods RsrUnknownClass
+
+doit
+(RsrError
+	subclass: 'RsrUnknownSID'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrUnknownSID
+removeallclassmethods RsrUnknownSID
+
+doit
+(RsrError
+	subclass: 'RsrUnknownTemplate'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrUnknownTemplate
+removeallclassmethods RsrUnknownTemplate
+
+doit
+(RsrError
+	subclass: 'RsrUnsupportedObject'
+	instVarNames: #(object)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrUnsupportedObject
+removeallclassmethods RsrUnsupportedObject
+
+doit
+(RsrError
+	subclass: 'RsrWaitForConnectionCancelled'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrWaitForConnectionCancelled
+removeallclassmethods RsrWaitForConnectionCancelled
+
+doit
+(Exception
+	subclass: 'RsrUnhandledException'
+	instVarNames: #(exception)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'This class is used in GemStone and Dolphin to help process unhandled exceptions. Pharo will used the native UnhandledError class.
+
+This should not be signaled outside of the framework.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrUnhandledException
+removeallclassmethods RsrUnhandledException
+
+doit
+(Notification
+	subclass: 'RsrNotification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNotification
+removeallclassmethods RsrNotification
+
+doit
+(Object
+	subclass: 'RsrForwarder'
+	instVarNames: #(_service)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrForwarder
+removeallclassmethods RsrForwarder
+
+doit
+(Object
+	subclass: 'RsrObject'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrObject
+removeallclassmethods RsrObject
+
+doit
+(RsrObject
+	subclass: 'RsrAbstractPolicy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'The Connection Policy
+
+This class defines the abstract interface for Policy. Policy provides a means of preventing Service replication. When a Service is created in a remote Connection and replicated locally, we first verify that the Policy allows the instantiation of the Service Template first. If the Policy does now allow a Service to be created, the incoming message send will be cancelled. RSR will report the message failure with a RsrPolicyRejectedService reason.
+
+Note:
+Subclasses of RsrReasonService are alway permitted as they are required by the framework.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAbstractPolicy
+removeallclassmethods RsrAbstractPolicy
+
+doit
+(RsrAbstractPolicy
+	subclass: 'RsrDefaultPolicy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrDefaultPolicy
+removeallclassmethods RsrDefaultPolicy
+
+doit
+(RsrAbstractPolicy
+	subclass: 'RsrTestPolicy'
+	instVarNames: #(deniedTemplates)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTestPolicy
+removeallclassmethods RsrTestPolicy
+
+doit
+(RsrObject
+	subclass: 'RsrAbstractReason'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'The superclass for Reasons generated for breaking Promise instances generated by the framework.
+
+If the reason will be replicated, the Reason should subclass RsrReasonService.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAbstractReason
+removeallclassmethods RsrAbstractReason
+
+doit
+(RsrAbstractReason
+	subclass: 'RsrConnectionClosedBeforeReceivingResponse'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectionClosedBeforeReceivingResponse
+removeallclassmethods RsrConnectionClosedBeforeReceivingResponse
+
+doit
+(RsrAbstractReason
+	subclass: 'RsrDecodingRaisedException'
+	instVarNames: #(exception)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrDecodingRaisedException
+removeallclassmethods RsrDecodingRaisedException
+
+doit
+(RsrObject
+	subclass: 'RsrAbstractService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAbstractService
+removeallclassmethods RsrAbstractService
+
+doit
+(RsrAbstractService
+	subclass: 'RsrService'
+	instVarNames: #(_id _connection remoteSelf)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'I represent a class of Objects that know offer Rsr Services.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrService
+removeallclassmethods RsrService
+
+doit
+(RsrService
+	subclass: 'RsrConcurrentTestService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConcurrentTestService
+removeallclassmethods RsrConcurrentTestService
+
+doit
+(RsrConcurrentTestService
+	subclass: 'RsrConcurrentTestClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConcurrentTestClient
+removeallclassmethods RsrConcurrentTestClient
+
+doit
+(RsrConcurrentTestService
+	subclass: 'RsrConcurrentTestServer'
+	instVarNames: #(counter semaphore stashedProcess)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConcurrentTestServer
+removeallclassmethods RsrConcurrentTestServer
+
+doit
+(RsrService
+	subclass: 'RsrInstrumentedService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		comment: 'No class-specific documentation for RsrInstrumentedService, hierarchy is:
+Object
+  RsrObject
+    RsrAbstractService
+      RsrService( _id _connection remoteSelf)
+        RsrInstrumentedService( sharedVariable preUpdateAction postUpdateAction)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInstrumentedService
+removeallclassmethods RsrInstrumentedService
+
+doit
+(RsrInstrumentedService
+	subclass: 'RsrInstrumentedClient'
+	instVarNames: #(preUpdateCount postUpdateCount postRegistrationCount)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		comment: 'No class-specific documentation for RsrInstrumentedClient, hierarchy is:
+Object
+  RsrObject
+    RsrAbstractService
+      RsrService( _id _connection remoteSelf)
+        RsrInstrumentedService
+          RsrInstrumentedClient( preUpdateAction postUpdateAction)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInstrumentedClient
+removeallclassmethods RsrInstrumentedClient
+
+doit
+(RsrInstrumentedService
+	subclass: 'RsrInstrumentedServer'
+	instVarNames: #(preUpdateCount postUpdateCount postRegistrationCount action)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		comment: 'No class-specific documentation for RsrInstrumentedServer, hierarchy is:
+Object
+  RsrObject
+    RsrAbstractService
+      RsrService( _id _connection remoteSelf)
+        RsrInstrumentedService
+          RsrInstrumentedServer( preUpdateAction postUpdateAction)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInstrumentedServer
+removeallclassmethods RsrInstrumentedServer
+
+doit
+(RsrService
+	subclass: 'RsrMockService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrMockService
+removeallclassmethods RsrMockService
+
+doit
+(RsrMockService
+	subclass: 'RsrMockClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrMockClient
+removeallclassmethods RsrMockClient
+
+doit
+(RsrMockService
+	subclass: 'RsrMockServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrMockServer
+removeallclassmethods RsrMockServer
+
+doit
+(RsrService
+	subclass: 'RsrReasonService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'This Service services as an abstract superclass for various Promise break reasons that must support replication.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReasonService
+removeallclassmethods RsrReasonService
+
+doit
+(RsrReasonService
+	subclass: 'RsrPolicyRejectedService'
+	instVarNames: #(sid templateName)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'PolicyRejectedService signals to a caller that their peer''s Connection Policy does not permit the described object''s creation.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPolicyRejectedService
+removeallclassmethods RsrPolicyRejectedService
+
+doit
+(RsrPolicyRejectedService
+	subclass: 'RsrPolicyRejectedServiceClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPolicyRejectedServiceClient
+removeallclassmethods RsrPolicyRejectedServiceClient
+
+doit
+(RsrPolicyRejectedService
+	subclass: 'RsrPolicyRejectedServiceServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPolicyRejectedServiceServer
+removeallclassmethods RsrPolicyRejectedServiceServer
+
+doit
+(RsrReasonService
+	subclass: 'RsrRemoteException'
+	instVarNames: #(exceptionClassName tag messageText stack)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemoteException
+removeallclassmethods RsrRemoteException
+
+doit
+(RsrRemoteException
+	subclass: 'RsrRemoteExceptionClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemoteExceptionClient
+removeallclassmethods RsrRemoteExceptionClient
+
+doit
+(RsrRemoteException
+	subclass: 'RsrRemoteExceptionServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemoteExceptionServer
+removeallclassmethods RsrRemoteExceptionServer
+
+doit
+(RsrService
+	subclass: 'RsrReflectedVariableTestServiceA'
+	instVarNames: #(varA)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReflectedVariableTestServiceA
+removeallclassmethods RsrReflectedVariableTestServiceA
+
+doit
+(RsrReflectedVariableTestServiceA
+	subclass: 'RsrReflectedVariableTestServiceB'
+	instVarNames: #(varB)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReflectedVariableTestServiceB
+removeallclassmethods RsrReflectedVariableTestServiceB
+
+doit
+(RsrReflectedVariableTestServiceB
+	subclass: 'RsrReflectedVariableTestClient'
+	instVarNames: #(private)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReflectedVariableTestClient
+removeallclassmethods RsrReflectedVariableTestClient
+
+doit
+(RsrReflectedVariableTestServiceB
+	subclass: 'RsrReflectedVariableTestServer'
+	instVarNames: #(private)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReflectedVariableTestServer
+removeallclassmethods RsrReflectedVariableTestServer
+
+doit
+(RsrService
+	subclass: 'RsrRemoteAction'
+	instVarNames: #(sharedVariable)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemoteAction
+removeallclassmethods RsrRemoteAction
+
+doit
+(RsrRemoteAction
+	subclass: 'RsrRemoteActionClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemoteActionClient
+removeallclassmethods RsrRemoteActionClient
+
+doit
+(RsrRemoteAction
+	subclass: 'RsrRemoteActionServer'
+	instVarNames: #(action debugHandler preUpdateHandler postUpdateHandler postRegistrationHandler)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemoteActionServer
+removeallclassmethods RsrRemoteActionServer
+
+doit
+(RsrService
+	subclass: 'RsrReturnUnknownService'
+	instVarNames: #(sharedVariable)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReturnUnknownService
+removeallclassmethods RsrReturnUnknownService
+
+doit
+(RsrReturnUnknownService
+	subclass: 'RsrKnownServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrKnownServer
+removeallclassmethods RsrKnownServer
+
+doit
+(RsrService
+	subclass: 'RsrSendUnknownService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSendUnknownService
+removeallclassmethods RsrSendUnknownService
+
+doit
+(RsrSendUnknownService
+	subclass: 'RsrKnownClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrKnownClient
+removeallclassmethods RsrKnownClient
+
+doit
+(RsrService
+	subclass: 'RsrServiceNoInstVars'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServiceNoInstVars
+removeallclassmethods RsrServiceNoInstVars
+
+doit
+(RsrServiceNoInstVars
+	subclass: 'RsrClientNoInstVars'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrClientNoInstVars
+removeallclassmethods RsrClientNoInstVars
+
+doit
+(RsrServiceNoInstVars
+	subclass: 'RsrServerNoInstVars'
+	instVarNames: #(marker)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServerNoInstVars
+removeallclassmethods RsrServerNoInstVars
+
+doit
+(RsrService
+	subclass: 'RsrServiceReferenceService'
+	instVarNames: #(service)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServiceReferenceService
+removeallclassmethods RsrServiceReferenceService
+
+doit
+(RsrServiceReferenceService
+	subclass: 'RsrClientReferenceService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrClientReferenceService
+removeallclassmethods RsrClientReferenceService
+
+doit
+(RsrServiceReferenceService
+	subclass: 'RsrServerReferenceService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServerReferenceService
+removeallclassmethods RsrServerReferenceService
+
+doit
+(RsrService
+	subclass: 'RsrTestService'
+	instVarNames: #(sharedVariable)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTestService
+removeallclassmethods RsrTestService
+
+doit
+(RsrTestService
+	subclass: 'RsrClientTestService'
+	instVarNames: #(privateVariable)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrClientTestService
+removeallclassmethods RsrClientTestService
+
+doit
+(RsrTestService
+	subclass: 'RsrServerTestService'
+	instVarNames: #(privateVariable)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServerTestService
+removeallclassmethods RsrServerTestService
+
+doit
+(RsrService
+	subclass: 'RsrValueHolder'
+	instVarNames: #(value)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrValueHolder
+removeallclassmethods RsrValueHolder
+
+doit
+(RsrValueHolder
+	subclass: 'RsrValueHolderClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrValueHolderClient
+removeallclassmethods RsrValueHolderClient
+
+doit
+(RsrValueHolder
+	subclass: 'RsrValueHolderServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrValueHolderServer
+removeallclassmethods RsrValueHolderServer
+
+doit
+(RsrService
+	subclass: 'RsrVersionService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrVersionService
+removeallclassmethods RsrVersionService
+
+doit
+(RsrVersionService
+	subclass: 'RsrVersionServiceClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrVersionServiceClient
+removeallclassmethods RsrVersionServiceClient
+
+doit
+(RsrVersionService
+	subclass: 'RsrVersionServiceServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrVersionServiceServer
+removeallclassmethods RsrVersionServiceServer
+
+doit
+(RsrObject
+	subclass: 'RsrAbstractTemplateResolver'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAbstractTemplateResolver
+removeallclassmethods RsrAbstractTemplateResolver
+
+doit
+(RsrAbstractTemplateResolver
+	subclass: 'RsrTemplateResolver'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTemplateResolver
+removeallclassmethods RsrTemplateResolver
+
+doit
+(RsrObject
+	subclass: 'RsrAsyncMournHandler'
+	instVarNames: #(process notifier isActive)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		comment: '+++This class is private and shouldn''t be used by any users of RSR+++
+
+In GemStone, Ephemeron interrupts are serviced on the active thread when the interrupt is asserted. This causes a problem in RSR. If we are in a critical section in the service registry, we can end up in a situation where we attempt to re-enter a registry critical section.
+
+A recursive lock isn''t a safe choice to resolve this problem. We may be part way through updating the registry data structures when we process a removal sparked by an Ephemeron mourn.
+
+This class gets around this issue by processing Ephemeron mourning on a separate and distict thread from all others in the program. It is possible that another process might already be processing events asynchronously. In that event, we notify the calling code. If they choose to continue using RSR, we abort the handler and allow RSR to continue its setup.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAsyncMournHandler
+removeallclassmethods RsrAsyncMournHandler
+
+doit
+(RsrObject
+	subclass: 'RsrBufferedSocketStream'
+	instVarNames: #(stream outBuffer writePosition nextToWrite)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrBufferedSocketStream
+removeallclassmethods RsrBufferedSocketStream
+
+doit
+(RsrObject
+	subclass: 'RsrChannel'
+	instVarNames: #(connection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrChannel, hierarchy is:
+Object
+  RsrObject
+    RsrChannel
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrChannel
+removeallclassmethods RsrChannel
+
+doit
+(RsrChannel
+	subclass: 'RsrBinaryStreamChannel'
+	instVarNames: #(sink source inStream outStream)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrSocketChannel, hierarchy is:
+Object
+  RsrObject
+    RsrChannel
+      RsrSocketChannel( reader writer socket stream)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrBinaryStreamChannel
+removeallclassmethods RsrBinaryStreamChannel
+
+doit
+(RsrChannel
+	subclass: 'RsrInMemoryChannel'
+	instVarNames: #(inQueue outQueue drainProcess)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'Example usage:
+
+	| aQueue bQueue channelA channelB |
+	aQueue := SharedQueue new.
+	bQueue := SharedQueue new.
+	channelA := RsrInMemoryChannel
+		inQueue: aQueue
+		outQueue: bQueue.
+	channelB := RsrInMemoryChannel
+		inQueue: bQueue
+		outQueue: aQueue.
+	connectionA := RsrConnection
+		channel: channelA
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals
+		oidSpigot: RsrThreadSafeNumericSpigot naturals.
+	connectionB := RsrConnection
+		channel: channelB
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals negated
+		oidSpigot: RsrThreadSafeNumericSpigot naturals negated.
+	connectionA open.
+	connectionB open.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemoryChannel
+removeallclassmethods RsrInMemoryChannel
+
+doit
+(RsrChannel
+	subclass: 'RsrNullChannel'
+	instVarNames: #(lastCommand)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNullChannel
+removeallclassmethods RsrNullChannel
+
+doit
+(RsrObject
+	subclass: 'RsrClassResolver'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrClassResolver
+removeallclassmethods RsrClassResolver
+
+doit
+(RsrObject
+	subclass: 'RsrCodec'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCodec
+removeallclassmethods RsrCodec
+
+doit
+(RsrCodec
+	subclass: 'RsrCommandCodec'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandCodec
+removeallclassmethods RsrCommandCodec
+
+doit
+(RsrCommandCodec
+	subclass: 'RsrCommandDecoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrDecoder, hierarchy is:
+Object
+  RsrObject
+    RsrCodec
+      RsrDecoder( registry connection decodeCommandMap)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandDecoder
+removeallclassmethods RsrCommandDecoder
+
+doit
+(RsrCommandCodec
+	subclass: 'RsrCommandEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandEncoder
+removeallclassmethods RsrCommandEncoder
+
+doit
+(RsrCodec
+	subclass: 'RsrProtocolVersionNegotiationCodec'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProtocolVersionNegotiationCodec
+removeallclassmethods RsrProtocolVersionNegotiationCodec
+
+doit
+(RsrCodec
+	subclass: 'RsrTokenExchangeCodec'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenExchangeCodec
+removeallclassmethods RsrTokenExchangeCodec
+
+doit
+(RsrObject
+	subclass: 'RsrCommand'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrCommand, hierarchy is:
+Object
+  RsrObject
+    RsrCommand( encoding)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommand
+removeallclassmethods RsrCommand
+
+doit
+(RsrCommand
+	subclass: 'RsrMessagingCommand'
+	instVarNames: #(snapshots transaction)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrMessagingCommand
+removeallclassmethods RsrMessagingCommand
+
+doit
+(RsrMessagingCommand
+	subclass: 'RsrDeliverResponse'
+	instVarNames: #(responseReference)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrDeliverResponse, hierarchy is:
+Object
+  RsrObject
+    RsrCommand( encoding)
+      RsrDeliverResponse( transaction response roots retainList)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrDeliverResponse
+removeallclassmethods RsrDeliverResponse
+
+doit
+(RsrMessagingCommand
+	subclass: 'RsrSendMessage'
+	instVarNames: #(receiverReference selectorReference argumentReferences)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrSendMessage, hierarchy is:
+Object
+  RsrObject
+    RsrCommand( encoding)
+      RsrSendMessage( transaction receiver selector arguments retainList)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSendMessage
+removeallclassmethods RsrSendMessage
+
+doit
+(RsrCommand
+	subclass: 'RsrReleaseServices'
+	instVarNames: #(sids)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrReleaseServices, hierarchy is:
+Object
+  RsrObject
+    RsrCommand( encoding)
+      RsrReleaseServices( oids)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReleaseServices
+removeallclassmethods RsrReleaseServices
+
+doit
+(RsrObject
+	subclass: 'RsrConnection'
+	instVarNames: #(channel transactionSpigot oidSpigot log registry pendingMessages specification announcer templateResolver policy)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'Connection is the central mediator for RSR. When using the framework, an associated application will hold onto Connection. When terminating or otherwise done with RSR, it will close the Connection to signal this.
+
+Connection offers a limited public interface. The private methods are subject to change and shouldn''t be used by any application.
+
+The Connection can be monitored by subscribing to any of the Announcements defined under ConnectionStateAnnouncement. See #announcer.
+
+The Connection is generally created indirectly via one of the ConnectionSpecification subclasses.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnection
+removeallclassmethods RsrConnection
+
+doit
+(RsrObject
+	subclass: 'RsrConnectionSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectionSpecification
+removeallclassmethods RsrConnectionSpecification
+
+doit
+(RsrConnectionSpecification
+	subclass: 'RsrInternalConnectionSpecification'
+	instVarNames: #(connectionA connectionB)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInternalConnectionSpecification
+removeallclassmethods RsrInternalConnectionSpecification
+
+doit
+(RsrInternalConnectionSpecification
+	subclass: 'RsrInMemoryConnectionSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemoryConnectionSpecification
+removeallclassmethods RsrInMemoryConnectionSpecification
+
+doit
+(RsrInternalConnectionSpecification
+	subclass: 'RsrInternalSocketConnectionSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInternalSocketConnectionSpecification
+removeallclassmethods RsrInternalSocketConnectionSpecification
+
+doit
+(RsrConnectionSpecification
+	subclass: 'RsrSocketConnectionSpecification'
+	instVarNames: #(host port)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'This class is abstract and defines the interface for manufacturing RsrConnection instances which are connected to a peer.
+
+Specialized subclasses are reponsible for either listening for or initiating connections with a peer.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketConnectionSpecification
+removeallclassmethods RsrSocketConnectionSpecification
+
+doit
+(RsrSocketConnectionSpecification
+	subclass: 'RsrAcceptConnection'
+	instVarNames: #(portRange listener isListening isWaitingForConnection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAcceptConnection
+removeallclassmethods RsrAcceptConnection
+
+doit
+(RsrAcceptConnection
+	subclass: 'RsrGciAcceptConnection'
+	instVarNames: #(token)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrGciAcceptConnection
+removeallclassmethods RsrGciAcceptConnection
+
+doit
+(RsrSocketConnectionSpecification
+	subclass: 'RsrInitiateConnection'
+	instVarNames: #(token)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'This class is responsible for initating a new RsrConnection. Sending #connect will result in an attempt to connect to the specified host and port. #connect is responsible for initating the attempted connection. If successful, an instance of RsrConnection is returned as a result.
+
+Example: 
+
+| initiator |
+initiator := RsrInitiateConnection
+	host: ''127.0.0.1''
+	port: 51820.
+^initiator connect';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInitiateConnection
+removeallclassmethods RsrInitiateConnection
+
+doit
+(RsrInitiateConnection
+	subclass: 'RsrGciInitiateConnection'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrGciInitiateConnection
+removeallclassmethods RsrGciInitiateConnection
+
+doit
+(RsrObject
+	subclass: 'RsrDateAndTime'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrDateAndTime
+removeallclassmethods RsrDateAndTime
+
+doit
+(RsrObject
+	subclass: 'RsrEnvironment'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrEnvironment
+removeallclassmethods RsrEnvironment
+
+doit
+(RsrObject
+	subclass: 'RsrEphemeron'
+	instVarNames: #(key mournAction)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrEphemeron
+removeallclassmethods RsrEphemeron
+
+doit
+(RsrObject
+	subclass: 'RsrGarbageCollector'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrGarbageCollector
+removeallclassmethods RsrGarbageCollector
+
+doit
+(RsrObject
+	subclass: 'RsrHandshake'
+	instVarNames: #(steps stream)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrHandshake
+removeallclassmethods RsrHandshake
+
+doit
+(RsrObject
+	subclass: 'RsrHandshakeStep'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrHandshakeStep
+removeallclassmethods RsrHandshakeStep
+
+doit
+(RsrHandshakeStep
+	subclass: 'RsrProtocolVersionNegotiation'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'This class serves as the abstract superclass for the classes which implement the actual handshake protocol.
+
+When the Client opens a Socket to the Server, it is responsible for sending the first message.
+
+Client -> Server: SupportedVersions
+Server -> Client:
+	alt: The Server and Client have overlap in their supported versions
+		- Server -> Client: ChosenVersion
+	alt: No overlap exists between the Client and Server.
+		- Server -> Client: NoVersionOverlap
+		- Server: Closes socket';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProtocolVersionNegotiation
+removeallclassmethods RsrProtocolVersionNegotiation
+
+doit
+(RsrProtocolVersionNegotiation
+	subclass: 'RsrProtocolVersionNegotiationClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProtocolVersionNegotiationClient
+removeallclassmethods RsrProtocolVersionNegotiationClient
+
+doit
+(RsrProtocolVersionNegotiation
+	subclass: 'RsrProtocolVersionNegotiationServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProtocolVersionNegotiationServer
+removeallclassmethods RsrProtocolVersionNegotiationServer
+
+doit
+(RsrHandshakeStep
+	subclass: 'RsrTokenExchange'
+	instVarNames: #(token)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenExchange
+removeallclassmethods RsrTokenExchange
+
+doit
+(RsrTokenExchange
+	subclass: 'RsrTokenReceiver'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenReceiver
+removeallclassmethods RsrTokenReceiver
+
+doit
+(RsrTokenExchange
+	subclass: 'RsrTokenSender'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenSender
+removeallclassmethods RsrTokenSender
+
+doit
+(RsrObject
+	subclass: 'RsrLog'
+	instVarNames: #(verbosity sinks)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrLog
+removeallclassmethods RsrLog
+
+doit
+(RsrObject
+	subclass: 'RsrLogSink'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrLogSink
+removeallclassmethods RsrLogSink
+
+doit
+(RsrLogSink
+	subclass: 'RsrCustomSink'
+	instVarNames: #(action)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCustomSink
+removeallclassmethods RsrCustomSink
+
+doit
+(RsrLogSink
+	subclass: 'RsrTranscriptSink'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTranscriptSink
+removeallclassmethods RsrTranscriptSink
+
+doit
+(RsrObject
+	subclass: 'RsrLogWithPrefix'
+	instVarNames: #(prefix log)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrLogWithPrefix
+removeallclassmethods RsrLogWithPrefix
+
+doit
+(RsrObject
+	subclass: 'RsrMessageSend'
+	instVarNames: #(receiver selector arguments)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrMessageSend
+removeallclassmethods RsrMessageSend
+
+doit
+(RsrObject
+	subclass: 'RsrNumericSpigot'
+	instVarNames: #(current step)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNumericSpigot
+removeallclassmethods RsrNumericSpigot
+
+doit
+(RsrNumericSpigot
+	subclass: 'RsrThreadSafeNumericSpigot'
+	instVarNames: #(mutex)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrThreadSafeNumericSpigot
+removeallclassmethods RsrThreadSafeNumericSpigot
+
+doit
+(RsrObject
+	subclass: 'RsrPendingMessage'
+	instVarNames: #(services promise)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPendingMessage
+removeallclassmethods RsrPendingMessage
+
+doit
+(RsrObject
+	subclass: 'RsrPromise'
+	instVarNames: #(mutex value state resolvedMutex resolutionActions)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'Purpose: Provide a simple Promise interface for use in RSR.
+
+A Promise may be in two high level states -- unresolved and resolved. Resolving a promise means either breaking or fulfilling the promise. Any users of the Notification Interface will be notified of the resolution. See individual methods for details.
+
+Resolution Interface:
+- #break:
+- #fulfill:
+
+Notification Interface:
+- #when:catch:
+- #wait
+- #value
+
+Example Usage:
+
+```
+	| promise |
+	promise := Promise new.
+	promise
+		when: [:anObject | Transcript show: ''Promise fulfilled to: '', anObject asString; cr]
+		catch: [:reason | Transcript show: ''Promise broken because of '', reason asString; cr].
+	"Time passes"
+	promise fulfill: Object new
+```
+
+```
+	| promise |
+	promise := Promise new.
+	self runAsynCalculationThenFulfill: promise.
+	promise wait.
+```';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPromise
+removeallclassmethods RsrPromise
+
+doit
+(RsrObject
+	subclass: 'RsrPromiseResolutionAction'
+	instVarNames: #(when catch)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPromiseResolutionAction
+removeallclassmethods RsrPromiseResolutionAction
+
+doit
+(RsrObject
+	subclass: 'RsrProtocolVersionNegotiationMessage'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'HandshakeMessage serves as a superclass for all Messages used while processing a Connection Handshake.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProtocolVersionNegotiationMessage
+removeallclassmethods RsrProtocolVersionNegotiationMessage
+
+doit
+(RsrProtocolVersionNegotiationMessage
+	subclass: 'RsrChosenVersion'
+	instVarNames: #(version)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'This message is sent when a Server has chosen a version it is willing to talk w/ a client Connection. The Server expects the Client to speak this version.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrChosenVersion
+removeallclassmethods RsrChosenVersion
+
+doit
+(RsrProtocolVersionNegotiationMessage
+	subclass: 'RsrNoVersionOverlap'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'This message is sent when a Server has determined it cannot talk any version of the protocol that the Client has requested to speak.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNoVersionOverlap
+removeallclassmethods RsrNoVersionOverlap
+
+doit
+(RsrProtocolVersionNegotiationMessage
+	subclass: 'RsrSupportedVersions'
+	instVarNames: #(versions)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'When a Client connects to a Server. It is required to send this message w/ the list of supported protocol versions it is willing to speak. The preference of the client is signified by the order of the version numbers in <versions>.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSupportedVersions
+removeallclassmethods RsrSupportedVersions
+
+doit
+(RsrObject
+	subclass: 'RsrReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #(referenceMapping)
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'RsrReference
+
+Reference instances are created as a by-product of freezing the state of a Service. This typically happens when the framework creates a SendMessage or DeliverResponse command.
+
+The Reference represents and is able to resolve the object it represents. In some cases, the value is immediate. In the case of ServiceReference, the stored Service Identifier is resolved in the context of a connection.
+
+Resolving must occur in the context of a Connection. Though this is true, the minimal information necessary for a Reference to resolve is the Registry.
+
+SendMessage and DeliverResponse store fields like receiver or result as references. They are resolved when the Command is set to execute.
+
+Collaborators:
+- ServiceSnapshot
+- Encoder
+- Decoder';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrReference
+removeallclassmethods RsrReference
+
+doit
+(RsrReference
+	subclass: 'RsrImmediateReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrImmediateReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference( value)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrImmediateReference
+removeallclassmethods RsrImmediateReference
+
+doit
+(RsrImmediateReference
+	subclass: 'RsrBooleanReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrBooleanReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrBooleanReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrBooleanReference
+removeallclassmethods RsrBooleanReference
+
+doit
+(RsrBooleanReference
+	subclass: 'RsrFalseReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrFalseReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrFalseReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrFalseReference
+removeallclassmethods RsrFalseReference
+
+doit
+(RsrBooleanReference
+	subclass: 'RsrTrueReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrTrueReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference( value)
+        RsrTrueReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTrueReference
+removeallclassmethods RsrTrueReference
+
+doit
+(RsrImmediateReference
+	subclass: 'RsrNilReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrNilReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrNilReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNilReference
+removeallclassmethods RsrNilReference
+
+doit
+(RsrImmediateReference
+	subclass: 'RsrValueReference'
+	instVarNames: #(intermediate)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrValueReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrValueReference
+removeallclassmethods RsrValueReference
+
+doit
+(RsrValueReference
+	subclass: 'RsrByteArrayReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrByteArrayReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrByteArrayReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrByteArrayReference
+removeallclassmethods RsrByteArrayReference
+
+doit
+(RsrValueReference
+	subclass: 'RsrCharacterArrayReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrCharacterArrayReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrCharacterArrayReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCharacterArrayReference
+removeallclassmethods RsrCharacterArrayReference
+
+doit
+(RsrCharacterArrayReference
+	subclass: 'RsrStringReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrStringReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrCharacterArrayReference( value)
+          RsrStringReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrStringReference
+removeallclassmethods RsrStringReference
+
+doit
+(RsrCharacterArrayReference
+	subclass: 'RsrSymbolReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrSymbolReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrCharacterArrayReference( value)
+          RsrSymbolReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSymbolReference
+removeallclassmethods RsrSymbolReference
+
+doit
+(RsrValueReference
+	subclass: 'RsrCharacterReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrCharacterReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrCharacterReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCharacterReference
+removeallclassmethods RsrCharacterReference
+
+doit
+(RsrValueReference
+	subclass: 'RsrCollectionReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrCollectionReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrCollectionReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCollectionReference
+removeallclassmethods RsrCollectionReference
+
+doit
+(RsrCollectionReference
+	subclass: 'RsrArrayReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrArrayReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrArrayReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrArrayReference
+removeallclassmethods RsrArrayReference
+
+doit
+(RsrCollectionReference
+	subclass: 'RsrDictionaryReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrDictionaryReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrDictionaryReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrDictionaryReference
+removeallclassmethods RsrDictionaryReference
+
+doit
+(RsrCollectionReference
+	subclass: 'RsrOrderedCollectionReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrOrderedCollectionReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrOrderedCollectionReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrOrderedCollectionReference
+removeallclassmethods RsrOrderedCollectionReference
+
+doit
+(RsrCollectionReference
+	subclass: 'RsrSetReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrSetReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrSetReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSetReference
+removeallclassmethods RsrSetReference
+
+doit
+(RsrValueReference
+	subclass: 'RsrDateAndTimeReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrDateAndTimeReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrValueReference( value)
+          RsrDateAndTimeReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrDateAndTimeReference
+removeallclassmethods RsrDateAndTimeReference
+
+doit
+(RsrValueReference
+	subclass: 'RsrDoubleReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrDoubleReference
+removeallclassmethods RsrDoubleReference
+
+doit
+(RsrValueReference
+	subclass: 'RsrIntegerReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrIntegerReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrIntegerReference( value)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrIntegerReference
+removeallclassmethods RsrIntegerReference
+
+doit
+(RsrIntegerReference
+	subclass: 'RsrNegativeIntegerReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrNegativeIntegerReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrIntegerReference( value)
+          RsrNegativeIntegerReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNegativeIntegerReference
+removeallclassmethods RsrNegativeIntegerReference
+
+doit
+(RsrIntegerReference
+	subclass: 'RsrPositiveIntegerReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrPositiveIntegerReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrImmediateReference
+        RsrIntegerReference( value)
+          RsrPositiveIntegerReference
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPositiveIntegerReference
+removeallclassmethods RsrPositiveIntegerReference
+
+doit
+(RsrReference
+	subclass: 'RsrServiceReference'
+	instVarNames: #(sid)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'No class-specific documentation for RsrServiceReference, hierarchy is:
+Object
+  RsrObject
+    RsrReference
+      RsrServiceReference( sid)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServiceReference
+removeallclassmethods RsrServiceReference
+
+doit
+(RsrObject
+	subclass: 'RsrRegistryEntry'
+	instVarNames: #(ephemeron strongStorage)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRegistryEntry
+removeallclassmethods RsrRegistryEntry
+
+doit
+(RsrObject
+	subclass: 'RsrRemotePromiseResolver'
+	instVarNames: #(mutex sendMessage connection extraRoots hasResolved)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'This class is responsible for taking breaking or fulfilling its associated Promise. The Promise exists in the remote RSR instance.
+
+This class may be mutated outside of the thread which created it. Therefore, it contains a protection mutex to ensure consistency.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrRemotePromiseResolver
+removeallclassmethods RsrRemotePromiseResolver
+
+doit
+(RsrObject
+	subclass: 'RsrScientist'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrScientist
+removeallclassmethods RsrScientist
+
+doit
+(RsrObject
+	subclass: 'RsrServiceEphemeron'
+	instVarNames: #(service action)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServiceEphemeron
+removeallclassmethods RsrServiceEphemeron
+
+doit
+(RsrObject
+	subclass: 'RsrServiceSnapshot'
+	instVarNames: #(sid templateName shouldCreateServer slots)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'RsrServiceSnapshot
+
+When a SendMessage or DeliverResponse command is processed, the entire transition closure of the MessageSend/Response is analyzed.
+
+A Snapshot of each Service found during this process is taken. The slots of the Service that need to be replicated are stored in the ServiceSnapshot as references.
+
+In addition, information about the template and service is stored. This allows the peer to reify the correct type of Service. For instance, a local Client will be a Server remotely. A local Server will become a remote Client.
+
+Collaborators:
+- Encoder
+- Decoder
+- Reference';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServiceSnapshot
+removeallclassmethods RsrServiceSnapshot
+
+doit
+(RsrObject
+	subclass: 'RsrSignalErrorInAsString'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSignalErrorInAsString
+removeallclassmethods RsrSignalErrorInAsString
+
+doit
+(RsrObject
+	subclass: 'RsrSnapshotAnalysis'
+	instVarNames: #(roots snapshots connection analyzedObjects)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrSnapshotAnalysis, hierarchy is:
+Object
+  RsrObject
+    RsrSnapshotAnalysis( roots snapshots inFlight connection)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSnapshotAnalysis
+removeallclassmethods RsrSnapshotAnalysis
+
+doit
+(RsrObject
+	subclass: 'RsrSocket'
+	instVarNames: #(nativeSocket)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocket
+removeallclassmethods RsrSocket
+
+doit
+(RsrObject
+	subclass: 'RsrSocketPair'
+	instVarNames: #(firstSocket secondSocket)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketPair
+removeallclassmethods RsrSocketPair
+
+doit
+(RsrObject
+	subclass: 'RsrStream'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrStream
+removeallclassmethods RsrStream
+
+doit
+(RsrStream
+	subclass: 'RsrSocketStream'
+	instVarNames: #(socket sendBuffer position)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'A stream to put on top of a socket, with a write buffer to avoid sending tiny packets. Bytes are accumulated until either an MSS-worth (we assume a conservative MSS of 1440 bytes) is waiting to be sent, or until flush is sent, to send the data through the underlying socket.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketStream
+removeallclassmethods RsrSocketStream
+
+doit
+(RsrObject
+	subclass: 'RsrStreamChannelLoop'
+	instVarNames: #(process channel state)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrEventLoop, hierarchy is:
+Object
+  RsrObject
+    RsrEventLoop( process connection state)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrStreamChannelLoop
+removeallclassmethods RsrStreamChannelLoop
+
+doit
+(RsrStreamChannelLoop
+	subclass: 'RsrCommandSink'
+	instVarNames: #(queue)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'No class-specific documentation for RsrCommandSink, hierarchy is:
+Object
+  RsrObject
+    RsrEventLoop( process connection state)
+      RsrCommandSink( queue)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandSink
+removeallclassmethods RsrCommandSink
+
+doit
+(RsrStreamChannelLoop
+	subclass: 'RsrCommandSource'
+	instVarNames: #(decoder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandSource
+removeallclassmethods RsrCommandSource
+
+doit
+(RsrObject
+	subclass: 'RsrThreadSafeDictionary'
+	instVarNames: #(mutex map)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		comment: 'I maintain the associations between locally stored objects and their remote counterparts.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrThreadSafeDictionary
+removeallclassmethods RsrThreadSafeDictionary
+
+doit
+(RsrObject
+	subclass: 'RsrTokenExchangeMessage'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenExchangeMessage
+removeallclassmethods RsrTokenExchangeMessage
+
+doit
+(RsrTokenExchangeMessage
+	subclass: 'RsrToken'
+	instVarNames: #(bytes)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrToken
+removeallclassmethods RsrToken
+
+doit
+(RsrTokenExchangeMessage
+	subclass: 'RsrTokenAccepted'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenAccepted
+removeallclassmethods RsrTokenAccepted
+
+doit
+(RsrTokenExchangeMessage
+	subclass: 'RsrTokenRejected'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenRejected
+removeallclassmethods RsrTokenRejected
+
+doit
+(Object
+	subclass: 'RsrPlatformInitializer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication';
+		comment: 'Does load-time initialization of any class instance variables of classes defined in Base but that have platform-specific contents and thus can''t be initialized by their own package, and can''t be lazily initialized because that fails on GemStone for non-privileged users.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPlatformInitializer
+removeallclassmethods RsrPlatformInitializer
+
+doit
+(Object
+	subclass: 'RsrProcessModel'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #(current)
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Base';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProcessModel
+removeallclassmethods RsrProcessModel
+
+doit
+(RsrProcessModel
+	subclass: 'RsrTestingProcessModel'
+	instVarNames: #(forkedException)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTestingProcessModel
+removeallclassmethods RsrTestingProcessModel
+
+doit
+(TestCase
+	subclass: 'RsrTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		comment: 'An abstract test class which contains utility methods';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTestCase
+removeallclassmethods RsrTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrAsyncMournHandlerTestCase'
+	instVarNames: #(handler)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrAsyncMournHandlerTestCase
+removeallclassmethods RsrAsyncMournHandlerTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrClassResolverTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrClassResolverTestCase
+removeallclassmethods RsrClassResolverTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrCommandCodecTest'
+	instVarNames: #(connection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandCodecTest
+removeallclassmethods RsrCommandCodecTest
+
+doit
+(RsrCommandCodecTest
+	subclass: 'RsrCommandDecoderTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		comment: 'No class-specific documentation for RsrDecoderTest, hierarchy is:
+Object
+  TestAsserter
+    TestCase( testSelector)
+      RsrTestCase
+        RsrCodecTest( registry decoder)
+          RsrDecoderTest
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandDecoderTest
+removeallclassmethods RsrCommandDecoderTest
+
+doit
+(RsrCommandCodecTest
+	subclass: 'RsrCommandEncoderTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		comment: 'No class-specific documentation for RsrEncoderTest, hierarchy is:
+Object
+  TestAsserter
+    TestCase( testSelector)
+      RsrTestCase
+        RsrCodecTest( registry decoder)
+          RsrEncoderTest( connection)
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrCommandEncoderTest
+removeallclassmethods RsrCommandEncoderTest
+
+doit
+(RsrTestCase
+	subclass: 'RsrConnectionSpecificationTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectionSpecificationTestCase
+removeallclassmethods RsrConnectionSpecificationTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrForwarderTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrForwarderTest
+removeallclassmethods RsrForwarderTest
+
+doit
+(RsrTestCase
+	subclass: 'RsrGarbageCollectorTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrGarbageCollectorTestCase
+removeallclassmethods RsrGarbageCollectorTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrNumericSpigotTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrNumericSpigotTest
+removeallclassmethods RsrNumericSpigotTest
+
+doit
+(RsrNumericSpigotTest
+	subclass: 'RsrThreadSafeNumericSpigotTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrThreadSafeNumericSpigotTest
+removeallclassmethods RsrThreadSafeNumericSpigotTest
+
+doit
+(RsrTestCase
+	subclass: 'RsrPromiseTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrPromiseTest
+removeallclassmethods RsrPromiseTest
+
+doit
+(RsrTestCase
+	subclass: 'RsrProtocolVersionNegotiationCodecTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrProtocolVersionNegotiationCodecTestCase
+removeallclassmethods RsrProtocolVersionNegotiationCodecTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrSnapshotAnalysisTest'
+	instVarNames: #(connection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		comment: 'No class-specific documentation for RsrSnapshotAnalysisTest, hierarchy is:
+Object
+  TestAsserter
+    TestCase( testSelector)
+      RsrTestCase
+        RsrSnapshotAnalysisTest
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSnapshotAnalysisTest
+removeallclassmethods RsrSnapshotAnalysisTest
+
+doit
+(RsrTestCase
+	subclass: 'RsrSocketStreamTestCase'
+	instVarNames: #(aStream bStream)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketStreamTestCase
+removeallclassmethods RsrSocketStreamTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrSocketTestCase'
+	instVarNames: #(sockets)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketTestCase
+removeallclassmethods RsrSocketTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrSystemTestCase'
+	instVarNames: #(connectionA connectionB)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSystemTestCase
+removeallclassmethods RsrSystemTestCase
+
+doit
+(RsrSystemTestCase
+	subclass: 'RsrConnectionTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrConnectionTestCase
+removeallclassmethods RsrConnectionTestCase
+
+doit
+(RsrConnectionTestCase
+	subclass: 'RsrInMemoryConnectionTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemoryConnectionTestCase
+removeallclassmethods RsrInMemoryConnectionTestCase
+
+doit
+(RsrConnectionTestCase
+	subclass: 'RsrSocketConnectionTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketConnectionTestCase
+removeallclassmethods RsrSocketConnectionTestCase
+
+doit
+(RsrSystemTestCase
+	subclass: 'RsrEphemeronMourningDeadlock'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrEphemeronMourningDeadlock
+removeallclassmethods RsrEphemeronMourningDeadlock
+
+doit
+(RsrSystemTestCase
+	subclass: 'RsrLifetimeTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrLifetimeTest
+removeallclassmethods RsrLifetimeTest
+
+doit
+(RsrLifetimeTest
+	subclass: 'RsrInMemoryLifetimeTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemoryLifetimeTest
+removeallclassmethods RsrInMemoryLifetimeTest
+
+doit
+(RsrLifetimeTest
+	subclass: 'RsrSocketLifetimeTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketLifetimeTest
+removeallclassmethods RsrSocketLifetimeTest
+
+doit
+(RsrSystemTestCase
+	subclass: 'RsrMessageSendingTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrMessageSendingTest
+removeallclassmethods RsrMessageSendingTest
+
+doit
+(RsrMessageSendingTest
+	subclass: 'RsrInMemoryMessageSendingTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemoryMessageSendingTest
+removeallclassmethods RsrInMemoryMessageSendingTest
+
+doit
+(RsrMessageSendingTest
+	subclass: 'RsrSocketMessageSendingTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketMessageSendingTest
+removeallclassmethods RsrSocketMessageSendingTest
+
+doit
+(RsrSystemTestCase
+	subclass: 'RsrServiceTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrServiceTest
+removeallclassmethods RsrServiceTest
+
+doit
+(RsrServiceTest
+	subclass: 'RsrInMemoryServiceTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemoryServiceTest
+removeallclassmethods RsrInMemoryServiceTest
+
+doit
+(RsrServiceTest
+	subclass: 'RsrSocketServiceTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketServiceTest
+removeallclassmethods RsrSocketServiceTest
+
+doit
+(RsrSystemTestCase
+	subclass: 'RsrSpeciesEquality'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSpeciesEquality
+removeallclassmethods RsrSpeciesEquality
+
+doit
+(RsrSpeciesEquality
+	subclass: 'RsrInMemorySpeciesEquality'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemorySpeciesEquality
+removeallclassmethods RsrInMemorySpeciesEquality
+
+doit
+(RsrSpeciesEquality
+	subclass: 'RsrSocketSpeciesEquality'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketSpeciesEquality
+removeallclassmethods RsrSocketSpeciesEquality
+
+doit
+(RsrSystemTestCase
+	subclass: 'RsrStressTest'
+	instVarNames: #(client server)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrStressTest
+removeallclassmethods RsrStressTest
+
+doit
+(RsrStressTest
+	subclass: 'RsrInMemoryStressTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrInMemoryStressTest
+removeallclassmethods RsrInMemoryStressTest
+
+doit
+(RsrStressTest
+	subclass: 'RsrSocketStressTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrSocketStressTest
+removeallclassmethods RsrSocketStressTest
+
+doit
+(RsrTestCase
+	subclass: 'RsrTemplateResolverTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTemplateResolverTestCase
+removeallclassmethods RsrTemplateResolverTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrTemplateResolverWithClassVersions'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-GemStone-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTemplateResolverWithClassVersions
+removeallclassmethods RsrTemplateResolverWithClassVersions
+
+doit
+(RsrTestCase
+	subclass: 'RsrTestingProcessModelTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Platform-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTestingProcessModelTestCase
+removeallclassmethods RsrTestingProcessModelTestCase
+
+doit
+(RsrTestCase
+	subclass: 'RsrTokenExchangeCodecTestCase'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'RemoteServiceReplication-Test';
+		immediateInvariant.
+true.
+%
+
+removeallmethods RsrTokenExchangeCodecTestCase
+removeallclassmethods RsrTokenExchangeCodecTestCase
+
+! Class implementation for 'RsrConnectionClosed'
+
+!		Class methods for 'RsrConnectionClosed'
+
+category: 'instance creation'
+classmethod: RsrConnectionClosed
+connection: aConnection
+
+	^self new
+		connection: aConnection;
+		yourself
+%
+
+!		Instance methods for 'RsrConnectionClosed'
+
+category: 'accessing'
+method: RsrConnectionClosed
+connection
+	"The Connection that was closed."
+
+	^connection
+%
+
+category: 'accessing'
+method: RsrConnectionClosed
+connection: aConnection
+	"Store the Connection that was closed."
+
+	connection := aConnection
+%
+
+! Class implementation for 'RsrAlreadyRegistered'
+
+!		Class methods for 'RsrAlreadyRegistered'
+
+category: 'instance creation'
+classmethod: RsrAlreadyRegistered
+signalService: aService
+intendedConnection: aConnection
+
+	^self new
+		service: aService;
+		intendedConnection: aConnection;
+		signal
+%
+
+!		Instance methods for 'RsrAlreadyRegistered'
+
+category: 'accessing'
+method: RsrAlreadyRegistered
+intendedConnection
+
+	^intendedConnection
+%
+
+category: 'accessing'
+method: RsrAlreadyRegistered
+intendedConnection: aConnection
+
+	intendedConnection := aConnection
+%
+
+category: 'accessing'
+method: RsrAlreadyRegistered
+service
+
+	^service
+%
+
+category: 'accessing'
+method: RsrAlreadyRegistered
+service: aService
+
+	service := aService
+%
+
+! Class implementation for 'RsrNonresumableError'
+
+!		Instance methods for 'RsrNonresumableError'
+
+category: 'testing'
+method: RsrNonresumableError
+isResumable
+
+	^false
+%
+
+! Class implementation for 'RsrBrokenPromise'
+
+!		Class methods for 'RsrBrokenPromise'
+
+category: 'signaling'
+classmethod: RsrBrokenPromise
+signalReason: aReason
+
+	^self new
+		reason: aReason;
+		signal
+%
+
+!		Instance methods for 'RsrBrokenPromise'
+
+category: 'accessing'
+method: RsrBrokenPromise
+reason
+
+	^reason
+%
+
+category: 'accessing'
+method: RsrBrokenPromise
+reason: aReason
+
+	reason := aReason
+%
+
+! Class implementation for 'RsrRemoteError'
+
+!		Class methods for 'RsrRemoteError'
+
+category: 'instance creation'
+classmethod: RsrRemoteError
+from: anException
+
+	| tag |
+	tag := anException tag
+		ifNotNil:
+			[[anException tag asString]
+				on: Error
+				do: [:ex | ex return: 'Unable to pack #tag containing an instance of ', anException tag class name]].
+	^self new
+		originalClassName: anException class name;
+		tag: tag;
+		messageText: anException messageText;
+		stack: RsrProcessModel currentStackDump;
+		yourself
+%
+
+!		Instance methods for 'RsrRemoteError'
+
+category: 'accessing'
+method: RsrRemoteError
+originalClassName
+
+	^originalClassName
+%
+
+category: 'accessing'
+method: RsrRemoteError
+originalClassName: aSymbol
+
+	originalClassName := aSymbol
+%
+
+category: 'accessing'
+method: RsrRemoteError
+stack
+
+	^stack
+%
+
+category: 'accessing'
+method: RsrRemoteError
+stack: aString
+
+	stack := aString
+%
+
+! Class implementation for 'RsrResumableError'
+
+!		Instance methods for 'RsrResumableError'
+
+category: 'testing'
+method: RsrResumableError
+isResumable
+
+	^true
+%
+
+! Class implementation for 'RsrServiceRejected'
+
+!		Class methods for 'RsrServiceRejected'
+
+category: 'signaling'
+classmethod: RsrServiceRejected
+signalReason: aReason
+
+	^self new
+		reason: aReason;
+		signal
+%
+
+!		Instance methods for 'RsrServiceRejected'
+
+category: 'accessing'
+method: RsrServiceRejected
+reason
+	"The PolicyRejectedService reason"
+
+	^reason
+%
+
+category: 'accessing'
+method: RsrServiceRejected
+reason: aPolicyRejectedService
+	"The PolicyRejectedService reason"
+
+	reason := aPolicyRejectedService
+%
+
+! Class implementation for 'RsrUnsupportedObject'
+
+!		Class methods for 'RsrUnsupportedObject'
+
+category: 'exceptioninstantiator'
+classmethod: RsrUnsupportedObject
+signal: anObject
+
+	^self new
+		object: anObject;
+		messageText: 'Instances of #', anObject class name, ' do not support replication.';
+		signal
+%
+
+!		Instance methods for 'RsrUnsupportedObject'
+
+category: 'accessing'
+method: RsrUnsupportedObject
+object
+
+	^object
+%
+
+category: 'accessing'
+method: RsrUnsupportedObject
+object: anObject
+
+	object := anObject
+%
+
+! Class implementation for 'RsrUnhandledException'
+
+!		Class methods for 'RsrUnhandledException'
+
+category: 'signaling'
+classmethod: RsrUnhandledException
+signal: anException
+	"Signal the exception in reference to the provided exception."
+
+	^self new
+		exception: anException;
+		signal
+%
+
+!		Instance methods for 'RsrUnhandledException'
+
+category: 'acccessing'
+method: RsrUnhandledException
+exception
+	"The exception that was unhandled."
+
+	^exception
+%
+
+category: 'acccessing'
+method: RsrUnhandledException
+exception: anException
+	"The exception that was unhandled."
+
+	exception := anException
+%
+
+! Class implementation for 'RsrObject'
+
+!		Class methods for 'RsrObject'
+
+category: 'tracing'
+classmethod: RsrObject
+trace
+
+	Transcript
+		show: RsrProcessModel currentStackDump;
+		cr;
+		cr
+%
+
+!		Instance methods for 'RsrObject'
+
+category: 'notes'
+method: RsrObject
+flag: aSymbol
+
+	"Send this message, with a relevant symbol as argument, to flag a message for subsequent retrieval.  For example, you might put the following line in a number of messages:
+	self flag: #returnHereUrgently
+	Then, to retrieve all such messages, browse all senders of #returnHereUrgently."
+%
+
+category: 'delaying'
+method: RsrObject
+minimalWait
+	"Ensure the calling process is not schedulable for a short period of time."
+
+	(Delay forMilliseconds: 1) wait
+%
+
+category: 'notes'
+method: RsrObject
+note: aString
+	"This method can be used to leave a note in code. For instance, a code path that needs to be tested."
+%
+
+category: 'tracing'
+method: RsrObject
+trace
+
+	Transcript
+		show: RsrProcessModel currentStackDump;
+		cr;
+		cr
+%
+
+! Class implementation for 'RsrAbstractPolicy'
+
+!		Instance methods for 'RsrAbstractPolicy'
+
+category: 'testing'
+method: RsrAbstractPolicy
+permits: aTemplate
+	"Returning true to allow the framework to instantiate 
+	a Service received over the Connection."
+
+	self subclassResponsibility
+%
+
+! Class implementation for 'RsrDefaultPolicy'
+
+!		Instance methods for 'RsrDefaultPolicy'
+
+category: 'testing'
+method: RsrDefaultPolicy
+permits: aTemplate
+	"Returning true to allow the framework to instantiate 
+	a Service received over the Connection."
+
+	^true
+%
+
+! Class implementation for 'RsrTestPolicy'
+
+!		Instance methods for 'RsrTestPolicy'
+
+category: 'accessing'
+method: RsrTestPolicy
+deny: aTemplate
+
+	deniedTemplates add: aTemplate
+%
+
+category: 'initialization'
+method: RsrTestPolicy
+initialize
+
+	super initialize.
+	deniedTemplates := Set new
+%
+
+category: 'testing'
+method: RsrTestPolicy
+permits: aTemplate
+	"Permit any Template that hasn't been denied"
+
+	^(deniedTemplates includes: aTemplate) not
+%
+
+! Class implementation for 'RsrDecodingRaisedException'
+
+!		Class methods for 'RsrDecodingRaisedException'
+
+category: 'instance creation'
+classmethod: RsrDecodingRaisedException
+exception: anException
+
+	^self new
+		exception: anException;
+		yourself
+%
+
+!		Instance methods for 'RsrDecodingRaisedException'
+
+category: 'accessing'
+method: RsrDecodingRaisedException
+exception
+
+	^exception
+%
+
+category: 'accessing'
+method: RsrDecodingRaisedException
+exception: anException
+
+	exception := anException
+%
+
+! Class implementation for 'RsrService'
+
+!		Class methods for 'RsrService'
+
+category: 'accessing'
+classmethod: RsrService
+clientClass
+
+	^RsrClassResolver classNamed: self clientClassName
+%
+
+category: 'accessing'
+classmethod: RsrService
+clientClassName
+
+	^(self templateClassName, 'Client') asSymbol
+%
+
+category: 'testing'
+classmethod: RsrService
+isClientClass
+
+	^self name == self clientClassName
+%
+
+category: 'testing'
+classmethod: RsrService
+isServerClass
+
+	^self name == self serverClassName
+%
+
+category: 'testing'
+classmethod: RsrService
+isTemplateClass
+
+	^self name == self templateClassName
+%
+
+category: 'accessing'
+classmethod: RsrService
+serverClass
+
+	^RsrClassResolver classNamed: self serverClassName
+%
+
+category: 'accessing'
+classmethod: RsrService
+serverClassName
+
+	^(self templateClassName, 'Server') asSymbol
+%
+
+category: 'accessing'
+classmethod: RsrService
+templateClass
+
+	^RsrClassResolver classNamed: self templateClassName
+%
+
+category: 'accessing'
+classmethod: RsrService
+templateClassName
+
+	self subclassResponsibility
+%
+
+category: 'instance creation'
+classmethod: RsrService
+_id: anId
+connection: aConnection
+
+	^super new
+		_id: anId connection: aConnection;
+		yourself
+%
+
+!		Instance methods for 'RsrService'
+
+category: 'public-events'
+method: RsrService
+configureProcess
+	"#configureProcess is called each time the framework calls into the framework to evaluate generic user code.
+	#preUpdate and #postUpdate run in a configuration manner prescribed by the framework."
+
+	Processor activeProcess
+		priority: self serviceSchedulingPriority
+%
+
+category: 'public-accessing'
+method: RsrService
+connection
+	"Returns the Connection associated w/ the receiver."
+
+	^self _connection
+%
+
+category: 'public-debugging'
+method: RsrService
+debug: anException
+raisedDuring: aMessageSend
+answerUsing: aResolver
+
+	aResolver break: (RsrRemoteException from: anException)
+%
+
+category: 'public-accessing'
+method: RsrService
+id
+	"Returns the Service ID associated w/ the receiver."
+
+	^self _id
+%
+
+category: 'public-testing'
+method: RsrService
+isClient
+
+	^self class isClientClass
+%
+
+category: 'public-testing'
+method: RsrService
+isMirrored
+
+	^_connection ~~ nil
+%
+
+category: 'public-testing'
+method: RsrService
+isNotMirrored
+
+	^self isMirrored not
+%
+
+category: 'public-testing'
+method: RsrService
+isServer
+
+	^self class isServerClass
+%
+
+category: 'public-events'
+method: RsrService
+postRegistration
+	"This message is sent immediately after the Service
+	is registered with a Connection for the first time.
+
+	The framework views both Client and Server peers as
+	the same object. When a peer is created by the
+	framework, it will not receive #postRegistration."
+
+	^self
+%
+
+category: 'public-events'
+method: RsrService
+postUpdate
+	"#postUpdate is called just after the Service's shared variables are updated by the framework.
+	This method can be overridden to ensure internal consistency."
+
+	^self
+%
+
+category: 'public-events'
+method: RsrService
+preUpdate
+	"#preUpdate is called just before the Service's shared variables are updated by the framework.
+	This method can be overridden to ensure internal consistency.
+	Note: If this method raises an exception, RSR will not signal #postUpdate."
+
+	^self
+%
+
+category: 'public-registration'
+method: RsrService
+registerWith: aConnection
+
+	aConnection _ensureRegistered: self
+%
+
+category: 'public-events'
+method: RsrService
+serviceSchedulingPriority
+
+	^Processor userSchedulingPriority
+%
+
+category: 'public-synchronization'
+method: RsrService
+synchronize
+	"Synchronize the service w/ its peer."
+
+	remoteSelf == nil
+		ifFalse: [remoteSelf _synchronize wait]
+%
+
+category: 'public-accessing'
+method: RsrService
+template
+	"Returns the template associated with this Service.
+	This method should NOT be redefined."
+
+	^self _template
+%
+
+category: 'private-accessing'
+method: RsrService
+_connection
+	"Private - Returns the Connection associated w/ the receiver."
+
+	^_connection
+%
+
+category: 'private-accessing'
+method: RsrService
+_id
+	"Private - Returns the Service ID associated w/ the receiver."
+
+	^_id
+%
+
+category: 'private-accessing'
+method: RsrService
+_id: anRsrId
+connection: aConnection
+	"Private - Configure this Service w/ a Service ID and Connection. This is a side-effect of registering a Service w/ a Connection."
+
+	_id := anRsrId.
+	_connection := aConnection.
+	remoteSelf := aConnection _forwarderClass on: self
+%
+
+category: 'private-synchronization'
+method: RsrService
+_synchronize
+	"Return self to synchronize with the remote peer"
+
+	^self
+%
+
+category: 'private-accessing'
+method: RsrService
+_template
+	"Returns the template associated with this Service. General users should use #template."
+
+	^_connection templateResolver templateFor: self
+%
+
+! Class implementation for 'RsrConcurrentTestService'
+
+!		Class methods for 'RsrConcurrentTestService'
+
+category: 'accessing'
+classmethod: RsrConcurrentTestService
+clientClassName
+
+	^#RsrConcurrentTestClient
+%
+
+category: 'accessing'
+classmethod: RsrConcurrentTestService
+serverClassName
+
+	^#RsrConcurrentTestServer
+%
+
+category: 'accessing'
+classmethod: RsrConcurrentTestService
+templateClassName
+
+	^#RsrConcurrentTestService
+%
+
+! Class implementation for 'RsrConcurrentTestClient'
+
+!		Instance methods for 'RsrConcurrentTestClient'
+
+category: 'accessing'
+method: RsrConcurrentTestClient
+counterWithIncrement
+
+	^remoteSelf counterWithIncrement wait
+%
+
+category: 'accessing'
+method: RsrConcurrentTestClient
+delayedCounter
+
+	^remoteSelf delayedCounter wait
+%
+
+category: 'actions'
+method: RsrConcurrentTestClient
+stashProcess
+
+	remoteSelf stashProcess wait
+%
+
+! Class implementation for 'RsrConcurrentTestServer'
+
+!		Class methods for 'RsrConcurrentTestServer'
+
+category: 'accessing'
+classmethod: RsrConcurrentTestServer
+initialCounter
+
+	^0
+%
+
+!		Instance methods for 'RsrConcurrentTestServer'
+
+category: 'accessing'
+method: RsrConcurrentTestServer
+counter: anArray
+
+	counter := anArray
+%
+
+category: 'accessing'
+method: RsrConcurrentTestServer
+counterWithIncrement
+
+	^[counter at: 1] ensure: [counter at: 1 put: (counter at: 1) + 1]
+%
+
+category: 'accessing'
+method: RsrConcurrentTestServer
+delayedCounter
+
+	semaphore signal.
+	(Delay forSeconds: 2) wait.
+	^counter at: 1
+%
+
+category: 'accessing'
+method: RsrConcurrentTestServer
+semaphore: aSemaphore
+
+	semaphore := aSemaphore
+%
+
+category: 'accessing'
+method: RsrConcurrentTestServer
+stashedProcess
+
+	^stashedProcess
+%
+
+category: 'actions'
+method: RsrConcurrentTestServer
+stashProcess
+
+	stashedProcess := Processor activeProcess
+%
+
+! Class implementation for 'RsrInstrumentedService'
+
+!		Class methods for 'RsrInstrumentedService'
+
+category: 'accessing'
+classmethod: RsrInstrumentedService
+clientClassName
+
+	^#RsrInstrumentedClient
+%
+
+category: 'accessing'
+classmethod: RsrInstrumentedService
+serverClassName
+
+	^#RsrInstrumentedServer
+%
+
+category: 'accessing'
+classmethod: RsrInstrumentedService
+templateClassName
+
+	^#RsrInstrumentedService
+%
+
+!		Instance methods for 'RsrInstrumentedService'
+
+category: 'events'
+method: RsrInstrumentedService
+postRegistration
+
+	self postRegistrationCount: self postRegistrationCount + 1
+%
+
+category: 'events'
+method: RsrInstrumentedService
+postUpdate
+
+	self postUpdateCount: self postUpdateCount + 1
+%
+
+category: 'events'
+method: RsrInstrumentedService
+preUpdate
+
+	self preUpdateCount: self preUpdateCount + 1
+%
+
+! Class implementation for 'RsrInstrumentedClient'
+
+!		Instance methods for 'RsrInstrumentedClient'
+
+category: 'accessing'
+method: RsrInstrumentedClient
+postRegistrationCount
+
+	^postRegistrationCount ifNil: [0]
+%
+
+category: 'accessing'
+method: RsrInstrumentedClient
+postRegistrationCount: anInteger
+
+	postRegistrationCount := anInteger
+%
+
+category: 'accessing'
+method: RsrInstrumentedClient
+postUpdateCount
+
+	^postUpdateCount ifNil: [0]
+%
+
+category: 'accessing'
+method: RsrInstrumentedClient
+postUpdateCount: anInteger
+
+	postUpdateCount := anInteger
+%
+
+category: 'accessing'
+method: RsrInstrumentedClient
+preUpdateCount
+
+	^preUpdateCount ifNil: [0]
+%
+
+category: 'accessing'
+method: RsrInstrumentedClient
+preUpdateCount: anInteger
+
+	preUpdateCount := anInteger
+%
+
+category: 'evaluating'
+method: RsrInstrumentedClient
+return: anObject
+
+	^(remoteSelf return: anObject) wait
+%
+
+category: 'evaluating'
+method: RsrInstrumentedClient
+value
+
+	^remoteSelf evaluateAction wait
+%
+
+category: 'evaluating'
+method: RsrInstrumentedClient
+value: anObject
+
+	^(remoteSelf evaluateAction: anObject) wait
+%
+
+! Class implementation for 'RsrInstrumentedServer'
+
+!		Instance methods for 'RsrInstrumentedServer'
+
+category: 'accessing'
+method: RsrInstrumentedServer
+action
+
+	^action
+%
+
+category: 'accessing'
+method: RsrInstrumentedServer
+action: aBlock
+
+	action := aBlock
+%
+
+category: 'evaluating'
+method: RsrInstrumentedServer
+evaluateAction
+
+	^self action value
+%
+
+category: 'evaluating'
+method: RsrInstrumentedServer
+evaluateAction: anObject
+
+	^self action cull: anObject
+%
+
+category: 'accessing'
+method: RsrInstrumentedServer
+postRegistrationCount
+
+	^postRegistrationCount ifNil: [0]
+%
+
+category: 'accessing'
+method: RsrInstrumentedServer
+postRegistrationCount: anInteger
+
+	postRegistrationCount := anInteger
+%
+
+category: 'accessing'
+method: RsrInstrumentedServer
+postUpdateCount
+
+	^postUpdateCount ifNil: [0]
+%
+
+category: 'accessing'
+method: RsrInstrumentedServer
+postUpdateCount: anInteger
+
+	postUpdateCount := anInteger
+%
+
+category: 'accessing'
+method: RsrInstrumentedServer
+preUpdateCount
+
+	^preUpdateCount ifNil: [0]
+%
+
+category: 'accessing'
+method: RsrInstrumentedServer
+preUpdateCount: anInteger
+
+	preUpdateCount := anInteger
+%
+
+category: 'evaluating'
+method: RsrInstrumentedServer
+return: anObject
+
+	^anObject
+%
+
+! Class implementation for 'RsrMockService'
+
+!		Class methods for 'RsrMockService'
+
+category: 'accessing'
+classmethod: RsrMockService
+clientClassName
+
+	^#RsrMockClient
+%
+
+category: 'accessing'
+classmethod: RsrMockService
+serverClassName
+
+	^#RsrMockServer
+%
+
+!		Instance methods for 'RsrMockService'
+
+category: 'initialize'
+method: RsrMockService
+initialize
+
+	super initialize.
+	_id := 1
+%
+
+category: 'testing'
+method: RsrMockService
+isClient
+
+	^self class == RsrMockClient
+%
+
+category: 'testing'
+method: RsrMockService
+isServer
+
+	^self class == RsrMockServer
+%
+
+category: 'accessing'
+method: RsrMockService
+service
+
+	^self
+%
+
+! Class implementation for 'RsrPolicyRejectedService'
+
+!		Class methods for 'RsrPolicyRejectedService'
+
+category: 'instance creation'
+classmethod: RsrPolicyRejectedService
+sid: aSID
+templateName: aTemplateName
+	"Create an instance of the PolicyRejectedService reason.
+	The client is used here because once we send it, we are done with it.
+	The client will GC and the server will later GC. We don't care to have
+	a server hanging around if we don't need it."
+
+	^self clientClass new
+		sid: aSID;
+		templateName: aTemplateName;
+		yourself
+%
+
+category: 'accessing'
+classmethod: RsrPolicyRejectedService
+templateClassName
+
+	^#RsrPolicyRejectedService
+%
+
+!		Instance methods for 'RsrPolicyRejectedService'
+
+category: 'accessing'
+method: RsrPolicyRejectedService
+sid
+	"Service ID"
+
+	^sid
+%
+
+category: 'accessing'
+method: RsrPolicyRejectedService
+sid: aSID
+	"Service ID"
+
+	sid := aSID
+%
+
+category: 'accessing'
+method: RsrPolicyRejectedService
+templateName
+	"The Template's name"
+
+	^templateName
+%
+
+category: 'accessing'
+method: RsrPolicyRejectedService
+templateName: aTemplateName
+	"The Template's name"
+
+	templateName := aTemplateName
+%
+
+! Class implementation for 'RsrRemoteException'
+
+!		Class methods for 'RsrRemoteException'
+
+category: 'accessing'
+classmethod: RsrRemoteException
+clientClassName
+
+	^#RsrRemoteExceptionClient
+%
+
+category: 'instance creation'
+classmethod: RsrRemoteException
+from: anException
+	"Create an instance of the RemoteException reason.
+	The client is used here because once we send it, we are done with it.
+	The client will GC and the server will later GC. We don't care to have
+	a server hanging around if we don't need it."
+
+	| tag |
+	tag := anException tag
+		ifNotNil:
+			[[anException tag asString]
+				on: Error
+				do: [:ex | ex return: 'Unable to pack #tag containing an instance of ', anException tag class name]].
+	^self clientClass new
+		exceptionClassName: anException class name;
+		tag: tag;
+		messageText: anException messageText;
+		stack: RsrProcessModel currentStackDump;
+		yourself
+%
+
+category: 'accessing'
+classmethod: RsrRemoteException
+serverClassName
+
+	^#RsrRemoteExceptionServer
+%
+
+category: 'accessing'
+classmethod: RsrRemoteException
+templateClassName
+
+	^#RsrRemoteException
+%
+
+!		Instance methods for 'RsrRemoteException'
+
+category: 'accessing'
+method: RsrRemoteException
+exceptionClassName
+
+	^exceptionClassName
+%
+
+category: 'accessing'
+method: RsrRemoteException
+exceptionClassName: aSymbol
+
+	exceptionClassName := aSymbol
+%
+
+category: 'testing'
+method: RsrRemoteException
+isRemoteException
+	"This is a RemoteException reason"
+
+	^true
+%
+
+category: 'accessing'
+method: RsrRemoteException
+messageText
+
+	^messageText
+%
+
+category: 'accessing'
+method: RsrRemoteException
+messageText: aString
+
+	messageText := aString
+%
+
+category: 'printing'
+method: RsrRemoteException
+printOn: aStream
+
+	aStream
+		nextPutAll: exceptionClassName;
+		cr;
+		nextPutAll: messageText;
+		cr;
+		nextPutAll: '===================';
+		cr;
+		nextPutAll: stack
+%
+
+category: 'accessing'
+method: RsrRemoteException
+stack
+
+	^stack
+%
+
+category: 'accessing'
+method: RsrRemoteException
+stack: aString
+
+	stack := aString
+%
+
+category: 'accessing'
+method: RsrRemoteException
+tag
+
+	^tag
+%
+
+category: 'accessing'
+method: RsrRemoteException
+tag: aString
+
+	tag := aString
+%
+
+! Class implementation for 'RsrReflectedVariableTestServiceA'
+
+!		Instance methods for 'RsrReflectedVariableTestServiceA'
+
+category: 'accessing'
+method: RsrReflectedVariableTestServiceA
+varA
+
+	^varA
+%
+
+! Class implementation for 'RsrReflectedVariableTestServiceB'
+
+!		Class methods for 'RsrReflectedVariableTestServiceB'
+
+category: 'accessing'
+classmethod: RsrReflectedVariableTestServiceB
+clientClassName
+
+	^#RsrReflectedVariableTestClient
+%
+
+category: 'accessing'
+classmethod: RsrReflectedVariableTestServiceB
+serverClassName
+
+	^#RsrReflectedVariableTestServer
+%
+
+category: 'accessing'
+classmethod: RsrReflectedVariableTestServiceB
+templateClassName
+
+	^#RsrReflectedVariableTestServiceB
+%
+
+!		Instance methods for 'RsrReflectedVariableTestServiceB'
+
+category: 'accessing'
+method: RsrReflectedVariableTestServiceB
+varB
+
+	^varB
+%
+
+! Class implementation for 'RsrReflectedVariableTestClient'
+
+!		Instance methods for 'RsrReflectedVariableTestClient'
+
+category: 'accessing'
+method: RsrReflectedVariableTestClient
+setVarsToAndReturn: anObject
+
+	^(remoteSelf setVarsToAndReturn: anObject) wait
+%
+
+! Class implementation for 'RsrReflectedVariableTestServer'
+
+!		Instance methods for 'RsrReflectedVariableTestServer'
+
+category: 'accessing'
+method: RsrReflectedVariableTestServer
+setVarsToAndReturn: anObject
+
+	^varA := varB := anObject
+%
+
+! Class implementation for 'RsrRemoteAction'
+
+!		Class methods for 'RsrRemoteAction'
+
+category: 'instance creation'
+classmethod: RsrRemoteAction
+sharedVariable: anObject
+
+	^self new
+		sharedVariable: anObject;
+		yourself
+%
+
+category: 'accessing'
+classmethod: RsrRemoteAction
+templateClassName
+
+	^#RsrRemoteAction
+%
+
+!		Instance methods for 'RsrRemoteAction'
+
+category: 'accessing'
+method: RsrRemoteAction
+sharedVariable
+
+	^sharedVariable
+%
+
+category: 'accessing'
+method: RsrRemoteAction
+sharedVariable: anObject
+
+	sharedVariable := anObject
+%
+
+! Class implementation for 'RsrRemoteActionClient'
+
+!		Instance methods for 'RsrRemoteActionClient'
+
+category: 'evaluating'
+method: RsrRemoteActionClient
+asyncValue
+
+	^remoteSelf evaluateAction
+%
+
+category: 'evaluating'
+method: RsrRemoteActionClient
+asyncValue: anObject
+
+	^remoteSelf evaluateAction: anObject
+%
+
+category: 'evaluating'
+method: RsrRemoteActionClient
+value
+
+	^self asyncValue wait
+%
+
+category: 'evaluating'
+method: RsrRemoteActionClient
+value: anObject
+
+	^(self asyncValue: anObject) wait
+%
+
+! Class implementation for 'RsrRemoteActionServer'
+
+!		Instance methods for 'RsrRemoteActionServer'
+
+category: 'accessing'
+method: RsrRemoteActionServer
+action
+
+	^action
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+action: aBlock
+
+	action := aBlock
+%
+
+category: 'debugging'
+method: RsrRemoteActionServer
+debug: anException
+raisedDuring: aMessageSend
+answerUsing: aResolver
+
+	^self debugHandler
+		value: anException
+		value: aMessageSend
+		value: aResolver
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+debugHandler
+
+	^debugHandler ifNil: [[:x :y :z | nil]]
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+debugHandler: aBlock
+
+	debugHandler := aBlock
+%
+
+category: 'evaluating'
+method: RsrRemoteActionServer
+evaluateAction
+
+	^self action value
+%
+
+category: 'evaluating'
+method: RsrRemoteActionServer
+evaluateAction: anObject
+
+	^self action value: anObject
+%
+
+category: 'processing'
+method: RsrRemoteActionServer
+postRegistration
+
+	self postRegistrationHandler value
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+postRegistrationHandler
+
+	^postRegistrationHandler ifNil: [[]]
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+postRegistrationHandler: aBlock
+
+	postRegistrationHandler := aBlock
+%
+
+category: 'processing'
+method: RsrRemoteActionServer
+postUpdate
+
+	self postUpdateHandler value
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+postUpdateHandler
+
+	^postUpdateHandler ifNil: [[]]
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+postUpdateHandler: aBlock
+
+	postUpdateHandler := aBlock
+%
+
+category: 'processing'
+method: RsrRemoteActionServer
+preUpdate
+
+	self preUpdateHandler value
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+preUpdateHandler
+
+	^preUpdateHandler ifNil: [[]]
+%
+
+category: 'accessing'
+method: RsrRemoteActionServer
+preUpdateHandler: aBlock
+
+	preUpdateHandler := aBlock
+%
+
+! Class implementation for 'RsrReturnUnknownService'
+
+!		Class methods for 'RsrReturnUnknownService'
+
+category: 'accessing'
+classmethod: RsrReturnUnknownService
+clientClassName
+
+	^#RsrDoNotCreateThisClass
+%
+
+category: 'accessing'
+classmethod: RsrReturnUnknownService
+serverClassName
+
+	^#RsrKnownServer
+%
+
+category: 'accessing'
+classmethod: RsrReturnUnknownService
+templateClassName
+
+	^#RsrReturnUnknownService
+%
+
+! Class implementation for 'RsrSendUnknownService'
+
+!		Class methods for 'RsrSendUnknownService'
+
+category: 'accessing'
+classmethod: RsrSendUnknownService
+clientClassName
+
+	^#RsrKnownClient
+%
+
+category: 'accessing'
+classmethod: RsrSendUnknownService
+serverClassName
+
+	^#RsrDoNotCreateThisClass
+%
+
+category: 'accessing'
+classmethod: RsrSendUnknownService
+templateClassName
+
+	^#RsrSendUnknownService
+%
+
+! Class implementation for 'RsrServiceNoInstVars'
+
+!		Class methods for 'RsrServiceNoInstVars'
+
+category: 'accessing'
+classmethod: RsrServiceNoInstVars
+clientClassName
+
+	^#RsrClientNoInstVars
+%
+
+category: 'accessing'
+classmethod: RsrServiceNoInstVars
+serverClassName
+
+	^#RsrServerNoInstVars
+%
+
+category: 'accessing'
+classmethod: RsrServiceNoInstVars
+templateClassName
+
+	^#RsrServiceNoInstVars
+%
+
+!		Instance methods for 'RsrServiceNoInstVars'
+
+category: 'testing-methods'
+method: RsrServiceNoInstVars
+asyncSendReturnArgument: anObject
+
+	^remoteSelf returnArgument: anObject
+%
+
+category: 'accessing'
+method: RsrServiceNoInstVars
+returnArgument: anObject
+
+	^anObject
+%
+
+category: 'testing-methods'
+method: RsrServiceNoInstVars
+sendReturnArgument: anObject
+
+	^(remoteSelf returnArgument: anObject) wait
+%
+
+! Class implementation for 'RsrClientNoInstVars'
+
+!		Instance methods for 'RsrClientNoInstVars'
+
+category: 'test selectors'
+method: RsrClientNoInstVars
+unimplementedRemoteSend
+	"Send a selector which is not implemented remotely resuling in a DNU."
+
+	^remoteSelf doNotImplementThisSelectorOrYouWillBreakATest
+%
+
+! Class implementation for 'RsrServiceReferenceService'
+
+!		Class methods for 'RsrServiceReferenceService'
+
+category: 'accessing'
+classmethod: RsrServiceReferenceService
+clientClassName
+
+	^#RsrClientReferenceService
+%
+
+category: 'accessing'
+classmethod: RsrServiceReferenceService
+serverClassName
+
+	^#RsrServerReferenceService
+%
+
+category: 'instance creation'
+classmethod: RsrServiceReferenceService
+service: aService
+
+	^self new
+		service: aService;
+		yourself
+%
+
+category: 'accessing'
+classmethod: RsrServiceReferenceService
+templateClassName
+
+	^#RsrServiceReferenceService
+%
+
+!		Instance methods for 'RsrServiceReferenceService'
+
+category: 'accessing'
+method: RsrServiceReferenceService
+service
+	^ service
+%
+
+category: 'accessing'
+method: RsrServiceReferenceService
+service: anObject
+	service := anObject
+%
+
+! Class implementation for 'RsrTestService'
+
+!		Class methods for 'RsrTestService'
+
+category: 'accessing'
+classmethod: RsrTestService
+clientClassName
+
+	^#RsrClientTestService
+%
+
+category: 'accessing'
+classmethod: RsrTestService
+serverClassName
+
+	^#RsrServerTestService
+%
+
+category: 'accessing'
+classmethod: RsrTestService
+templateClassName
+
+	^#RsrTestService
+%
+
+!		Instance methods for 'RsrTestService'
+
+category: 'accessing'
+method: RsrTestService
+remoteSelf
+
+	^remoteSelf
+%
+
+category: 'accessing'
+method: RsrTestService
+sharedVariable
+
+	^sharedVariable
+%
+
+category: 'accessing'
+method: RsrTestService
+sharedVariable: anObject
+
+	sharedVariable := anObject
+%
+
+! Class implementation for 'RsrClientTestService'
+
+!		Instance methods for 'RsrClientTestService'
+
+category: 'accessing'
+method: RsrClientTestService
+privateVariable
+
+	^privateVariable
+%
+
+category: 'accessing'
+method: RsrClientTestService
+privateVariable: anObject
+
+	privateVariable := anObject
+%
+
+! Class implementation for 'RsrServerTestService'
+
+!		Instance methods for 'RsrServerTestService'
+
+category: 'accessing'
+method: RsrServerTestService
+privateVariable
+
+	^privateVariable
+%
+
+category: 'accessing'
+method: RsrServerTestService
+privateVariable: anObject
+
+	privateVariable := anObject
+%
+
+! Class implementation for 'RsrValueHolder'
+
+!		Class methods for 'RsrValueHolder'
+
+category: 'accessing'
+classmethod: RsrValueHolder
+clientClassName
+
+	^#RsrValueHolderClient
+%
+
+category: 'accessing'
+classmethod: RsrValueHolder
+serverClassName
+
+	^#RsrValueHolderServer
+%
+
+category: 'accessing'
+classmethod: RsrValueHolder
+templateClassName
+
+	^#RsrValueHolder
+%
+
+category: 'instance creation'
+classmethod: RsrValueHolder
+value: anRsrObject
+
+	^self new
+		value: anRsrObject;
+		yourself
+%
+
+!		Instance methods for 'RsrValueHolder'
+
+category: 'accessing'
+method: RsrValueHolder
+value
+
+	^value
+%
+
+category: 'accessing'
+method: RsrValueHolder
+value: anObject
+
+	value := anObject.
+	self synchronize
+%
+
+! Class implementation for 'RsrVersionService'
+
+!		Class methods for 'RsrVersionService'
+
+category: 'accessing'
+classmethod: RsrVersionService
+templateClassName
+
+	^#RsrVersionService
+%
+
+! Class implementation for 'RsrAbstractTemplateResolver'
+
+!		Instance methods for 'RsrAbstractTemplateResolver'
+
+category: 'resolving'
+method: RsrAbstractTemplateResolver
+templateFor: aService
+	"Resolve the template associated with the provided Service."
+
+	self subclassResponsibility
+%
+
+category: 'resolving'
+method: RsrAbstractTemplateResolver
+templateNamed: aTemplateName
+	"Resolve a template with the provided name."
+
+	^self
+		templateNamed: aTemplateName
+		ifAbsent: [RsrUnknownTemplate signal: aTemplateName]
+%
+
+category: 'resolving'
+method: RsrAbstractTemplateResolver
+templateNamed: aTemplateName
+ifAbsent: aBlock
+	"Resolve a template with the provided name."
+
+	self flag: 'This should not send #templateClass. This can go away once ServiceSnapshot wire encoding is updated.'.
+	^(RsrClassResolver classNamed: aTemplateName ifAbsent: aBlock) templateClass
+%
+
+! Class implementation for 'RsrTemplateResolver'
+
+!		Instance methods for 'RsrTemplateResolver'
+
+category: 'resolving'
+method: RsrTemplateResolver
+templateFor: aService
+	"Resolve the template associated with the provided Service."
+
+	| template |
+	template := aService class.
+	[template isTemplateClass]
+		whileFalse: [template := template superclass].
+	^template
+%
+
+category: 'resolving'
+method: RsrTemplateResolver
+templateNamed: aTemplateName
+ifAbsent: aBlock
+	"Resolve a template with the provided name."
+
+	self flag: 'This should not send #templateClass. This can go away once ServiceSnapshot wire encoding is updated.'.
+	^(RsrClassResolver classNamed: aTemplateName ifAbsent: [^aBlock value]) templateClass
+%
+
+! Class implementation for 'RsrAsyncMournHandler'
+
+!		Class methods for 'RsrAsyncMournHandler'
+
+category: 'accessing'
+classmethod: RsrAsyncMournHandler
+current
+
+	^SessionTemps current
+		at: #CurrentRsrAsyncEventHandler
+		ifAbsentPut: [super new]
+%
+
+category: 'instance creation'
+classmethod: RsrAsyncMournHandler
+new
+
+	^RsrError signal: '', self name, ' is a singleton. See #current.'
+%
+
+!		Instance methods for 'RsrAsyncMournHandler'
+
+category: 'lifecycle'
+method: RsrAsyncMournHandler
+ensureStarted
+	"Ensure that the handler is currently active."
+
+	self isActive ifFalse: [self start]
+%
+
+category: 'initializing'
+method: RsrAsyncMournHandler
+initialize
+
+	super initialize.
+	isActive := false
+%
+
+category: 'testing'
+method: RsrAsyncMournHandler
+isActive
+
+	^isActive
+%
+
+category: 'accessing'
+method: RsrAsyncMournHandler
+process
+
+	^process
+%
+
+category: 'other'
+method: RsrAsyncMournHandler
+runLoop
+
+	[[self isActive]
+		whileTrue:
+			[[notifier readNotification]
+				on: GcFinalizeNotification
+				do: [:ex | ex _finalizeEphemerons]]]
+		on: SocketError
+		do: [:ex | ex return]
+%
+
+category: 'lifecycle'
+method: RsrAsyncMournHandler
+start
+
+	[notifier := GsSignalingSocket newForAsyncExceptions: {GcFinalizeNotification }.
+	notifier interrupting: true]
+		on: SocketError
+		do:
+			[:ex |
+			RsrNotification signal: 'Async event notifications are already being processed by an external process. Aborting async event processing in RSR.'.
+			^self].
+	process := RsrProcessModel
+		fork:
+			[[isActive := true.
+			self runLoop]
+				ensure:
+					[GsSignalingSocket disableAsyncExceptions.
+					process := nil.
+					notifier := nil.
+					isActive := false]]
+		at: Processor highIOPriority + 1
+		named: 'Ephemeron Mourning Process'
+%
+
+category: 'lifecycle'
+method: RsrAsyncMournHandler
+stop
+	"Stop processing Asynchronous Events"
+
+	self isActive
+		ifTrue:
+			[GsSignalingSocket disableAsyncExceptions.
+			Processor yield]
+%
+
+! Class implementation for 'RsrBufferedSocketStream'
+
+!		Class methods for 'RsrBufferedSocketStream'
+
+category: 'instance creation'
+classmethod: RsrBufferedSocketStream
+on: aSocketStream
+
+	^self new
+		stream: aSocketStream;
+		yourself
+%
+
+!		Instance methods for 'RsrBufferedSocketStream'
+
+category: 'writing'
+method: RsrBufferedSocketStream
+atEnd
+
+	^stream atEnd
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+checkAutoFlush
+
+	nextToWrite > 4096
+		ifTrue: [ self flush ]
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+close
+
+	stream close
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+flush
+
+	writePosition = nextToWrite
+		ifTrue: [^self].
+	stream nextPutAll: (outBuffer copyFrom: writePosition to: nextToWrite - 1).
+	writePosition := nextToWrite := 1.
+	stream flush
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+growOutBufferTo: aNumberOfBytes
+
+	| rounding |
+	rounding := ((aNumberOfBytes \\ 4096) + 1) * 4096.
+	outBuffer := outBuffer , (ByteArray new: rounding - outBuffer size)
+%
+
+category: 'initialization'
+method: RsrBufferedSocketStream
+initialize
+
+	super initialize.
+	outBuffer := ByteArray new: 4096.
+	nextToWrite := 1.
+	writePosition := 1
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+isConnected
+
+	^stream isConnected
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+next
+
+	^self next: 1
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+next: aCount
+
+	^stream next: aCount
+%
+
+category: 'writing'
+method: RsrBufferedSocketStream
+nextPutAll: aByteArray
+
+	(outBuffer size >= (aByteArray size + nextToWrite))
+		ifFalse: [self growOutBufferTo: outBuffer size + nextToWrite].
+	outBuffer
+		replaceFrom: nextToWrite
+		to: nextToWrite + aByteArray size - 1
+		with: aByteArray
+		startingAt: 1.
+	nextToWrite := nextToWrite + aByteArray size.
+	self checkAutoFlush
+%
+
+category: 'accessing'
+method: RsrBufferedSocketStream
+stream: aStream
+
+	stream := aStream
+%
+
+! Class implementation for 'RsrChannel'
+
+!		Instance methods for 'RsrChannel'
+
+category: 'accessing'
+method: RsrChannel
+addCommunicationProcessesTo: aSet
+	"Add all processes used for Communication to the provided set."
+	
+	self subclassResponsibility
+%
+
+category: 'lifecycle'
+method: RsrChannel
+close
+	"Ensure the channel is closed to further communication."
+
+	^self subclassResponsibility
+%
+
+category: 'accessing'
+method: RsrChannel
+connection
+
+	^connection
+%
+
+category: 'accessing'
+method: RsrChannel
+connection: aConnection
+
+	connection := aConnection
+%
+
+category: 'events'
+method: RsrChannel
+genericError: anError
+
+	^self connection unknownError: anError
+%
+
+category: 'testing'
+method: RsrChannel
+isConnected
+	"Report whether the Channel is open between Connections."
+
+	^self subclassResponsibility
+%
+
+category: 'accessing'
+method: RsrChannel
+log
+
+	^self connection log
+%
+
+category: 'lifecycle'
+method: RsrChannel
+open
+	"Ensure the channel is open and ready for communication."
+
+	^self subclassResponsibility
+%
+
+category: 'events'
+method: RsrChannel
+received: aCommand
+	"A command has come in over the channel. Propogate it to the Connection."
+
+	self connection _receivedCommand: aCommand
+%
+
+category: 'events'
+method: RsrChannel
+send: aCommand
+	"Send the provided command over the channel."
+
+	^self subclassResponsibility
+%
+
+! Class implementation for 'RsrBinaryStreamChannel'
+
+!		Class methods for 'RsrBinaryStreamChannel'
+
+category: 'instance creation'
+classmethod: RsrBinaryStreamChannel
+inStream: inStream
+outStream: outStream
+
+	^self new
+		inStream: inStream;
+		outStream: outStream;
+		yourself
+%
+
+!		Instance methods for 'RsrBinaryStreamChannel'
+
+category: 'accessing'
+method: RsrBinaryStreamChannel
+addCommunicationProcessesTo: aSet
+	"Add all processes used for Communication to the provided set."
+
+	sink addCommunicationProcessesTo: aSet.
+	source addCommunicationProcessesTo: aSet
+%
+
+category: 'lifecycle'
+method: RsrBinaryStreamChannel
+close
+	"Shutdown the Command sink and source."
+
+	source stop.
+	sink stop.
+	outStream
+		flush;
+		close.
+	inStream close
+%
+
+category: 'lifecycle'
+method: RsrBinaryStreamChannel
+disconnected
+	"The socket has disconnected so the channel is no longer open."
+
+	self connection channelDisconnected
+%
+
+category: 'initializing'
+method: RsrBinaryStreamChannel
+initialize
+
+	super initialize.
+	source := RsrCommandSource on: self.
+	sink := RsrCommandSink on: self
+%
+
+category: 'accessing'
+method: RsrBinaryStreamChannel
+inStream
+	"Returns the stream associated w/ reading"
+
+	^inStream
+%
+
+category: 'accessing'
+method: RsrBinaryStreamChannel
+inStream: aBinaryReadStream
+	"Sets the stream associated w/ reading"
+
+	inStream := aBinaryReadStream
+%
+
+category: 'testing'
+method: RsrBinaryStreamChannel
+isConnected
+
+	^self inStream atEnd not and: [self outStream atEnd not]
+%
+
+category: 'lifecycle'
+method: RsrBinaryStreamChannel
+open
+	"Ensure the Command sink and source are running"
+
+	source start.
+	sink start
+%
+
+category: 'accessing'
+method: RsrBinaryStreamChannel
+outStream
+	"Returns the stream associated w/ writing"
+
+	^outStream
+%
+
+category: 'accessing'
+method: RsrBinaryStreamChannel
+outStream: aBinaryWriteStream
+	"Sets the stream associated w/ writing"
+
+	outStream := aBinaryWriteStream
+%
+
+category: 'command processing'
+method: RsrBinaryStreamChannel
+send: aCommand
+	"Send the provided command over the channel"
+
+	sink enqueue: aCommand
+%
+
+category: 'accessing'
+method: RsrBinaryStreamChannel
+sink
+
+	^sink
+%
+
+category: 'accessing'
+method: RsrBinaryStreamChannel
+source
+
+	^source
+%
+
+! Class implementation for 'RsrInMemoryChannel'
+
+!		Class methods for 'RsrInMemoryChannel'
+
+category: 'instance creation'
+classmethod: RsrInMemoryChannel
+inQueue: inQueue
+outQueue: outQueue
+
+	^self new
+		inQueue: inQueue;
+		outQueue: outQueue;
+		yourself
+%
+
+!		Instance methods for 'RsrInMemoryChannel'
+
+category: 'accessing'
+method: RsrInMemoryChannel
+addCommunicationProcessesTo: aSet
+	"Add all processes used for Communication to the provided set."
+	
+	aSet add: drainProcess 
+%
+
+category: 'lifecycle'
+method: RsrInMemoryChannel
+close
+
+	outQueue nextPut: nil.
+	inQueue nextPut: nil
+%
+
+category: 'processing'
+method: RsrInMemoryChannel
+drainLoop
+
+	| command |
+	[command := inQueue next.
+	command isNil]
+		whileFalse:
+			[self received: command].
+	self connection channelDisconnected
+%
+
+category: 'accessing'
+method: RsrInMemoryChannel
+inQueue
+
+	^inQueue
+%
+
+category: 'accessing'
+method: RsrInMemoryChannel
+inQueue: aSharedQueue
+
+	inQueue := aSharedQueue
+%
+
+category: 'testing'
+method: RsrInMemoryChannel
+isConnected
+
+	^drainProcess isNil not
+%
+
+category: 'lifecycle'
+method: RsrInMemoryChannel
+open
+
+	drainProcess := RsrProcessModel
+		fork:
+			[RsrProcessModel configureCommunicationsProcess.
+			self drainLoop.
+			drainProcess := nil]
+		named: 'InMemoryChannel Receiving'
+%
+
+category: 'accessing'
+method: RsrInMemoryChannel
+outQueue
+
+	^outQueue
+%
+
+category: 'accessing'
+method: RsrInMemoryChannel
+outQueue: aSharedQueue
+
+	outQueue := aSharedQueue
+%
+
+category: 'lifecycle'
+method: RsrInMemoryChannel
+send: aCommand
+
+	outQueue nextPut: aCommand
+%
+
+! Class implementation for 'RsrNullChannel'
+
+!		Instance methods for 'RsrNullChannel'
+
+category: 'lifecycle'
+method: RsrNullChannel
+close
+
+	"NOP"
+%
+
+category: 'testing'
+method: RsrNullChannel
+isConnected
+
+	^true
+%
+
+category: 'accessing'
+method: RsrNullChannel
+lastCommand
+
+	^lastCommand
+%
+
+category: 'lifecycle'
+method: RsrNullChannel
+open
+
+	"NOP"
+%
+
+category: 'events'
+method: RsrNullChannel
+received: aCommand
+
+	lastCommand := aCommand
+%
+
+category: 'events'
+method: RsrNullChannel
+send: aCommand
+
+	lastCommand := aCommand
+%
+
+! Class implementation for 'RsrClassResolver'
+
+!		Class methods for 'RsrClassResolver'
+
+category: 'accessing'
+classmethod: RsrClassResolver
+classNamed: aSymbol
+
+	^self
+		classNamed: aSymbol
+		ifAbsent: [RsrUnknownClass signal: aSymbol]
+%
+
+category: 'accessing'
+classmethod: RsrClassResolver
+classNamed: aSymbol
+ifAbsent: aBlock
+
+	| assoc |
+	assoc := System myUserProfile resolveSymbol: aSymbol.
+	^assoc
+		ifNil: aBlock
+		ifNotNil: [assoc value]
+%
+
+! Class implementation for 'RsrCodec'
+
+!		Instance methods for 'RsrCodec'
+
+category: 'converting'
+method: RsrCodec
+bytesAsInteger: bytes
+
+	| res |
+	res := 0.
+	bytes do: [:e | res := (res bitShift: 8) bitOr: e].
+	^res
+%
+
+category: 'accessing'
+method: RsrCodec
+controlWordMax
+
+	^(2 raisedTo: 63) - 1
+%
+
+category: 'accessing'
+method: RsrCodec
+controlWordMin
+
+	^(2 raisedTo: 63) negated
+%
+
+category: 'decoding'
+method: RsrCodec
+decodeControlWord: aStream
+
+	| bytes unsignedResult |
+	bytes := aStream next: self sizeOfInteger.
+	unsignedResult := self bytesAsInteger: bytes.
+	^unsignedResult > self controlWordMax
+		ifTrue: [(2 raisedTo: 64) negated + unsignedResult]
+		ifFalse: [unsignedResult]
+%
+
+category: 'encoding'
+method: RsrCodec
+encodeControlWord: anInteger
+onto: aStream
+
+	| encodedInteger encodedBytes |
+	(anInteger between: self controlWordMin and: self controlWordMax)
+		ifFalse: [self error: anInteger printString, ' is outside the supported size of a control word.'].
+	encodedInteger := (anInteger positive
+		ifTrue: [anInteger]
+		ifFalse: [(2 raisedTo: 64) + anInteger]).
+	encodedBytes := self
+		integerAsByteArray: encodedInteger
+		ofSize: self sizeOfInteger.
+	aStream nextPutAll: encodedBytes
+%
+
+category: 'converting'
+method: RsrCodec
+integerAsByteArray: anInteger
+ofSize: aNumberOfBytes
+
+	| bytes int |
+	bytes := ByteArray new: aNumberOfBytes.
+	int := anInteger.
+	aNumberOfBytes
+		to: 1
+		by: -1
+		do:
+			[:i | | byte |
+			byte := int bitAnd: 16rFF.
+			int := int bitShift: -8.
+			bytes at: i put: byte].
+	int ~= 0
+		ifTrue: [self error: 'Loss of precision detected'].
+	^bytes
+%
+
+category: 'accessing'
+method: RsrCodec
+sizeOfInteger
+	"Return the number of bytes used to encode an integer"
+
+	^8
+%
+
+! Class implementation for 'RsrCommandCodec'
+
+!		Instance methods for 'RsrCommandCodec'
+
+category: 'private-accessing-commands'
+method: RsrCommandCodec
+deliverErrorResponseCommand
+
+	^4
+%
+
+category: 'private-accessing-commands'
+method: RsrCommandCodec
+deliverResponseCommand
+
+	^2
+%
+
+category: 'private-accessing'
+method: RsrCommandCodec
+immediateOID
+
+	^0
+%
+
+category: 'private-accessing-commands'
+method: RsrCommandCodec
+releaseObjectsCommand
+
+	^3
+%
+
+category: 'private-accessing-commands'
+method: RsrCommandCodec
+sendMessageCommand
+
+	^1
+%
+
+! Class implementation for 'RsrCommandDecoder'
+
+!		Class methods for 'RsrCommandDecoder'
+
+category: 'instance creation'
+classmethod: RsrCommandDecoder
+registry: aRegistry
+
+	^self new
+		registry: aRegistry;
+		yourself
+%
+
+!		Instance methods for 'RsrCommandDecoder'
+
+category: 'decoding-commands'
+method: RsrCommandDecoder
+decodeCommand: aStream
+	"Decode an object from the stream"
+
+	| command |
+	command := self decodeControlWord: aStream.
+	command == self sendMessageCommand ifTrue: [^self decodeSendMessage: aStream].
+	command == self deliverResponseCommand ifTrue: [^self decodeDeliverResponse: aStream].
+	command == self releaseObjectsCommand ifTrue: [^self decodeReleaseServices: aStream].
+	^RsrError signal: 'Unknown command identifier: ', command printString
+%
+
+category: 'decoding-commands'
+method: RsrCommandDecoder
+decodeDeliverResponse: aStream
+
+    | transaction numServices serviceSnapshots response |
+    transaction := self decodeControlWord: aStream.
+    numServices := self decodeControlWord: aStream.
+    serviceSnapshots := (1 to: numServices) collect: [:each | self decodeServiceSnapshot: aStream].
+    response := self decodeReference: aStream.
+    ^RsrDeliverResponse new
+        transaction: transaction;
+        snapshots: serviceSnapshots;
+        response: response;
+        yourself
+%
+
+category: 'decoding-services'
+method: RsrCommandDecoder
+decodeImmediateReference: aStream
+
+	| referenceType |
+	referenceType := self decodeControlWord: aStream.
+	^(self instanceOfImmediate: referenceType)
+		decode: aStream
+		using: self
+%
+
+category: 'decoding'
+method: RsrCommandDecoder
+decodeReference: aStream
+
+	| oid |
+	oid := self decodeControlWord: aStream.
+	oid = self immediateOID ifTrue: [^self decodeImmediateReference: aStream].
+	^RsrServiceReference sid: oid
+%
+
+category: 'decoding-commands'
+method: RsrCommandDecoder
+decodeReleaseServices: aStream
+
+	| count oids |
+	count := self decodeControlWord: aStream.
+	oids := Array new: count.
+	1
+		to: count
+		do:
+			[:i | | oid |
+			oid := self decodeControlWord: aStream.
+			oids at: i put: oid].
+	^RsrReleaseServices sids: oids
+%
+
+category: 'decoding-commands'
+method: RsrCommandDecoder
+decodeSendMessage: aStream
+
+	| transaction argCount receiverReference selector numServices serviceSnapshots arguments instance |
+	transaction := self decodeControlWord: aStream.
+	numServices := self decodeControlWord: aStream.
+	serviceSnapshots := (1 to: numServices) collect: [:each | self decodeServiceSnapshot: aStream].
+	receiverReference := self decodeReference: aStream.
+	selector := self decodeReference: aStream.
+	argCount := self decodeControlWord: aStream.
+	arguments := (1 to: argCount) collect: [:each | self decodeReference: aStream].
+	instance := RsrSendMessage
+		transaction: transaction
+		receiverReference: receiverReference
+		selectorReference: selector
+		argumentReferences: arguments.
+	instance snapshots: serviceSnapshots.
+	^instance
+%
+
+category: 'decoding-services'
+method: RsrCommandDecoder
+decodeServiceSnapshot: aStream
+
+	| snapshot |
+	snapshot := RsrServiceSnapshot new.
+	snapshot
+		decode: aStream
+		using: self.
+	^snapshot
+%
+
+category: 'decoding-services'
+method: RsrCommandDecoder
+instanceOfImmediate: aReferenceType
+
+	aReferenceType = 1
+		ifTrue: [^RsrSymbolReference new].
+	aReferenceType = 2
+		ifTrue: [^RsrStringReference new].
+	aReferenceType = 3
+		ifTrue: [^RsrPositiveIntegerReference new].
+	aReferenceType = 4
+		ifTrue: [^RsrNegativeIntegerReference new].
+	aReferenceType = 5
+		ifTrue: [^RsrCharacterReference new].
+	aReferenceType = 6
+		ifTrue: [^RsrNilReference new].
+	aReferenceType = 7
+		ifTrue: [^RsrTrueReference new].
+	aReferenceType = 8
+		ifTrue: [^RsrFalseReference new].
+	aReferenceType = 9
+		ifTrue: [^RsrArrayReference new].
+	aReferenceType = 10
+		ifTrue: [^RsrByteArrayReference new].
+	aReferenceType = 11
+		ifTrue: [^RsrSetReference new].
+	aReferenceType = 12
+		ifTrue: [^RsrOrderedCollectionReference new].
+	aReferenceType = 13
+		ifTrue: [^RsrDictionaryReference new].
+	aReferenceType = 14
+		ifTrue: [^RsrDateAndTimeReference new].
+	aReferenceType = 15
+		ifTrue: [^RsrDoubleReference new].
+	self error: 'ReferenceType(', aReferenceType printString, ') not yet implemented'.
+%
+
+! Class implementation for 'RsrCommandEncoder'
+
+!		Instance methods for 'RsrCommandEncoder'
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeDeliverResponse: aDeliverResponse
+
+	^ByteArray streamContents: [:stream | self encodeDeliverResponse: aDeliverResponse onto: stream]
+%
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeDeliverResponse: aDeliverResponse
+onto: aStream
+
+	self
+		encodeControlWord: self deliverResponseCommand
+		onto: aStream.
+	self
+		encodeControlWord: aDeliverResponse transaction
+		onto: aStream.
+	self
+		encodeControlWord: aDeliverResponse snapshots size
+		onto: aStream.
+	aDeliverResponse snapshots do: [:each | self encodeServiceSnapshot: each onto: aStream].
+	self
+		encodeReference: aDeliverResponse response
+		onto: aStream
+%
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeReference: aReference
+onto: aStream
+
+	aReference
+		encode: aStream
+		using: self
+%
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeReleaseServices: aReleaseServices
+
+	^ByteArray streamContents: [:stream | self encodeReleaseServices: aReleaseServices onto: stream]
+%
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeReleaseServices: aReleaseServices
+onto: aStream
+
+	self
+		encodeControlWord: self releaseObjectsCommand
+		onto: aStream.
+	self
+		encodeControlWord: aReleaseServices sids size
+		onto: aStream.
+	aReleaseServices sids
+		do:
+			[:sid |
+			self
+				encodeControlWord: sid
+				onto: aStream]
+%
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeSendMessage: aSendMessage
+
+	^ByteArray streamContents: [:stream | self encodeSendMessage: aSendMessage onto: stream]
+%
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeSendMessage: aSendMessage
+onto: aStream
+
+	self
+		encodeControlWord: self sendMessageCommand
+		onto: aStream.
+	self
+		encodeControlWord: aSendMessage transaction
+		onto: aStream.
+	self
+		encodeControlWord: aSendMessage snapshots size
+		onto: aStream.
+	aSendMessage snapshots
+		do:
+			[:each |
+			self
+				encodeServiceSnapshot: each
+				onto: aStream].
+	self
+		encodeReference:  aSendMessage receiverReference
+		onto: aStream.
+	self
+		encodeReference: aSendMessage selectorReference
+		onto: aStream.
+	self
+		encodeControlWord: aSendMessage argumentReferences size
+		onto: aStream.
+	aSendMessage argumentReferences
+		do:
+			[:each |
+			self
+				encodeReference: each
+				onto: aStream]
+%
+
+category: 'encoding'
+method: RsrCommandEncoder
+encodeServiceSnapshot: aServiceSnapshot
+
+	^ByteArray
+		streamContents:
+			[:stream |
+			self
+				encodeServiceSnapshot: aServiceSnapshot
+				onto: stream]
+%
+
+category: 'private-encoding'
+method: RsrCommandEncoder
+encodeServiceSnapshot: aServiceSnapshot
+onto: aStream
+
+	aServiceSnapshot
+		encode: aStream
+		using: self
+%
+
+! Class implementation for 'RsrProtocolVersionNegotiationCodec'
+
+!		Instance methods for 'RsrProtocolVersionNegotiationCodec'
+
+category: 'accessing'
+method: RsrProtocolVersionNegotiationCodec
+chosenVersionIdentifier
+
+	^1
+%
+
+category: 'decoding'
+method: RsrProtocolVersionNegotiationCodec
+decode: aStream
+	"Decode a message from <aStream>"
+
+	| identifier |
+	identifier := self decodeControlWord: aStream.
+	identifier = self supportedVersionsIdentifier
+		ifTrue: [^self decodeSupportedVersions: aStream].
+	identifier = self chosenVersionIdentifier
+		ifTrue: [^self decodeChosenVersion: aStream].
+	identifier = self noVersionOverlapIdentifier
+		ifTrue: [^self decodeNoVersionOverlap: aStream].
+	^RsrProtocolVersionNegotiationFailed signal: 'Unknown identifier: ', identifier printString
+%
+
+category: 'decoding'
+method: RsrProtocolVersionNegotiationCodec
+decodeChosenVersion: aStream
+
+	| version |
+	version := self decodeControlWord: aStream.
+	^RsrChosenVersion version: version
+%
+
+category: 'decoding'
+method: RsrProtocolVersionNegotiationCodec
+decodeNoVersionOverlap: aStream
+
+	^RsrNoVersionOverlap new
+%
+
+category: 'decoding'
+method: RsrProtocolVersionNegotiationCodec
+decodeSupportedVersions: aStream
+
+	| numberOfVersions versions |
+	numberOfVersions := self decodeControlWord: aStream.
+	versions := (1 to: numberOfVersions) collect: [:each | self decodeControlWord: aStream].
+	^RsrSupportedVersions versions: versions
+%
+
+category: 'encoding'
+method: RsrProtocolVersionNegotiationCodec
+encodeChosenVersion: aChosenVersion
+onto: aStream
+
+	self
+		encodeControlWord: self chosenVersionIdentifier
+		onto: aStream.
+	self
+		encodeControlWord: aChosenVersion version
+		onto: aStream
+%
+
+category: 'encoding'
+method: RsrProtocolVersionNegotiationCodec
+encodeNoVersionOverlap: aNoVersionOverlap
+onto: aStream
+
+	self
+		encodeControlWord: self noVersionOverlapIdentifier
+		onto: aStream
+%
+
+category: 'encoding'
+method: RsrProtocolVersionNegotiationCodec
+encodeSupportedVersions: aSupportedVersions
+onto: aStream
+
+	| versions |
+	versions := aSupportedVersions versions.
+	self
+		encodeControlWord: self supportedVersionsIdentifier
+		onto: aStream.
+	self
+		encodeControlWord: versions size
+		onto: aStream.
+	versions do: [:each | self encodeControlWord: each onto: aStream]
+%
+
+category: 'accessing'
+method: RsrProtocolVersionNegotiationCodec
+noVersionOverlapIdentifier
+
+	^2
+%
+
+category: 'accessing'
+method: RsrProtocolVersionNegotiationCodec
+supportedVersionsIdentifier
+
+	^0
+%
+
+! Class implementation for 'RsrTokenExchangeCodec'
+
+!		Instance methods for 'RsrTokenExchangeCodec'
+
+category: 'decoding'
+method: RsrTokenExchangeCodec
+decode: aStream
+
+	| identifier |
+	identifier := self decodeControlWord: aStream.
+	identifier = self tokenIdentifier
+		ifTrue: [^self decodeToken: aStream].
+	identifier = self tokenAcceptedIdentifier
+		ifTrue: [^RsrTokenAccepted new].
+	identifier = self tokenRejectedIdentifier
+		ifTrue: [^RsrTokenRejected new].
+	^RsrTokenExchangeFailed signal: 'Unknown identifier: ', identifier printString
+%
+
+category: 'decoding'
+method: RsrTokenExchangeCodec
+decodeToken: aStream
+
+	| size |
+	size := self decodeControlWord: aStream.
+	^RsrToken bytes: (aStream next: size)
+%
+
+category: 'encoding'
+method: RsrTokenExchangeCodec
+encodeToken: aToken
+onto: aStream
+
+	self
+		encodeControlWord: self tokenIdentifier
+		onto: aStream.
+	self
+		encodeControlWord: aToken bytes size
+		onto: aStream.
+	aStream nextPutAll: aToken bytes
+%
+
+category: 'encoding'
+method: RsrTokenExchangeCodec
+encodeTokenAccepted: aTokenAccepted
+onto: aStream
+
+	self
+		encodeControlWord: self tokenAcceptedIdentifier
+		onto: aStream
+%
+
+category: 'encoding'
+method: RsrTokenExchangeCodec
+encodeTokenRejected: aTokenRejected
+onto: aStream
+
+	self
+		encodeControlWord: self tokenRejectedIdentifier
+		onto: aStream
+%
+
+category: 'accessing'
+method: RsrTokenExchangeCodec
+tokenAcceptedIdentifier
+
+	^1
+%
+
+category: 'accessing'
+method: RsrTokenExchangeCodec
+tokenIdentifier
+
+	^0
+%
+
+category: 'accessing'
+method: RsrTokenExchangeCodec
+tokenRejectedIdentifier
+
+	^2
+%
+
+! Class implementation for 'RsrCommand'
+
+!		Instance methods for 'RsrCommand'
+
+category: 'encoding'
+method: RsrCommand
+encode: aStream
+using: anEncoder
+
+	self subclassResponsibility
+%
+
+category: 'executing'
+method: RsrCommand
+executeFor: aConnection
+
+	self subclassResponsibility
+%
+
+category: 'reporting'
+method: RsrCommand
+reportOn: aLog
+
+	self subclassResponsibility
+%
+
+! Class implementation for 'RsrMessagingCommand'
+
+!		Instance methods for 'RsrMessagingCommand'
+
+category: 'executing'
+method: RsrMessagingCommand
+reifyAllIn: aConnection
+
+	| servicesStrongly |
+	"Must keep a strong reference to each service until we're sure a parent service is reified"
+	servicesStrongly := snapshots collect: [ :each | 
+		                    (each instanceIn: aConnection) preUpdate ].
+	snapshots do: [ :each | each reifyIn: aConnection ].
+	servicesStrongly do: [ :each | each postUpdate ].
+	^ servicesStrongly "Sender must keep a strong reference until the root is anchored."
+%
+
+category: 'accessing'
+method: RsrMessagingCommand
+snapshots
+
+	^snapshots
+%
+
+category: 'accessing'
+method: RsrMessagingCommand
+snapshots: anArrayOfSnapshots
+
+	snapshots := anArrayOfSnapshots
+%
+
+category: 'accessing'
+method: RsrMessagingCommand
+transaction
+	^ transaction
+%
+
+category: 'accessing'
+method: RsrMessagingCommand
+transaction: anObject
+	transaction := anObject
+%
+
+! Class implementation for 'RsrDeliverResponse'
+
+!		Class methods for 'RsrDeliverResponse'
+
+category: 'instance creation'
+classmethod: RsrDeliverResponse
+transaction: aTransactionId
+responseReference: aReference
+snapshots: anArrayOfSnapshots
+
+	^self new
+		transaction: aTransactionId;
+		responseReference: aReference;
+		snapshots: anArrayOfSnapshots;
+		yourself
+%
+
+!		Instance methods for 'RsrDeliverResponse'
+
+category: 'encoding'
+method: RsrDeliverResponse
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeDeliverResponse: self
+		onto: aStream
+%
+
+category: 'executing'
+method: RsrDeliverResponse
+executeFor: aConnection
+
+	| pendingMessage result servicesStrongly |
+	pendingMessage := aConnection pendingMessages
+		                  removeKey: self transaction
+		                  ifAbsent: [ 
+		                  ^ self reportUnknownTransactionIn: aConnection ].
+	"Must keep a strong reference to each service until the roots are referenced."
+	[ 
+	servicesStrongly := self reifyAllIn: aConnection.
+	result := self responseReference resolve: aConnection.
+	"result should now be the root of the services graph"
+	servicesStrongly := nil.
+	result first == #fulfill
+		ifTrue: [ pendingMessage promise fulfill: result last ]
+		ifFalse: [ pendingMessage promise break: result last ] ]
+		on: Error
+		do: [ :ex | 
+			pendingMessage promise break:
+				(RsrDecodingRaisedException exception: ex) ]
+%
+
+category: 'reporting'
+method: RsrDeliverResponse
+reportOn: aLog
+
+	aLog debug: 'RsrDeliverResponse(', self response class name, ')'
+%
+
+category: 'reporting'
+method: RsrDeliverResponse
+reportUnknownTransactionIn: aConnection
+
+	aConnection log error: 'Unknown transaction (', self transaction asString, ') while processing Response'
+%
+
+category: 'accessing'
+method: RsrDeliverResponse
+response
+
+	^self responseReference
+%
+
+category: 'accessing'
+method: RsrDeliverResponse
+response: anObject
+
+	^self responseReference: anObject
+%
+
+category: 'accessing'
+method: RsrDeliverResponse
+responseReference
+
+	^responseReference
+%
+
+category: 'accessing'
+method: RsrDeliverResponse
+responseReference: aReference
+
+	responseReference := aReference
+%
+
+! Class implementation for 'RsrSendMessage'
+
+!		Class methods for 'RsrSendMessage'
+
+category: 'instance creation'
+classmethod: RsrSendMessage
+transaction: aTransactionId
+receiverReference: aServiceReference
+selectorReference: aSelectorReference
+argumentReferences: anArrayOfReferences
+
+	^self new
+		transaction: aTransactionId;
+		receiverReference: aServiceReference;
+		selectorReference: aSelectorReference;
+		argumentReferences: anArrayOfReferences;
+		yourself
+%
+
+!		Instance methods for 'RsrSendMessage'
+
+category: 'accessing'
+method: RsrSendMessage
+argumentReferences
+
+	^argumentReferences
+%
+
+category: 'accessing'
+method: RsrSendMessage
+argumentReferences: anArrayOfReferences
+
+	argumentReferences := anArrayOfReferences
+%
+
+category: 'encoding'
+method: RsrSendMessage
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeSendMessage: self
+		onto: aStream
+%
+
+category: 'executing'
+method: RsrSendMessage
+executeFor: aConnection
+
+	| resolver servicesStrongly receiver selector arguments messageSend |
+	resolver := RsrRemotePromiseResolver for: self over: aConnection.
+	"Must keep a strong reference to each service until the roots are referenced."
+	[[RsrProcessModel configureUnhandleExceptionProtection.
+	[servicesStrongly := self reifyAllIn: aConnection]
+		on: RsrServiceRejected
+		do: [:ex | resolver break: ex reason. ^self].
+	receiver := self receiverReference resolve: aConnection.
+	selector := self selectorReference resolve: aConnection.
+	arguments := self argumentReferences collect: [:each | each resolve: aConnection].
+	RsrProcessModel renameProcess: '', receiver class name, '>>', selector.
+	"receiver and arguments should now be the roots of the service graph, discard strong references."
+	servicesStrongly := nil.
+	resolver addRoot: receiver. "Ensure we always send back the receiver -- this ensures sending a message results in by-directional syncing."
+	messageSend := RsrMessageSend
+		               receiver: receiver
+		               selector: selector
+		               arguments: arguments.
+	self perform: messageSend answerUsing: resolver]
+		on: self unhandledExceptionClass
+		do: [:ex | 
+			resolver break: (RsrRemoteException from: ex exception).
+			ex return]]
+		ensure:
+			[resolver hasResolved
+				ifFalse: [resolver break: 'Message send terminated without a result']]
+%
+
+category: 'reporting'
+method: RsrSendMessage
+logException: anException
+to: aLog
+
+	| message |
+	message := String
+		streamContents:
+			[:stream |
+			stream
+				print: self receiverReference;
+				nextPutAll: '>>';
+				print: self selectorReference;
+				nextPutAll: ' due to: ';
+				nextPutAll: anException description].
+	aLog error: message
+%
+
+category: 'executing'
+method: RsrSendMessage
+perform: aMessageSend
+answerUsing: aResolver
+
+	[| result |
+	aMessageSend receiver configureProcess.
+	result := aMessageSend perform.
+	RsrProcessModel configureFrameworkProcess.
+	aResolver fulfill: result]
+		on: self unhandledExceptionClass
+		do:
+			[:ex | | debugResult |
+			debugResult := [aMessageSend receiver
+									debug: ex exception
+									raisedDuring: aMessageSend
+									answerUsing: aResolver]
+									on: self unhandledExceptionClass
+									do:
+										[:debugEx |
+										RsrProcessModel configureFrameworkProcess.
+										aResolver break: (RsrRemoteException from: debugEx exception).
+										ex return].
+			RsrProcessModel configureFrameworkProcess.
+			aResolver hasResolved
+				ifTrue: [ex return]
+				ifFalse:
+					[ex exception isResumable
+						ifTrue: [[ex resume: debugResult] ensure: [aMessageSend receiver configureProcess]] "This needs to be a protected call."
+						ifFalse:
+							[aResolver break: (RsrRemoteException from: ex exception).
+							ex return]]]
+%
+
+category: 'accessing'
+method: RsrSendMessage
+receiverReference
+
+	^receiverReference
+%
+
+category: 'accessing'
+method: RsrSendMessage
+receiverReference: aServiceReference
+
+	receiverReference := aServiceReference
+%
+
+category: 'reporting'
+method: RsrSendMessage
+reportOn: aLog
+
+	aLog debug: 'RsrSendMessage(', self receiverReference asString, '>>', self selectorReference asString, ')'
+%
+
+category: 'accessing'
+method: RsrSendMessage
+selectorReference
+
+	^selectorReference
+%
+
+category: 'accessing'
+method: RsrSendMessage
+selectorReference: aSymbolReference
+
+	selectorReference := aSymbolReference
+%
+
+category: 'accessing'
+method: RsrSendMessage
+unhandledExceptionClass
+	"The class which signals that an unhandled execption has been signaled."
+
+	^RsrProcessModel unhandledExceptionClass
+%
+
+! Class implementation for 'RsrReleaseServices'
+
+!		Class methods for 'RsrReleaseServices'
+
+category: 'instance creation'
+classmethod: RsrReleaseServices
+sids: anArrayOfServiceIDs
+
+	^self new
+		sids: anArrayOfServiceIDs;
+		yourself
+%
+
+!		Instance methods for 'RsrReleaseServices'
+
+category: 'encoding'
+method: RsrReleaseServices
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeReleaseServices: self
+		onto: aStream
+%
+
+category: 'executing'
+method: RsrReleaseServices
+executeFor: aConnection
+
+	sids do: [:sid | aConnection _remoteClientReleased: sid]
+%
+
+category: 'reporting'
+method: RsrReleaseServices
+reportOn: aLog
+
+	aLog debug: 'RsrReleaseObjects(', self sids printString, ')'
+%
+
+category: 'accessing'
+method: RsrReleaseServices
+sids
+
+	^sids
+%
+
+category: 'accessing'
+method: RsrReleaseServices
+sids: anArrayOfServiceIDs
+
+	sids := anArrayOfServiceIDs
+%
+
+! Class implementation for 'RsrConnection'
+
+!		Class methods for 'RsrConnection'
+
+category: 'instance creation'
+classmethod: RsrConnection
+channel: aChannel
+transactionSpigot: aNumericSpigot
+oidSpigot: anOidSpigot
+	"Create a new Connection with an already Configured Channel.
+	Provide spigots as their behavior is specified by the Channel creation
+	protocols."
+
+	^self
+		specification: nil
+		channel: aChannel
+		transactionSpigot: aNumericSpigot
+		oidSpigot: anOidSpigot
+%
+
+category: 'instance creation'
+classmethod: RsrConnection
+new
+	"Instances of Connection should not be created via #new.
+	Instead use ConnectionSpecification.
+	See SystemTestCase>>#setUp for an example."
+
+	self shouldNotImplement
+%
+
+category: 'instance creation'
+classmethod: RsrConnection
+specification: aConnectionSpecification
+channel: aChannel
+transactionSpigot: aNumericSpigot
+oidSpigot: anOidSpigot
+	"Create a new Connection with an already Configured Channel.
+	Provide spigots as their behavior is specified by the Channel creation
+	protocols."
+
+	^super new
+		specification: aConnectionSpecification;
+		channel: aChannel;
+		transactionSpigot: aNumericSpigot;
+		oidSpigot: anOidSpigot;
+		yourself
+%
+
+!		Instance methods for 'RsrConnection'
+
+category: 'public-accessing'
+method: RsrConnection
+announcer
+	"Returns the announcer used by RSR to announce events."
+
+	^announcer
+%
+
+category: 'public-lifecycle'
+method: RsrConnection
+close
+
+	| pm temp |
+	channel close.
+	temp := Dictionary new.
+	pm := pendingMessages.
+	pendingMessages := temp.
+	pm do: [:each | each promise break: RsrConnectionClosedBeforeReceivingResponse new].
+	registry := RsrThreadSafeDictionary new.
+	announcer announce: (RsrConnectionClosed connection: self)
+%
+
+category: 'public-testing'
+method: RsrConnection
+isOpen
+
+	^channel isConnected
+%
+
+category: 'public-lifecycle'
+method: RsrConnection
+open
+
+	self platformSpecificOpeningTasks.
+	channel open
+%
+
+category: 'public-accessing'
+method: RsrConnection
+policy
+	"Policy which determines if we can reify a received Service."
+
+	^policy
+%
+
+category: 'public-accessing'
+method: RsrConnection
+policy: aPolicy
+	"Policy which determines if we can reify a received Service."
+
+	policy := aPolicy
+%
+
+category: 'public-accessing'
+method: RsrConnection
+specification
+	"Returns the Specification used to create this Connection.
+	If the Connection was not create using a Specification, returns nil."
+
+	^specification
+%
+
+category: 'public-accessing'
+method: RsrConnection
+specification: aConnectionSpecification
+	"Store the Specification used to the create this Connection."
+
+	specification := aConnectionSpecification
+%
+
+category: 'public-accessing'
+method: RsrConnection
+templateResolver
+	"Returns the TemplateResolver used to lookup a template by name or Service."
+
+	^templateResolver
+%
+
+category: 'public-accessing'
+method: RsrConnection
+templateResolver: aTemplateResolver
+	"Sets the TemplateResolver, used to lookup a template by name or Service,
+	to a custom version."
+
+	templateResolver := aTemplateResolver
+%
+
+category: 'public-accessing'
+method: RsrConnection
+vitalProcesses
+	"Return the set of processes required in order for this RSR connection to function.
+	This may be a subset of the processes used by RSR.
+	For instance, in GemStone, this need not return the ephemeron mourning
+	process as this isn't critical to the basic functioning of RSR."
+
+	| processes |
+	processes := IdentitySet new.
+	channel addCommunicationProcessesTo: processes.
+	^processes
+%
+
+category: 'public-waiting'
+method: RsrConnection
+waitUntilClose
+
+	| semaphore |
+	semaphore := Semaphore new.
+	announcer
+		when: RsrConnectionClosed
+		send: #signal
+		to: semaphore.
+	semaphore wait
+%
+
+! Class implementation for 'RsrInternalConnectionSpecification'
+
+!		Instance methods for 'RsrInternalConnectionSpecification'
+
+category: 'asserting'
+method: RsrInternalConnectionSpecification
+assertOpen
+	"Assert that connectionA and connectionB are open.
+	Signal RsrConnectionFailed if they are not."
+
+	(connectionA isOpen and: [connectionB isOpen])
+		ifFalse: [RsrConnectionFailed signal]
+%
+
+category: 'connecting'
+method: RsrInternalConnectionSpecification
+connect
+	"Establish an internal Connection pair."
+
+	self subclassResponsibility
+%
+
+category: 'accessing'
+method: RsrInternalConnectionSpecification
+connectionA
+
+	^connectionA
+%
+
+category: 'accessing'
+method: RsrInternalConnectionSpecification
+connectionA: anObject
+
+	^ connectionA := anObject
+%
+
+category: 'accessing'
+method: RsrInternalConnectionSpecification
+connectionB
+
+	^connectionB
+%
+
+category: 'accessing'
+method: RsrInternalConnectionSpecification
+connectionB: anObject
+
+	connectionB := anObject
+%
+
+! Class implementation for 'RsrInMemoryConnectionSpecification'
+
+!		Instance methods for 'RsrInMemoryConnectionSpecification'
+
+category: 'connecting'
+method: RsrInMemoryConnectionSpecification
+connect
+	"Establish an internal Connection pair via SharedQueues."
+
+	| aQueue bQueue channelA channelB |
+	aQueue := SharedQueue new.
+	bQueue := SharedQueue new.
+	channelA := RsrInMemoryChannel
+		inQueue: aQueue
+		outQueue: bQueue.
+	channelB := RsrInMemoryChannel
+		inQueue: bQueue
+		outQueue: aQueue.
+	connectionA := RsrConnection
+		specification: self
+		channel: channelA
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals
+		oidSpigot: RsrThreadSafeNumericSpigot naturals.
+	connectionB := RsrConnection
+		specification: self
+		channel: channelB
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals negated
+		oidSpigot: RsrThreadSafeNumericSpigot naturals negated.
+	connectionA open.
+	connectionB open.
+	self assertOpen.
+	^connectionA
+%
+
+! Class implementation for 'RsrInternalSocketConnectionSpecification'
+
+!		Instance methods for 'RsrInternalSocketConnectionSpecification'
+
+category: 'connecting'
+method: RsrInternalSocketConnectionSpecification
+connect
+	"Establish an internal Connection pair via socket."
+
+	| acceptor initiator |
+	acceptor := RsrAcceptConnection port: self defaultPort.
+	initiator := RsrInitiateConnection host: '127.0.0.1' port: self defaultPort.
+	RsrProcessModel
+		fork: [connectionA := acceptor waitForConnection]
+		named: 'Pending AcceptConnection'.
+	self minimalWait. "Allow other process to schedule."
+	connectionB := initiator connect.
+	self minimalWait. "Allow other process to schedule."
+	self assertOpen.
+	connectionA specification: self.
+	connectionB specification: self.
+	^connectionA
+%
+
+category: 'accessing'
+method: RsrInternalSocketConnectionSpecification
+defaultPort
+	"Returns the default port number used to listen for connections."
+
+	^61982
+%
+
+! Class implementation for 'RsrSocketConnectionSpecification'
+
+!		Class methods for 'RsrSocketConnectionSpecification'
+
+category: 'instance creation'
+classmethod: RsrSocketConnectionSpecification
+host: hostnameOrAddress port: port
+
+	^ self subclassResponsibility
+%
+
+!		Instance methods for 'RsrSocketConnectionSpecification'
+
+category: 'accessing'
+method: RsrSocketConnectionSpecification
+host
+	"Return the configured hostname or IP address"
+
+	^host
+%
+
+category: 'accessing'
+method: RsrSocketConnectionSpecification
+host: hostnameOrAddress
+	"The hostname or IP address used to establish a connection."
+
+	host := hostnameOrAddress
+%
+
+category: 'accessing'
+method: RsrSocketConnectionSpecification
+port
+	"The port number used for establishing a socket"
+
+	^port
+%
+
+category: 'accessing'
+method: RsrSocketConnectionSpecification
+port: aPort
+	"The port number used for establishing a socket"
+
+	port := aPort
+%
+
+category: 'accessing'
+method: RsrSocketConnectionSpecification
+socketClass
+	"Return the class that should be used for creating Socket instances."
+
+	^RsrSocket
+%
+
+! Class implementation for 'RsrAcceptConnection'
+
+!		Class methods for 'RsrAcceptConnection'
+
+category: 'instance creation'
+classmethod: RsrAcceptConnection
+host: hostnameOrAddress port: portNumber
+
+	^ self new
+		  host: hostnameOrAddress;
+		  portRange: (portNumber to: portNumber);
+		  yourself
+%
+
+category: 'instance creation'
+classmethod: RsrAcceptConnection
+host: hostnameOrAddress portRange: anInterval
+
+	^ self new
+		  host: hostnameOrAddress;
+		  portRange: anInterval;
+		  yourself
+%
+
+category: 'instance creation'
+classmethod: RsrAcceptConnection
+port: aPortInteger
+
+	^ self host: self wildcardAddress port: aPortInteger
+%
+
+category: 'instance creation'
+classmethod: RsrAcceptConnection
+portRange: anInterval
+
+	^ self host: self wildcardAddress portRange: anInterval
+%
+
+category: 'accessing'
+classmethod: RsrAcceptConnection
+wildcardAddress
+
+	^'0.0.0.0'
+%
+
+category: 'accessing'
+classmethod: RsrAcceptConnection
+wildcardPort
+
+	^0
+%
+
+!		Instance methods for 'RsrAcceptConnection'
+
+category: 'private'
+method: RsrAcceptConnection
+bind
+
+	"Attempt to listen on each of the port range, answer the successful port or signal RsrInvalidBind"
+
+	portRange do: [ :portToTry | 
+		[ 
+		listener bindAddress: self host port: portToTry.
+		^ portToTry ]
+			on: RsrInvalidBind
+			do: [ :ex | ex return ] ].
+	RsrInvalidBind signal:
+		'Cannot bind to any port in range ' , portRange printString
+%
+
+category: 'actions'
+method: RsrAcceptConnection
+cancelWaitForConnection
+
+	listener ifNotNil: [:socket | socket close]
+%
+
+category: 'actions'
+method: RsrAcceptConnection
+ensureListening
+
+	isListening ifTrue: [^self].
+	self bind.
+	listener listen: 5.
+	isListening := true
+%
+
+category: 'accessing'
+method: RsrAcceptConnection
+handshakeSteps
+	"Returns a sequence of steps needed to perform a successful handshake."
+
+	^Array
+		with: RsrProtocolVersionNegotiationServer new
+%
+
+category: 'other'
+method: RsrAcceptConnection
+initialize
+
+	super initialize.
+	listener := self socketClass new.
+	isWaitingForConnection := false.
+	isListening := false
+%
+
+category: 'testing'
+method: RsrAcceptConnection
+isWaitingForConnection
+
+	^isWaitingForConnection
+%
+
+category: 'accessing'
+method: RsrAcceptConnection
+listeningPort
+	"Return the port the underlying socket is listening on.
+	This is useful when using the wildcard port to dynamically
+	assign a port number."
+
+	isListening ifFalse: [^nil].
+	^listener port
+%
+
+category: 'accessing'
+method: RsrAcceptConnection
+portRange
+
+	^ portRange
+%
+
+category: 'accessing'
+method: RsrAcceptConnection
+portRange: anObject
+
+	portRange := anObject
+%
+
+category: 'actions'
+method: RsrAcceptConnection
+waitForConnection
+
+	| socket stream handshake channel connection |
+	self ensureListening.
+	[isWaitingForConnection := true.
+	socket := [listener accept]
+		on: RsrSocketError
+		do: [:ex | ex resignalAs: RsrWaitForConnectionCancelled new]]
+			ensure:
+				[listener close.
+				listener := nil.
+				isWaitingForConnection := false].
+	stream := RsrSocketStream on: socket.
+	handshake := RsrHandshake
+		steps: self handshakeSteps
+		stream: stream.
+	handshake perform.
+	channel := RsrBinaryStreamChannel
+		inStream: stream
+		outStream: stream.
+	connection := RsrConnection
+		specification: self
+		channel: channel
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals
+		oidSpigot: RsrThreadSafeNumericSpigot naturals.
+	^connection open
+%
+
+! Class implementation for 'RsrGciAcceptConnection'
+
+!		Class methods for 'RsrGciAcceptConnection'
+
+category: 'instance creation'
+classmethod: RsrGciAcceptConnection
+host: hostnameOrAddress
+port: port
+token: aToken
+
+	^self new
+		host: hostnameOrAddress;
+		port: port;
+		token: aToken;
+		yourself
+%
+
+!		Instance methods for 'RsrGciAcceptConnection'
+
+category: 'accessing'
+method: RsrGciAcceptConnection
+handshakeSteps
+	"Returns a sequence of steps needed to perform a successful handshake."
+
+	^Array
+		with: RsrProtocolVersionNegotiationServer new
+		with: (RsrTokenReceiver token: self token)
+%
+
+category: 'initializing'
+method: RsrGciAcceptConnection
+initialize
+
+	super initialize.
+	token := RsrToken newRandom
+%
+
+category: 'accessing'
+method: RsrGciAcceptConnection
+token
+	"Returns the token used during handshake."
+
+	^token
+%
+
+category: 'accessing'
+method: RsrGciAcceptConnection
+token: aToken
+	"Stores the token used during handshake."
+
+	token := aToken
+%
+
+! Class implementation for 'RsrInitiateConnection'
+
+!		Class methods for 'RsrInitiateConnection'
+
+category: 'instance creation'
+classmethod: RsrInitiateConnection
+host: hostnameOrAddress port: port
+
+	^ self new
+		  host: hostnameOrAddress;
+		  port: port;
+		  yourself
+%
+
+!		Instance methods for 'RsrInitiateConnection'
+
+category: 'connecting'
+method: RsrInitiateConnection
+connect
+
+	| socket stream handshake channel connection |
+	socket := self socketClass new.
+	socket
+		connectToHost: self host
+		port: self port.
+	stream := RsrSocketStream on: socket.
+	handshake := RsrHandshake
+		steps: self handshakeSteps
+		stream: stream.
+	handshake perform.
+	channel := RsrBinaryStreamChannel
+		inStream: stream
+		outStream: stream.
+	connection := RsrConnection
+		specification: self
+		channel: channel
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals negated
+		oidSpigot: RsrThreadSafeNumericSpigot naturals negated.
+	^connection open
+%
+
+category: 'accessing'
+method: RsrInitiateConnection
+handshakeSteps
+	"Returns a sequence of steps needed to perform a successful handshake."
+
+	^Array
+		with: RsrProtocolVersionNegotiationClient new
+%
+
+! Class implementation for 'RsrGciInitiateConnection'
+
+!		Class methods for 'RsrGciInitiateConnection'
+
+category: 'instance creation'
+classmethod: RsrGciInitiateConnection
+host: hostnameOrAddress
+port: port
+token: aToken
+
+	^self new
+		host: hostnameOrAddress;
+		port: port;
+		token: aToken;
+		yourself
+%
+
+!		Instance methods for 'RsrGciInitiateConnection'
+
+category: 'accessing'
+method: RsrGciInitiateConnection
+handshakeSteps
+	"Returns a sequence of steps needed to perform a successful handshake."
+
+	^Array
+		with: RsrProtocolVersionNegotiationClient new
+		with: (RsrTokenSender token: self token)
+%
+
+category: 'accessing'
+method: RsrGciInitiateConnection
+token
+	"Returns the token used during handshake."
+
+	^token
+%
+
+category: 'accessing'
+method: RsrGciInitiateConnection
+token: aToken
+	"Stores the token used during handshake."
+
+	token := aToken
+%
+
+! Class implementation for 'RsrEnvironment'
+
+!		Class methods for 'RsrEnvironment'
+
+category: 'branching'
+classmethod: RsrEnvironment
+ifPharo: aPharoBlock
+ifGemStone: aGemStoneBlock
+ifDolphin: aDolphinBlock
+
+	^aGemStoneBlock value
+%
+
+! Class implementation for 'RsrEphemeron'
+
+!		Class methods for 'RsrEphemeron'
+
+category: 'instance-creation'
+classmethod: RsrEphemeron
+on: anObject
+mournAction: aBlock
+
+	^self new
+        key: anObject;
+        mournAction: aBlock;
+        beEphemeron: true;
+        yourself
+%
+
+!		Instance methods for 'RsrEphemeron'
+
+category: 'accessing'
+method: RsrEphemeron
+key
+
+	^key
+%
+
+category: 'accessing'
+method: RsrEphemeron
+key: anObject
+
+	key := anObject
+%
+
+category: 'mourning'
+method: RsrEphemeron
+mourn
+
+	mournAction value.
+    key := mournAction := nil
+%
+
+category: 'accessing'
+method: RsrEphemeron
+mournAction
+
+	^mournAction
+%
+
+category: 'accessing'
+method: RsrEphemeron
+mournAction: aBlock
+
+	mournAction := aBlock
+%
+
+! Class implementation for 'RsrGarbageCollector'
+
+!		Class methods for 'RsrGarbageCollector'
+
+category: 'cleaning'
+classmethod: RsrGarbageCollector
+maximumReclamation
+
+	| sema ephemeron |
+	sema := Semaphore new.
+	ephemeron := RsrEphemeron
+		on: Object new
+		mournAction: [sema signal].
+	System
+		_generationScavenge_vmMarkSweep;
+		_generationScavenge_vmMarkSweep.
+	^sema waitForMilliseconds: 10
+%
+
+! Class implementation for 'RsrHandshake'
+
+!		Class methods for 'RsrHandshake'
+
+category: 'instance creation'
+classmethod: RsrHandshake
+steps: anArrayOfSteps
+stream: aStream
+
+	^self new
+		steps: anArrayOfSteps;
+		stream: aStream;
+		yourself
+%
+
+!		Instance methods for 'RsrHandshake'
+
+category: 'performing'
+method: RsrHandshake
+perform
+	"Perform the sequence of configured steps."
+
+	self steps do: [:each | each performOver: self stream]
+%
+
+category: 'accessing'
+method: RsrHandshake
+steps
+	"The sequence of handshake steps to perform."
+
+	^steps
+%
+
+category: 'accessing'
+method: RsrHandshake
+steps: anArrayOfSteps
+	"The sequence of handshake steps to perform."
+
+	steps := anArrayOfSteps
+%
+
+category: 'accessing'
+method: RsrHandshake
+stream
+	"The stream used by each step."
+
+	^stream
+%
+
+category: 'accessing'
+method: RsrHandshake
+stream: aStream
+	"The stream used by each step."
+
+	stream := aStream
+%
+
+! Class implementation for 'RsrHandshakeStep'
+
+!		Instance methods for 'RsrHandshakeStep'
+
+category: 'performing'
+method: RsrHandshakeStep
+performOver: aStream
+	"Perform the work for this step."
+
+	^self subclassResponsibility
+%
+
+! Class implementation for 'RsrProtocolVersionNegotiation'
+
+!		Instance methods for 'RsrProtocolVersionNegotiation'
+
+category: 'accessing'
+method: RsrProtocolVersionNegotiation
+codec
+
+	^RsrProtocolVersionNegotiationCodec new
+%
+
+! Class implementation for 'RsrProtocolVersionNegotiationClient'
+
+!		Instance methods for 'RsrProtocolVersionNegotiationClient'
+
+category: 'handshaking'
+method: RsrProtocolVersionNegotiationClient
+performOver: aStream
+	"Perform the Client's porition of the handshake"
+
+	| supportedVersions answer |
+	supportedVersions := RsrSupportedVersions versions: #(1).
+	self codec
+		encodeSupportedVersions: supportedVersions
+		onto: aStream.
+	aStream flush.
+	answer := self codec decode: aStream.
+	answer hasSharedVersion
+		ifFalse: [^RsrProtocolVersionNegotiationFailed signal: 'The Client and Server could not agree on an RSR protocol version.']
+%
+
+! Class implementation for 'RsrProtocolVersionNegotiationServer'
+
+!		Instance methods for 'RsrProtocolVersionNegotiationServer'
+
+category: 'handshaking'
+method: RsrProtocolVersionNegotiationServer
+performOver: aStream
+	"Peform the Server's side of the handshake."
+
+	| supportedVersions |
+	supportedVersions := self codec decode: aStream.
+	(supportedVersions versions includes: 1)
+		ifTrue:
+			[self codec
+				encodeChosenVersion: (RsrChosenVersion version: 1)
+				onto: aStream.
+			aStream flush]
+		ifFalse:
+			[self codec
+				encodeNoVersionOverlap: RsrNoVersionOverlap new
+				onto: aStream.
+			aStream flush; close.
+			^RsrProtocolVersionNegotiationFailed signal: 'Client versions did not overlap w/ Server']
+%
+
+! Class implementation for 'RsrTokenExchange'
+
+!		Class methods for 'RsrTokenExchange'
+
+category: 'accessing'
+classmethod: RsrTokenExchange
+token: aToken
+
+	^self new
+		token: aToken;
+		yourself
+%
+
+!		Instance methods for 'RsrTokenExchange'
+
+category: 'accessing'
+method: RsrTokenExchange
+codec
+
+	^RsrTokenExchangeCodec new
+%
+
+category: 'accessing'
+method: RsrTokenExchange
+token
+
+	^token
+%
+
+category: 'accessing'
+method: RsrTokenExchange
+token: aToken
+
+	token := aToken
+%
+
+! Class implementation for 'RsrTokenReceiver'
+
+!		Instance methods for 'RsrTokenReceiver'
+
+category: 'performing'
+method: RsrTokenReceiver
+performOver: aStream
+	"Send the token. Wait for confirmation."
+
+	| receivedToken |
+	receivedToken := self codec decode: aStream.
+	receivedToken = self token
+		ifTrue:
+			[self codec
+				encodeTokenAccepted: nil "RsrTokenAccepted new"
+				onto: aStream.
+			aStream flush]
+		ifFalse:
+			[self codec
+				encodeTokenRejected: nil "RsrTokenRejected new"
+				onto: aStream.
+			aStream flush.
+			RsrTokenExchangeFailed signal]
+%
+
+! Class implementation for 'RsrTokenSender'
+
+!		Instance methods for 'RsrTokenSender'
+
+category: 'performing'
+method: RsrTokenSender
+performOver: aStream
+	"Send the token. Wait for confirmation."
+
+	| confirmation |
+	self codec
+		encodeToken: self token
+		onto: aStream.
+	aStream flush.
+	confirmation := self codec decode: aStream.
+	confirmation wasAccepted
+		ifFalse: [RsrTokenExchangeFailed signal: 'Token was rejected']
+%
+
+! Class implementation for 'RsrLog'
+
+!		Instance methods for 'RsrLog'
+
+category: 'configuring'
+method: RsrLog
+addSink: aLogSink
+
+	sinks add: aLogSink
+%
+
+category: 'logging'
+method: RsrLog
+critical: aString
+
+	self verbosity >= self levelCritical
+		ifTrue: [self log: aString level: #critical]
+%
+
+category: 'logging'
+method: RsrLog
+debug: aString
+
+	self verbosity >= self levelDebug
+		ifTrue: [	self log: aString level: #debug]
+%
+
+category: 'logging'
+method: RsrLog
+error: aString
+
+	self verbosity >= self levelError
+		ifTrue: [self log: aString level: #error]
+%
+
+category: 'logging'
+method: RsrLog
+info: aString
+
+	self verbosity >= self levelInfo
+		ifTrue: [self log: aString level: #info]
+%
+
+category: 'initialization'
+method: RsrLog
+initialize
+
+	super initialize.
+	verbosity := self levelTrace.
+	sinks := OrderedCollection new
+%
+
+category: 'accessing'
+method: RsrLog
+levelCritical
+
+	^0
+%
+
+category: 'accessing'
+method: RsrLog
+levelDebug
+
+	^4
+%
+
+category: 'accessing'
+method: RsrLog
+levelError
+
+	^1
+%
+
+category: 'accessing'
+method: RsrLog
+levelInfo
+
+	^3
+%
+
+category: 'accessing'
+method: RsrLog
+levelTrace
+
+	^5
+%
+
+category: 'accessing'
+method: RsrLog
+levelWarn
+
+	^2
+%
+
+category: 'logging'
+method: RsrLog
+log: aMessage
+level: aLevelString
+
+	| message |
+	message := RsrDateAndTime now printString, '-', aLevelString, '-', aMessage.
+	sinks do: [:each | each write: message]
+%
+
+category: 'logging'
+method: RsrLog
+trace: aString
+
+	self verbosity >= self levelTrace
+		ifTrue: [self log: aString level: #trace]
+%
+
+category: 'accessing'
+method: RsrLog
+verbosity
+
+	^verbosity
+%
+
+category: 'accessing'
+method: RsrLog
+verbosity: aLogLevel
+
+	verbosity := aLogLevel
+%
+
+category: 'logging'
+method: RsrLog
+warning: aString
+
+	self verbosity >= self levelWarn
+		ifTrue: [self log: aString level: #warning]
+%
+
+! Class implementation for 'RsrLogSink'
+
+!		Instance methods for 'RsrLogSink'
+
+category: 'writing'
+method: RsrLogSink
+write: aMessage
+
+	self subclassResponsibility
+%
+
+! Class implementation for 'RsrCustomSink'
+
+!		Class methods for 'RsrCustomSink'
+
+category: 'instance creation'
+classmethod: RsrCustomSink
+action: aBlock
+
+	^self new
+		action: aBlock;
+		yourself
+%
+
+!		Instance methods for 'RsrCustomSink'
+
+category: 'accessing'
+method: RsrCustomSink
+action
+
+	^action
+%
+
+category: 'accessing'
+method: RsrCustomSink
+action: aBlock
+
+	action := aBlock
+%
+
+category: 'writing'
+method: RsrCustomSink
+write: aMessage
+
+	self action value: aMessage
+%
+
+! Class implementation for 'RsrTranscriptSink'
+
+!		Instance methods for 'RsrTranscriptSink'
+
+category: 'writing'
+method: RsrTranscriptSink
+write: aMessageString
+
+	Transcript
+		show: aMessageString;
+		cr
+%
+
+! Class implementation for 'RsrLogWithPrefix'
+
+!		Class methods for 'RsrLogWithPrefix'
+
+category: 'logging'
+classmethod: RsrLogWithPrefix
+log: aLog
+
+	^self new
+		log: aLog;
+		yourself
+%
+
+category: 'logging'
+classmethod: RsrLogWithPrefix
+prefix: aString
+log: aLog
+
+	^self new
+		prefix: aString;
+		log: aLog;
+		yourself
+%
+
+!		Instance methods for 'RsrLogWithPrefix'
+
+category: 'debugging'
+method: RsrLogWithPrefix
+debug: aString
+
+	^self log debug: self prefix, '/', aString
+%
+
+category: 'accessing'
+method: RsrLogWithPrefix
+log
+
+	^log
+%
+
+category: 'accessing'
+method: RsrLogWithPrefix
+log: aLog
+
+	log := aLog
+%
+
+category: 'accessing'
+method: RsrLogWithPrefix
+prefix
+
+	^prefix
+%
+
+category: 'accessing'
+method: RsrLogWithPrefix
+prefix: aString
+
+	prefix := aString
+%
+
+! Class implementation for 'RsrMessageSend'
+
+!		Class methods for 'RsrMessageSend'
+
+category: 'instance creation'
+classmethod: RsrMessageSend
+receiver: anObject
+selector: aSelector
+arguments: anArray
+
+	^self new
+		receiver: anObject;
+		selector: aSelector;
+		arguments: anArray;
+		yourself
+%
+
+!		Instance methods for 'RsrMessageSend'
+
+category: 'accessing'
+method: RsrMessageSend
+arguments
+
+	^arguments
+%
+
+category: 'accessing'
+method: RsrMessageSend
+arguments: anArray
+
+	arguments := anArray
+%
+
+category: 'evaluating'
+method: RsrMessageSend
+perform
+
+	^self receiver
+		perform: self selector
+		withArguments: self arguments
+%
+
+category: 'accessing'
+method: RsrMessageSend
+receiver
+
+	^receiver
+%
+
+category: 'accessing'
+method: RsrMessageSend
+receiver: anObject
+
+	receiver := anObject
+%
+
+category: 'accessing'
+method: RsrMessageSend
+selector
+
+	^selector
+%
+
+category: 'accessing'
+method: RsrMessageSend
+selector: aSelector
+
+	selector := aSelector
+%
+
+! Class implementation for 'RsrNumericSpigot'
+
+!		Class methods for 'RsrNumericSpigot'
+
+category: 'instance creation'
+classmethod: RsrNumericSpigot
+naturals
+
+	^self
+		start: 1
+		step: 1
+%
+
+category: 'instance creation'
+classmethod: RsrNumericSpigot
+new
+
+	^self
+		start: 0
+		step: 1
+%
+
+category: 'instance creation'
+classmethod: RsrNumericSpigot
+start: aNumber
+step: anIncrement
+
+	^super new
+		start: aNumber;
+		step: anIncrement;
+		yourself
+%
+
+!		Instance methods for 'RsrNumericSpigot'
+
+category: 'accessing'
+method: RsrNumericSpigot
+negated
+
+	^self class
+		start: current negated
+		step: step negated
+%
+
+category: 'accessing'
+method: RsrNumericSpigot
+next
+
+	| result |
+	result := current.
+	current := current + step.
+	^result
+%
+
+category: 'accessing'
+method: RsrNumericSpigot
+next: aCount
+
+	| result |
+	result := Array new: aCount.
+	1 to: aCount do: [:i | result at: i put: self next].
+	^result
+%
+
+category: 'accessing'
+method: RsrNumericSpigot
+start: aNumber
+
+	current := aNumber
+%
+
+category: 'accessing'
+method: RsrNumericSpigot
+step
+
+	^step
+%
+
+category: 'accessing'
+method: RsrNumericSpigot
+step: anIncrement
+
+	step := anIncrement
+%
+
+! Class implementation for 'RsrThreadSafeNumericSpigot'
+
+!		Instance methods for 'RsrThreadSafeNumericSpigot'
+
+category: 'initialization'
+method: RsrThreadSafeNumericSpigot
+initialize
+
+	super initialize.
+	mutex := Semaphore forMutualExclusion
+%
+
+category: 'accessing'
+method: RsrThreadSafeNumericSpigot
+next
+
+	^mutex critical: [super next]
+%
+
+! Class implementation for 'RsrPendingMessage'
+
+!		Class methods for 'RsrPendingMessage'
+
+category: 'instance creation'
+classmethod: RsrPendingMessage
+services: aList
+promise: aPromise
+
+	^self new
+		services: aList;
+		promise: aPromise;
+		yourself
+%
+
+!		Instance methods for 'RsrPendingMessage'
+
+category: 'accessing'
+method: RsrPendingMessage
+promise
+
+	^promise
+%
+
+category: 'accessing'
+method: RsrPendingMessage
+promise: aPromise
+
+	promise := aPromise
+%
+
+category: 'accessing'
+method: RsrPendingMessage
+services
+
+	^services
+%
+
+category: 'accessing'
+method: RsrPendingMessage
+services: aList
+
+	services := aList
+%
+
+! Class implementation for 'RsrPromise'
+
+!		Instance methods for 'RsrPromise'
+
+category: 'private'
+method: RsrPromise
+assertNotResolved
+
+	self isResolved
+		ifTrue: [RsrAlreadyResolved signal].
+%
+
+category: 'resolving'
+method: RsrPromise
+break: aReason
+	"Notify the receiver's observers that the Promise will not be fulfilled."
+
+	mutex
+		critical:
+			[self assertNotResolved.
+			value := aReason.
+			state := #Broken].
+	self notifyActions.
+	resolvedMutex signal
+%
+
+category: 'signalling'
+method: RsrPromise
+exception
+	"Answer the reason the promise is broken"
+
+	^ self isBroken
+		ifTrue: [ value ]
+		ifFalse: [ self error: 'Promise not broken' ]
+%
+
+category: 'resolving'
+method: RsrPromise
+fulfill: anObject
+	"Fulfill the receiver and notify any observers."
+
+	mutex
+		critical:
+			[self assertNotResolved.
+			value := anObject.
+			state := #Fulfilled].
+	self notifyActions.
+	resolvedMutex signal
+%
+
+category: 'private'
+method: RsrPromise
+initialize
+
+	super initialize.
+	mutex := Semaphore forMutualExclusion.
+	resolvedMutex := Semaphore new.
+	state := #PendingResolution.
+	resolutionActions := OrderedCollection new
+%
+
+category: 'testing'
+method: RsrPromise
+isBroken
+	"Report if the receiver is currently broken"
+
+	^state == #Broken
+%
+
+category: 'testing'
+method: RsrPromise
+isFulfilled
+	"Report is the receiver is currently fulfilled"
+
+	^state == #Fulfilled
+%
+
+category: 'testing'
+method: RsrPromise
+isResolved
+	"Report if the receiver is currently resolved."
+
+	^self isFulfilled or: [self isBroken]
+%
+
+category: 'private'
+method: RsrPromise
+notifyActions
+	"Activate any registered action's fulfillment blocks.
+	Ensure that they are activated only once and that
+	future actions are allowed."
+
+	| actions |
+	mutex
+		critical:
+			[actions := resolutionActions.
+			resolutionActions := OrderedCollection new].
+	actions
+		do:
+			[:each |
+			self isFulfilled
+				ifTrue: [RsrProcessModel fork: [each when value: value] named: 'Promise Fulfillment Notification']
+				ifFalse: [RsrProcessModel fork: [each catch value: value] named: 'Promise Break Notification']]
+%
+
+category: 'observing'
+method: RsrPromise
+value
+	"Alias for #wait"
+
+	^self wait
+%
+
+category: 'observing'
+method: RsrPromise
+wait
+	"Wait for a the receiver to be Resolved.
+	If fulfilled - return the fulfillment value.
+	If broken - raise an RsrBrokenPromise exception w/ the reason."
+	<gemstoneDebuggerSignal>
+
+	self waitForResolution.
+	^self isBroken
+		ifTrue: [RsrBrokenPromise signalReason: value]
+		ifFalse: [value]
+%
+
+category: 'private'
+method: RsrPromise
+waitForResolution
+	"There doesn't seem to be a great way to implement this method.
+	The ensure below is generally safe but does have a side-effect of signaling
+	the mutex when the process is terminated while waiting.
+	Removing the ensure allows the signal to be lost if the process is terminated
+	just after #wait but before #signal is processed.
+	In order to solve this, the loop verifies the promise is actually resolved before
+	continuing."
+
+	self isResolved
+		ifTrue: [^self].
+	[[self isResolved] whileFalse: [resolvedMutex wait]] ensure: [resolvedMutex signal]
+%
+
+category: 'observing'
+method: RsrPromise
+when: aWhenBlock
+catch: aCatchBlock
+	"Activate an appropriate block when the receiver is resolved.
+	If the receiver is currently resolved, schedule the block activation.
+	The block is activated in a new thread. The thread is not given any specific
+	error handler.
+	<aWhenBlock> will be sent #value: with the same value provided to #fulfill:.
+	<aCatchBlock> will be sent #value: with the same reason provided to #break:."
+
+	| action shouldNotifyActions |
+	action := RsrPromiseResolutionAction
+		when: aWhenBlock
+		catch: aCatchBlock.
+	mutex
+		critical:
+			[shouldNotifyActions := self isResolved.
+			resolutionActions add: action].
+	shouldNotifyActions ifTrue: [self notifyActions]
+%
+
+! Class implementation for 'RsrPromiseResolutionAction'
+
+!		Class methods for 'RsrPromiseResolutionAction'
+
+category: 'instance creation'
+classmethod: RsrPromiseResolutionAction
+when: aWhenBlock
+catch: aCatchBlock
+
+	^self new
+		when: aWhenBlock;
+		catch: aCatchBlock;
+		yourself
+%
+
+!		Instance methods for 'RsrPromiseResolutionAction'
+
+category: 'accessing'
+method: RsrPromiseResolutionAction
+catch
+
+	^catch
+%
+
+category: 'accessing'
+method: RsrPromiseResolutionAction
+catch: aBlock
+
+	catch := aBlock
+%
+
+category: 'accessing'
+method: RsrPromiseResolutionAction
+when
+
+	^when
+%
+
+category: 'accessing'
+method: RsrPromiseResolutionAction
+when: aBlock
+
+	when := aBlock
+%
+
+! Class implementation for 'RsrChosenVersion'
+
+!		Class methods for 'RsrChosenVersion'
+
+category: 'instance creation'
+classmethod: RsrChosenVersion
+version: aVersionNumber
+
+	^self new
+		version: aVersionNumber;
+		yourself
+%
+
+!		Instance methods for 'RsrChosenVersion'
+
+category: 'comparing'
+method: RsrChosenVersion
+= aChosenVersion
+
+	^self class = aChosenVersion class and: [self version = aChosenVersion version]
+%
+
+category: 'testing'
+method: RsrChosenVersion
+hasSharedVersion
+	"Answer whether there is a valid shared protocol version between the Client and Server."
+
+	^true
+%
+
+category: 'accessing'
+method: RsrChosenVersion
+version
+
+	^version
+%
+
+category: 'accessing'
+method: RsrChosenVersion
+version: aVersionNumber
+
+	version := aVersionNumber
+%
+
+! Class implementation for 'RsrNoVersionOverlap'
+
+!		Instance methods for 'RsrNoVersionOverlap'
+
+category: 'comparing'
+method: RsrNoVersionOverlap
+= aNoVersionOverlap
+
+	^self class = aNoVersionOverlap class
+%
+
+category: 'comparing'
+method: RsrNoVersionOverlap
+hash
+
+	^self class hash
+%
+
+category: 'testing'
+method: RsrNoVersionOverlap
+hasSharedVersion
+	"Answer whether there is a valid shared protocol version between the Client and Server."
+
+	^false
+%
+
+! Class implementation for 'RsrSupportedVersions'
+
+!		Class methods for 'RsrSupportedVersions'
+
+category: 'instance creation'
+classmethod: RsrSupportedVersions
+versions: anArray
+
+	^self new
+		versions: anArray;
+		yourself
+%
+
+!		Instance methods for 'RsrSupportedVersions'
+
+category: 'comparing'
+method: RsrSupportedVersions
+= aSupportedVersions
+
+	self class = aSupportedVersions class
+		ifFalse: [^false].
+	^self versions = aSupportedVersions versions
+%
+
+category: 'comparing'
+method: RsrSupportedVersions
+hash
+
+	^self versions hash
+%
+
+category: 'accessing'
+method: RsrSupportedVersions
+versions
+
+	^versions
+%
+
+category: 'accessing'
+method: RsrSupportedVersions
+versions: anArray
+
+	versions := anArray
+%
+
+! Class implementation for 'RsrReference'
+
+!		Class methods for 'RsrReference'
+
+category: 'analyzing'
+classmethod: RsrReference
+analyze: anObject
+using: anAnalyzer
+
+	^self subclassResponsibility
+%
+
+category: 'instance creation'
+classmethod: RsrReference
+from: anObject
+
+	| referenceClass |
+	referenceClass := self referenceClassFor: anObject.
+	^referenceClass from: anObject
+%
+
+category: 'accessing'
+classmethod: RsrReference
+referenceMapping
+
+	^referenceMapping
+%
+
+category: 'accessing'
+classmethod: RsrReference
+typeIdentifier
+
+	^self subclassResponsibility
+%
+
+!		Instance methods for 'RsrReference'
+
+category: 'resolving'
+method: RsrReference
+resolve: aConnection
+	"Resolve the reference in the context of the provided Connection."
+
+	^self subclassResponsibility
+%
+
+category: 'accessing'
+method: RsrReference
+typeIdentifier
+
+	^self class typeIdentifier
+%
+
+! Class implementation for 'RsrImmediateReference'
+
+!		Class methods for 'RsrImmediateReference'
+
+category: 'analyzing'
+classmethod: RsrImmediateReference
+analyze: anObject
+using: anAnalyzer
+
+	^anAnalyzer analyzeImmediate: anObject
+%
+
+category: 'instance creation'
+classmethod: RsrImmediateReference
+from: anObject
+
+	^self subclassResponsiblity
+%
+
+!		Instance methods for 'RsrImmediateReference'
+
+category: 'accessing'
+method: RsrImmediateReference
+immediateOID
+
+	^0
+%
+
+! Class implementation for 'RsrBooleanReference'
+
+!		Class methods for 'RsrBooleanReference'
+
+category: 'instance creation'
+classmethod: RsrBooleanReference
+from: aBoolean
+
+	^aBoolean
+		ifTrue: [RsrTrueReference new]
+		ifFalse: [RsrFalseReference new]
+%
+
+!		Instance methods for 'RsrBooleanReference'
+
+category: 'encoding/decoding'
+method: RsrBooleanReference
+decode: aStream
+using: aDecoder
+
+	"Boolean has no additional value"
+%
+
+category: 'encoding/decoding'
+method: RsrBooleanReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream
+%
+
+! Class implementation for 'RsrFalseReference'
+
+!		Class methods for 'RsrFalseReference'
+
+category: 'accessing'
+classmethod: RsrFalseReference
+typeIdentifier
+
+	^8
+%
+
+!		Instance methods for 'RsrFalseReference'
+
+category: 'resolving'
+method: RsrFalseReference
+resolve: aConnection
+
+	^false
+%
+
+! Class implementation for 'RsrTrueReference'
+
+!		Class methods for 'RsrTrueReference'
+
+category: 'accessing'
+classmethod: RsrTrueReference
+typeIdentifier
+
+	^7
+%
+
+!		Instance methods for 'RsrTrueReference'
+
+category: 'resolving'
+method: RsrTrueReference
+resolve: aConnection
+
+	^true
+%
+
+! Class implementation for 'RsrNilReference'
+
+!		Class methods for 'RsrNilReference'
+
+category: 'instance creation'
+classmethod: RsrNilReference
+from: aNil
+
+	^self new
+%
+
+category: 'accessing'
+classmethod: RsrNilReference
+typeIdentifier
+
+	^6
+%
+
+!		Instance methods for 'RsrNilReference'
+
+category: 'encoding/decoding'
+method: RsrNilReference
+decode: aStream
+using: aDecoder
+
+	"Nil has no additional value"
+%
+
+category: 'encoding/decoding'
+method: RsrNilReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream
+%
+
+category: 'resolving'
+method: RsrNilReference
+resolve: aConnection
+
+	^nil
+%
+
+! Class implementation for 'RsrValueReference'
+
+!		Class methods for 'RsrValueReference'
+
+category: 'instance creation'
+classmethod: RsrValueReference
+intermediate: anObject
+
+	^self new
+		intermediate: anObject;
+		yourself
+%
+
+!		Instance methods for 'RsrValueReference'
+
+category: 'private-accessing'
+method: RsrValueReference
+intermediate: anObject
+	"Store the intermediate form of this object"
+
+	intermediate := anObject
+%
+
+category: 'resolving'
+method: RsrValueReference
+resolve: aConnection
+
+	^intermediate
+%
+
+! Class implementation for 'RsrByteArrayReference'
+
+!		Class methods for 'RsrByteArrayReference'
+
+category: 'instance creation'
+classmethod: RsrByteArrayReference
+from: aByteArray
+
+	^self intermediate: aByteArray copy
+%
+
+category: 'accessing'
+classmethod: RsrByteArrayReference
+typeIdentifier
+
+	^10
+%
+
+!		Instance methods for 'RsrByteArrayReference'
+
+category: 'encoding/decoding'
+method: RsrByteArrayReference
+decode: aStream
+using: aDecoder
+
+	| length |
+	length := aDecoder decodeControlWord: aStream.
+	intermediate := aStream next: length
+%
+
+category: 'encoding/decoding'
+method: RsrByteArrayReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: intermediate size
+		onto: aStream.
+	aStream nextPutAll: intermediate
+%
+
+! Class implementation for 'RsrCharacterArrayReference'
+
+!		Class methods for 'RsrCharacterArrayReference'
+
+category: 'instance creation'
+classmethod: RsrCharacterArrayReference
+from: aCharacterArray
+
+	| bytes |
+	bytes := self convertToBytes: aCharacterArray.
+	^self intermediate: bytes
+%
+
+!		Instance methods for 'RsrCharacterArrayReference'
+
+category: 'encoding/decoding'
+method: RsrCharacterArrayReference
+decode: aStream
+using: aDecoder
+
+	| length |
+	length := aDecoder decodeControlWord: aStream.
+	intermediate := aStream next: length
+%
+
+category: 'encoding/decoding'
+method: RsrCharacterArrayReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: intermediate size
+		onto: aStream.
+	aStream nextPutAll: intermediate
+%
+
+category: 'resolving'
+method: RsrCharacterArrayReference
+resolve: aConnection
+
+	^self convertBytes: intermediate
+%
+
+! Class implementation for 'RsrStringReference'
+
+!		Class methods for 'RsrStringReference'
+
+category: 'accessing'
+classmethod: RsrStringReference
+typeIdentifier
+
+	^2
+%
+
+! Class implementation for 'RsrSymbolReference'
+
+!		Class methods for 'RsrSymbolReference'
+
+category: 'accessing'
+classmethod: RsrSymbolReference
+typeIdentifier
+
+	^1
+%
+
+!		Instance methods for 'RsrSymbolReference'
+
+category: 'converting'
+method: RsrSymbolReference
+convertBytes: aByteArray
+
+	^(super convertBytes: aByteArray) asSymbol
+%
+
+! Class implementation for 'RsrCharacterReference'
+
+!		Class methods for 'RsrCharacterReference'
+
+category: 'instance creation'
+classmethod: RsrCharacterReference
+from: aCharacter
+
+	^self intermediate: aCharacter codePoint
+%
+
+category: 'accessing'
+classmethod: RsrCharacterReference
+typeIdentifier
+
+	^5
+%
+
+!		Instance methods for 'RsrCharacterReference'
+
+category: 'encoding/decoding'
+method: RsrCharacterReference
+decode: aStream
+using: aDecoder
+
+	intermediate := aDecoder decodeControlWord: aStream
+%
+
+category: 'encoding/decoding'
+method: RsrCharacterReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: intermediate
+		onto: aStream
+%
+
+category: 'resolving'
+method: RsrCharacterReference
+resolve: aConnection
+
+	^Character codePoint: intermediate
+%
+
+! Class implementation for 'RsrCollectionReference'
+
+!		Class methods for 'RsrCollectionReference'
+
+category: 'analyzing'
+classmethod: RsrCollectionReference
+analyze: aCollection
+using: anAnalyzer
+
+	^anAnalyzer analyzeCollection: aCollection
+%
+
+category: 'instance creation'
+classmethod: RsrCollectionReference
+from: aSequencedCollection
+
+	| references |
+	references := (1 to: aSequencedCollection size) collect: [:i | RsrReference from: (aSequencedCollection at: i)].
+	^self intermediate: references
+%
+
+!		Instance methods for 'RsrCollectionReference'
+
+category: 'encoding/decoding'
+method: RsrCollectionReference
+decode: aStream
+using: aDecoder
+
+	| size |
+	size := aDecoder decodeControlWord: aStream.
+	intermediate := (1 to: size) collect: [:i | aDecoder decodeReference: aStream]
+%
+
+category: 'encoding/decoding'
+method: RsrCollectionReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: intermediate size
+		onto: aStream.
+	intermediate
+		do:
+			[:each |
+			each
+				encode: aStream
+				using: anEncoder]
+%
+
+! Class implementation for 'RsrArrayReference'
+
+!		Class methods for 'RsrArrayReference'
+
+category: 'accessing'
+classmethod: RsrArrayReference
+typeIdentifier
+
+	^9
+%
+
+!		Instance methods for 'RsrArrayReference'
+
+category: 'resolving'
+method: RsrArrayReference
+resolve: aConnection
+
+	^intermediate collect: [:each | each resolve: aConnection]
+%
+
+! Class implementation for 'RsrDictionaryReference'
+
+!		Class methods for 'RsrDictionaryReference'
+
+category: 'analyzing'
+classmethod: RsrDictionaryReference
+analyze: aDictionary
+using: anAnalyzer
+
+	^anAnalyzer analyzeDictionary: aDictionary
+%
+
+category: 'instance creation'
+classmethod: RsrDictionaryReference
+from: aDictionary
+
+	| referenceStream |
+	referenceStream := WriteStream on: (Array new: aDictionary size * 2).
+	aDictionary
+		keysAndValuesDo:
+			[:key :value |
+			referenceStream
+				nextPut: (RsrReference from: key);
+				nextPut: (RsrReference from: value)].
+	^self intermediate: referenceStream contents
+%
+
+category: 'accessing'
+classmethod: RsrDictionaryReference
+typeIdentifier
+
+	^13
+%
+
+!		Instance methods for 'RsrDictionaryReference'
+
+category: 'encoding/decoding'
+method: RsrDictionaryReference
+decode: aStream
+using: aDecoder
+
+	| size |
+	size := aDecoder decodeControlWord: aStream.
+	intermediate := (1 to: size * 2) collect: [:each | aDecoder decodeReference: aStream]
+%
+
+category: 'encoding/decoding'
+method: RsrDictionaryReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: intermediate size / 2
+		onto: aStream.
+	intermediate do: [:each | each encode: aStream using: anEncoder]
+%
+
+category: 'resolving'
+method: RsrDictionaryReference
+resolve: aConnection
+
+	| stream numEntries dictionary |
+	stream := ReadStream on: intermediate.
+	numEntries := intermediate size / 2.
+	dictionary := Dictionary new: numEntries.
+	numEntries
+		timesRepeat:
+			[dictionary
+				at: (stream next resolve: aConnection)
+				put: (stream next resolve: aConnection)].
+	^dictionary
+%
+
+! Class implementation for 'RsrOrderedCollectionReference'
+
+!		Class methods for 'RsrOrderedCollectionReference'
+
+category: 'accessing'
+classmethod: RsrOrderedCollectionReference
+typeIdentifier
+
+	^12
+%
+
+!		Instance methods for 'RsrOrderedCollectionReference'
+
+category: 'other'
+method: RsrOrderedCollectionReference
+resolve: aConnection
+
+	| oc |
+	oc := OrderedCollection new: intermediate size.
+	intermediate do: [:each | oc add: (each resolve: aConnection)].
+	^oc
+%
+
+! Class implementation for 'RsrSetReference'
+
+!		Class methods for 'RsrSetReference'
+
+category: 'instance creation'
+classmethod: RsrSetReference
+from: aSet
+
+	| referenceStream |
+	referenceStream := WriteStream on: (Array new: aSet size).
+	aSet do:  [:each | referenceStream nextPut: (RsrReference from: each)].
+	^self intermediate: referenceStream contents
+%
+
+category: 'accessing'
+classmethod: RsrSetReference
+typeIdentifier
+
+	^11
+%
+
+!		Instance methods for 'RsrSetReference'
+
+category: 'resolving'
+method: RsrSetReference
+resolve: aConnection
+
+	| set |
+	set := Set new: intermediate size * 2.
+	intermediate do: [:each | set add: (each resolve: aConnection)].
+	^set
+%
+
+! Class implementation for 'RsrDateAndTimeReference'
+
+!		Class methods for 'RsrDateAndTimeReference'
+
+category: 'instance creation'
+classmethod: RsrDateAndTimeReference
+from: aDateAndTime
+
+	| intermediate |
+	intermediate := RsrDateAndTime microsecondsSinceEpoch: aDateAndTime.
+	^self intermediate: intermediate
+%
+
+category: 'accessing'
+classmethod: RsrDateAndTimeReference
+typeIdentifier
+
+	^14
+%
+
+!		Instance methods for 'RsrDateAndTimeReference'
+
+category: 'encoding/decoding'
+method: RsrDateAndTimeReference
+decode: aStream
+using: aDecoder
+
+	intermediate := aDecoder decodeControlWord: aStream
+%
+
+category: 'encoding/decoding'
+method: RsrDateAndTimeReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: intermediate
+		onto: aStream
+%
+
+category: 'resolving'
+method: RsrDateAndTimeReference
+resolve: aConnection
+
+	^RsrDateAndTime fromMicroseconds: intermediate
+%
+
+! Class implementation for 'RsrDoubleReference'
+
+!		Class methods for 'RsrDoubleReference'
+
+category: 'instance creation'
+classmethod: RsrDoubleReference
+from: aFloat
+
+	| intermediate |
+	intermediate := self convertToBytes: aFloat.
+	^self intermediate: intermediate
+%
+
+category: 'accessing'
+classmethod: RsrDoubleReference
+typeIdentifier
+
+	^15
+%
+
+!		Instance methods for 'RsrDoubleReference'
+
+category: 'encoding/decoding'
+method: RsrDoubleReference
+decode: aStream
+using: aDecoder
+
+	intermediate := aStream next: 8
+%
+
+category: 'encoding/decoding'
+method: RsrDoubleReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	aStream nextPutAll: intermediate
+%
+
+category: 'resolving'
+method: RsrDoubleReference
+resolve: aConnection
+
+	^self convertBytes: intermediate
+%
+
+! Class implementation for 'RsrIntegerReference'
+
+!		Class methods for 'RsrIntegerReference'
+
+category: 'converting'
+classmethod: RsrIntegerReference
+convertToBytes: anInteger
+
+	| stream int |
+	anInteger <= 0
+		ifTrue: [^#[0]].
+	stream := WriteStream on: (ByteArray new: 8).
+	int := anInteger.
+	[int > 0]
+		whileTrue:
+			[stream nextPut: (int bitAnd: 16rFF).
+			int := int bitShift: -8].
+	^stream contents reverse
+%
+
+category: 'instance creation'
+classmethod: RsrIntegerReference
+from: anInteger
+
+	| intermediate |
+	intermediate := self convertToBytes: anInteger abs.
+	^anInteger positive
+		ifTrue: [RsrPositiveIntegerReference intermediate: intermediate]
+		ifFalse: [RsrNegativeIntegerReference intermediate: intermediate]
+%
+
+!		Instance methods for 'RsrIntegerReference'
+
+category: 'converting'
+method: RsrIntegerReference
+convertBytes: aByteArray
+
+	^aByteArray
+		inject: 0
+		into: [:integer :byte | (integer bitShift: 8) bitOr: byte]
+%
+
+category: 'encoding/decoding'
+method: RsrIntegerReference
+decode: aStream
+using: aDecoder
+
+	| length |
+	length := aDecoder decodeControlWord: aStream.
+	intermediate := aStream next: length
+%
+
+category: 'encoding/decoding'
+method: RsrIntegerReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: anEncoder immediateOID
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self typeIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: intermediate size
+		onto: aStream.
+	aStream nextPutAll: intermediate
+%
+
+category: 'resolving'
+method: RsrIntegerReference
+resolve: aConnection
+
+	^self convertBytes: intermediate
+%
+
+! Class implementation for 'RsrNegativeIntegerReference'
+
+!		Class methods for 'RsrNegativeIntegerReference'
+
+category: 'accessing'
+classmethod: RsrNegativeIntegerReference
+typeIdentifier
+
+	^4
+%
+
+!		Instance methods for 'RsrNegativeIntegerReference'
+
+category: 'converting'
+method: RsrNegativeIntegerReference
+convertBytes: aByteArray
+
+	^(super convertBytes: aByteArray) negated
+%
+
+! Class implementation for 'RsrPositiveIntegerReference'
+
+!		Class methods for 'RsrPositiveIntegerReference'
+
+category: 'accessing'
+classmethod: RsrPositiveIntegerReference
+typeIdentifier
+
+	^3
+%
+
+! Class implementation for 'RsrServiceReference'
+
+!		Class methods for 'RsrServiceReference'
+
+category: 'analyzing'
+classmethod: RsrServiceReference
+analyze: aService
+using: anAnalyzer
+
+	^anAnalyzer analyzeService: aService
+%
+
+category: 'instance creation'
+classmethod: RsrServiceReference
+from: aService
+
+	^self sid: aService _id
+%
+
+category: 'instance creation'
+classmethod: RsrServiceReference
+sid: aServiceID
+
+	^self new
+		sid: aServiceID;
+		yourself
+%
+
+!		Instance methods for 'RsrServiceReference'
+
+category: 'encoding/decoding'
+method: RsrServiceReference
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: self sid
+		onto: aStream
+%
+
+category: 'resolving'
+method: RsrServiceReference
+resolve: aConnection
+
+	^aConnection serviceAt: self sid
+%
+
+category: 'accessing'
+method: RsrServiceReference
+sid
+
+	^sid
+%
+
+category: 'accessing'
+method: RsrServiceReference
+sid: aServiceID
+
+	sid := aServiceID
+%
+
+! Class implementation for 'RsrRegistryEntry'
+
+!		Class methods for 'RsrRegistryEntry'
+
+category: 'instance creation'
+classmethod: RsrRegistryEntry
+service: aService
+onMourn: aBlock
+
+	| ephemeron |
+	ephemeron := RsrServiceEphemeron
+		service: aService
+		action: aBlock.
+	^self new
+		ephemeron: ephemeron;
+		yourself
+%
+
+!		Instance methods for 'RsrRegistryEntry'
+
+category: 'transitions'
+method: RsrRegistryEntry
+becomeStrong
+
+	strongStorage := self service
+%
+
+category: 'transitions'
+method: RsrRegistryEntry
+becomeWeak
+
+	strongStorage := nil
+%
+
+category: 'private-accessing'
+method: RsrRegistryEntry
+ephemeron: aServiceEphemeron
+
+	ephemeron := aServiceEphemeron
+%
+
+category: 'accessing'
+method: RsrRegistryEntry
+service
+
+	^ephemeron service
+%
+
+! Class implementation for 'RsrRemotePromiseResolver'
+
+!		Class methods for 'RsrRemotePromiseResolver'
+
+category: 'instance creation'
+classmethod: RsrRemotePromiseResolver
+for: aSendMessage
+over: aConnection
+
+	^self new
+		sendMessage: aSendMessage;
+		connection: aConnection;
+		yourself
+%
+
+!		Instance methods for 'RsrRemotePromiseResolver'
+
+category: 'accessing'
+method: RsrRemotePromiseResolver
+addRoot: aService
+
+	mutex critical: [extraRoots add: aService]
+%
+
+category: 'private'
+method: RsrRemotePromiseResolver
+assertNotResolved
+
+	self hasResolved
+		ifTrue: [RsrAlreadyResolved signal]
+%
+
+category: 'resolving'
+method: RsrRemotePromiseResolver
+break: aReason
+	"<aReason> can be any object supported by RSR."
+
+	self resolution: (Array with: #break with: aReason)
+%
+
+category: 'accessing'
+method: RsrRemotePromiseResolver
+connection
+
+	^connection
+%
+
+category: 'accessing'
+method: RsrRemotePromiseResolver
+connection: aConnection
+
+	connection := aConnection
+%
+
+category: 'resolving'
+method: RsrRemotePromiseResolver
+fulfill: result
+	"Fulfill the remote promise with a fulfilled value of <result>"
+
+	self resolution: (Array with: #fulfill with: result)
+%
+
+category: 'testing'
+method: RsrRemotePromiseResolver
+hasResolved
+
+	^hasResolved
+%
+
+category: 'private'
+method: RsrRemotePromiseResolver
+initialize
+
+	super initialize.
+	extraRoots := OrderedCollection new.
+	hasResolved := false.
+	mutex := Semaphore forMutualExclusion
+%
+
+category: 'resolving'
+method: RsrRemotePromiseResolver
+resolution: result
+	"Process and dispatch the result"
+
+	mutex
+		critical:
+			[self hasResolved ifTrue: [^self].
+			[self
+				sendResult: result
+				closureRoots: (Array with: result), extraRoots]
+				on: Error
+				do:
+					[:ex | | answer |
+					answer := Array
+						with: #break
+						with: (RsrRemoteException from: ex).
+					self
+						sendResult: answer
+						closureRoots: answer.
+					ex return].
+			hasResolved := true]
+%
+
+category: 'accessing'
+method: RsrRemotePromiseResolver
+sendMessage
+
+	^sendMessage
+%
+
+category: 'accessing'
+method: RsrRemotePromiseResolver
+sendMessage: aSendMessage
+
+	sendMessage := aSendMessage
+%
+
+category: 'resolving'
+method: RsrRemotePromiseResolver
+sendResult: result
+closureRoots: roots
+
+	| analysis resultReference |
+	analysis := RsrSnapshotAnalysis
+		roots: roots
+		connection: self connection.
+	analysis perform.
+	resultReference := RsrReference from: result.
+	self
+		sendResultReference: resultReference
+		snapshots: analysis snapshots
+%
+
+category: 'resolving'
+method: RsrRemotePromiseResolver
+sendResultReference: resultReference
+snapshots: snapshots
+
+	| response |
+	response := RsrDeliverResponse
+				transaction: self sendMessage transaction
+				responseReference: resultReference
+				snapshots: snapshots.
+	self connection _sendCommand: response
+%
+
+! Class implementation for 'RsrScientist'
+
+!		Instance methods for 'RsrScientist'
+
+category: 'instrumenting'
+method: RsrScientist
+instrument: aBlock
+label: aString
+
+	^aBlock value
+%
+
+category: 'instrumenting'
+method: RsrScientist
+profile: aBlock
+label: aString
+
+	^aBlock value
+%
+
+category: 'instrumenting'
+method: RsrScientist
+profile: aBlock
+label: aString
+if: aCondition
+
+	^aBlock value
+%
+
+! Class implementation for 'RsrServiceEphemeron'
+
+!		Class methods for 'RsrServiceEphemeron'
+
+category: 'instance creation'
+classmethod: RsrServiceEphemeron
+service: aService
+action: aBlock
+
+	^self new
+		service: aService;
+		action: aBlock;
+		beEphemeron: true;
+		yourself
+%
+
+!		Instance methods for 'RsrServiceEphemeron'
+
+category: 'accessing'
+method: RsrServiceEphemeron
+action
+
+	^action
+%
+
+category: 'accessing'
+method: RsrServiceEphemeron
+action: aBlock
+
+	action := aBlock
+%
+
+category: 'mourning'
+method: RsrServiceEphemeron
+mourn
+
+	action value.
+	service := action := nil
+%
+
+category: 'accessing'
+method: RsrServiceEphemeron
+service
+
+	^service
+%
+
+category: 'accessing'
+method: RsrServiceEphemeron
+service: aService
+
+	service := aService
+%
+
+! Class implementation for 'RsrServiceSnapshot'
+
+!		Class methods for 'RsrServiceSnapshot'
+
+category: 'instance creation'
+classmethod: RsrServiceSnapshot
+from: aService
+
+	^self new
+		snapshot: aService;
+		yourself
+%
+
+category: 'variable utilites'
+classmethod: RsrServiceSnapshot
+reflectedVariableIndicesFor: aService
+do: aBlock
+
+	| allVariables |
+	allVariables := aService class allInstVarNames.
+	(self reflectedVariablesFor: aService)
+		do:
+			[:varName | | index |
+			index := allVariables indexOf: varName.
+			aBlock value: index]
+%
+
+category: 'variable utilites'
+classmethod: RsrServiceSnapshot
+reflectedVariablesFor: aService
+
+	| currentClass variables template |
+	variables := OrderedCollection new.
+	template := aService _template.
+	currentClass := template.
+	[currentClass == RsrService]
+		whileFalse:
+			[currentClass instVarNames reverseDo: [:each | variables addFirst: each].
+			currentClass := currentClass superclass].
+	^variables
+%
+
+category: 'variable utilites'
+classmethod: RsrServiceSnapshot
+reflectedVariablesFor: aService
+do: aBlock
+
+	self
+		reflectedVariableIndicesFor: aService
+		do: [:index | aBlock value: (aService instVarAt: index)]
+%
+
+!		Instance methods for 'RsrServiceSnapshot'
+
+category: 'accessing'
+method: RsrServiceSnapshot
+createInstanceRegisteredIn: aConnection
+
+	| instance template |
+	templateName isNil
+		ifTrue:
+			[self flag: 'This should go away once we cleanup the on-the-wire encoding.'.
+			RsrUnknownClass signal].
+	template := aConnection templateResolver templateNamed: self templateName.
+	((aConnection policy permits: template) or: [template inheritsFrom: RsrReasonService])
+		ifFalse: [RsrServiceRejected signalReason: (RsrPolicyRejectedService sid: sid templateName: templateName)].
+	instance := self shouldCreateServer
+		ifTrue: [template serverClass basicNew]
+		ifFalse: [template clientClass basicNew].
+	aConnection
+		_register: instance
+		as: self sid.
+	^instance
+%
+
+category: 'other'
+method: RsrServiceSnapshot
+decode: aStream
+using: aDecoder
+
+	| species instVarCount targetClassName resolver template |
+	species := aDecoder decodeControlWord: aStream.
+	sid := aDecoder decodeControlWord: aStream.
+	instVarCount := aDecoder decodeControlWord: aStream.
+	targetClassName := (aDecoder decodeReference: aStream) resolve: nil.
+	slots := OrderedCollection new: instVarCount.
+	instVarCount timesRepeat: [slots add: (aDecoder decodeReference: aStream)].
+	resolver := RsrTemplateResolver new.
+	template := resolver templateNamed: targetClassName ifAbsent: [^nil].
+	templateName := template name.
+	shouldCreateServer := template serverClassName = targetClassName.
+%
+
+category: 'encoding/decoding'
+method: RsrServiceSnapshot
+encode: aStream
+using: anEncoder
+
+	anEncoder
+		encodeControlWord: self snapshotIdentifier
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self sid
+		onto: aStream.
+	anEncoder
+		encodeControlWord: self slots size
+		onto: aStream.
+	self targetClassNameReference
+		encode: aStream
+		using: anEncoder.
+	self slots do: [:each | each encode: aStream using: anEncoder]
+%
+
+category: 'accessing'
+method: RsrServiceSnapshot
+instanceIn: aConnection
+
+	| instance |
+	instance := aConnection
+		serviceAt: self sid
+		ifAbsent: [self createInstanceRegisteredIn: aConnection].
+	self shouldCreateServer
+		ifTrue: [aConnection _stronglyRetain: instance].
+	^instance
+%
+
+category: 'reifying'
+method: RsrServiceSnapshot
+reifyIn: aConnection
+
+	| instance referenceStream |
+	instance := self instanceIn: aConnection.
+	(self class reflectedVariablesFor: instance) size = slots size 
+		ifFalse: [ self error: 'Incorrectly encoded instance detected' ].
+	referenceStream := ReadStream on: slots.
+	self class reflectedVariableIndicesFor: instance do: [ :index | 
+		instance
+			instVarAt: index
+			put: (referenceStream next resolve: aConnection) ].
+	^ instance
+%
+
+category: 'testing'
+method: RsrServiceSnapshot
+shouldCreateServer
+
+	^shouldCreateServer
+%
+
+category: 'accessing'
+method: RsrServiceSnapshot
+sid
+
+	^sid
+%
+
+category: 'accessing'
+method: RsrServiceSnapshot
+sid: aServiceID
+
+	sid := aServiceID
+%
+
+category: 'accessing'
+method: RsrServiceSnapshot
+slots
+
+	^slots
+%
+
+category: 'accessing'
+method: RsrServiceSnapshot
+slots: anArrayOfReferences
+
+	slots := anArrayOfReferences
+%
+
+category: 'other'
+method: RsrServiceSnapshot
+snapshot: aService
+
+	| template |
+	template := aService _template.
+	sid := aService _id.
+	templateName := template name.
+	"If I am snapshotting a Client, the Snapshot represents a Server."
+	shouldCreateServer := aService class isClientClass.
+	slots := OrderedCollection new.
+	RsrServiceSnapshot
+		reflectedVariablesFor: aService
+		do: [:each | slots add: (RsrReference from: each)]
+%
+
+category: 'accessing'
+method: RsrServiceSnapshot
+snapshotIdentifier
+
+	^0
+%
+
+category: 'other'
+method: RsrServiceSnapshot
+targetClassName
+
+	| template |
+	template := RsrTemplateResolver new templateNamed: self templateName.
+	^self shouldCreateServer
+		ifTrue: [template serverClassName]
+		ifFalse: [template clientClassName]
+%
+
+category: 'other'
+method: RsrServiceSnapshot
+targetClassNameReference
+
+	^RsrSymbolReference from: self targetClassName
+%
+
+category: 'other'
+method: RsrServiceSnapshot
+templateName
+
+	^templateName
+%
+
+! Class implementation for 'RsrSignalErrorInAsString'
+
+!		Instance methods for 'RsrSignalErrorInAsString'
+
+category: 'converting'
+method: RsrSignalErrorInAsString
+asString
+
+	^Error signal
+%
+
+! Class implementation for 'RsrSnapshotAnalysis'
+
+!		Class methods for 'RsrSnapshotAnalysis'
+
+category: 'instance creation'
+classmethod: RsrSnapshotAnalysis
+roots: anArray
+connection: aConnection
+
+	^self new
+		roots: anArray;
+		connection: aConnection;
+		yourself
+%
+
+!		Instance methods for 'RsrSnapshotAnalysis'
+
+category: 'analyzing'
+method: RsrSnapshotAnalysis
+analyze: anObject
+
+	(analyzedObjects includes: anObject) ifTrue: [ ^ self ].
+	analyzedObjects add: anObject.
+	^ (self referenceClassFor: anObject) analyze: anObject using: self
+%
+
+category: 'analyzing'
+method: RsrSnapshotAnalysis
+analyzeCollection: aCollection
+
+	aCollection do: [ :each | self analyze: each ].
+	^ aCollection
+%
+
+category: 'analyzing'
+method: RsrSnapshotAnalysis
+analyzeDictionary: aDictionary
+
+	aDictionary keysAndValuesDo: [ :key :value | 
+		self
+			analyze: key;
+			analyze: value ].
+	^ aDictionary
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+analyzedObjects
+
+	^ analyzedObjects
+%
+
+category: 'analyzing'
+method: RsrSnapshotAnalysis
+analyzeImmediate: anImmediateObject
+
+	^anImmediateObject
+%
+
+category: 'analyzing'
+method: RsrSnapshotAnalysis
+analyzeService: aService
+
+	self ensureRegistered: aService.
+	RsrServiceSnapshot
+		reflectedVariablesFor: aService
+		do: [ :each | self analyze: each ].
+	snapshots add: (RsrServiceSnapshot from: aService)
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+connection
+
+	^connection
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+connection: aConnection
+
+	connection := aConnection
+%
+
+category: 'actions'
+method: RsrSnapshotAnalysis
+ensureRegistered: aService
+
+	self connection _ensureRegistered: aService.
+	aService isServer
+		ifTrue: [self connection _stronglyRetain: aService]
+%
+
+category: 'initialization'
+method: RsrSnapshotAnalysis
+initialize
+
+	super initialize.
+	snapshots := OrderedCollection new.
+	analyzedObjects := IdentitySet new
+%
+
+category: 'actions'
+method: RsrSnapshotAnalysis
+perform
+
+	roots do: [:each | self analyze: each]
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+referenceClassFor: anObject
+
+	^RsrReference referenceClassFor: anObject
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+roots
+
+	^roots
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+roots: anArray
+
+	roots := anArray
+%
+
+category: 'actions'
+method: RsrSnapshotAnalysis
+snapshot: aService
+
+	snapshots add: (RsrServiceSnapshot from: aService)
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+snapshots
+
+	^snapshots
+%
+
+category: 'accessing'
+method: RsrSnapshotAnalysis
+snapshots: anOrderedCollection
+
+	snapshots := anOrderedCollection
+%
+
+! Class implementation for 'RsrSocket'
+
+!		Class methods for 'RsrSocket'
+
+category: 'private-instance creation'
+classmethod: RsrSocket
+_nativeSocket: aGsSignalingSocket
+	"Private - Create a instance backed by the provided GsSignalingSocket"
+
+	^self basicNew
+		_nativeSocket: aGsSignalingSocket;
+		yourself
+%
+
+!		Instance methods for 'RsrSocket'
+
+category: 'accepting connections'
+method: RsrSocket
+accept
+	"Return an RsrSocket which is connected to a peer. In the event that the socket is closed while waiting, signal RsrSocketClosed."
+
+	^[self class _nativeSocket: nativeSocket accept]
+		on: SocketError
+		do: [:ex | ex resignalAs: (RsrSocketError new messageText: ex messageText)]
+%
+
+category: 'accepting connections'
+method: RsrSocket
+bindAddress: address
+port: port
+	"Bind the socket to the provided port and address. Signal RsrInvalidBind in the event the bind fails."
+
+	[nativeSocket
+		bindTo: port
+		toAddress: address]
+			on: SocketError, OutOfRange
+			do: [:ex | ex resignalAs: (RsrInvalidBind new messageText: ex messageText)]
+%
+
+category: 'terminating connections'
+method: RsrSocket
+close
+	"Ensure closure of the Socket and cleanup any associated resources."
+
+	nativeSocket close
+%
+
+category: 'establishing connections'
+method: RsrSocket
+connectToHost: hostname
+port: port
+	"Establish a connect to the provided host and port. If the socket is unable to establish, signal RsrConnectFailed.
+	If the socket is bound to an address/port, signal RsrInvalidConnect.
+	<hostname> - The name or ip address of a machine which should accept a connection.
+	<port> - An integer representing a valid TCP port."
+
+	nativeSocket interrupting: true.
+	[nativeSocket
+		connectTo: port
+		on: hostname]
+			on: SocketError, OutOfRange
+			do: [:ex | ex resignalAs: (RsrConnectFailed new messageText: ex messageText)]
+%
+
+category: 'initialize'
+method: RsrSocket
+initialize
+
+	super initialize.
+	nativeSocket := GsSignalingSocket new.
+%
+
+category: 'testing'
+method: RsrSocket
+isConnected
+	"Return true if the socket is open and connected with a peer. Return false otherwise."
+
+	^nativeSocket isConnected
+%
+
+category: 'accepting connections'
+method: RsrSocket
+listen: backlogLength
+	"Starting listening for connections. <backlogLength> specifies the number of connections to allow in a pending state.
+	The actual backlog may support fewer prending connections depending upon implementation."
+
+	nativeSocket makeListener: backlogLength
+%
+
+category: 'accessing'
+method: RsrSocket
+port
+	"Return the port associated with the socket."
+
+	^nativeSocket port
+%
+
+category: 'read/write'
+method: RsrSocket
+read: count
+into: bytes
+startingAt: index
+	"Read <count> number of bytes into <bytes> and place the first byte into slot <index>.
+	<bytes> is assumed to be at least <count + index> bytes in size.
+	Return the number of bytes successfully read. Signal RsrSocketClosed if the socket is closed before or during the call."
+
+	| numRead |
+	[numRead := nativeSocket
+		read: count
+		into: bytes
+		startingAt: index]
+			on: SocketError
+			do: [:ex | ex resignalAs: (RsrSocketClosed new messageText: ex messageText)].
+	^numRead > 0
+		ifTrue: [numRead]
+		ifFalse:
+			[nativeSocket close.
+			RsrSocketClosed signal]
+%
+
+category: 'read/write'
+method: RsrSocket
+write: count
+from: bytes
+startingAt: index
+	"Write <count> number of bytes from <bytes> with <index> as the index of the first bytes.
+	If <bytes> is smaller than <index + count> the behavior is undefined.
+	If the socket is not connected, signal RsrSocketClosed."
+
+	^[nativeSocket
+		write: count
+		from: bytes
+		startingAt: index]
+			on: SocketError
+			do: [:ex | ex resignalAs: (RsrSocketClosed new messageText: ex messageText)]
+%
+
+category: 'private-accessing'
+method: RsrSocket
+_nativeSocket: aGsSignalingSocket
+	"Private - Configure w/ a platform socket"
+
+	nativeSocket := aGsSignalingSocket.
+	nativeSocket interrupting: true
+%
+
+! Class implementation for 'RsrSocketPair'
+
+!		Class methods for 'RsrSocketPair'
+
+category: 'instance creation'
+classmethod: RsrSocketPair
+firstSocket: firstSocket
+secondSocket: secondSocket
+
+	^super new
+		firstSocket: firstSocket;
+		secondSocket: secondSocket;
+		yourself
+%
+
+category: 'accessing'
+classmethod: RsrSocketPair
+listenPort
+
+	^64455
+%
+
+category: 'instance creation'
+classmethod: RsrSocketPair
+new
+
+	| localhost port listener firstSocket secondSocket |
+	localhost := '127.0.0.1'.
+	port := 8765.
+	listener := self socketClass new.
+	secondSocket := self socketClass new.
+	listener
+		bindAddress: localhost
+		port: port.
+	listener listen: 1.
+	secondSocket
+		connectToHost: localhost
+		port: port.
+	firstSocket := listener accept.
+	listener close.
+	(firstSocket isConnected and: [secondSocket isConnected])
+		ifFalse: [self error: 'Failed to create socket pair'].
+	^self
+		firstSocket: firstSocket
+		secondSocket: secondSocket
+%
+
+category: 'accessing'
+classmethod: RsrSocketPair
+socketClass
+
+	^RsrSocket
+%
+
+!		Instance methods for 'RsrSocketPair'
+
+category: 'closing'
+method: RsrSocketPair
+close
+
+	firstSocket close.
+	secondSocket close
+%
+
+category: 'accessing'
+method: RsrSocketPair
+firstSocket
+
+	^firstSocket
+%
+
+category: 'accessing'
+method: RsrSocketPair
+firstSocket: anObject
+
+	firstSocket := anObject
+%
+
+category: 'accessing'
+method: RsrSocketPair
+firstStream
+
+	^self socketStreamClass on: firstSocket
+%
+
+category: 'accessing'
+method: RsrSocketPair
+secondSocket
+
+	^secondSocket
+%
+
+category: 'accessing'
+method: RsrSocketPair
+secondSocket: anObject
+
+	secondSocket := anObject
+%
+
+category: 'accessing'
+method: RsrSocketPair
+secondStream
+
+	^self socketStreamClass on: secondSocket
+%
+
+category: 'accessing'
+method: RsrSocketPair
+socketStreamClass
+
+	^(RsrClassResolver classNamed: #RsrSocketStream)
+%
+
+! Class implementation for 'RsrStream'
+
+!		Instance methods for 'RsrStream'
+
+category: 'testing'
+method: RsrStream
+atEnd
+	"Answers when the Stream cannot take or provide any additional bytes."
+
+	^self subclassResponsibility
+%
+
+category: 'closing'
+method: RsrStream
+close
+	"Close the Stream. The semantics of this are defined by the subclass."
+
+	self subclassResponsibility
+%
+
+category: 'writing'
+method: RsrStream
+flush
+	"Ensure any data cached by the receiver is pushed to its destination."
+	"By default, do nothing."
+%
+
+category: 'reading'
+method: RsrStream
+next
+	"Read and return exactly 1 byte."
+
+	^self next: 1
+%
+
+category: 'reading'
+method: RsrStream
+next: count
+	"Read and return exactly <count> bytes"
+
+	^self subclassResponsibility
+%
+
+category: 'writing'
+method: RsrStream
+nextPutAll: aByteArray
+	"Write <aByteArray>'s elements to the backing store."
+
+	^self subclassResponsibility
+%
+
+! Class implementation for 'RsrSocketStream'
+
+!		Class methods for 'RsrSocketStream'
+
+category: 'instance creation'
+classmethod: RsrSocketStream
+on: anRsrSocket
+
+	^self new
+		socket: anRsrSocket;
+		yourself
+%
+
+!		Instance methods for 'RsrSocketStream'
+
+category: 'testing'
+method: RsrSocketStream
+atEnd
+	"Return whether additional bytes could become available on the socket."
+
+	^socket isConnected not
+%
+
+category: 'accessing'
+method: RsrSocketStream
+bufferSize
+	"The most bytes we'll send to the underlying socket at once, or 
+	attempt to read from the underlying socket at one time."
+
+	^65536
+%
+
+category: 'closing'
+method: RsrSocketStream
+close
+
+	socket close
+%
+
+category: 'adding'
+method: RsrSocketStream
+flush
+
+	"Write buffered bytes to the socket"
+
+	| allBytesWritten |
+	allBytesWritten := 0.
+	[ allBytesWritten < position ] whileTrue: [ 
+		| bytesWritten |
+		bytesWritten := socket
+			                write: position - allBytesWritten
+			                from: sendBuffer
+			                startingAt: allBytesWritten + 1.
+		allBytesWritten := allBytesWritten + bytesWritten ].
+	position := 0
+%
+
+category: 'initializing'
+method: RsrSocketStream
+initialize
+
+	super initialize.
+	sendBuffer := ByteArray new: self bufferSize.
+	self reset
+%
+
+category: 'accessing'
+method: RsrSocketStream
+next
+	"Return the next byte"
+
+	^self next: 1
+%
+
+category: 'accessing'
+method: RsrSocketStream
+next: count
+
+	"Return exactly <count> number of bytes.
+	Signal RsrSocketClosed if the socket closes."
+
+	| chunkSize bytes totalRead numRead |
+	chunkSize := self bufferSize.
+	bytes := ByteArray new: count.
+	totalRead := 0.
+	[ totalRead < count ] whileTrue: [ 
+		numRead := socket
+			           read: (chunkSize min: count - totalRead)
+			           into: bytes
+			           startingAt: totalRead + 1.
+		totalRead := totalRead + numRead ].
+	^ bytes
+%
+
+category: 'adding'
+method: RsrSocketStream
+nextPut: aByte
+
+	position = sendBuffer size ifTrue: [ self flush ].
+	position := position + 1.
+	sendBuffer at: position put: aByte
+%
+
+category: 'adding'
+method: RsrSocketStream
+nextPutAll: bytes
+
+	"Write <bytes> to the buffer, sending to socket if the buffer fills."
+
+	| numPut yetToPut |
+	numPut := 0.
+	[ 
+	yetToPut := bytes size - numPut.
+	yetToPut > 0 ] whileTrue: [ 
+		| copyCount |
+		copyCount := yetToPut min: sendBuffer size - position.
+		sendBuffer
+			replaceFrom: position + 1
+			to: position + copyCount
+			with: bytes
+			startingAt: numPut + 1.
+		position := position + copyCount.
+		position = sendBuffer size ifTrue: [ self flush ].
+		numPut := numPut + copyCount ]
+%
+
+category: 'accessing'
+method: RsrSocketStream
+reset
+
+	position := 0
+%
+
+category: 'accessing'
+method: RsrSocketStream
+socket: anRsrSocket
+
+	socket := anRsrSocket
+%
+
+! Class implementation for 'RsrStreamChannelLoop'
+
+!		Class methods for 'RsrStreamChannelLoop'
+
+category: 'instance creation'
+classmethod: RsrStreamChannelLoop
+on: aChannel
+
+	^self new
+		channel: aChannel;
+		yourself
+%
+
+!		Instance methods for 'RsrStreamChannelLoop'
+
+category: 'accessing'
+method: RsrStreamChannelLoop
+channel
+
+	^channel
+%
+
+category: 'accessing'
+method: RsrStreamChannelLoop
+channel: aChannel
+
+	channel := aChannel
+%
+
+category: 'running'
+method: RsrStreamChannelLoop
+executeCycle
+
+	self subclassResponsibility
+%
+
+category: 'initialization'
+method: RsrStreamChannelLoop
+initialize
+
+	super initialize.
+	state := self stoppedState
+%
+
+category: 'testing'
+method: RsrStreamChannelLoop
+isActive
+
+	^state == self runningState
+%
+
+category: 'testing'
+method: RsrStreamChannelLoop
+isProcessActive
+
+	^process ~~ nil
+%
+
+category: 'running'
+method: RsrStreamChannelLoop
+log
+
+	^RsrLogWithPrefix
+		prefix: self class name asString
+		log: self channel log
+%
+
+category: 'running'
+method: RsrStreamChannelLoop
+log: aString
+
+	self log debug: aString
+%
+
+category: 'running'
+method: RsrStreamChannelLoop
+report: aCommand
+
+	aCommand reportOn: self log
+%
+
+category: 'running'
+method: RsrStreamChannelLoop
+reportException: anException
+
+	self log: anException description
+%
+
+category: 'running'
+method: RsrStreamChannelLoop
+runLoop
+
+	[self isActive]
+		whileTrue:
+			[[self executeCycle]
+				on: Error
+				do:
+					[:ex |
+					self reportException: ex.
+					self channel genericError: ex]]
+%
+
+category: 'accessing'
+method: RsrStreamChannelLoop
+runLoopName
+	"Return the name of the associated run loop.
+	This name is assigned to the Process used to execute the run loop."
+
+	^self subclassResponsibility
+%
+
+category: 'accessing'
+method: RsrStreamChannelLoop
+runningState
+
+	^#Running
+%
+
+category: 'commands'
+method: RsrStreamChannelLoop
+start
+
+	state := self runningState.
+	process := RsrProcessModel
+		fork:
+			[RsrProcessModel configureCommunicationsProcess.
+			self runLoop.
+			process := nil]
+		named: self runLoopName
+%
+
+category: 'commands'
+method: RsrStreamChannelLoop
+stop
+
+	self isActive ifFalse: [^self].
+	state := self stoppedState
+%
+
+category: 'accessing'
+method: RsrStreamChannelLoop
+stoppedState
+
+	^#Stop
+%
+
+! Class implementation for 'RsrCommandSink'
+
+!		Instance methods for 'RsrCommandSink'
+
+category: 'accessing'
+method: RsrCommandSink
+addCommunicationProcessesTo: aSet
+	"Add all processes used for Communication to the provided set."
+	
+	aSet add: process
+%
+
+category: 'accessing'
+method: RsrCommandSink
+encoder
+
+	^RsrCommandEncoder new
+%
+
+category: 'commands'
+method: RsrCommandSink
+enqueue: aCommand
+
+	self isActive ifTrue: [queue nextPut: aCommand]
+%
+
+category: 'commands'
+method: RsrCommandSink
+executeCycle
+
+	[| command |
+	command := queue next.
+	command == self stopToken
+		ifTrue: [^self].
+	self writeCommand: command.
+	(queue size = 0) "Dolphin does not support #isEmpty"
+		ifTrue: [self flush]]
+		on: RsrSocketClosed
+		do:
+			[:ex |
+			self reportException: ex.
+			self channel disconnected]
+%
+
+category: 'commands'
+method: RsrCommandSink
+flush
+
+	self outStream flush
+%
+
+category: 'initialization'
+method: RsrCommandSink
+initialize
+
+	super initialize.
+	queue := SharedQueue new
+%
+
+category: 'accessing'
+method: RsrCommandSink
+outStream
+
+	^self channel outStream
+%
+
+category: 'accessing'
+method: RsrCommandSink
+runLoopName
+
+	^'Connection Writing'
+%
+
+category: 'commands'
+method: RsrCommandSink
+stop
+
+	super stop.
+	queue nextPut: self stopToken
+%
+
+category: 'accessing'
+method: RsrCommandSink
+stopToken
+
+	^self stoppedState
+%
+
+category: 'writing'
+method: RsrCommandSink
+write: aByteArray
+
+	self outStream nextPutAll: aByteArray
+%
+
+category: 'writing'
+method: RsrCommandSink
+writeCommand: aCommand
+
+	self report: aCommand.
+	aCommand
+		encode: self outStream
+		using: self encoder
+%
+
+! Class implementation for 'RsrCommandSource'
+
+!		Instance methods for 'RsrCommandSource'
+
+category: 'accessing'
+method: RsrCommandSource
+addCommunicationProcessesTo: aSet
+	"Add all processes used for Communication to the provided set."
+	
+	aSet add: process
+%
+
+category: 'accessing'
+method: RsrCommandSource
+decoder
+
+	^RsrCommandDecoder new
+%
+
+category: 'commands'
+method: RsrCommandSource
+executeCycle
+
+	[| command |
+	command := self nextCommand.
+	self report: command.
+	self channel received: command]
+		on: RsrSocketClosed
+		do:
+			[:ex |
+			self reportException: ex.
+			self channel disconnected]
+%
+
+category: 'accessing'
+method: RsrCommandSource
+inStream
+	"Return the read stream associated w/ this channel."
+
+	^self channel inStream
+%
+
+category: 'commands'
+method: RsrCommandSource
+nextCommand
+
+	^self decoder decodeCommand: self inStream
+%
+
+category: 'accessing'
+method: RsrCommandSource
+runLoopName
+
+	^'Connection Reading'
+%
+
+! Class implementation for 'RsrThreadSafeDictionary'
+
+!		Instance methods for 'RsrThreadSafeDictionary'
+
+category: 'accessing'
+method: RsrThreadSafeDictionary
+at: aKey
+ifAbsent: aBlock
+
+	| isPresent result |
+	isPresent := true.
+	result := self critical: [map at: aKey ifAbsent: [isPresent := false]].
+	^isPresent
+		ifTrue: [result]
+		ifFalse: [aBlock value]
+%
+
+category: 'accessing'
+method: RsrThreadSafeDictionary
+at: aKey
+put: aValue
+
+	self critical: [map at: aKey put: aValue].
+	^aValue
+%
+
+category: 'utilities'
+method: RsrThreadSafeDictionary
+critical: aBlock
+
+	^mutex critical: aBlock
+%
+
+category: 'enumerating'
+method: RsrThreadSafeDictionary
+do: aBlock
+
+	| values |
+	values := self critical: [map values].
+	values do: aBlock
+%
+
+category: 'initialization'
+method: RsrThreadSafeDictionary
+initialize
+
+	super initialize.
+	mutex := Semaphore forMutualExclusion.
+	map := Dictionary new
+%
+
+category: 'removing'
+method: RsrThreadSafeDictionary
+removeKey: anRsrId
+
+	^self critical: [map removeKey: anRsrId ifAbsent: [nil]]
+%
+
+category: 'removing'
+method: RsrThreadSafeDictionary
+removeKey: anRsrId
+ifAbsent: aBlock
+
+	| element wasRemoved |
+	wasRemoved := true.
+	element := self critical: [map removeKey: anRsrId ifAbsent: [wasRemoved := false]].
+	^wasRemoved
+		ifTrue: [element]
+		ifFalse: [aBlock value]
+%
+
+! Class implementation for 'RsrTokenExchangeMessage'
+
+!		Instance methods for 'RsrTokenExchangeMessage'
+
+category: 'comparing'
+method: RsrTokenExchangeMessage
+= aTokenExchangeMessage
+
+	^self class == aTokenExchangeMessage class
+%
+
+category: 'hashing'
+method: RsrTokenExchangeMessage
+hash
+
+	^self class hash
+%
+
+! Class implementation for 'RsrToken'
+
+!		Class methods for 'RsrToken'
+
+category: 'instance creation'
+classmethod: RsrToken
+bytes: aByteArray
+
+	^self new
+		bytes: aByteArray;
+		yourself
+%
+
+!		Instance methods for 'RsrToken'
+
+category: 'comparing'
+method: RsrToken
+= aToken
+
+	^self class == aToken class and: [self bytes = aToken bytes]
+%
+
+category: 'accessing'
+method: RsrToken
+bytes
+
+	^bytes
+%
+
+category: 'accessing'
+method: RsrToken
+bytes: aByteArray
+
+	bytes := aByteArray
+%
+
+category: 'hashing'
+method: RsrToken
+hash
+
+	^self bytes hash
+%
+
+! Class implementation for 'RsrTokenAccepted'
+
+!		Instance methods for 'RsrTokenAccepted'
+
+category: 'testing'
+method: RsrTokenAccepted
+wasAccepted
+
+	^true
+%
+
+! Class implementation for 'RsrTokenRejected'
+
+!		Instance methods for 'RsrTokenRejected'
+
+category: 'testing'
+method: RsrTokenRejected
+wasAccepted
+
+	^false
+%
+
+! Class implementation for 'RsrPlatformInitializer'
+
+!		Class methods for 'RsrPlatformInitializer'
+
+category: 'class initialization'
+classmethod: RsrPlatformInitializer
+initialize
+
+	RsrReference initializeReferenceMapping
+%
+
+! Class implementation for 'RsrProcessModel'
+
+!		Class methods for 'RsrProcessModel'
+
+category: 'configuring'
+classmethod: RsrProcessModel
+configureCommunicationsProcess
+	"Apply framework configuration to the currently running communications process."
+
+	^self current configureCommunicationsProcess
+%
+
+category: 'configuring'
+classmethod: RsrProcessModel
+configureFrameworkProcess
+	"Apply framework configuration to the currently running process."
+
+	^self current configureFrameworkProcess
+%
+
+category: 'configuring'
+classmethod: RsrProcessModel
+configureUnhandleExceptionProtection
+	"Configure the process to ensure we are able to trap any unhandled exceptions."
+
+	^self current configureUnhandleExceptionProtection
+%
+
+category: 'managing-concurrency'
+classmethod: RsrProcessModel
+currentStackDump
+
+	^self current currentStackDump
+%
+
+category: 'managing-concurrency'
+classmethod: RsrProcessModel
+fork: aBlock
+at: aPriority
+named: aString
+
+	^self current
+		fork: aBlock
+		at: aPriority
+		named: aString
+%
+
+category: 'managing-concurrency'
+classmethod: RsrProcessModel
+fork: aBlock
+named: aString
+
+	^self current fork: aBlock named: aString
+%
+
+category: 'managing-concurrency'
+classmethod: RsrProcessModel
+renameProcess: aString
+	"Rename the current process to the provided string"
+
+	^self current renameProcess: aString
+%
+
+!		Instance methods for 'RsrProcessModel'
+
+category: 'configuring'
+method: RsrProcessModel
+communicationsSchedulePriority
+	"Returns the priority level used by communications processes."
+
+	^Processor highIOPriority
+%
+
+category: 'configuring'
+method: RsrProcessModel
+configureCommunicationsProcess
+	"Apply framework configuration to the currently running communications process."
+
+	Processor activeProcess
+		priority: self communicationsSchedulePriority
+%
+
+category: 'configuring'
+method: RsrProcessModel
+configureFrameworkProcess
+	"Apply framework configuration to the currently running process."
+
+	Processor activeProcess
+		priority: self frameworkSchedulingPriority
+%
+
+category: 'managing-concurrency'
+method: RsrProcessModel
+fork: aBlock
+at: aPriority
+named: aString
+
+	^[self renameProcess: aString.
+	aBlock value] forkAt: aPriority
+%
+
+category: 'managing-concurrency'
+method: RsrProcessModel
+fork: aBlock
+named: aString
+
+	^[self renameProcess: aString.
+	aBlock value] fork
+%
+
+category: 'configuring'
+method: RsrProcessModel
+frameworkSchedulingPriority
+	"Returns the priority level used by normal framework processes."
+
+	^Processor userInterruptPriority
+%
+
+category: 'renaming'
+method: RsrProcessModel
+renameProcess: aString
+
+	Processor activeProcess name: aString
+%
+
+! Class implementation for 'RsrTestingProcessModel'
+
+!		Instance methods for 'RsrTestingProcessModel'
+
+category: 'managing-concurrency'
+method: RsrTestingProcessModel
+fork: aBlock
+at: aPriority
+named: aString
+
+	^super
+		fork: (self protect: aBlock)
+		at: aPriority
+		named: aString
+%
+
+category: 'managing-concurrency'
+method: RsrTestingProcessModel
+fork: aBlock
+named: aString
+
+	^super
+		fork: (self protect: aBlock)
+		named: aString
+%
+
+category: 'accessing'
+method: RsrTestingProcessModel
+forkedException
+
+	^forkedException
+%
+
+category: 'accessing'
+method: RsrTestingProcessModel
+protect: aBlock
+
+	^[aBlock on: self class unhandledExceptionClass do: [:ue | forkedException := ue exception copy. ue return]]
+%
+
+! Class implementation for 'RsrTestCase'
+
+!		Class methods for 'RsrTestCase'
+
+category: 'accessing'
+classmethod: RsrTestCase
+defaultTimeLimit
+	"This is needed for Pharo"
+
+	^5 seconds
+%
+
+category: 'testing'
+classmethod: RsrTestCase
+isAbstract
+
+	^self == RsrTestCase
+%
+
+!		Instance methods for 'RsrTestCase'
+
+category: 'asserting'
+method: RsrTestCase
+assert: anObject
+identicalTo: bObject
+
+	self assert: anObject == bObject
+%
+
+category: 'utilities'
+method: RsrTestCase
+assumption: aString
+	"This method serves as a marker for assumptions made in the tests.
+	Perhaps some of the senders can be removed in the future."
+%
+
+category: 'asserting'
+method: RsrTestCase
+deny: anObject
+identicalTo: bObject
+
+	self assert: anObject ~~ bObject
+%
+
+category: 'utilities'
+method: RsrTestCase
+hack: aString
+	"Placeholder for things that need to be fixed"
+%
+
+category: 'utilities'
+method: RsrTestCase
+maximumReclamation
+
+	self assert: RsrGarbageCollector maximumReclamation
+%
+
+category: 'running'
+method: RsrTestCase
+runCase
+
+	| pm |
+	pm := RsrTestingProcessModel new.
+	RsrProcessModel current: pm.
+	[super runCase]
+		ensure:
+			[RsrProcessModel resetCurrent].
+	pm forkedException ifNotNil: [:ex | ex signal]
+%
+
+category: 'utilities'
+method: RsrTestCase
+shortWait
+
+	(Delay forMilliseconds: 100) wait
+%
+
+! Class implementation for 'RsrAsyncMournHandlerTestCase'
+
+!		Instance methods for 'RsrAsyncMournHandlerTestCase'
+
+category: 'utilities'
+method: RsrAsyncMournHandlerTestCase
+finalizationProcess
+
+	| proc |
+	self finalizeEphemeronWithAction: [proc := Processor activeProcess].
+	^proc
+%
+
+category: 'utilities'
+method: RsrAsyncMournHandlerTestCase
+finalizeEphemeronWithAction: aBlock
+
+	| semaphore ephemeron |
+	semaphore := Semaphore new.
+	ephemeron := RsrEphemeron
+		on: Object new
+		mournAction:
+			[aBlock value.
+			semaphore signal].
+	RsrGarbageCollector maximumReclamation.
+	self assert: (semaphore waitForSeconds: 1)
+%
+
+category: 'initializing'
+method: RsrAsyncMournHandlerTestCase
+setUp
+
+	super setUp.
+	handler := RsrAsyncMournHandler current.
+	handler start
+%
+
+category: 'initializing'
+method: RsrAsyncMournHandlerTestCase
+tearDown
+
+	handler stop.
+	super tearDown
+%
+
+category: 'running'
+method: RsrAsyncMournHandlerTestCase
+testAnotherAsyncHandlerExists
+
+	| notifier |
+	handler stop.
+	[notifier := GsSignalingSocket newForAsyncExceptions: {GcFinalizeNotification }.
+	self
+		should: [handler start]
+		raise: RsrNotification] ensure: [GsSignalingSocket disableAsyncExceptions].
+	self
+		shouldnt: [handler start]
+		raise: RsrNotification
+%
+
+category: 'running'
+method: RsrAsyncMournHandlerTestCase
+testEnsureSingletonWhileActive
+
+	| duplicateHandler |
+	duplicateHandler := RsrAsyncMournHandler current.
+	self
+		assert: duplicateHandler
+		identicalTo: handler
+%
+
+category: 'running'
+method: RsrAsyncMournHandlerTestCase
+testEnsureStarted
+
+	| nonHandlerFinalizeProcess handlerFinalizeProcess1 handlerFinalizeProcess2 |
+	handler stop.
+	nonHandlerFinalizeProcess := self finalizationProcess.
+	self deny: handler isActive.
+	handler ensureStarted.
+	self assert: handler isActive.
+	handlerFinalizeProcess1 := self finalizationProcess.
+	handler ensureStarted.
+	self assert: handler isActive.
+	handlerFinalizeProcess2 := self finalizationProcess.
+	self
+		deny: nonHandlerFinalizeProcess
+		identicalTo: handlerFinalizeProcess1.
+	self
+		assert: handlerFinalizeProcess1
+		identicalTo: handlerFinalizeProcess2
+%
+
+category: 'running'
+method: RsrAsyncMournHandlerTestCase
+testHandlerStops
+
+	| handlerProcess mournProcess |
+	handlerProcess := handler process.
+	handler stop.
+	mournProcess := self finalizationProcess.
+	self
+		deny: mournProcess
+		equals: handlerProcess.
+	self deny: handlerProcess isNil
+%
+
+category: 'running'
+method: RsrAsyncMournHandlerTestCase
+testMournEphemeron
+
+	| mournProcess |
+	mournProcess := self finalizationProcess.
+	self
+		assert: mournProcess
+		equals: handler process
+%
+
+category: 'running'
+method: RsrAsyncMournHandlerTestCase
+testNewRaisesError
+
+	self
+		should: [RsrAsyncMournHandler new]
+		raise: RsrError
+%
+
+! Class implementation for 'RsrClassResolverTestCase'
+
+!		Instance methods for 'RsrClassResolverTestCase'
+
+category: 'asserting'
+method: RsrClassResolverTestCase
+assert: aClassName
+resolvesTo: expectedClass
+
+	| actualClass |
+	actualClass := RsrClassResolver classNamed: aClassName.
+	self
+		assert: actualClass
+		identicalTo: expectedClass
+%
+
+category: 'running'
+method: RsrClassResolverTestCase
+testFailedResolution
+
+	| actual marker |
+	self
+		should: [RsrClassResolver classNamed: #Xlerb]
+		raise: RsrUnknownClass.
+	marker := Object new.
+	actual := RsrClassResolver
+		classNamed: #Xlerb
+		ifAbsent: [marker].
+	self
+		assert: actual
+		identicalTo: marker
+%
+
+category: 'running'
+method: RsrClassResolverTestCase
+testSuccessfulResolution
+
+	| actual |
+	actual := RsrClassResolver classNamed: #Object.
+	self
+		assert: actual
+		identicalTo: Object.
+	actual := RsrClassResolver
+		classNamed: #Object
+		ifAbsent: [self assert: false].
+	self
+		assert: actual
+		identicalTo: Object
+%
+
+! Class implementation for 'RsrCommandCodecTest'
+
+!		Class methods for 'RsrCommandCodecTest'
+
+category: 'testing'
+classmethod: RsrCommandCodecTest
+isAbstract
+
+	^self == RsrCommandCodecTest
+%
+
+!		Instance methods for 'RsrCommandCodecTest'
+
+category: 'accessing'
+method: RsrCommandCodecTest
+connection
+
+	^connection
+%
+
+category: 'other'
+method: RsrCommandCodecTest
+decoder
+
+	^RsrCommandDecoder new
+%
+
+category: 'accessing'
+method: RsrCommandCodecTest
+encoder
+
+	^RsrCommandEncoder new
+%
+
+category: 'encode/decode'
+method: RsrCommandCodecTest
+encodeReferenceOf: anObject
+
+	| reference |
+	reference := RsrReference from: anObject.
+	^ByteArray streamContents: [:stream | self encoder encodeReference: reference onto: stream]
+%
+
+category: 'running-symbol'
+method: RsrCommandCodecTest
+genericSymbol
+
+	^#genericSymbol
+%
+
+category: 'running-symbol'
+method: RsrCommandCodecTest
+genericSymbolEncoding
+
+	^#[0 0 0 0 0 0 0 0], "OID = 0"
+	#[0 0 0 0 0 0 0 1], "Immediate Type = 1"
+	#[0 0 0 0 0 0 0 13], "Length of UTF-8 data"
+	#[103 101 110 101 114 105 99 83 121 109 98 111 108]	"#genericSymbol"
+%
+
+category: 'accessing-objects'
+method: RsrCommandCodecTest
+referencedServiceEncoding
+
+	^#[0 0 0 0 0 0 0 0], "type"
+	#[0 0 0 0 0 0 0 2], "referencedService's OID = 2"
+	#[0 0 0 0 0 0 0 0], "Inst Var Count"
+	#[0 0 0 0 0 0 0 0], "Start of service name. OID = 0"
+	#[0 0 0 0 0 0 0 1], "Service name = 1 -> Symbol"
+	#[0 0 0 0 0 0 0 19], "Length of UTF-8 encoded bytes"
+	#[82 115 114 83 101 114 118 101 114 78 111 73 110 115 116 86 97 114 115]. "#RsrServerNoInstVars"
+%
+
+category: 'accessing-objects'
+method: RsrCommandCodecTest
+rootServiceEncoding
+
+	^#[0 0 0 0 0 0 0 0], "type"
+	#[0 0 0 0 0 0 0 1], "rootService's OID = 1"
+	#[0 0 0 0 0 0 0 1], "Inst Var Count"
+	#[0 0 0 0 0 0 0 0], "Start of service name. OID = 0"
+	#[0 0 0 0 0 0 0 1], "Service name = 1 -> Symbol"
+	#[0 0 0 0 0 0 0 25], "Length of UTF-8 encoded bytes"
+	#[82 115 114 83 101 114 118 101 114 82 101 102 101 114 101 110 99 101 83 101 114 118 105 99 101],
+	#[0 0 0 0 0 0 0 2]. "#RsrServerReferenceService"
+%
+
+category: 'running'
+method: RsrCommandCodecTest
+serviceNoInstVarsEncoding
+
+	^#[0 0 0 0 0 0 0 0], "type"
+	#[0 0 0 0 0 0 0 1], "rootService's OID = 1"
+	#[0 0 0 0 0 0 0 0], "Inst Var Count"
+	#[0 0 0 0 0 0 0 0], "Start of service name. OID = 0"
+	#[0 0 0 0 0 0 0 1], "Service name = 1 -> Symbol"
+	#[0 0 0 0 0 0 0 19], "Length of UTF-8 encoded bytes"
+	#[82 115 114 83 101 114 118 101 114 78 111 73 110 115 116 86 97 114 115] "#RsrServerNoInstVars"
+%
+
+category: 'other'
+method: RsrCommandCodecTest
+setUp
+
+	super setUp.
+	connection := RsrConnection
+		channel: RsrNullChannel new
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals
+		oidSpigot: RsrThreadSafeNumericSpigot naturals.
+	connection open
+%
+
+category: 'other'
+method: RsrCommandCodecTest
+tearDown
+
+	connection close.
+	connection := nil.
+	super tearDown
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testArray
+
+	| array encoding |
+	array := Array
+		with: self genericSymbol
+		with: 5
+		with: nil.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "Immediate Object OID"
+		#[0 0 0 0 0 0 0 9], "Array type"
+		#[0 0 0 0 0 0 0 3], "3 elements"
+		self genericSymbolEncoding, "Generic Symbol"
+		#[0 0 0 0 0 0 0 0], "Immediate OID"
+		#[0 0 0 0 0 0 0 3], "Positive Integer"
+		#[0 0 0 0 0 0 0 1], "num bytes"
+		#[5], "5"
+		#[0 0 0 0 0 0 0 0], "Immediate OID"
+		#[0 0 0 0 0 0 0 6].
+	self
+		verifyImmediate: array
+		encoding: encoding.
+	array := Array new.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "Immediate OID"
+		#[0 0 0 0 0 0 0 9], "Array type"
+		#[0 0 0 0 0 0 0 0].
+	self
+		verifyImmediate: array
+		encoding: encoding
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testBoolean
+
+	| encoding |
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 7].
+	self
+		verifyImmediate: true
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 8].
+	self
+		verifyImmediate: false
+		encoding: encoding.
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testByteArray
+
+	| bytes encoding |
+	bytes := #[].
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "Immediate Object OID"
+		#[0 0 0 0 0 0 0 10], "ByteArray type"
+		#[0 0 0 0 0 0 0 0], "size"
+		bytes.
+	self
+		verifyImmediate: bytes
+		encoding: encoding.
+	bytes := #[1 2 3 4 5].
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 10],
+		#[0 0 0 0 0 0 0 5],
+		bytes.
+	self
+		verifyImmediate: bytes
+		encoding: encoding
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testCharacter
+
+	| encoding |
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 5],
+		#[0 0 0 0 0 0 0 0].
+	self
+		verifyImmediate: (Character codePoint: 0)
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 5],
+		#[0 0 0 0 0 0 0 65].
+	self
+		verifyImmediate: (Character codePoint: 65)
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 5],
+		#[0 0 0 0 0 0 0 65].
+	self
+		verifyImmediate: $A
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 5],
+		#[0 0 0 0 0 0 1 212].
+	self
+		verifyImmediate: (Character codePoint: 16r01D4)
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 5],
+		#[0 0 0 0 0 0 131 52].
+	self
+		verifyImmediate: (Character codePoint: 16r8334)
+		encoding: encoding.
+%
+
+category: 'running-control words'
+method: RsrCommandCodecTest
+testControlWord
+	
+	self
+		verifyControlWord: 0
+		encoding: #[0 0 0 0 0 0 0 0].
+	self
+		verifyControlWord: 1
+		encoding: #[0 0 0 0 0 0 0 1].
+	self
+		verifyControlWord: -1
+		encoding: #[255 255 255 255 255 255 255 255].
+	self
+		verifyControlWord: (2 raisedTo: 63) - 1
+		encoding: #[127 255 255 255 255 255 255 255].
+	self
+		verifyControlWord: (2 raisedTo: 63) negated
+		encoding: #[128 0 0 0 0 0 0 0]
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testDateTime
+
+	| dt encoding |
+	dt := RsrDateAndTime posixEpoch.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 14],
+		#[0 0 0 0 0 0 0 0].
+	self
+		verifyImmediate: dt
+		encoding: encoding.
+	dt := RsrDateAndTime fromMicroseconds: 1562692562657612. "2019-07-09T10:16:02.657612-07:00"
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 14],
+		#[0 5 141 66 183 23 33 76].
+	self
+		verifyImmediate: dt
+		encoding: encoding.
+	dt := RsrDateAndTime fromMicroseconds: -1000000. "1969-12-31T23:59:59-00:00"
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 14],
+		#[255 255 255 255 255 240 189 192].
+	self
+		verifyImmediate: dt
+		encoding: encoding.
+	dt := RsrDateAndTime fromMicroseconds: -491277642567488. "1954-06-07T14:59:17.432512-07:00"
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 14],
+		#[255 254 65 47 130 160 240 192].
+	self
+		verifyImmediate: dt
+		encoding: encoding
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testDictionary
+
+	| dictionary encoding result |
+	dictionary := Dictionary new.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "Immediate Object OID"
+		#[0 0 0 0 0 0 0 13], "Dictionary type"
+		#[0 0 0 0 0 0 0 0]. "0 associations"
+	self
+		verifyImmediate: dictionary
+		encoding: encoding.
+	dictionary := Dictionary new
+		at: 1 put: self genericSymbol;
+		at: false put: true;
+		yourself.
+	encoding := self encodeReferenceOf: dictionary.
+	result := (self decoder decodeReference: encoding readStream) resolve: self connection.
+	self
+		assert: result
+		equals: dictionary.
+	self
+		deny: result
+		identicalTo: dictionary.
+	"self hack: 'Order is not guaranteed in a dictionary'.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], ""Immediate OID""
+		#[0 0 0 0 0 0 0 13], ""Dictionary Type""
+		#[0 0 0 0 0 0 0 2], ""Two assocs""
+		#[0 0 0 0 0 0 0 0], ""nil""
+		#[0 0 0 0 0 0 0 6],
+		#[0 0 0 0 0 0 0 0], ""true""
+		#[0 0 0 0 0 0 0 7],
+		#[0 0 0 0 0 0 0 0], ""Integer 1""
+		#[0 0 0 0 0 0 0 3],
+		#[0 0 0 0 0 0 0 1],
+		#[1],
+		self genericSymbolEncoding.
+	self
+		verifyImmediate: dictionary
+		encoding: encoding"
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testDouble
+
+	| encoding |
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[128 0 0 0 0 0 0 0].
+	self
+		verifyImmediate: -0.0
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[0 0 0 0 0 0 0 0].
+	self
+		verifyImmediate: 0.0
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[191 240 0 0 0 0 0 0].
+	self
+		verifyImmediate: -1.0
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[63 240 0 0 0 0 0 0].
+	self
+		verifyImmediate: 1.0
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[63 185 153 153 153 153 153 154].
+	self
+		verifyImmediate: 0.1
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[191 185 153 153 153 153 153 154].
+	self
+		verifyImmediate: -0.1
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[127 240 0 0 0 0 0 0].
+	self
+		verifyImmediate: RsrDoubleReference infinity
+		encoding: encoding
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testInteger
+
+	| encoding |
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 3],
+		#[0 0 0 0 0 0 0 1],
+		#[0].
+	self
+		verifyImmediate: 0
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 3],
+		#[0 0 0 0 0 0 0 1],
+		#[4].
+	self
+		verifyImmediate: 4
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 3],
+		#[0 0 0 0 0 0 0 5],
+		#[1 15 248 235 121].
+	self
+		verifyImmediate: 4562938745
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 4],
+		#[0 0 0 0 0 0 0 5],
+		#[1 15 248 235 121].
+	self
+		verifyImmediate: -4562938745
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 3],
+		#[0 0 0 0 0 0 0 13],
+		#[10 101 181 177 179 46 128 92 96 64 190 76 107].
+	self
+		verifyImmediate: 823759265872134912569713249387
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 4],
+		#[0 0 0 0 0 0 0 13],
+		#[10 101 181 177 179 46 128 92 96 64 190 76 107].
+	self
+		verifyImmediate: -823759265872134912569713249387
+		encoding: encoding.
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testNil
+
+	| encoding |
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 6].
+	self
+		verifyImmediate: nil
+		encoding: encoding
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testOrderedCollection
+
+	| oc encoding |
+	oc := OrderedCollection new.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "Immediate OID"
+		#[0 0 0 0 0 0 0 12], "OrderedCollection type"
+		#[0 0 0 0 0 0 0 0].
+	self
+		verifyImmediate: oc
+		encoding: encoding.
+	oc := OrderedCollection
+		with: self genericSymbol
+		with: 5
+		with: nil.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "Immediate Object OID"
+		#[0 0 0 0 0 0 0 12], "OrderedCollection type"
+		#[0 0 0 0 0 0 0 3], "3 elements"
+		self genericSymbolEncoding, "Generic Symbol"
+		#[0 0 0 0 0 0 0 0], "Immediate OID"
+		#[0 0 0 0 0 0 0 3], "Positive Integer"
+		#[0 0 0 0 0 0 0 1], "num bytes"
+		#[5], "5"
+		#[0 0 0 0 0 0 0 0], "Immediate OID"
+		#[0 0 0 0 0 0 0 6].
+	self
+		verifyImmediate: oc
+		encoding: encoding
+%
+
+category: 'running-immediates'
+method: RsrCommandCodecTest
+testSet
+
+	| set encoding result |
+	set := Set new.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "OID"
+		#[0 0 0 0 0 0 0 11], "Set"
+		#[0 0 0 0 0 0 0 0]. "0 elements"
+	self
+		verifyImmediate: set
+		encoding: encoding.
+	set := Set
+		with: true
+		with: nil.
+	encoding := self encodeReferenceOf: set.
+	result := (self decoder decodeReference: encoding readStream) resolve: self connection.
+	self
+		assert: result
+		equals: set.
+	self
+		deny: result
+		identicalTo: set.
+	"self hack: 'Hashed collections do not have an ordering'.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], ""OID""
+		#[0 0 0 0 0 0 0 11], ""Set""
+		#[0 0 0 0 0 0 0 2], ""2 elements""
+		#[0 0 0 0 0 0 0 0], ""true""
+		#[0 0 0 0 0 0 0 7],
+		#[0 0 0 0 0 0 0 0], ""nil""
+		#[0 0 0 0 0 0 0 6].
+	self
+		verifyImmediate: set
+		encoding: encoding"
+%
+
+category: 'running-symbol'
+method: RsrCommandCodecTest
+testString
+
+	| encoding |
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "OID = 0"
+		#[0 0 0 0 0 0 0 2], "Immediate Type = 2"
+		#[0 0 0 0 0 0 0 0], "length"
+		#[].	 "empty string"
+	self
+		verifyImmediate: ''
+		encoding: encoding.
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "OID = 0"
+		#[0 0 0 0 0 0 0 2], "Immediate Type = 2"
+		#[0 0 0 0 0 0 0 13], "length"
+		#[103 101 110 101 114 105 99 83 116 114 105 110 103].	 "genericString"
+	self
+		verifyImmediate: 'genericString'
+		encoding: encoding
+%
+
+category: 'running-symbol'
+method: RsrCommandCodecTest
+testSymbol
+
+	self
+		verifyImmediate: self genericSymbol
+		encoding: self genericSymbolEncoding
+%
+
+category: 'asserting'
+method: RsrCommandCodecTest
+verifyControlWord: anInteger
+encoding: bytes
+
+	self subclassResponsibility
+%
+
+category: 'asserting'
+method: RsrCommandCodecTest
+verifyImmediate: anImmediateObject
+encoding: encoding
+
+	self subclassResponsibility
+%
+
+! Class implementation for 'RsrCommandDecoderTest'
+
+!		Instance methods for 'RsrCommandDecoderTest'
+
+category: 'asserting'
+method: RsrCommandDecoderTest
+assertReference: bytes
+decodesTo: expected
+
+	| actual |
+	actual := self decodeReference: bytes.
+	self
+		assert: actual
+		equals: expected
+%
+
+category: 'decoding'
+method: RsrCommandDecoderTest
+decodeReference: bytes
+
+	^(self decoder decodeReference: bytes readStream) resolve: self connection
+%
+
+category: 'decoding'
+method: RsrCommandDecoderTest
+decodeService: anObjectBytes
+
+	^(self decoder decodeServiceSnapshot: anObjectBytes readStream) reifyIn: self connection
+%
+
+category: 'running'
+method: RsrCommandDecoderTest
+testDeliverResponse
+
+	| service response encoding command decodedService |
+	service := RsrServerNoInstVars new.
+	self connection _ensureRegistered: service.
+	response := #responseSymbol.
+	encoding :=
+		#[0 0 0 0 0 0 0 2], "DeliverResponse Command"
+		#[0 0 0 0 0 0 0 1], "Transaction Id"
+		#[0 0 0 0 0 0 0 1], "Number of services"
+		self serviceNoInstVarsEncoding,
+		#[0 0 0 0 0 0 0 0], "Service Name Symbol Reference"
+		#[0 0 0 0 0 0 0 1], "Object Type for Symbol"
+		#[0 0 0 0 0 0 0 14], "Length of UTF-8 bytes"
+		#[114 101 115 112 111 110 115 101 83 121 109 98 111 108]. "#responseSymbol"
+	command := self decoder decodeCommand: encoding readStream.
+	self
+		assert: command class
+		equals: RsrDeliverResponse.
+	self
+		assert: command transaction
+		equals: 1.
+	self
+		assert: command snapshots size
+		equals: 1.
+	decodedService := command snapshots first reifyIn: self connection.
+	self
+		assert: decodedService
+		equals: service.
+	self
+		assert: (command response resolve: self connection)
+		equals: response
+%
+
+category: 'running'
+method: RsrCommandDecoderTest
+testReleaseServices
+
+	| command encoding |
+	encoding :=
+		#[0 0 0 0 0 0 0 3], "ReleaseObjects Command"
+		#[0 0 0 0 0 0 0 5], "Num OIDS"
+		#[0 0 0 0 0 0 0 1], "First OID"
+		#[0 0 0 0 0 0 0 2],
+		#[0 0 0 0 0 0 0 3],
+		#[0 0 0 0 0 0 0 4],
+		#[0 0 0 0 0 0 0 5]. "Last OID"
+	command := self decoder decodeCommand: encoding readStream.
+	self
+		assert: command sids
+		equals: #(1 2 3 4 5)
+%
+
+category: 'running'
+method: RsrCommandDecoderTest
+testSendMessage
+
+	| service encoding command |
+	service := RsrServerNoInstVars new.
+	self connection _ensureRegistered: service.
+	encoding :=
+		#[0 0 0 0 0 0 0 1], "SendMessage Command"
+		#[0 0 0 0 0 0 0 1], "Transaction ID"
+		#[0 0 0 0 0 0 0 1], "One service is part of this message"
+		self serviceNoInstVarsEncoding,
+		#[0 0 0 0 0 0 0 1], "Receiver OID"
+		#[0 0 0 0 0 0 0 0], "Selector Reference"
+		#[0 0 0 0 0 0 0 1], "Object Type for Symbol"
+		#[0 0 0 0 0 0 0 8], "Length of UTF-8 bytes"
+		#[114 101 116 117 114 110 52 50], "#return42"
+		#[0 0 0 0 0 0 0 0]. "Argument Count"
+	command := self decoder decodeCommand: encoding readStream.
+	self
+		assert: command class
+		equals: RsrSendMessage.
+	self
+		assert: command transaction
+		equals: 1.
+	self
+		assert: (command receiverReference resolve: self connection)
+		identicalTo: service.
+	self
+		assert: (command selectorReference resolve: self connection)
+		identicalTo: #return42.
+	self
+		assert: command argumentReferences
+		equals: #().
+	self
+		assert: command snapshots size
+		equals: 1
+%
+
+category: 'running'
+method: RsrCommandDecoderTest
+testServiceDecodeIdentity
+	"Ensure that decoding an object multiple times results in
+	a single object getting created."
+
+	| firstService secondService |
+	firstService := self decodeService: self serviceNoInstVarsEncoding.
+	secondService := self decodeService: self serviceNoInstVarsEncoding.
+	self
+		assert: firstService
+		identicalTo: secondService
+%
+
+category: 'running'
+method: RsrCommandDecoderTest
+testServiceNoInstVars
+
+	| decodedService |
+	decodedService := self decodeService: self serviceNoInstVarsEncoding.
+	self
+		assert: decodedService class
+		equals: RsrServerNoInstVars.
+	self
+		assert: decodedService _id
+		equals: 1
+%
+
+category: 'running'
+method: RsrCommandDecoderTest
+testServiceReferenceService
+
+	| rootService referencedService |
+	referencedService := self decodeService: self referencedServiceEncoding.
+	self
+		assert: referencedService class
+		equals: RsrServerNoInstVars.
+	self
+		assert: referencedService _id
+		equals: 2.
+	rootService := self decodeService: self rootServiceEncoding.
+	self
+		assert: rootService class
+		equals: RsrServerReferenceService.
+	self
+		assert: rootService service
+		equals: referencedService
+%
+
+category: 'asserting'
+method: RsrCommandDecoderTest
+verifyControlWord: expected
+encoding: bytes
+
+	| actual |
+	actual := self decoder decodeControlWord: bytes readStream.
+	self
+		assert: actual
+		equals: expected
+%
+
+category: 'asserting'
+method: RsrCommandDecoderTest
+verifyImmediate: expected
+encoding: encoding
+
+	| actual |
+	actual := (self decoder decodeReference: encoding readStream) resolve: self connection.
+	self
+		assert: actual
+		equals: expected
+%
+
+! Class implementation for 'RsrCommandEncoderTest'
+
+!		Instance methods for 'RsrCommandEncoderTest'
+
+category: 'other'
+method: RsrCommandEncoderTest
+register: aService
+
+	self connection _ensureRegistered: aService
+%
+
+category: 'running-immediates'
+method: RsrCommandEncoderTest
+testDeliverResponse
+
+	| service response command result expectedEncoding |
+	service := RsrClientNoInstVars new.
+	self register: service.
+	response := #responseSymbol.
+	command := RsrDeliverResponse
+		transaction: 1
+		responseReference: (RsrReference from: response)
+		snapshots: (Array with: (RsrServiceSnapshot from: service)).
+	result := self encoder encodeDeliverResponse: command.
+	expectedEncoding :=
+		#[0 0 0 0 0 0 0 2], "DeliverResponse Command"
+		#[0 0 0 0 0 0 0 1], "Transaction Id"
+		#[0 0 0 0 0 0 0 1], "One service is part of this response"
+		self serviceNoInstVarsEncoding,
+		#[0 0 0 0 0 0 0 0], "Service Name Symbol Reference"
+		#[0 0 0 0 0 0 0 1], "Object Type for Symbol"
+		#[0 0 0 0 0 0 0 14], "Length of UTF-8 bytes"
+		#[114 101 115 112 111 110 115 101 83 121 109 98 111 108]. "#responseSymbol"
+	self
+		assert: result
+		equals: expectedEncoding
+%
+
+category: 'running'
+method: RsrCommandEncoderTest
+testNaN
+
+	| encoding |
+	"Signaling NaN is not tested.
+	Negative NaN is not tested."
+	encoding :=
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 15],
+		#[255 248 0 0 0 0 0 0].
+	self
+		verifyImmediate: RsrDoubleReference nan
+		encoding: encoding.
+%
+
+category: 'running-immediates'
+method: RsrCommandEncoderTest
+testReleaseServices
+
+	| command result expectedEncoding |
+	command := RsrReleaseServices sids: #(1 2 3 4 5).
+	result := self encoder encodeReleaseServices: command.
+	expectedEncoding :=
+		#[0 0 0 0 0 0 0 3], "ReleaseObjects Command"
+		#[0 0 0 0 0 0 0 5], "Num OIDS"
+		#[0 0 0 0 0 0 0 1], "First OID"
+		#[0 0 0 0 0 0 0 2],
+		#[0 0 0 0 0 0 0 3],
+		#[0 0 0 0 0 0 0 4],
+		#[0 0 0 0 0 0 0 5]. "Last OID"
+	self
+		assert: result
+		equals: expectedEncoding
+%
+
+category: 'running-immediates'
+method: RsrCommandEncoderTest
+testSendMessage
+
+	| service analysis command result expectedEncoding |
+	service := RsrClientNoInstVars new.
+	self register: service.
+	analysis := RsrSnapshotAnalysis
+		roots: (Array with: service)
+		connection: self connection.
+	analysis perform.
+	command := RsrSendMessage
+		transaction: 1
+		receiverReference: (RsrReference from: service)
+		selectorReference: (RsrSymbolReference from: #return42)
+		argumentReferences: #().
+	command snapshots: analysis snapshots.
+	result := self encoder encodeSendMessage: command.
+	expectedEncoding :=
+		#[0 0 0 0 0 0 0 1], "SendMessage Command"
+		#[0 0 0 0 0 0 0 1], "Transaction ID"
+		#[0 0 0 0 0 0 0 1], "One service is part of this message"
+		self serviceNoInstVarsEncoding,
+		#[0 0 0 0 0 0 0 1], "Receiver OID"
+		#[0 0 0 0 0 0 0 0], "Selector Reference"
+		#[0 0 0 0 0 0 0 1], "Object Type for Symbol"
+		#[0 0 0 0 0 0 0 8], "Length of UTF-8 bytes"
+		#[114 101 116 117 114 110 52 50], "#return42"
+		#[0 0 0 0 0 0 0 0]. "Argument Count"
+	self
+		assert: result
+		equals: expectedEncoding
+%
+
+category: 'running'
+method: RsrCommandEncoderTest
+testServiceNoInstVars
+
+	| rootService encodedBytes expectedEncoding |
+	rootService := RsrClientNoInstVars new.
+	self register: rootService.
+	encodedBytes := self encoder encodeServiceSnapshot: (RsrServiceSnapshot from: rootService).
+	expectedEncoding := self serviceNoInstVarsEncoding.
+	self
+		assert: encodedBytes
+		equals: expectedEncoding
+%
+
+category: 'running'
+method: RsrCommandEncoderTest
+testServiceReferenceService
+
+	| rootService referencedService encodedObject expectedEncoding |
+	referencedService := RsrClientNoInstVars new.
+	rootService := RsrClientReferenceService service: referencedService.
+	self
+		register: rootService;
+		register: referencedService.
+	encodedObject := self encoder encodeServiceSnapshot: (RsrServiceSnapshot from: rootService).
+	expectedEncoding :=
+		#[0 0 0 0 0 0 0 0], "type"
+		#[0 0 0 0 0 0 0 1], "rootService's OID = 1"
+		#[0 0 0 0 0 0 0 1], "Inst Var Count"
+		#[0 0 0 0 0 0 0 0], "Start of service name. OID = 0"
+		#[0 0 0 0 0 0 0 1], "Service name = 1 -> Symbol"
+		#[0 0 0 0 0 0 0 25], "Length of UTF-8 encoded bytes"
+		#[82 115 114 83 101 114 118 101 114 82 101 102 101 114 101 110 99 101 83 101 114 118 105 99 101],
+		#[0 0 0 0 0 0 0 2]. "#RsrServerReferenceService"
+	self
+		assert: encodedObject
+		equals: expectedEncoding.
+	encodedObject := self encoder encodeServiceSnapshot: (RsrServiceSnapshot from: referencedService).
+	expectedEncoding :=
+		#[0 0 0 0 0 0 0 0], "type"
+		#[0 0 0 0 0 0 0 2], "referencedService's OID = 2"
+		#[0 0 0 0 0 0 0 0], "Inst Var Count"
+		#[0 0 0 0 0 0 0 0], "Start of service name. OID = 0"
+		#[0 0 0 0 0 0 0 1], "Service name = 1 -> Symbol"
+		#[0 0 0 0 0 0 0 19], "Length of UTF-8 encoded bytes"
+		#[82 115 114 83 101 114 118 101 114 78 111 73 110 115 116 86 97 114 115]. "#RsrServerNoInstVars"
+	self
+		assert: encodedObject
+		equals: expectedEncoding
+%
+
+category: 'running'
+method: RsrCommandEncoderTest
+testUnsupportedObject
+
+	self
+		should: [self encoder encodeReference: (RsrReference from: Object new) onto: (WriteStream on: ByteArray new)]
+		raise: RsrUnsupportedObject
+%
+
+category: 'running-immediates'
+method: RsrCommandEncoderTest
+verifyControlWord: anInteger
+encoding: expected
+
+	| actual |
+	actual := ByteArray streamContents: [:stream | self encoder encodeControlWord: anInteger onto: stream].
+	self
+		assert: actual
+		equals: expected
+%
+
+category: 'running-immediates'
+method: RsrCommandEncoderTest
+verifyImmediate: anObject
+encoding: expected
+
+	| actual |
+	actual := ByteArray streamContents: [:stream | self encoder encodeReference: (RsrReference from: anObject) onto: stream].
+	self
+		assert: actual
+		equals: expected
+%
+
+! Class implementation for 'RsrConnectionSpecificationTestCase'
+
+!		Instance methods for 'RsrConnectionSpecificationTestCase'
+
+category: 'accessing'
+method: RsrConnectionSpecificationTestCase
+alternativeLocalhost
+
+	^'127.0.1.1'
+%
+
+category: 'accessing'
+method: RsrConnectionSpecificationTestCase
+localhost
+
+	^'127.0.0.1'
+%
+
+category: 'accessing'
+method: RsrConnectionSpecificationTestCase
+port
+
+	^47652
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testAcceptOnLocalhost
+
+	| acceptor initiator semaphore connectionA connectionB |
+	acceptor := RsrAcceptConnection host: self localhost port: self port.
+	acceptor ensureListening.
+	self assert: acceptor listeningPort equals: self port.
+	initiator := RsrInitiateConnection
+		             host: self localhost
+		             port: self port.
+	semaphore := Semaphore new.
+	RsrProcessModel
+		fork: [ 
+			[ connectionA := acceptor waitForConnection ] ensure: [ 
+					semaphore signal ] ]
+		named: 'Pending AcceptConnection';
+		fork: [ 
+			[ connectionB := initiator connect ] ensure: [ semaphore signal ] ]
+		named: 'Pending InitiateConnection'.
+	semaphore
+		wait;
+		wait.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen.
+	connectionA close.
+	connectionB close
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testBindToAvailablePortRange
+
+	"If no one is listening on self port, we should get that port."
+
+	| acceptor initiator semaphore connectionA connectionB |
+	acceptor := RsrAcceptConnection
+		            host: self localhost
+		            portRange: (self port to: self port + 1).
+	acceptor ensureListening.
+	self assert: acceptor listeningPort equals: self port.
+	initiator := RsrInitiateConnection
+		             host: self localhost
+		             port: acceptor listeningPort.
+	semaphore := Semaphore new.
+	RsrProcessModel
+		fork: [ 
+			[ connectionA := acceptor waitForConnection ] ensure: [ 
+					semaphore signal ] ]
+		named: 'Pending AcceptConnection';
+		fork: [ 
+			[ connectionB := initiator connect ] ensure: [ semaphore signal ] ]
+		named: 'Pending InitiateConnection'.
+	semaphore
+		wait;
+		wait.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen.
+	connectionA close.
+	connectionB close
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testBindToPartlyAvailablePortRange
+
+	"Listen on first port to force range to listen on second port."
+
+	| blocker acceptor initiator semaphore connectionA connectionB |
+	blocker := RsrAcceptConnection host: self localhost port: self port.
+	[ 
+	blocker ensureListening.
+	self assert: blocker listeningPort equals: self port.
+	acceptor := RsrAcceptConnection
+		            host: self localhost
+		            portRange: (self port to: self port + 1).
+	acceptor ensureListening.
+	self assert: acceptor listeningPort equals: self port + 1.
+	initiator := RsrInitiateConnection
+		             host: self localhost
+		             port: acceptor listeningPort.
+	semaphore := Semaphore new.
+	RsrProcessModel
+		fork: [ 
+			[ connectionA := acceptor waitForConnection ] ensure: [ 
+					semaphore signal ] ]
+		named: 'Pending AcceptConnection';
+		fork: [ 
+			[ connectionB := initiator connect ] ensure: [ semaphore signal ] ]
+		named: 'Pending InitiateConnection'.
+	semaphore
+		wait;
+		wait.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen.
+	connectionA close.
+	connectionB close ] ensure: [ blocker cancelWaitForConnection ]
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testBindToUnavailablePortRange
+
+	"Listen on both ports in range -- range should then fail."
+
+	| blocker1 blocker2 acceptor |
+	blocker1 := RsrAcceptConnection host: self localhost port: self port.
+	blocker2 := RsrAcceptConnection
+		            host: self localhost
+		            port: self port + 1.
+	[ 
+	blocker1 ensureListening.
+	self assert: blocker1 listeningPort equals: self port.
+	blocker2 ensureListening.
+	self assert: blocker2 listeningPort equals: self port + 1.
+	acceptor := RsrAcceptConnection
+		            host: self localhost
+		            portRange: (self port to: self port + 1).
+	self should: [ acceptor ensureListening ] raise: RsrInvalidBind ] 
+		ensure: [ 
+			{ 
+				blocker1.
+				blocker2 } do: [ :each | each cancelWaitForConnection ] ]
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testBindToWildcardPort
+
+	| acceptor initiator semaphore connectionA connectionB |
+	acceptor := RsrAcceptConnection
+		host: self localhost
+		port: RsrAcceptConnection wildcardPort.
+	acceptor ensureListening.
+	self assert: acceptor listeningPort > 0.
+	initiator := RsrInitiateConnection
+		host: self localhost
+		port: acceptor listeningPort.
+	semaphore := Semaphore new.
+	RsrProcessModel
+		fork: [[connectionA := acceptor waitForConnection] ensure: [semaphore signal]] named: 'Pending AcceptConnection';
+		fork: [[connectionB := initiator connect] ensure: [semaphore signal]] named: 'Pending InitiateConnection'.
+	semaphore wait; wait.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen.
+	connectionA close.
+	connectionB close
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testCancelWaitForConnection
+
+	| acceptor |
+	acceptor := RsrAcceptConnection port: self port.
+	RsrProcessModel
+		fork: [(Delay forSeconds: 1) wait. acceptor cancelWaitForConnection]
+		named: 'Canceling AcceptConnection'.
+	self
+		should: [acceptor waitForConnection]
+		raise: RsrWaitForConnectionCancelled
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testEstablishConnection
+
+	| acceptor initiator semaphore connectionA connectionB |
+	acceptor := RsrAcceptConnection port: self port.
+	initiator := RsrInitiateConnection
+		host: self localhost
+		port: self port.
+	semaphore := Semaphore new.
+	RsrProcessModel
+		fork: [[connectionA := acceptor waitForConnection] ensure: [semaphore signal]] named: 'Pending AcceptConnection';
+		fork: [[connectionB := initiator connect] ensure: [semaphore signal]] named: 'Pending InitiateConnection'.
+	semaphore wait; wait.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen.
+	connectionA close.
+	connectionB close
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testFailedAcceptOnAlternativeLocalhost
+
+	| acceptor initiator semaphore |
+	acceptor := RsrAcceptConnection
+		host: self alternativeLocalhost
+		port: self port.
+	initiator := RsrInitiateConnection
+		host: self localhost
+		port: self port.
+	semaphore := Semaphore new.
+	RsrProcessModel
+		fork: [[semaphore signal. acceptor waitForConnection] on: RsrWaitForConnectionCancelled do: [:ex | ex return]]
+		named: 'Pending WaitForConnectionCancelled'.
+	[semaphore wait.
+	self
+		should: [initiator connect]
+		raise: RsrSocketError]
+			ensure: [acceptor cancelWaitForConnection]
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testInternalConnectionSpecificationConnectReturnsConnection
+	"Ensure that sending #connect to an InternalConnectionSpecification
+	results in returning one of the created Connections."
+
+	| spec connection |
+	spec := RsrInMemoryConnectionSpecification new.
+	connection := spec connect.
+	self assert: connection isOpen.
+	connection close.
+	spec := RsrInternalSocketConnectionSpecification new.
+	connection := spec connect.
+	self assert: connection isOpen.
+	connection close
+%
+
+category: 'running'
+method: RsrConnectionSpecificationTestCase
+testListenThenLaterAccept
+
+	| acceptor initiator semaphore connectionA connectionB |
+	acceptor := RsrAcceptConnection
+		host: self localhost 
+		port: self port.
+	initiator := RsrInitiateConnection
+		host: self localhost
+		port: self port.
+	semaphore := Semaphore new.
+	acceptor ensureListening.
+	RsrProcessModel
+		fork: [semaphore signal. [connectionB := initiator connect] ensure: [semaphore signal]]
+		named: 'Pending InitiateConnection'.
+	semaphore wait.
+	connectionA := acceptor waitForConnection.
+	semaphore wait.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen.
+	connectionA close.
+	connectionB close
+%
+
+! Class implementation for 'RsrForwarderTest'
+
+!		Instance methods for 'RsrForwarderTest'
+
+category: 'running'
+method: RsrForwarderTest
+testForwarding
+	"This test needs to be improved. It is out of sync."
+
+	| service id connection forwarder sendMessage |
+	service := RsrTestService clientClass new.
+	id := 1.
+	connection := RsrConnection
+		channel: RsrNullChannel new
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals
+		oidSpigot: RsrThreadSafeNumericSpigot naturals.
+	connection open.
+	service registerWith: connection.
+	forwarder := service remoteSelf.
+	forwarder
+		arg1: 15
+		arg2: 42.
+	sendMessage := connection channel lastCommand.
+	self
+		assert: sendMessage transaction
+		equals: 1.
+	self
+		assert: (sendMessage receiverReference resolve: connection)
+		equals: service.
+	self
+		assert: (sendMessage selectorReference resolve: connection)
+		equals: #arg1:arg2:.
+	self
+		assert: (sendMessage argumentReferences collect: [:each | each resolve: connection])
+		equals: #(15 42).
+%
+
+! Class implementation for 'RsrGarbageCollectorTestCase'
+
+!		Instance methods for 'RsrGarbageCollectorTestCase'
+
+category: 'running'
+method: RsrGarbageCollectorTestCase
+testMaximumReclamation
+
+	self assert: RsrGarbageCollector maximumReclamation
+%
+
+! Class implementation for 'RsrNumericSpigotTest'
+
+!		Instance methods for 'RsrNumericSpigotTest'
+
+category: 'accessing'
+method: RsrNumericSpigotTest
+spigotClass
+
+	^RsrNumericSpigot
+%
+
+category: 'running'
+method: RsrNumericSpigotTest
+testDefault
+
+	| spigot |
+	spigot := self spigotClass new.
+	self
+		assert: spigot next
+		equals: 0.
+	self
+		assert: spigot next
+		equals: 1
+%
+
+category: 'running'
+method: RsrNumericSpigotTest
+testFloat
+
+	| spigot |
+	spigot := self spigotClass
+		start: 0
+		step: 0.5.
+	self
+		assert: spigot next
+		equals: 0.
+	self
+		assert: spigot next
+		equals: 0.5.
+	self
+		assert: spigot next
+		equals: 1.0.
+%
+
+category: 'running'
+method: RsrNumericSpigotTest
+testNaturals
+
+	| spigot |
+	spigot := self spigotClass naturals.
+	self
+		assert: spigot next
+		equals: 1.
+	self
+		assert: spigot next
+		equals: 2
+%
+
+category: 'running'
+method: RsrNumericSpigotTest
+testNegativeStep
+
+	| spigot |
+	spigot := self spigotClass
+		start: 0
+		step: -1.
+	self
+		assert: spigot next
+		equals: 0.
+	self
+		assert: spigot next
+		equals: -1.
+	self
+		assert: spigot next
+		equals: -2
+%
+
+category: 'running'
+method: RsrNumericSpigotTest
+testNext
+
+	| spigot |
+	spigot := self spigotClass naturals.
+	self
+		assert: (Array with: 1 with: 2 with: 3)
+		equals: (spigot next: 3)
+%
+
+! Class implementation for 'RsrThreadSafeNumericSpigotTest'
+
+!		Instance methods for 'RsrThreadSafeNumericSpigotTest'
+
+category: 'accessing'
+method: RsrThreadSafeNumericSpigotTest
+spigotClass
+
+	^RsrThreadSafeNumericSpigot
+%
+
+! Class implementation for 'RsrPromiseTest'
+
+!		Instance methods for 'RsrPromiseTest'
+
+category: 'running'
+method: RsrPromiseTest
+testAsyncBreak
+
+	| promise semaphore expected whenRan first second third |
+	promise := RsrPromise new.
+	semaphore := Semaphore new.
+	expected := Object new.
+	whenRan := false.
+	promise
+		when: [:object | whenRan := true. semaphore signal]
+		catch: [:reason | first := reason. semaphore signal].
+	promise
+		when: [:object | whenRan := true. semaphore signal]
+		catch: [:reason | second := reason. semaphore signal].
+	self
+		deny: promise isResolved;
+		deny: promise isBroken;
+		deny: promise isFulfilled.
+	promise break: expected.
+	self
+		assert: promise isResolved;
+		assert: promise isBroken;
+		deny: promise isFulfilled.
+	semaphore wait; wait.
+	self shortWait. "Ensure any when blocks run if they are going to schedule."
+	self deny: whenRan.
+	self
+		assert: first
+		identicalTo: expected.
+	self
+		assert: second
+		identicalTo: expected.
+	promise
+		when: [:object | whenRan := true. semaphore signal]
+		catch: [:reason | third := reason. semaphore signal].
+	semaphore wait.
+	self shortWait.
+	self deny: whenRan.
+	self
+		assert: third
+		identicalTo: expected
+%
+
+category: 'running'
+method: RsrPromiseTest
+testAsyncFulfill
+
+	| promise semaphore expected catchRan first second third |
+	promise := RsrPromise new.
+	semaphore := Semaphore new.
+	expected := Object new.
+	catchRan := false.
+	promise
+		when: [:object | first := object. semaphore signal]
+		catch: [:reason | catchRan := true. semaphore signal].
+	promise
+		when: [:object | second := object. semaphore signal]
+		catch: [:reason | catchRan := true. semaphore signal].
+	self
+		deny: promise isResolved;
+		deny: promise isBroken;
+		deny: promise isFulfilled.
+	promise fulfill: expected.
+	self
+		assert: promise isResolved;
+		deny: promise isBroken;
+		assert: promise isFulfilled.
+	semaphore wait; wait.
+	self shortWait. "Ensure any catch blocks run if they are going to schedule."
+	self deny: catchRan.
+	self
+		assert: first
+		identicalTo: expected.
+	self
+		assert: second
+		identicalTo: expected.
+	promise
+		when: [:object | third := object. semaphore signal]
+		catch: [:reason | catchRan := true. semaphore signal].
+	semaphore wait.
+	self shortWait.
+	self deny: catchRan.
+	self
+		assert: third
+		identicalTo: expected
+%
+
+category: 'running'
+method: RsrPromiseTest
+testSyncBreak
+
+	| promise expected exceptionRaised first second third |
+	promise := RsrPromise new.
+	expected := Object new.
+	exceptionRaised := false.
+	RsrProcessModel
+		fork: [[promise wait] on: RsrBrokenPromise do: [:ex | exceptionRaised := true. first := ex reason. ex return]]
+		named: 'Pending BrokenPromise'.
+	RsrProcessModel
+		fork: [[promise wait] on: RsrBrokenPromise do: [:ex | exceptionRaised := true. second := ex reason. ex return]]
+		named: 'Pending BrokenPromise'.
+	promise break: expected.
+	self shortWait. "Allow results to process."
+	self assert: exceptionRaised.
+	self
+		assert: first
+		identicalTo: expected.
+	self
+		assert: second
+		identicalTo: expected.
+	self
+		should: [promise wait]
+		raise: RsrBrokenPromise.
+	third := [promise wait]
+		on: RsrBrokenPromise
+		do: [:ex | ex return: ex reason].
+	self
+		assert: third
+		identicalTo: expected
+%
+
+category: 'running'
+method: RsrPromiseTest
+testSyncFulfill
+
+	| promise expected exceptionRaised first second |
+	promise := RsrPromise new.
+	expected := Object new.
+	exceptionRaised := false.
+	RsrProcessModel
+		fork: [[first := promise wait] on: RsrBrokenPromise do: [:ex | exceptionRaised := true. ex return]]
+		named: 'Pending BrokenPromise'.
+	RsrProcessModel
+		fork: [[second := promise wait] on: RsrBrokenPromise do: [:ex | exceptionRaised := true. ex return]]
+		named: 'Pending BrokenPromise'.
+	promise fulfill: expected.
+	self shortWait. "Allow results to process."
+	self deny: exceptionRaised.
+	self
+		assert: first
+		identicalTo: expected.
+	self
+		assert: second
+		identicalTo: expected.
+	self
+		assert: promise wait
+		identicalTo: expected
+%
+
+! Class implementation for 'RsrProtocolVersionNegotiationCodecTestCase'
+
+!		Instance methods for 'RsrProtocolVersionNegotiationCodecTestCase'
+
+category: 'accessing'
+method: RsrProtocolVersionNegotiationCodecTestCase
+codec
+
+	^RsrProtocolVersionNegotiationCodec new
+%
+
+category: 'utilities'
+method: RsrProtocolVersionNegotiationCodecTestCase
+stream: aBlock
+
+	^ByteArray streamContents: [:stream | aBlock value: stream]
+%
+
+category: 'running'
+method: RsrProtocolVersionNegotiationCodecTestCase
+testChosenVersion
+
+	| chosenVersion encoding result |
+	chosenVersion := RsrChosenVersion version: 7.
+	encoding :=
+		#[0 0 0 0 0 0 0 1], "Type"
+		#[0 0 0 0 0 0 0 7]. "Version"
+	result := self stream: [:stream | self codec encodeChosenVersion: chosenVersion onto: stream].
+	self
+		assert: result
+		equals: encoding.
+	result := self codec decode: encoding readStream.
+	self
+		assert: result
+		equals: chosenVersion
+%
+
+category: 'running'
+method: RsrProtocolVersionNegotiationCodecTestCase
+testNoVersionOverlap
+
+	| noVersionOverlap encoding result |
+	noVersionOverlap := RsrNoVersionOverlap new.
+	encoding := #[0 0 0 0 0 0 0 2]. "Type"
+	result := self stream: [:stream | self codec encodeNoVersionOverlap: noVersionOverlap onto: stream].
+	self
+		assert: result
+		equals: encoding.
+	result := self codec decode: encoding readStream.
+	self
+		assert: result
+		equals: noVersionOverlap
+%
+
+category: 'running'
+method: RsrProtocolVersionNegotiationCodecTestCase
+testSupportedVersions
+
+	| supportedVersions encoding result |
+	supportedVersions := RsrSupportedVersions versions: #(0 1 2 7).
+	encoding :=
+		#[0 0 0 0 0 0 0 0], "Type"
+		#[0 0 0 0 0 0 0 4], "4 versions supported"
+		#[0 0 0 0 0 0 0 0],
+		#[0 0 0 0 0 0 0 1],
+		#[0 0 0 0 0 0 0 2],
+		#[0 0 0 0 0 0 0 7].
+	result := self stream: [:stream | self codec encodeSupportedVersions: supportedVersions onto: stream].
+	self
+		assert: result
+		equals: encoding.
+	result := self codec decode: encoding readStream.
+	self
+		assert: result
+		equals: supportedVersions
+%
+
+! Class implementation for 'RsrSnapshotAnalysisTest'
+
+!		Instance methods for 'RsrSnapshotAnalysisTest'
+
+category: 'utilites'
+method: RsrSnapshotAnalysisTest
+analyze: anObject
+
+	| analysis |
+	analysis := RsrSnapshotAnalysis
+		roots: (Array with: anObject)
+		connection: connection.
+	analysis perform.
+	^analysis
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+setUp
+
+	super setUp.
+	connection := RsrConnection
+		channel: RsrNullChannel new
+		transactionSpigot: RsrThreadSafeNumericSpigot naturals
+		oidSpigot: RsrThreadSafeNumericSpigot naturals.
+	connection open
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+tearDown
+
+	connection close.
+	connection := nil.
+	super tearDown
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testArrayCycle
+
+	| array analysis |
+	array := Array new: 1.
+	array at: 1 put: array.
+	analysis := self analyze: array.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 1.
+	array at: 1 put: { array }.
+	analysis := self analyze: array.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 2.
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testDictionaryCycle
+
+	| dictionary analysis |
+	dictionary := Dictionary new.
+	dictionary at: 1 put: dictionary.
+	analysis := self analyze: dictionary.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 2.
+
+	dictionary removeKey: 1.
+	dictionary at: dictionary put: 1.
+	analysis := self analyze: dictionary.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 2
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testMultiPathsToSameService
+
+	"Tests issue 76, Unnecessary duplicate snapshots being sent."
+
+	| childService parentService orderedCollection analysis |
+	childService := RsrRemoteAction clientClass new.
+	parentService := RsrRemoteAction clientClass sharedVariable:
+		                 childService.
+	orderedCollection := OrderedCollection
+		                     with: childService
+		                     with: parentService.
+	analysis := self analyze: orderedCollection.
+	self assert: analysis snapshots size equals: 2.
+	self
+		assert: parentService isMirrored;
+		assert: childService isMirrored
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testNewServiceInArray
+	"Ensure a new service in a collection is properly tagged"
+
+	| service analysis expected |
+	service := RsrServerNoInstVars new.
+	analysis := self analyze: (Array with: service).
+	expected := OrderedCollection with: service.
+	self
+		assert: analysis snapshots size
+		equals: 1.
+	self assert: service isMirrored
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testNewServicesInDictionary
+	"Ensure a new service in a collection is properly tagged"
+
+	| key value dictionary analysis |
+	key := RsrServerNoInstVars new.
+	value := RsrServerNoInstVars new.
+	dictionary := Dictionary new
+		at: key put: value;
+		yourself.
+	analysis := self analyze: dictionary.
+	self
+		assert: analysis snapshots size
+		equals: 2.
+	self
+		assert: key isMirrored;
+		assert: value isMirrored
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testOrderedCollectionCycle
+
+	| oc analysis |
+	oc := OrderedCollection new.
+	oc add: oc.
+	analysis := self analyze: oc.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 1.
+
+	oc := OrderedCollection with: (Array with: oc).
+	analysis := self analyze: oc.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 3
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testServiceAllDataObjects
+	"While this code is structurally similar to #testClientNoInstVars, it ensures
+	that Data Objects are actually encoded in-line."
+
+	| client analysis expected |
+	client := RsrRemoteAction clientClass new.
+	analysis := self analyze: client.
+	expected := OrderedCollection with: client.
+	self
+		assert: analysis snapshots size
+		equals: 1.
+	self assert: client isMirrored
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testServiceNoInstVars
+
+	| client analysis expected snapshot snapshotTemplate |
+	client := RsrClientNoInstVars new.
+	analysis := self analyze: client.
+	expected := OrderedCollection with: client.
+	self assert: client isMirrored.
+	self
+		assert: analysis snapshots size
+		equals: 1.
+	snapshot := analysis snapshots first.
+	self
+		assert: snapshot slots size
+		equals: 0.
+	self assert: snapshot shouldCreateServer.
+	snapshotTemplate := connection templateResolver templateNamed: snapshot templateName.
+	self
+		assert: snapshotTemplate
+		equals: client _template
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testServiceReferencingAnotherService
+	"While this code is structurally similar to #testClientNoInstVars, it ensures
+	that Data Objects are actually encoded in-line."
+
+	| referencedService client analysis |
+	referencedService := RsrRemoteAction clientClass new.
+	client := RsrRemoteAction clientClass sharedVariable: referencedService.
+	analysis := self analyze: client.
+	self
+		assert: analysis snapshots size
+		equals: 2.
+	self
+		assert: client isMirrored;
+		assert: referencedService isMirrored
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testServiceWithCycle
+
+	| rootClient referencedClient analysis |
+	rootClient := RsrRemoteAction new.
+	referencedClient := RsrRemoteAction sharedVariable: rootClient.
+	rootClient sharedVariable: referencedClient.
+	analysis := self analyze: rootClient.
+	self
+		assert: analysis snapshots size equals: 2;
+		assert: analysis analyzedObjects size equals: 2
+%
+
+category: 'running'
+method: RsrSnapshotAnalysisTest
+testSetCycle
+
+	| set analysis |
+	set := Set new.
+	set add: set.
+	analysis := self analyze: set.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 1.
+
+	set := Set new.
+	set add: (Array with: set).
+	analysis := self analyze: set.
+	self
+		assert: analysis snapshots size equals: 0;
+		assert: analysis analyzedObjects size equals: 2
+%
+
+! Class implementation for 'RsrSocketStreamTestCase'
+
+!		Instance methods for 'RsrSocketStreamTestCase'
+
+category: 'initializing'
+method: RsrSocketStreamTestCase
+initializeStreams
+
+	| socketPair |
+	socketPair := RsrSocketPair new.
+	aStream := socketPair firstStream.
+	bStream := socketPair secondStream
+%
+
+category: 'initializing'
+method: RsrSocketStreamTestCase
+setUp
+
+	super setUp.
+	self initializeStreams
+%
+
+category: 'initializing'
+method: RsrSocketStreamTestCase
+tearDown
+
+	aStream close.
+	bStream close.
+	super tearDown
+%
+
+category: 'running'
+method: RsrSocketStreamTestCase
+testNextAfterClose
+
+	aStream close.
+	self
+		should: [aStream next]
+		raise: RsrSocketClosed.
+	self
+		should: [bStream next]
+		raise: RsrSocketClosed
+%
+
+category: 'running'
+method: RsrSocketStreamTestCase
+testNextPutAllAfterClose
+
+	self deny: aStream atEnd.
+	aStream close.
+	self assert: aStream atEnd.
+	self
+		should: [ 
+			aStream
+				nextPutAll: #[ 1 2 3 ];
+				flush ]
+		raise: RsrSocketClosed
+%
+
+category: 'running'
+method: RsrSocketStreamTestCase
+testSendReceive
+
+	| count bytes |
+	count := 1024.
+	bytes := ByteArray new: count.
+	aStream
+		nextPutAll: bytes;
+		flush.
+	self
+		assert: (bStream next: count)
+		equals: bytes
+%
+
+! Class implementation for 'RsrSocketTestCase'
+
+!		Class methods for 'RsrSocketTestCase'
+
+category: 'accessing'
+classmethod: RsrSocketTestCase
+defaultTimeLimit
+
+	^20 seconds
+%
+
+!		Instance methods for 'RsrSocketTestCase'
+
+category: 'accessing'
+method: RsrSocketTestCase
+createPair: aBlock
+
+	| address port listener peerA peerB semaphore |
+	address := '127.0.0.1'.
+	port := 45301.
+	listener := self newSocket.
+	listener
+		bindAddress: address
+		port: port.
+	listener listen: 1.
+	peerB := self newSocket.
+	semaphore := Semaphore new.
+	RsrProcessModel
+		fork: [[peerA := self deferClose: listener accept] ensure: [semaphore signal]]
+		named: 'Pending Socket Accept'.
+	RsrProcessModel
+		fork: [[peerB connectToHost: address port: port] ensure: [semaphore signal]]
+		named: 'Pending Socket Connect'.
+	semaphore wait; wait.
+	listener close.
+	((peerA notNil and: [peerA isConnected]) and: [peerB isConnected])
+		ifTrue: [aBlock value: peerA value: peerB]
+		ifFalse: [self error: 'Unable to create Socket Pair']
+%
+
+category: 'cleanup'
+method: RsrSocketTestCase
+deferClose: aSocket
+
+	sockets nextPut: aSocket.
+	^aSocket
+%
+
+category: 'accessing'
+method: RsrSocketTestCase
+newSocket
+
+	^self deferClose: RsrSocket new
+%
+
+category: 'running'
+method: RsrSocketTestCase
+setUp
+
+	super setUp.
+	sockets := SharedQueue new.
+%
+
+category: 'running'
+method: RsrSocketTestCase
+tearDown
+
+	[sockets isEmpty]
+		whileFalse: [sockets next close].
+	super tearDown
+%
+
+category: 'running-server'
+method: RsrSocketTestCase
+testAcceptConnects
+
+	| listener client server |
+	listener := self newSocket.
+	listener
+		bindAddress: '127.0.0.1'
+		port: 45300.
+	self
+		assert: listener port
+		equals: 45300.
+	listener listen: 1.
+	client := self newSocket.
+	self
+		deny: client isConnected;
+		deny: listener isConnected.
+	client connectToHost: '127.0.0.1' port: 45300.
+	server := self deferClose: listener accept.
+	self
+		assert: server port
+		equals: 45300.
+	self assert: (client port > 1023).
+	self
+		assert: client isConnected;
+		assert: server isConnected;
+		deny: listener isConnected
+%
+
+category: 'running-server'
+method: RsrSocketTestCase
+testAcceptOnAlreadyClosedSocket
+
+	| listener |
+	listener := self newSocket.
+	listener
+		bindAddress: '127.0.0.1'
+		port: 45300.
+	listener listen: 1.
+	listener close.
+	self
+		should: [listener accept]
+		raise: RsrSocketError
+%
+
+category: 'running-server'
+method: RsrSocketTestCase
+testCloseDuringAccept
+
+	| listener |
+	listener := self newSocket.
+	listener
+		bindAddress: '127.0.0.1'
+		port: 45300.
+	listener listen: 1.
+	RsrProcessModel
+		fork: [(Delay forSeconds: 1) wait. listener close]
+		named: 'Pending Socket Close'.
+	self
+		should: [listener accept]
+		raise: RsrSocketError
+%
+
+category: 'running-client'
+method: RsrSocketTestCase
+testConnectBoundSocket
+
+	| listener |
+	listener := self newSocket.
+	listener
+		bindAddress: '127.0.0.1'
+		port: 45300.
+	self
+		should:
+			[listener
+				connectToHost: 'gemtalksystems.com'
+				port: 80]
+		raise: RsrSocketError
+%
+
+category: 'running-client'
+method: RsrSocketTestCase
+testFailedConnects
+
+	| socket |
+	socket := self newSocket.
+	self deny: socket isConnected.
+	self
+		should:
+			[socket
+				connectToHost: 'do.no.create.used.for.testing.gemtalksystems.com'
+				port: 80]
+		raise: RsrConnectFailed.
+	socket := self newSocket.
+	self
+		should:
+			[socket
+				connectToHost: 'gemtalksystems.com'
+				port: 70000]
+		raise: RsrConnectFailed.
+	socket := self newSocket.
+	self
+		should:
+			[socket
+				connectToHost: '127.0.0.1'
+				port: 79]
+		raise: RsrConnectFailed.
+	socket close
+%
+
+category: 'running-server'
+method: RsrSocketTestCase
+testInvalidBind
+
+	| listener |
+	listener := self newSocket.
+	self "This IP is publicly routable and owned by Cloudflare. Should be invalid on all testing hosts."
+		should: [listener bindAddress: '1.1.1.1' port: 45300]
+		raise: RsrInvalidBind.
+	listener := self newSocket.
+	self
+		should: [listener bindAddress: '127.0.0.1' port: 98765432]
+		raise: RsrInvalidBind
+%
+
+category: 'running-server'
+method: RsrSocketTestCase
+testListenWithoutBind
+
+	| listener |
+	listener := self newSocket.
+	listener listen: 1.
+	self assert: (listener port > 1023)
+%
+
+category: 'running-read/write'
+method: RsrSocketTestCase
+testPartialRead
+
+	| peerA peerB writeBuffer readBuffer count numRead |
+	self
+		createPair:
+			[:a :b |
+			peerA := a.
+			peerB := b].
+	count := 1024.
+	writeBuffer := ByteArray new: count.
+	1
+		to: count
+		do: [:i | writeBuffer at: i put: (i \\ 256)].
+	readBuffer := ByteArray withAll: writeBuffer.
+	peerA
+		write: count - 1
+		from: writeBuffer
+		startingAt: 1.
+	numRead := peerB
+		read: count
+		into: readBuffer
+		startingAt: 1.
+	self
+		assert: numRead
+		equals: count - 1.
+	self
+		assert: readBuffer
+		equals: writeBuffer
+%
+
+category: 'running-read/write'
+method: RsrSocketTestCase
+testReadAfterPeerClose
+
+	| peerA peerB readBuffer count numRead |
+	self
+		createPair:
+			[:a :b |
+			peerA := a.
+			peerB := b].
+	count := 1024.
+	readBuffer := ByteArray new: count.
+	peerA close.
+	self
+		should:
+			[numRead := peerB
+				read: count
+				into: readBuffer
+				startingAt: 1]
+		raise: RsrSocketClosed
+%
+
+category: 'running-read/write'
+method: RsrSocketTestCase
+testReadWrite
+
+	| peerA peerB writeBuffer readBuffer count numWritten numRead |
+	self
+		createPair:
+			[:a :b |
+			peerA := a.
+			peerB := b].
+	count := 1024.
+	writeBuffer := ByteArray new: count.
+	1
+		to: count
+		do: [:i | writeBuffer at: i put: (i \\ 256)].
+	readBuffer := ByteArray withAll: writeBuffer.
+	numWritten := peerA
+		write: count
+		from: writeBuffer
+		startingAt: 1.
+	self
+		assert: numWritten
+		equals: count.
+	numRead := peerB
+		read: count
+		into: readBuffer
+		startingAt: 1.
+	self
+		assert: numRead
+		equals: count.
+	self
+		assert: readBuffer
+		equals: writeBuffer
+%
+
+category: 'running-client'
+method: RsrSocketTestCase
+testSuccessfulConnect
+
+	| socket |
+	socket := self newSocket.
+	self deny: socket isConnected.
+	socket
+		connectToHost: 'gemtalksystems.com'
+		port: 80.
+	self assert: socket isConnected.
+	socket close.
+	self deny: socket isConnected
+%
+
+category: 'running-read/write'
+method: RsrSocketTestCase
+testUnconnectedReadWrite
+
+	| socket count bytes |
+	socket := self newSocket.
+	count := 1024.
+	bytes := ByteArray new: 1024.
+	self
+		should:
+			[socket
+				read: count
+				into: bytes
+				startingAt: 1]
+		raise: RsrSocketClosed.
+	self
+		should:
+			[socket
+				write: count
+				from: bytes
+				startingAt: 1]
+		raise: RsrSocketClosed
+%
+
+! Class implementation for 'RsrSystemTestCase'
+
+!		Class methods for 'RsrSystemTestCase'
+
+category: 'testing'
+classmethod: RsrSystemTestCase
+isAbstract
+
+	^self == RsrSystemTestCase
+%
+
+!		Instance methods for 'RsrSystemTestCase'
+
+category: 'expecting'
+method: RsrSystemTestCase
+expectCatch: aPromise
+
+	| semaphore wasFulfilled result whenValue |
+	semaphore := Semaphore new.
+	wasFulfilled := false.
+	aPromise
+		when: [:value | whenValue := value. wasFulfilled := true. semaphore signal]
+		catch: [:reason | result := reason. semaphore signal].
+	semaphore wait.
+	self deny: wasFulfilled.
+	^result
+%
+
+category: 'expecting'
+method: RsrSystemTestCase
+expectWhen: aPromise
+
+	| semaphore wasBroken result |
+	semaphore := Semaphore new.
+	wasBroken := false.
+	aPromise
+		when: [:value | result := value. semaphore signal]
+		catch: [:r | wasBroken := true. semaphore signal].
+	semaphore wait.
+	self deny: wasBroken.
+	^result
+%
+
+category: 'initialization'
+method: RsrSystemTestCase
+initializeInMemoryConnections
+
+	| spec |
+	spec := RsrInMemoryConnectionSpecification new.
+	spec connect.
+	connectionA := spec connectionA.
+	connectionB := spec connectionB.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen
+%
+
+category: 'initialization'
+method: RsrSystemTestCase
+initializeSocketConnections
+
+	| spec |
+	spec := RsrInternalSocketConnectionSpecification new.
+	spec connect.
+	connectionA := spec connectionA.
+	connectionB := spec connectionB.
+	self
+		assert: connectionA isOpen;
+		assert: connectionB isOpen
+%
+
+category: 'accessing'
+method: RsrSystemTestCase
+peerOf: aService
+
+	| connectionInPeer |
+	connectionInPeer := aService _connection.
+	connectionInPeer ifNil: [self assert: false description: 'Unable to obtain the peer of an unregistered Service.'].
+	^connectionInPeer == connectionA
+		ifTrue: [connectionB serviceAt: aService _id]
+		ifFalse: [connectionA serviceAt: aService _id]
+%
+
+category: 'initialization'
+method: RsrSystemTestCase
+setUp
+	"Subclasses need to start their connections by calling
+	#initializeInMemoryConnections or #initializeSocketConnections.
+	#tearDown will close connections."
+
+	super setUp
+%
+
+category: 'initialization'
+method: RsrSystemTestCase
+tearDown
+
+	connectionA ifNotNil: [:conn | conn close].
+	connectionB ifNotNil: [:conn | conn close].
+	connectionA := connectionB := nil.
+	super tearDown
+%
+
+! Class implementation for 'RsrConnectionTestCase'
+
+!		Class methods for 'RsrConnectionTestCase'
+
+category: 'testing'
+classmethod: RsrConnectionTestCase
+isAbstract
+
+	^self == RsrConnectionTestCase
+%
+
+!		Instance methods for 'RsrConnectionTestCase'
+
+category: 'running'
+method: RsrConnectionTestCase
+testAllowExistingInstancesOfDeniedTemplate
+
+	| policy template allow value promise result |
+	policy := RsrTestPolicy new.
+	template := RsrServiceNoInstVars.
+	connectionB policy: policy.
+	value := Time millisecondClockValue.
+
+	"Send a new instance before Policy denies it."
+	allow := template clientClass new.
+	allow registerWith: connectionA.
+	promise := allow asyncSendReturnArgument: value.
+	result := self expectWhen: promise.
+	self
+		assert: result
+		equals: value.
+
+	"Reject the template and try again with the existing instance."
+	policy deny: template.
+	promise := allow asyncSendReturnArgument: value.
+	result := self expectWhen: promise.
+	self
+		assert: result
+		equals: value.
+%
+
+category: 'running'
+method: RsrConnectionTestCase
+testPolicyRejection
+
+	| policy template allow reject value promise result reason |
+	policy := RsrTestPolicy new.
+	template := RsrServiceNoInstVars.
+	connectionB policy: policy.
+	value := Time millisecondClockValue.
+
+	"Send a new instance before Policy denies it."
+	allow := template clientClass new.
+	allow registerWith: connectionA.
+	promise := allow asyncSendReturnArgument: value.
+	result := self expectWhen: promise.
+	self
+		assert: result
+		equals: value.
+
+	"Reject the template and try again with a new instance."
+	policy deny: template.
+	reject := template clientClass new.
+	reject registerWith: connectionA.
+	promise := reject asyncSendReturnArgument: value.
+	reason := self expectCatch: promise.
+	self
+		assert: reason class
+		equals: RsrPolicyRejectedServiceServer.
+	self
+		assert: reason templateName
+		equals: template templateClassName.
+	self
+		assert: reason sid
+		equals: reject _id
+%
+
+category: 'running'
+method: RsrConnectionTestCase
+testPolicyRejectsFrameworkTemplate
+
+	| policy template service frameworkService promise result |
+	policy := RsrTestPolicy new.
+	template := RsrPolicyRejectedService.
+	connectionA policy: policy.
+	connectionB policy: policy.
+	service := RsrServiceNoInstVars clientClass new.
+	service registerWith: connectionA.
+
+	"Send a new instance before Policy denies it."
+	frameworkService := template clientClass new.
+	promise := service asyncSendReturnArgument: frameworkService.
+	result := self expectWhen: promise.
+	self
+		assert: result
+		identicalTo: frameworkService.
+
+	"Ensure it is allowed even if the Policy rejects it."
+	policy deny: template.
+	frameworkService := template clientClass new.
+	promise := service asyncSendReturnArgument: frameworkService.
+	result := self expectWhen: promise.
+	self
+		assert: result
+		identicalTo: frameworkService.
+%
+
+category: 'running'
+method: RsrConnectionTestCase
+testWaitUntilClose
+
+	| semaphore marker |
+	semaphore := Semaphore new.
+	marker := false.
+	RsrProcessModel
+		fork:
+			[semaphore signal.
+			[connectionB waitUntilClose.
+			marker := true]
+				ensure: [semaphore signal]]
+		named: 'Pending Connection Closure'.
+	semaphore wait.
+	self deny: marker.
+	connectionA close.
+	semaphore wait.
+	self assert: marker
+%
+
+! Class implementation for 'RsrInMemoryConnectionTestCase'
+
+!		Instance methods for 'RsrInMemoryConnectionTestCase'
+
+category: 'running'
+method: RsrInMemoryConnectionTestCase
+setUp
+
+	super setUp.
+	self initializeInMemoryConnections
+%
+
+! Class implementation for 'RsrSocketConnectionTestCase'
+
+!		Instance methods for 'RsrSocketConnectionTestCase'
+
+category: 'running'
+method: RsrSocketConnectionTestCase
+setUp
+
+	super setUp.
+	self initializeSocketConnections
+%
+
+! Class implementation for 'RsrEphemeronMourningDeadlock'
+
+!		Instance methods for 'RsrEphemeronMourningDeadlock'
+
+category: 'running'
+method: RsrEphemeronMourningDeadlock
+setUp
+
+	super setUp.
+	self initializeSocketConnections
+%
+
+category: 'running'
+method: RsrEphemeronMourningDeadlock
+testEphemeronMourningDoesNotDeadlock
+	"The RsrRegistry protects its backing datastructure using a mutex.
+	When returning a large number of new Services, the data structure
+	can grow triggering a garbage collection. Any services which are 
+	collected need to be removed from the registry.
+	The ephemeron mourning by default happens on the currently active
+	thread. This can result in attempting to access the critical section in
+	the registry twice. It isn't safe to use a recursive lock.
+	This test is intended to recreate this case ensuring that RSR properly
+	activates a background mourning process preventing the deadlock.
+
+	We lock the registry by waiting in a critical section. Then, we mourn an ephemeron.
+	This should force the mourning process to wait until the test exits the critical section."
+
+	| service semaphore isRunning |
+	"Ensure we are processing #mourn async"
+	self assert: RsrAsyncMournHandler current isActive.
+	"We now have an ephemeron setup for this service."
+	service := RsrClientNoInstVars new
+		registerWith: connectionA;
+		yourself.
+	semaphore := Semaphore new.
+	isRunning := true.
+	RsrProcessModel
+		fork:
+			[connectionA _privateRegistryOnlyForTests critical: [semaphore signal; wait]]
+		named: 'Lock registry'.
+	[semaphore wait.
+	service := nil.
+	RsrGarbageCollector maximumReclamation.
+	self
+		assert: RsrAsyncMournHandler current process waitingOn class
+		equals: Semaphore]
+		ensure: [semaphore signal]
+%
+
+! Class implementation for 'RsrLifetimeTest'
+
+!		Class methods for 'RsrLifetimeTest'
+
+category: 'testing'
+classmethod: RsrLifetimeTest
+isAbstract
+
+	^self == RsrLifetimeTest
+%
+
+!		Instance methods for 'RsrLifetimeTest'
+
+category: 'utilities'
+method: RsrLifetimeTest
+evaluateAsRemoteAction: aBlock
+	"Evaluate the block and return the result through RSR."
+
+	| client server |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: aBlock.
+	^client value
+%
+
+category: 'running'
+method: RsrLifetimeTest
+testEnsurePushedClientServerLifetime
+	"This test is designed to ensure that a Server created via a 'pushed' Client
+	exhibit the correct lifetime properties."
+
+	| client sid server actual |
+	client := RsrClientNoInstVars new
+		registerWith: connectionA;
+		synchronize.
+	sid := client _id.
+	self maximumReclamation. "Ensure the Server is strongly referenced in connectionB."
+	server := connectionB
+		serviceAt: sid
+		ifAbsent: [self assert: false].
+	client := nil.
+	self maximumReclamation. "Ensure the Client is garbage collected."
+	(Delay forSeconds: 1) wait. "Ensure the ReleaseServices Command is propogated and processed by connectionB."
+	self maximumReclamation. "Ensure the Server is still referenced even after a garbage collect."
+	actual := connectionA
+		serviceAt: sid
+		ifAbsent: [nil].
+	self
+		assert: actual
+		equals: nil.
+	actual := connectionB
+		serviceAt: sid
+		ifAbsent: [self assert: false].
+	self
+		assert: actual
+		identicalTo: server.
+	actual := nil. "Ensure we do not retain an extra reference to the Server."
+	server := nil.
+	self maximumReclamation. "Ensure Server is removed."
+	actual := connectionB
+		serviceAt: sid
+		ifAbsent: [nil].
+	self
+		assert: actual
+		equals: nil
+%
+
+category: 'running'
+method: RsrLifetimeTest
+testEnsureReturnedServerLifetime
+	"Return a newly created Server (that is not registered.) It should persist in the framework until 
+	both the associated Client is garbage collected and local references are dropped.
+
+	If you change this method -- change #testEnsureReturnRegisteredServerLifetime as well."
+
+	| client sid server result |
+	client := self evaluateAsRemoteAction: [RsrServerNoInstVars new].
+	sid := client _id.
+	self maximumReclamation. "Ensure the Server instance is referenced."
+	server := connectionB
+		serviceAt: sid
+		ifAbsent: [self assert: false].
+	client := nil.
+	self maximumReclamation.
+	(Delay forSeconds: 1) wait. "Release Client."
+	self maximumReclamation.
+	"Ensure Client is released."
+	result := connectionA
+		serviceAt: sid
+		ifAbsent: [nil].
+	self
+		assert: result
+		equals: nil.
+	"Ensure Server is still registered."
+	result := connectionB
+		serviceAt: sid
+		ifAbsent: [self assert: false].
+	self
+		assert: result
+		equals: server.
+	result := server := nil.
+	self maximumReclamation.
+	result := connectionB
+		serviceAt: sid
+		ifAbsent: [nil].
+	self
+		assert: result
+		equals: nil
+%
+
+category: 'running'
+method: RsrLifetimeTest
+testEnsureReturnRegisteredServerLifetime
+	"Return a newly created Server (that is registered.) It should persist in the framework until 
+	both the associated Client is garbage collected and local references are dropped.
+
+	If you change this method -- change #testEnsureReturnedServerLifetime as well."
+
+	| client sid server result |
+	client := self evaluateAsRemoteAction: [RsrServerNoInstVars new registerWith: connectionB].
+	sid := client _id.
+	self maximumReclamation. "Ensure the Server instance is referenced."
+	server := connectionB
+		serviceAt: sid
+		ifAbsent: [self assert: false].
+	client := nil.
+	self maximumReclamation.
+	(Delay forSeconds: 1) wait. "Release Client."
+	self maximumReclamation.
+	"Ensure Client is released."
+	result := connectionA
+		serviceAt: sid
+		ifAbsent: [nil].
+	self
+		assert: result
+		equals: nil.
+	"Ensure Server is still registered."
+	result := connectionB
+		serviceAt: sid
+		ifAbsent: [self assert: false].
+	self
+		assert: result
+		equals: server.
+	result := server := nil.
+	self maximumReclamation.
+	result := connectionB
+		serviceAt: sid
+		ifAbsent: [nil].
+	self
+		assert: result
+		equals: nil
+%
+
+! Class implementation for 'RsrInMemoryLifetimeTest'
+
+!		Instance methods for 'RsrInMemoryLifetimeTest'
+
+category: 'running'
+method: RsrInMemoryLifetimeTest
+setUp
+
+	super setUp.
+	self initializeInMemoryConnections
+%
+
+! Class implementation for 'RsrSocketLifetimeTest'
+
+!		Instance methods for 'RsrSocketLifetimeTest'
+
+category: 'running'
+method: RsrSocketLifetimeTest
+setUp
+
+	super setUp.
+	self initializeSocketConnections
+%
+
+! Class implementation for 'RsrMessageSendingTest'
+
+!		Class methods for 'RsrMessageSendingTest'
+
+category: 'testing'
+classmethod: RsrMessageSendingTest
+isAbstract
+
+	^self == RsrMessageSendingTest
+%
+
+!		Instance methods for 'RsrMessageSendingTest'
+
+category: 'utilities'
+method: RsrMessageSendingTest
+terminateCurrentProcess
+
+	Processor activeProcess terminate
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testAsyncRemoteError
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [Error new tag: 'tag'; messageText: 'messageText'; signal].
+	reason := self expectCatch: client asyncValue.
+	self assert: reason isRemoteException.
+	self
+		assert: reason exceptionClassName
+		equals: #Error.
+	self
+		assert: reason tag
+		equals: 'tag'.
+	self
+		assert: reason messageText
+		equals: 'messageText'.
+	self
+		assert: reason stack isString;
+		assert: reason stack size > 0
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testAsyncReturnArgument
+
+	| client server promise result |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [:arg | arg].
+	promise := client asyncValue: client.
+	result := self expectWhen: promise.
+	self
+		assert: result
+		identicalTo: client
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testAsyncReturnService
+
+	| client server service |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrValueHolderServer new].
+	service := self expectWhen: client asyncValue.
+	self
+		assert: service class
+		equals: RsrValueHolderClient
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testChangeRemoteState
+
+	| marker client server |
+	marker := false.
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [marker := true].
+	client value.
+	self assert: marker
+%
+
+category: 'running-close during message'
+method: RsrMessageSendingTest
+testCloseConnectionDuringMessageSend
+
+	| client server promise reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [(Delay forSeconds: 10) wait].
+	promise := client asyncValue.
+	connectionA close.
+	reason := self expectCatch: promise.
+	self
+		assert: reason class
+		equals: RsrConnectionClosedBeforeReceivingResponse
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testDebugHandlerBreak
+	"Ensure that if a debug handler resolves the message,
+	that the correct reason is received remotely."
+
+	| marker client server reason |
+	marker := #testMarker.
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrResumableError signal. 42 "ensure we do not return the marker"].
+	server debugHandler: [:exception :messageSend :resolver | resolver break: marker. nil "ensure we do not return the marker"].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason
+		equals: marker.
+	server action: [RsrNonresumableError signal. 42 "ensure we do not return the marker"].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason
+		equals: marker
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testDebugHandlerException
+	"Ensure that an exception that occurs in the debug handler
+	is reported back as the reason for Promise breaking."
+
+	| marker client server reason |
+	marker := #testMarker.
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrResumableError signal].
+	server debugHandler: [:exception :messageSend :resolver | Error signal].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason exceptionClassName
+		equals: #Error.
+	server action: [RsrNonresumableError signal].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason exceptionClassName
+		equals: #Error.
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testDebugHandlerFulfill
+	"Ensure that if a debug handler resolves the message,
+	that the fulfillment value is received remotely."
+
+	| marker client server |
+	marker := #testMarker.
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrResumableError signal. 42 "ensure we do not return the marker"].
+	server debugHandler: [:exception :messageSend :resolver | resolver fulfill: marker. nil "ensure we do not return the marker"].
+	self
+		assert: client value
+		equals: marker.
+	server action: [RsrNonresumableError signal. 42 "ensure we do not return the marker"].
+	self
+		assert: client value
+		equals: marker
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testDebugHandlerNoResolutionWithNonresumableException
+	"Ensure that if the debug handler does not resolve the exception
+	and the exception is nonresumable, that we Break the Promise
+	reporting on the unresolved exception."
+
+	| marker client server reason |
+	marker := #testMarker.
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrNonresumableError signal].
+	server debugHandler: [:exception :messageSend :resolver | marker].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason exceptionClassName
+		equals: #RsrNonresumableError
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testDebugHandlerNoResolutionWithResumableException
+	"Ensure that if the debug handler does not resolve the exception
+	and the exception is resumable, we resume with the evaluation
+	result of the debug handler."
+
+	| marker client server |
+	marker := #testMarker.
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrResumableError signal].
+	server debugHandler: [:exception :messageSend :resolver | marker].
+	self
+		assert: client value
+		equals: marker
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testPrePostUpdate
+
+	| client server pre post |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	pre := post := false.
+	server
+		preUpdateHandler: [pre := true];
+		postUpdateHandler: [post := true];
+		action: [].
+	client value.
+	self
+		assert: pre;
+		assert: post
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testPrePostUpdateError
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [true].
+	self assert: client value.
+	server
+		preUpdateHandler: [Error signal: 'preUpdate'];
+		postUpdateHandler: [].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason exceptionClassName
+		equals: #Error.
+	self
+		assert: reason messageText
+		equals: 'preUpdate'.
+	server
+		preUpdateHandler: [];
+		postUpdateHandler:  [Error signal: 'postUpdate'].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason exceptionClassName
+		equals: #Error.
+	self
+		assert: reason messageText
+		equals: 'postUpdate'.
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testRemoteError
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [Error new tag: 'tag'; messageText: 'messageText'; signal].
+	[client value]
+		on: RsrBrokenPromise
+		do: [:ex | reason := ex reason. ex return].
+	self assert: reason isRemoteException.
+	self
+		assert: reason exceptionClassName
+		equals: #Error.
+	self
+		assert: reason tag
+		equals: 'tag'.
+	self
+		assert: reason messageText
+		equals: 'messageText'.
+	self
+		assert: reason stack isString;
+		assert: reason stack size > 0
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testRemoteErrorWithTag
+
+	| client server tag messageText reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	tag := nil.
+	messageText := 'messageText'.
+	server action: [Error new tag: tag; messageText: messageText; signal].
+	reason := [client value]
+		on: RsrBrokenPromise
+		do: [:ex | ex return: ex reason].
+	self assert: reason isRemoteException.
+	self
+		assert: reason tag
+		equals: 'messageText'.
+	self
+		assert: reason messageText
+		equals: 'messageText'.
+	self
+		assert: reason stack isString;
+		assert: reason stack size > 0.
+	tag := 42.
+	reason := [client value]
+		on: RsrBrokenPromise
+		do: [:ex | ex return: ex reason].
+	self
+		assert: reason tag
+		equals: '42'.
+	tag := RsrSignalErrorInAsString new.
+	reason := [client value]
+		on: RsrBrokenPromise
+		do: [:ex | ex return: ex reason].
+	self
+		assert: reason tag
+		equals: 'Unable to pack #tag containing an instance of RsrSignalErrorInAsString'
+%
+
+category: 'running-termination'
+method: RsrMessageSendingTest
+testRemoteProcessTerminationDuringDebugHandler
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server
+		action: [Error signal];
+		debugHandler: [:ex :message :resolver | self terminateCurrentProcess].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason
+		equals: 'Message send terminated without a result'
+%
+
+category: 'running-termination'
+method: RsrMessageSendingTest
+testRemoteProcessTerminationDuringMessageSend
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [self terminateCurrentProcess].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason
+		equals: 'Message send terminated without a result'
+%
+
+category: 'running-termination'
+method: RsrMessageSendingTest
+testRemoteProcessTerminationDuringPrePostUpdate
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server
+		preUpdateHandler: [self terminateCurrentProcess];
+		postUpdateHandler: [];
+		action: [].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason
+		equals: 'Message send terminated without a result'
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testReturnAlsoUpdatesLocalService
+	"Ensure that when the remote peer service returns a value,
+	that it is also sent to update the local service."
+
+	| client server value response |
+	client := RsrReflectedVariableTestClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	value := 42.
+	self
+		deny: client varA
+		equals: value.
+	self
+		deny: client varB
+		equals: value.
+	response := client setVarsToAndReturn: value.
+	self
+		assert: response
+		equals: value.
+	self
+		assert: server varA
+		equals: value.
+	self
+		assert: server varB
+		equals: value.
+	self
+		assert: client varA
+		equals: value.
+	self
+		assert: client varB
+		equals: value
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testReturnArgument
+
+	| client server arguments dt response |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [:object | object].
+	arguments := OrderedCollection new
+		addAll: #( '' #symbol 'string' $h 0 -14 14 18446744073709551616 -18446744073709551616 nil true false );
+ 		add: (Character codePoint: 16r259F);
+		add: (Dictionary new at: 1 put: 2; yourself);
+		add: (Set with: 14);
+		add: #[1 2 3 4];
+		add: (OrderedCollection with: 42 with: 43);
+		add: #(1 2 #(nil));
+		yourself.
+	dt := RsrDateAndTime now.
+	response := client value: dt.
+	self
+		assert: (dt asSeconds * 1000000) rounded
+		equals: (response asSeconds * 1000000) rounded.
+	arguments
+		do:
+			[:each | | result |
+			result := client value: each.
+			self
+				assert: result
+				equals: each].
+	arguments
+		do:
+			[:each | | result |
+			result := server evaluateAction: each.
+			self
+				assert: result
+				equals: each].
+	self
+		assert: (client value: arguments)
+		equals: arguments.
+	self
+		assert: (server evaluateAction: arguments)
+		equals: arguments.
+	self
+		assert: (client value: client)
+		identicalTo: client
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testReturnInvalidObject
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [Object new].
+	self
+		should: [client value]
+		raise: RsrBrokenPromise.
+	reason := [client value]
+		on: RsrBrokenPromise
+		do: [:ex | ex return: ex reason].
+	self assert: reason isRemoteException.
+	self
+		assert: reason exceptionClassName
+		equals: #RsrUnsupportedObject.
+	self
+		assert: reason tag
+		equals: 'Instances of #Object do not support replication.'.
+	self
+		assert: reason messageText
+		equals: 'Instances of #Object do not support replication.'.
+	self
+		assert: reason stack isString;
+		assert: reason stack size > 0
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testReturnNewService
+
+	| client server returnedService |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrValueHolderServer new].
+	returnedService := client value.
+	self
+		assert: returnedService class
+		equals: RsrValueHolderClient
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testReturnNewServiceInArray
+
+	| client server array returnedService |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [Array with: RsrValueHolderServer new].
+	array := client value.
+	returnedService := array first.
+	self
+		assert: returnedService class
+		equals: RsrValueHolderClient
+%
+
+category: 'running'
+method: RsrMessageSendingTest
+testReturnSymbol
+
+	| client server symbol result |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	symbol := #testSymbol.
+	server action: [symbol].
+	result := client value.
+	self
+		assert: result
+		equals: symbol
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testSendInvalidObject
+
+	| client server |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [:arg | arg].
+	self
+		should: [client value: Object new]
+		raise: RsrUnsupportedObject
+%
+
+category: 'running-errors'
+method: RsrMessageSendingTest
+testUnimplementedRemoteSend
+	"Ensure a remote DNU is reported back to the sender."
+
+	| marker client reason |
+	marker := #testMarker.
+	client := RsrClientNoInstVars new
+		registerWith: connectionA;
+		synchronize.
+	reason := self expectCatch: client unimplementedRemoteSend.
+	self
+		assert: reason class
+		equals: RsrRemoteExceptionServer.
+	self
+		assert: reason exceptionClassName
+		equals: #MessageNotUnderstood
+%
+
+! Class implementation for 'RsrInMemoryMessageSendingTest'
+
+!		Instance methods for 'RsrInMemoryMessageSendingTest'
+
+category: 'running'
+method: RsrInMemoryMessageSendingTest
+setUp
+
+	super setUp.
+	self initializeInMemoryConnections
+%
+
+! Class implementation for 'RsrSocketMessageSendingTest'
+
+!		Instance methods for 'RsrSocketMessageSendingTest'
+
+category: 'running'
+method: RsrSocketMessageSendingTest
+setUp
+
+	super setUp.
+	self initializeSocketConnections
+%
+
+! Class implementation for 'RsrServiceTest'
+
+!		Class methods for 'RsrServiceTest'
+
+category: 'testing'
+classmethod: RsrServiceTest
+isAbstract
+
+	^self == RsrServiceTest
+%
+
+!		Instance methods for 'RsrServiceTest'
+
+category: 'running-utilities'
+method: RsrServiceTest
+mirror: aService
+
+	| client |
+	client := RsrClientNoInstVars new
+		registerWith: connectionA;
+		yourself.
+	^client sendReturnArgument: aService
+%
+
+category: 'running'
+method: RsrServiceTest
+testAnalyzeServiceRegisteredWithDifferentConnection
+
+	| instance analysis |
+	instance := RsrRemoteAction clientClass new.
+	analysis := RsrSnapshotAnalysis
+		roots: (Array with: instance)
+		connection: connectionA.
+	analysis perform.
+	self assert: instance isMirrored.
+	analysis := RsrSnapshotAnalysis
+		roots: (Array with: instance)
+		connection: connectionB.
+	self
+		should: [analysis perform]
+		raise: RsrAlreadyRegistered
+%
+
+category: 'running'
+method: RsrServiceTest
+testEnsureServersAreCachedAndReused
+
+	| client service1 service2 |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	service1 := connectionB serviceAt: client _id.
+	self mirror: client.
+	service2 := connectionB serviceAt: client _id.
+	self
+		assert: service1
+		identicalTo: service2
+%
+
+category: 'running'
+method: RsrServiceTest
+testHasRemoteSelf
+
+	| service |
+	service := RsrTestService clientClass new.
+	self mirror: service.
+	self deny: nil == service remoteSelf
+%
+
+category: 'running'
+method: RsrServiceTest
+testInitialization
+
+	| instance |
+	instance := RsrRemoteAction clientClass new.
+	self
+		assert: instance isMirrored
+		equals: false.
+	self
+		assert: instance _id
+		equals: nil.
+	self
+		assert: instance _connection
+		equals: nil
+%
+
+category: 'running'
+method: RsrServiceTest
+testIsMirrored
+
+	| instance |
+	instance := RsrRemoteAction clientClass new.
+	self deny: instance isMirrored.
+	self mirror: instance.
+	self assert: instance isMirrored
+%
+
+category: 'running'
+method: RsrServiceTest
+testMessageDispatchedConcurrentlyToSingleService
+	"Ensure all messages are sent concurrently (including those sent to a single service)"
+
+	| client server counter promise1 promise2 |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	counter := 0.
+	server action: [counter := counter + 1. self shortWait. counter].
+	promise1 := client asyncValue.
+	promise2 := client asyncValue.
+	self
+		assert: promise1 wait
+		equals: 2. "The #shortWait will cause the second counter increment before the counter is returned."
+	self
+		assert: promise2 wait
+		equals: 2
+%
+
+category: 'running'
+method: RsrServiceTest
+testMessagesDispactchedConcurrentlyForMultipleServices
+	"Ensure messages are dispatched concurrently"
+
+	| client1 server1 client2 server2 semaphore expected1 expected2 promise1 promise2 |
+	client1 := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	client2 := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server1 := connectionB serviceAt: client1 _id.
+	server2 := connectionB serviceAt: client2 _id.
+	semaphore := Semaphore new.
+	expected1 := #expected1.
+	expected2 := #expected2.
+	server1 action: [semaphore wait. expected1].
+	server2 action: [semaphore signal. expected2].
+	promise1 := client1 asyncValue.
+	promise2 := client2 asyncValue.
+	self shortWait.
+	self
+		assert: promise1 isResolved;
+		assert: promise2 isResolved.
+	self
+		assert: promise1 value
+		equals: expected1.
+	self
+		assert: promise2 value
+		equals: expected2
+%
+
+category: 'running'
+method: RsrServiceTest
+testPostRegistration
+
+	| client  server testClient testServer regCount |
+	"#registerWith: validation"
+	client := RsrInstrumentedClient new.
+	self
+		assert: client postRegistrationCount
+		equals: 0.
+	client registerWith: connectionA.
+	self
+		assert: client postRegistrationCount
+		equals: 1.
+	client registerWith: connectionA.
+	self
+		assert: client postRegistrationCount
+		equals: 1.
+	client synchronize.
+	server := self peerOf: client.
+	self
+		assert: client postRegistrationCount
+		equals: 1.
+	self
+		assert: server postRegistrationCount
+		equals: 0.
+
+	"Validate implicit registration of argument Service"
+	testClient := RsrInstrumentedClient new.
+	server action: [:testServerArg | testServerArg postRegistrationCount].
+	regCount := client value: testClient.
+	self
+		assert: regCount
+		equals: 0.
+	self
+		assert: testClient postRegistrationCount
+		equals: 1.
+	testServer := self peerOf: testClient.
+	self
+		assert: testServer postRegistrationCount
+		equals: 0.
+
+	"Validate implicit registration of returned Services"
+	testClient := testServer := nil.
+	server action: [testServer := RsrInstrumentedServer new].
+	testClient := client value.
+	self
+		assert: testClient postRegistrationCount
+		equals: 0.
+	self
+		assert: testServer postRegistrationCount
+		equals: 1
+%
+
+category: 'running'
+method: RsrServiceTest
+testPostRegistrationRaisesException
+
+	| client server reason tag badService signaledException caughtException |
+	"Return values"
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := self peerOf: client.
+	tag := DateAndTime now asString.
+	server action: [RsrRemoteActionServer new postRegistrationHandler: [Error new tag: tag; signal]; yourself].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason exceptionClassName
+		equals: #Error.
+	self
+		assert: reason tag
+		equals: tag. "This string came through RSR. It is equivalent but not identical."
+
+	"Message sends"
+	signaledException := Error new.
+	badService := RsrRemoteActionServer new
+		postRegistrationHandler: [signaledException signal];
+		yourself.
+	caughtException := [client value: badService]
+		on: Error
+		do: [:ex | ex return: ex].
+	self
+		assert: signaledException
+		identicalTo: caughtException "RSR did not alter this exception. It should be identical."
+%
+
+category: 'running'
+method: RsrServiceTest
+testPrePostUpdate
+
+	| client server | 
+	client := RsrInstrumentedClient new
+		registerWith: connectionA;
+		yourself.
+	self
+		assert: client preUpdateCount
+		equals: 0.
+	self
+		assert: client postUpdateCount
+		equals: 0.
+	client return: nil.
+	server := connectionB serviceAt: client _id.
+	self
+		assert: client preUpdateCount
+		equals: 1.
+	self
+		assert: client postUpdateCount
+		equals: 1.
+	self
+		assert: server preUpdateCount
+		equals: 1.
+	self
+		assert: server postUpdateCount
+		equals: 1.
+	client return: nil.
+	self
+		assert: client preUpdateCount
+		equals: 2.
+	self
+		assert: client postUpdateCount
+		equals: 2.
+	self
+		assert: server preUpdateCount
+		equals: 2.
+	self
+		assert: server postUpdateCount
+		equals: 2.
+%
+
+category: 'running'
+method: RsrServiceTest
+testReflectedVariableNames
+
+	| client server clientNames serverNames |
+	client := RsrClientTestService new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	clientNames := RsrServiceSnapshot reflectedVariablesFor: client.
+	serverNames := RsrServiceSnapshot reflectedVariablesFor: server.
+	self
+		assert: clientNames
+		equals: serverNames.
+	self
+		assert: clientNames size
+		equals: 1.
+	self
+		assert: (clientNames at: 1) asSymbol
+		equals: #sharedVariable.
+	client := RsrReflectedVariableTestClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	clientNames := RsrServiceSnapshot reflectedVariablesFor: client.
+	serverNames := RsrServiceSnapshot reflectedVariablesFor: server.
+	self
+		assert: clientNames
+		equals: serverNames.
+	self
+		assert: clientNames size
+		equals: 2.
+	self
+		assert: (clientNames at: 1) asSymbol
+		equals: #varA.
+	self
+		assert: (clientNames at: 2) asSymbol
+		equals: #varB
+%
+
+category: 'running'
+method: RsrServiceTest
+testRegisterWith
+
+	| instance |
+	instance := RsrRemoteAction clientClass new.
+	self deny: instance isMirrored.
+	instance registerWith: connectionA.
+	self assert: instance isMirrored.
+	self
+		should: [instance registerWith: connectionB]
+		raise: RsrAlreadyRegistered
+%
+
+category: 'running'
+method: RsrServiceTest
+testReturnServerWithoutAssociatedClient
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [RsrKnownServer new].
+	reason := self expectCatch: client asyncValue.
+	self
+		assert: reason class
+		equals: RsrDecodingRaisedException
+%
+
+category: 'running'
+method: RsrServiceTest
+testSendClientWithoutAssociatedServer
+
+	| client server reason |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [:x | x].
+	reason := self expectCatch: (client asyncValue: RsrKnownClient new).
+	self
+		assert: reason class
+		equals: RsrRemoteExceptionServer.
+	self
+		assert: reason exceptionClassName
+		equals: #RsrUnknownClass
+%
+
+category: 'running'
+method: RsrServiceTest
+testVariableReflection
+
+	| localService remoteService |
+	localService := RsrTestService clientClass new
+		sharedVariable: #shared;
+		privateVariable: #private;
+		yourself.
+	self mirror: localService.
+	remoteService := connectionB serviceAt: localService _id.
+	self
+		assert: localService sharedVariable
+		identicalTo: remoteService sharedVariable.
+	self
+		assert: localService privateVariable
+		identicalTo: #private.
+	self
+		assert: remoteService privateVariable
+		identicalTo: nil
+%
+
+! Class implementation for 'RsrInMemoryServiceTest'
+
+!		Instance methods for 'RsrInMemoryServiceTest'
+
+category: 'running'
+method: RsrInMemoryServiceTest
+setUp
+
+	super setUp.
+	self initializeInMemoryConnections
+%
+
+! Class implementation for 'RsrSocketServiceTest'
+
+!		Instance methods for 'RsrSocketServiceTest'
+
+category: 'running'
+method: RsrSocketServiceTest
+setUp
+
+	super setUp.
+	self initializeSocketConnections
+%
+
+! Class implementation for 'RsrSpeciesEquality'
+
+!		Class methods for 'RsrSpeciesEquality'
+
+category: 'testing'
+classmethod: RsrSpeciesEquality
+isAbstract
+
+	^self == RsrSpeciesEquality
+%
+
+!		Instance methods for 'RsrSpeciesEquality'
+
+category: 'accessing'
+method: RsrSpeciesEquality
+basicExamples
+	"Give a samples of each species to ensure Collection classes are able to encode each type successfully."
+
+	^{RsrClientNoInstVars new.
+	#h.
+	#''.
+	'h'.
+	''.
+	0.
+	234.
+	-97.
+	$s.
+	nil.
+	true.
+	false.
+	{}.
+	{RsrClientNoInstVars new. {}.}.
+	#[].
+	#[123].
+	Set new.
+	Set with: 42.
+	OrderedCollection new.
+	OrderedCollection with: #x.
+	Dictionary new.
+	Dictionary new at: #key put: #value; yourself.
+	RsrDateAndTime posixEpoch.
+	RsrDateAndTime fromMicroseconds: -1000000. "1969-12-31T23:59:59-00:00"}
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testArray
+
+	self
+		verify: #();
+		verify: (Array withAll: self basicExamples)
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testBoolean
+
+	self
+		verify: true;
+		verify: false
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testByteArray
+
+	self
+		verify: #[];
+		verify: (ByteArray withAll: (0 to: 255));
+		verify: (ByteArray new: 1024)
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testCharacter
+
+	self
+		verify: (Character codePoint: 0);
+		verify: (Character codePoint: 65);
+		verify: $A;
+		verify: (Character codePoint: 16r01D4);
+		verify: (Character codePoint: 16r8334)
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testDateAndTime
+
+	self
+		verify: (RsrDateAndTime fromMicroseconds: -491277642567488); "1954-06-07T14:59:17.432512-07:00"
+		verify: (RsrDateAndTime fromMicroseconds: 1562692562657612). "2019-07-09T10:16:02.657612-07:00"
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testDictionary
+
+	| example |
+	example := Dictionary new.
+	self verify: example.
+	self basicExamples do: [:each | each ifNotNil: [example at: each put: each]].
+	example at: #testDictionaryPrivateKey put: nil.
+	self verify: example
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testInteger
+
+	self
+		verify: 0;
+		verify: -1;
+		verify: 1;
+		verify: (2 raisedTo: 32);
+		verify: (2 raisedTo: 32) negated;
+		verify: (2 raisedTo: 64);
+		verify: (2 raisedTo: 64) negated;
+		verify: 4598754392654025898794;
+		verify: -13750198234577893465
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testOrderedCollection
+
+	self
+		verify: OrderedCollection new;
+		verify: (OrderedCollection withAll: self basicExamples)
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testService
+
+	| clientClass serverClass |
+	clientClass := RsrRemoteAction clientClass.
+	serverClass := RsrRemoteAction serverClass.
+	self
+		verify: clientClass new;
+		verify: (clientClass sharedVariable: clientClass new);
+		verify: (serverClass sharedVariable: clientClass new)
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testServiceWithUnsupportedObject
+
+	| service |
+	service := RsrClientNoInstVars new
+		registerWith: connectionA;
+		yourself.
+	self
+		should: [service sendReturnArgument: (RsrValueHolderClient value: Object new)]
+		raise: RsrUnsupportedObject
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testSet
+
+	self
+		verify: Set new;
+		verify: (Set withAll: self basicExamples)
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testString
+
+	self
+		verify: '';
+		verify: 'string'
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testSymbol
+
+	self
+		verify: #'';
+		verify: #symbol
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testUndefinedObject
+
+	self verify: nil
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testUnicodeString
+
+	self verify: self unicodeString
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+testUnicodeSymbol
+
+	self verify: self unicodeString asSymbol
+%
+
+category: 'running'
+method: RsrSpeciesEquality
+unicodeString
+
+	^String
+		with: $a
+		with: (Character codePoint: 16r8349)
+		with: (Character codePoint: 16r10E60)
+%
+
+category: 'asserting'
+method: RsrSpeciesEquality
+verify: anObject
+	"Send <anObject> through RSR and have it returned. Assert it is equivalent."
+
+	| client server |
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [:object | server sharedVariable: object. object].
+	self
+		assert: (client value: anObject)
+		equals: anObject.
+	self
+		assert: client sharedVariable
+		equals: anObject
+%
+
+! Class implementation for 'RsrInMemorySpeciesEquality'
+
+!		Instance methods for 'RsrInMemorySpeciesEquality'
+
+category: 'running'
+method: RsrInMemorySpeciesEquality
+setUp
+
+	super setUp.
+	self initializeInMemoryConnections
+%
+
+! Class implementation for 'RsrSocketSpeciesEquality'
+
+!		Instance methods for 'RsrSocketSpeciesEquality'
+
+category: 'running'
+method: RsrSocketSpeciesEquality
+setUp
+
+	super setUp.
+	self initializeSocketConnections
+%
+
+! Class implementation for 'RsrStressTest'
+
+!		Class methods for 'RsrStressTest'
+
+category: 'accessing'
+classmethod: RsrStressTest
+defaultTimeLimit
+
+	^30 seconds
+%
+
+category: 'testing'
+classmethod: RsrStressTest
+isAbstract
+
+	^self == RsrStressTest
+%
+
+!		Instance methods for 'RsrStressTest'
+
+category: 'initialize/release'
+method: RsrStressTest
+cleanupServices
+
+	client := server := nil
+%
+
+category: 'accessing'
+method: RsrStressTest
+client
+
+	^client
+%
+
+category: 'running-utilities'
+method: RsrStressTest
+concurrentlyRun: aBlock
+
+	| anyCurtailed semaphores |
+	anyCurtailed := false.
+	semaphores := (1 to: self numThreads) collect: [:each | Semaphore new].
+	semaphores do: [:semaphore | RsrProcessModel fork: [[self repeatedlyRun: aBlock. semaphore signal] ifCurtailed: [anyCurtailed := true. semaphore signal]] named: 'Concurrent Test Thread'].
+	semaphores do: [:semaphore | semaphore wait].
+	self deny: anyCurtailed
+%
+
+category: 'initialize/release'
+method: RsrStressTest
+initializeServices
+
+	client := RsrRemoteActionClient new
+		registerWith: connectionA;
+		synchronize.
+	server := connectionB serviceAt: client _id.
+	server action: [:x | x]
+%
+
+category: 'accessing'
+method: RsrStressTest
+numThreads
+
+	^15
+%
+
+category: 'running-utilities'
+method: RsrStressTest
+repeatedlyRun: aBlock
+
+	self repetitions timesRepeat: aBlock
+%
+
+category: 'running-utilities'
+method: RsrStressTest
+repeatedlySend: anObject
+
+	self repeatedlyRun: [self send: anObject]
+%
+
+category: 'accessing'
+method: RsrStressTest
+repetitions
+
+	^1000
+%
+
+category: 'running-utilities'
+method: RsrStressTest
+send: anObject
+
+	self client value: anObject
+%
+
+category: 'accessing'
+method: RsrStressTest
+server
+
+	^server
+%
+
+category: 'initialize/release'
+method: RsrStressTest
+setUp
+
+	super setUp.
+	self
+		initializeConnections;
+		initializeServices
+%
+
+category: 'initialize/release'
+method: RsrStressTest
+tearDown
+
+	self cleanupServices.
+	super tearDown
+%
+
+category: 'running'
+method: RsrStressTest
+test10MBytes
+
+	| bytes |
+	bytes := ByteArray new: 1024 * 1024 * 10.
+	50 timesRepeat: [self send: bytes]
+%
+
+category: 'running'
+method: RsrStressTest
+test1KBytes
+
+	self repeatedlySend: (ByteArray new: 1024)
+%
+
+category: 'running'
+method: RsrStressTest
+test1MBytes
+
+	self repeatedlySend: (ByteArray new: 1024 squared)
+%
+
+category: 'running'
+method: RsrStressTest
+test2KBytes
+
+	self repeatedlySend: (ByteArray new: 1024 *2)
+%
+
+category: 'running'
+method: RsrStressTest
+testBasicSends
+
+	self repeatedlySend: nil
+%
+
+category: 'running'
+method: RsrStressTest
+testConcurrent1KBytes
+
+	self concurrentlyRun: [self client value: (ByteArray new: 1024)]
+%
+
+category: 'running'
+method: RsrStressTest
+testConcurrent2KBytes
+
+	self concurrentlyRun: [self client value: (ByteArray new: 2 * 1024)]
+%
+
+category: 'running'
+method: RsrStressTest
+testConcurrentBasicSends
+
+	self concurrentlyRun: [self client value: nil]
+%
+
+! Class implementation for 'RsrInMemoryStressTest'
+
+!		Instance methods for 'RsrInMemoryStressTest'
+
+category: 'initializing'
+method: RsrInMemoryStressTest
+initializeConnections
+
+	self initializeInMemoryConnections
+%
+
+! Class implementation for 'RsrSocketStressTest'
+
+!		Class methods for 'RsrSocketStressTest'
+
+category: 'accessing'
+classmethod: RsrSocketStressTest
+defaultTimeLimit
+	"These tests take longer over a Socket"
+
+	^60 seconds
+%
+
+!		Instance methods for 'RsrSocketStressTest'
+
+category: 'initializing'
+method: RsrSocketStressTest
+initializeConnections
+
+	self initializeSocketConnections
+%
+
+! Class implementation for 'RsrTemplateResolverTestCase'
+
+!		Instance methods for 'RsrTemplateResolverTestCase'
+
+category: 'accessing'
+method: RsrTemplateResolverTestCase
+resolver
+
+	^RsrTemplateResolver new
+%
+
+category: 'running'
+method: RsrTemplateResolverTestCase
+testTemplateFor
+
+	| service template |
+	service := RsrRemoteActionClient new.
+	template := self resolver templateFor: service.
+	self
+		assert: template
+		identicalTo: RsrRemoteAction.
+	service := RsrRemoteActionServer new.
+	template := self resolver templateFor: service.
+	self
+		assert: template
+		identicalTo: RsrRemoteAction
+%
+
+category: 'running'
+method: RsrTemplateResolverTestCase
+testTemplateNamed
+
+	| template |
+	template := self resolver templateNamed: #RsrRemoteAction.
+	self
+		assert: template
+		identicalTo: RsrRemoteAction.
+	self
+		should: [self resolver templateNamed: #DoNotCreateThisClass]
+		raise: RsrUnknownTemplate
+%
+
+category: 'running'
+method: RsrTemplateResolverTestCase
+testTemplateNamedIfAbsent
+
+	| marker template |
+	marker := Object new.
+	template := self resolver
+		templateNamed: #RsrRemoteAction
+		ifAbsent: [marker].
+	self
+		assert: template
+		identicalTo: RsrRemoteAction.
+	template := self resolver
+		templateNamed: #DoNotCreateThisClass
+		ifAbsent: [marker].
+	self
+		assert: template
+		identicalTo: marker
+%
+
+! Class implementation for 'RsrTemplateResolverWithClassVersions'
+
+!		Instance methods for 'RsrTemplateResolverWithClassVersions'
+
+category: 'accessing'
+method: RsrTemplateResolverWithClassVersions
+resolver
+
+	^RsrTemplateResolver new
+%
+
+category: 'cleanup'
+method: RsrTemplateResolverWithClassVersions
+tearDown
+
+	RsrService
+		rwSubclass: 'RsrVersionService'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: 'RemoteServiceReplication-GemStone-Test'
+		options: #().
+	super tearDown
+%
+
+category: 'running'
+method: RsrTemplateResolverWithClassVersions
+testVersionClassAfterCreatingService
+
+	| template service result |
+	template := RsrVersionService.
+	service := template clientClass new.
+	result := self resolver templateFor: service.
+	self
+		assert: result
+		identicalTo: template.
+	"Revision the Service class and Template"
+	RsrService
+		rwSubclass: 'RsrVersionService'
+		instVarNames: {'a' + Time millisecondClockValue printString}
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: 'RemoteServiceReplication-GemStone-Test'
+		options: #().
+	result := self resolver templateFor: service.
+	self
+		assert: result
+		identicalTo: template.
+	self
+		deny: result
+		identicalTo: RsrVersionService.
+	result := self resolver templateFor: RsrVersionService clientClass new.
+	self
+		assert: result
+		identicalTo: RsrVersionService
+%
+
+! Class implementation for 'RsrTestingProcessModelTestCase'
+
+!		Instance methods for 'RsrTestingProcessModelTestCase'
+
+category: 'running'
+method: RsrTestingProcessModelTestCase
+exceptionCase
+
+	| sema |
+	sema := Semaphore new.
+	RsrProcessModel fork: [[Error signal] ensure: [sema signal]] ensure: 'Ensure w/ signal'.
+	sema wait
+%
+
+category: 'running'
+method: RsrTestingProcessModelTestCase
+noExceptionCase
+
+	| sema |
+	sema := Semaphore new.
+	RsrProcessModel fork: [sema signal] named: 'Signal Semaphore'.
+	sema wait
+%
+
+category: 'running'
+method: RsrTestingProcessModelTestCase
+testCurrentStackDump
+
+	| stack |
+	stack := RsrProcessModel currentStackDump.
+	self
+		assert: stack isString;
+		assert: stack size > 0
+%
+
+category: 'running'
+method: RsrTestingProcessModelTestCase
+testException
+
+	| testCase |
+	testCase := self class selector: #exceptionCase.
+	self
+		should: [testCase runCase]
+		raise: Exception
+%
+
+category: 'running'
+method: RsrTestingProcessModelTestCase
+testNoException
+
+	| testCase |
+	testCase := self class selector: #noExceptionCase.
+	self
+		shouldnt: [testCase runCase]
+		raise: Exception
+%
+
+! Class implementation for 'RsrTokenExchangeCodecTestCase'
+
+!		Instance methods for 'RsrTokenExchangeCodecTestCase'
+
+category: 'accessing'
+method: RsrTokenExchangeCodecTestCase
+codec
+
+	^RsrTokenExchangeCodec new
+%
+
+category: 'utilities'
+method: RsrTokenExchangeCodecTestCase
+stream: aBlock
+
+	^ByteArray streamContents: aBlock
+%
+
+category: 'running'
+method: RsrTokenExchangeCodecTestCase
+testToken
+
+	| tokenBytes expected token result |
+	tokenBytes := #[16r58 16r18 16rE8 16rA2 16rB6 16rA6 16r91 16r39 16rD2 16rA6 16rC1 16r13 16r15 16r65 16r0F 16r6A].
+	expected := 
+		#[0 0 0 0 0 0 0 0], "Type"
+		#[0 0 0 0 0 0 0 16], "token byte length"
+		tokenBytes.
+	token := RsrToken bytes: tokenBytes.
+	result := self stream: [:stream | self codec encodeToken: token onto: stream].
+	self
+		assert: result
+		equals: expected.
+	result := self codec decode: expected readStream.
+	self
+		assert: result
+		equals: token
+%
+
+category: 'running'
+method: RsrTokenExchangeCodecTestCase
+testTokenAccepted
+
+	| expected tokenAccepted result |
+	expected := #[0 0 0 0 0 0 0 1]. "Type"
+	tokenAccepted := RsrTokenAccepted new.
+	result := self stream: [:stream | self codec encodeTokenAccepted: tokenAccepted onto: stream].
+	self
+		assert: result
+		equals: expected.
+	result := self codec decode: expected readStream.
+	self
+		assert: result
+		equals: tokenAccepted
+%
+
+category: 'running'
+method: RsrTokenExchangeCodecTestCase
+testTokenRejected
+
+	| expected tokenRejected result |
+	expected := #[0 0 0 0 0 0 0 2]. "Type"
+	tokenRejected := RsrTokenRejected new.
+	result := self stream: [:stream | self codec encodeTokenRejected: tokenRejected onto: stream].
+	self
+		assert: result
+		equals: expected.
+	result := self codec decode: expected readStream.
+	self
+		assert: result
+		equals: tokenRejected
+%
+
+! Class extensions for 'RsrCharacterArrayReference'
+
+!		Class methods for 'RsrCharacterArrayReference'
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrCharacterArrayReference
+convertToBytes: aCharacterArray
+
+	^aCharacterArray encodeAsUTF8
+%
+
+!		Instance methods for 'RsrCharacterArrayReference'
+
+category: '*remoteservicereplication-gemstone'
+method: RsrCharacterArrayReference
+convertBytes: aByteArray
+
+	^aByteArray decodeFromUTF8ToString
+%
+
+! Class extensions for 'RsrConnection'
+
+!		Instance methods for 'RsrConnection'
+
+category: '*remoteservicereplication'
+method: RsrConnection
+channel
+
+	^channel
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+channel: aChannel
+
+	channel := aChannel.
+	channel connection: self
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+channelDisconnected
+
+	self log info: 'Disconnected'.
+	self close
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+initialize
+
+	super initialize.
+	transactionSpigot := RsrThreadSafeNumericSpigot naturals.
+	pendingMessages := RsrThreadSafeDictionary new.
+	registry := RsrThreadSafeDictionary new.
+	log := RsrLog new.
+	announcer := Announcer new.
+	templateResolver := RsrTemplateResolver new.
+	policy := RsrDefaultPolicy new
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+log
+
+	^log
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+mournActionForClientSID: aSID
+
+	^[registry removeKey: aSID.
+			self _releaseSID: aSID]
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+mournActionForServerSID: aSID
+
+	^[registry removeKey: aSID]
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+oidSpigot
+
+	^oidSpigot
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+oidSpigot: anIntegerSpigot
+
+	oidSpigot := anIntegerSpigot
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+pendingMessages
+
+	^pendingMessages
+%
+
+category: '*remoteservicereplication-gemstone'
+method: RsrConnection
+platformSpecificOpeningTasks
+	"Ensure that we are mourning ephemerons asynchronously."
+
+	RsrAsyncMournHandler current ensureStarted
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+serviceAt: aSID
+
+	^self
+		serviceAt: aSID
+		ifAbsent: [RsrUnknownSID signal: aSID printString]
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+serviceAt: aSID
+ifAbsent: aBlock
+	"Return the service associated with the provided SID."
+
+	| entry |
+	entry := registry at: aSID ifAbsent: [nil].
+	"Ensure we do not hold the lock for long."
+	entry == nil
+		ifTrue: [^aBlock value].
+	"The Service may have been garbage collected but
+	the entry may not yet be removed. Ensure we
+	evaluate the block in that case as well."
+	^entry service
+		ifNil: aBlock
+		ifNotNil: [:service | service]
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+transactionSpigot
+
+	^transactionSpigot
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+transactionSpigot: anObject
+
+	transactionSpigot := anObject
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+unknownError: anException
+
+	self close
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_ensureRegistered: aService
+	aService _connection == nil
+		ifTrue: [ 
+			self _register: aService as: oidSpigot next.
+			aService postRegistration.
+			^ self ].
+	aService _connection == self
+		ifFalse: [ ^ RsrAlreadyRegistered signalService: aService intendedConnection: self ]
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_forwarderClass
+
+	^RsrForwarder
+%
+
+category: '*remoteservicereplication-gemstone-test'
+method: RsrConnection
+_privateRegistryOnlyForTests
+
+	^registry
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_receivedCommand: aCommand
+	"Execute the command in the context of the receiving Connection."
+
+	RsrProcessModel
+		fork:
+			[RsrProcessModel configureFrameworkProcess.
+			aCommand executeFor: self]
+		named: 'Processing ', aCommand class name
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_register: aService
+as: sid
+
+	| registryEntry mournAction |
+	aService
+		_id: sid
+		connection: self.
+	mournAction := aService isClient
+		ifTrue: [self mournActionForClientSID: sid]
+		ifFalse: [self mournActionForServerSID: sid].
+	registryEntry := RsrRegistryEntry
+		service: aService
+		onMourn: mournAction.
+	registry
+		at: sid
+		put: registryEntry
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_releaseSID: aSID
+
+	| command |
+	self isOpen
+		ifFalse: [^self].
+	self log trace: 'Cleaning up OID:', aSID printString.
+	command := RsrReleaseServices sids: (Array with: aSID).
+	self _sendCommand: command
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_remoteClientReleased: aSID
+	"Remotely, a Client instance has been garbage collected.
+	Ensure we only reference the associated service weakly."
+
+	| entry |
+	entry := registry
+		at: aSID
+		ifAbsent: [^self].
+	entry becomeWeak.
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_sendCommand: aCommand
+	"Send the provided Command to our peer."
+
+	channel send: aCommand
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_sendMessage: aMessage
+to: aService
+
+"Open coordination window"
+	"Send dirty transitive closure of aRemoteMessage"
+	"Send DispatchMessage command"
+"Coorination window closed"
+	"Return Promise"
+	| analysis receiverReference selectorReference argumentReferences dispatchCommand promise pendingMessage |
+	self isOpen
+		ifFalse: [self error: 'Connection is not open'].
+	analysis := RsrSnapshotAnalysis
+		roots: (Array with: aService), aMessage arguments
+		connection: self.
+	analysis perform.
+	receiverReference := RsrReference from: aService.
+	selectorReference := RsrReference from: aMessage selector.
+	argumentReferences := aMessage arguments collect: [:each | RsrReference from: each].
+	dispatchCommand := RsrSendMessage
+		transaction: self transactionSpigot next
+		receiverReference: receiverReference
+		selectorReference: selectorReference
+		argumentReferences: argumentReferences.
+	dispatchCommand snapshots: analysis snapshots.
+	promise := RsrPromise new.
+	pendingMessage := RsrPendingMessage
+		services: nil "I don't think we need to cache services here. They will remain on the stack unless they were removed from the transitive closure by another proc"
+		promise: promise.
+	self pendingMessages
+		at: dispatchCommand transaction
+		put: pendingMessage.
+	self _sendCommand: dispatchCommand.
+	^promise
+%
+
+category: '*remoteservicereplication'
+method: RsrConnection
+_stronglyRetain: aServer
+	"Retain the already registered server strongly."
+
+	| entry |
+	entry := registry
+		at: aServer _id
+		ifAbsent: [RsrUnknownSID signal: aServer _id printString].
+	entry becomeStrong
+%
+
+! Class extensions for 'RsrDateAndTime'
+
+!		Class methods for 'RsrDateAndTime'
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrDateAndTime
+fromMicroseconds: anInteger
+
+    ^DateAndTime
+        posixSeconds: (anInteger / 1000000)
+        offset: Duration zero
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrDateAndTime
+microsecondsSinceEpoch: aDateAndTime
+
+	^((aDateAndTime asSeconds - self posixEpoch asSeconds) * 1000000) rounded
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrDateAndTime
+now
+
+	^DateAndTime now
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrDateAndTime
+posixEpoch
+
+	^DateAndTime
+        posixSeconds: 0
+        offset: Duration zero
+%
+
+! Class extensions for 'RsrDoubleReference'
+
+!		Class methods for 'RsrDoubleReference'
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrDoubleReference
+convertToBytes: aFloat
+
+	| bytes |
+	bytes := ByteArray new: 8.
+	bytes
+		doubleAt: 1
+		put: aFloat.
+	^bytes
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrDoubleReference
+infinity
+
+	^Float fromString: 'Infinity'
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrDoubleReference
+nan
+
+	^Float fromString: '-NaN'
+%
+
+!		Instance methods for 'RsrDoubleReference'
+
+category: '*remoteservicereplication-gemstone'
+method: RsrDoubleReference
+convertBytes: aByteArray
+
+	^aByteArray doubleAt: 1
+%
+
+! Class extensions for 'RsrForwarder'
+
+!		Class methods for 'RsrForwarder'
+
+category: '*remoteservicereplication'
+classmethod: RsrForwarder
+on: anRsrObject
+
+	| instance |
+	instance := self new.
+	instance _service: anRsrObject.
+	^instance
+%
+
+!		Instance methods for 'RsrForwarder'
+
+category: '*remoteservicereplication'
+method: RsrForwarder
+doesNotUnderstand: aMessage
+
+	^_service _connection
+		_sendMessage: aMessage
+		to: _service
+%
+
+category: '*remoteservicereplication'
+method: RsrForwarder
+_service: aService
+
+	_service := aService
+%
+
+! Class extensions for 'RsrObject'
+
+!		Class methods for 'RsrObject'
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrObject
+new
+
+	^super new initialize
+%
+
+!		Instance methods for 'RsrObject'
+
+category: '*remoteservicereplication-gemstone'
+method: RsrObject
+initialize
+
+	^self
+%
+
+! Class extensions for 'RsrProcessModel'
+
+!		Class methods for 'RsrProcessModel'
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrProcessModel
+current
+	^ SessionTemps current
+		at: self keyForCurrent
+		ifAbsent: [ self resetCurrent ]
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrProcessModel
+current: concurrency
+	^ SessionTemps current at: self keyForCurrent put: concurrency
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrProcessModel
+keyForCurrent
+	^ #'RsrCurrentProcessModel'
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrProcessModel
+resetCurrent
+	^ self current: self new
+%
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrProcessModel
+unhandledExceptionClass
+	"Return the class which signals that an unhandled exception has been signaled."
+
+	^RsrUnhandledException
+%
+
+!		Instance methods for 'RsrProcessModel'
+
+category: '*remoteservicereplication-gemstone'
+method: RsrProcessModel
+configureUnhandleExceptionProtection
+
+	Processor activeProcess
+		breakpointLevel: 1;
+		debugActionBlock:
+			[:ex |
+			({ClientForwarderSend. Halt. RsrUnhandledException.} includes: ex class)
+				ifTrue: [ex _signalGciError]
+				ifFalse: [RsrUnhandledException signal: ex]].
+%
+
+category: '*remoteservicereplication-gemstone'
+method: RsrProcessModel
+currentStackDump
+
+	^GsProcess stackReportToLevel: 1000
+%
+
+! Class extensions for 'RsrReference'
+
+!		Class methods for 'RsrReference'
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrReference
+initializeReferenceMapping
+	"RsrReference initializeReferenceMapping"
+
+	referenceMapping := Dictionary new.
+	referenceMapping
+		at: Symbol
+		put: RsrSymbolReference.
+	referenceMapping
+		at: DoubleByteSymbol
+		put: RsrSymbolReference.
+	referenceMapping
+		at: QuadByteSymbol
+		put: RsrSymbolReference.
+	referenceMapping
+		at: String
+		put: RsrStringReference.
+    referenceMapping
+        at: Unicode7
+        put: RsrStringReference.
+    referenceMapping
+        at: DoubleByteString
+        put: RsrStringReference.
+    referenceMapping
+        at: QuadByteString
+        put: RsrStringReference.
+	referenceMapping
+		at: LargeInteger
+		put: RsrIntegerReference.
+	referenceMapping
+		at: SmallInteger
+		put: RsrIntegerReference.
+	referenceMapping
+		at: Character
+		put: RsrCharacterReference.
+	referenceMapping
+		at: UndefinedObject
+		put: RsrNilReference.
+	referenceMapping
+		at: Boolean
+		put: RsrTrueReference.
+	referenceMapping
+		at: Array
+		put: RsrArrayReference.
+	referenceMapping
+		at: ByteArray
+		put: RsrByteArrayReference.
+	referenceMapping
+		at: Set
+		put: RsrSetReference.
+	referenceMapping
+		at: OrderedCollection
+		put: RsrOrderedCollectionReference.
+	referenceMapping
+		at: Dictionary
+		put: RsrDictionaryReference.
+	referenceMapping
+		at: DateAndTime
+		put: RsrDateAndTimeReference.
+	referenceMapping
+		at: SmallDateAndTime
+		put: RsrDateAndTimeReference.
+	referenceMapping
+		at: SmallDouble
+		put: RsrDoubleReference.
+	referenceMapping
+		at: Float
+		put: RsrDoubleReference.
+	^referenceMapping
+%
+
+category: '*remoteservicereplication'
+classmethod: RsrReference
+referenceClassFor: anObject
+
+	(anObject isKindOf: RsrService)
+		ifTrue: [^RsrServiceReference].
+	^self referenceMapping
+		at: anObject class
+		ifAbsent: [RsrUnsupportedObject signal: anObject]
+%
+
+! Class extensions for 'RsrToken'
+
+!		Class methods for 'RsrToken'
+
+category: '*remoteservicereplication-gemstone'
+classmethod: RsrToken
+newRandom
+	"Create a new Token with random bytes."
+
+	| random bytes |
+	random := HostRandom new.
+	bytes := ByteArray new: 16.
+	bytes unsigned32At: 1 put: random integer.
+	bytes unsigned32At: 5 put: random integer.
+	bytes unsigned32At: 9 put: random integer.
+	bytes unsigned32At: 13 put: random integer.
+	^self bytes: bytes
+%
+
+! Class Initialization
+
+run
+RsrPlatformInitializer initialize.
+true
+%

--- a/docs/gtSupport/STON.gs
+++ b/docs/gtSupport/STON.gs
@@ -1,0 +1,2383 @@
+! Class Declarations
+! Generated file, do not Edit
+
+doit
+(Error
+	subclass: 'STONReaderError'
+	instVarNames: #(streamPosition)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONReaderError is the error/exception signalled by STONReader when illegal/incorrect input is seen. 
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONReaderError
+removeallclassmethods STONReaderError
+
+doit
+(Error
+	subclass: 'STONWriterError'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONWriterError is the error/exception signalled by STONWriter when illegal/incorrect input is seen. ';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONWriterError
+removeallclassmethods STONWriterError
+
+doit
+(FileReference
+	subclass: 'STONFileReference'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-GemStone-Kernel';
+		comment: 'Part of STON (not FileSystem)
+
+===
+
+This utility class is used to support serializing FileReference instances for disk-based file systems and in-memory file systems. STON expects a single serialization/deserialization format per class. To match Pharo''s behavior, we need to serialize disk-based file systems specially. This class handles this special treatment.
+
+Do not create instances of this class.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONFileReference
+removeallclassmethods STONFileReference
+
+doit
+(Object
+	subclass: 'STON'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STON implements serialization and materialization using the Smalltalk Object Notation format.
+ 
+S y n t a x
+
+	value
+	  primitive-value
+	  object-value
+	  reference
+	  nil
+	primitive-value
+	  number
+	  true
+	  false
+	  symbol
+	  string
+	object-value
+	  object
+	  map
+	  list
+	object
+	  classname map
+	  classname list
+	reference
+	  @ int-index-previous-object-value
+	map
+	  {}
+	  { members }
+	members
+	  pair
+	  pair , members
+	pair
+	  string : value
+	  symbol : value
+	  number : value
+	list
+	  []
+	  [ elements ]
+	elements
+	  value 
+	  value , elements
+	string
+	  ''''
+	  '' chars ''
+	chars
+	  char
+	  char chars
+	char
+	  any-printable-ASCII-character-
+	    except-''-"-or-\
+	  \''
+	  \"
+	  \\
+	  \/
+	  \b
+	  \f
+	  \n
+	  \r
+	  \t
+	  \u four-hex-digits
+	symbol
+	  # chars-limited
+	  # '' chars ''
+	chars-limited
+	  char-limited
+	  char-limited chars-limited
+	char-limited
+	  a-z A-Z 0-9 - _ . /
+	classname
+	  uppercase-alpha-char alphanumeric-char
+	number
+	  int
+	  int frac
+	  int exp
+	  int frac exp
+	int
+	  digit
+	  digit1-9 digits 
+	  - digit
+	  - digit1-9 digits
+	frac
+	  . digits
+	exp
+	  e digits
+	digits
+	  digit
+	  digit digits
+	e
+	  e
+	  e+
+	  e-
+	  E
+	  E+
+	  E-
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STON
+removeallclassmethods STON
+
+doit
+(Object
+	subclass: 'STONReader'
+	instVarNames: #(readStream objects classes unresolvedReferences stringStream allowComplexMapKeys stack)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONReader materializes objects using the Smalltalk Object Notation format.
+
+This parser is backwards compatible with standard JSON.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONReader
+removeallclassmethods STONReader
+
+doit
+(Object
+	subclass: 'STONReference'
+	instVarNames: #(index)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONReference holds a forward reference to another object during materialization.
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONReference
+removeallclassmethods STONReference
+
+doit
+(Object
+	subclass: 'STONStreamWriter'
+	instVarNames: #(writer first)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONStreamWriter helps in streaming writing STON representations.
+This is an abstract class.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONStreamWriter
+removeallclassmethods STONStreamWriter
+
+doit
+(STONStreamWriter
+	subclass: 'STONListWriter'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONArrayWriter helps in writing array based STON representations.
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONListWriter
+removeallclassmethods STONListWriter
+
+doit
+(STONListWriter
+	subclass: 'STONShortListWriter'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONShortArrayWriter helps in writing short array based STON representations.
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONShortListWriter
+removeallclassmethods STONShortListWriter
+
+doit
+(STONStreamWriter
+	subclass: 'STONMapWriter'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONDictionaryWriter helps in writing dictionary based STON representations.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONMapWriter
+removeallclassmethods STONMapWriter
+
+doit
+(Object
+	subclass: 'STONWriter'
+	instVarNames: #(writeStream prettyPrint newLine jsonMode referencePolicy level objects)
+	classVars: #(STONCharacters STONSimpleSymbolCharacters)
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #()
+)
+		category: 'STON-Core';
+		comment: 'STONWriter serializes objects using the Smalltalk Object Notation format. 
+
+Customization options are:
+
+- prettyPrint <Boolean> default is false
+	if true, produce pretty printed output
+- jsonMode <Boolean> default is false
+	if true, the follow changes occur
+	- strings are delimited with double quotes
+	- nil is encoded as null
+	- symbols are treated as strings
+	- only STON listClass and STON mapClass instances are allowed as composite objects
+	it is wise to also use either #error or #ignore as referencePolicy to avoid references
+- referencePolicy <#normal|#ignore|#error> default is #normal
+	if #normal, track and count object references and use references to implement sharing and break cycles
+	if #error, track object references and signal STONWriterError when a shared reference is encountered
+	if #ignore, don''t track object references which might loop forever on cycles
+ ';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONWriter
+removeallclassmethods STONWriter
+
+! Class implementation for 'STONReaderError'
+
+!		Class methods for 'STONReaderError'
+
+category: 'instance creation'
+classmethod: STONReaderError
+signal: aString streamPosition: streamPosition 
+	^ self new
+		streamPosition: streamPosition;
+		signal: aString;
+		yourself
+%
+
+!		Instance methods for 'STONReaderError'
+
+category: 'accessing'
+method: STONReaderError
+buildMessageText
+	streamPosition ifNotNil: [ :pos | 
+    self details: 'Error at character position ', pos asString 
+  ].
+  super buildMessageText .
+%
+
+category: 'accessing'
+method: STONReaderError
+streamPosition
+	^ streamPosition
+%
+
+category: 'accessing'
+method: STONReaderError
+streamPosition: aNumber
+	streamPosition := aNumber
+%
+
+! Class implementation for 'STONFileReference'
+
+!		Class methods for 'STONFileReference'
+
+category: 'ston'
+classmethod: STONFileReference
+fromSton: stonReader
+
+	^stonReader parseListSingleton asFileReference
+%
+
+category: 'ston'
+classmethod: STONFileReference
+stonName
+
+	^#FILE
+%
+
+! Class implementation for 'STON'
+
+!		Class methods for 'STON'
+
+category: 'convenience'
+classmethod: STON
+fromStream: readStream
+	^ (self reader on: readStream) next
+%
+
+category: 'convenience'
+classmethod: STON
+fromString: string
+  ^ self fromStream: string readStream
+%
+
+category: 'accessing'
+classmethod: STON
+jsonWriter
+	^ STONWriter new
+		  jsonMode: true;
+		  yourself
+%
+
+category: 'accessing'
+classmethod: STON
+listClass
+	^ Array
+%
+
+category: 'accessing'
+classmethod: STON
+mapClass
+	^ Dictionary
+%
+
+category: 'convenience'
+classmethod: STON
+put: object asJsonOnStream: stream
+	(self jsonWriter on: stream) nextPut: object
+%
+
+category: 'convenience'
+classmethod: STON
+put: object asJsonOnStreamPretty: stream
+	(self jsonWriter on: stream)
+		prettyPrint: true; 
+		nextPut: object
+%
+
+category: 'convenience'
+classmethod: STON
+put: object onStream: stream
+	(self writer on: stream) nextPut: object
+%
+
+category: 'convenience'
+classmethod: STON
+put: object onStreamPretty: stream
+	(self writer on: stream)
+		prettyPrint: true; 
+		nextPut: object
+%
+
+category: 'accessing'
+classmethod: STON
+reader
+	^ STONReader new
+%
+
+category: 'convenience'
+classmethod: STON
+toJsonString: object
+  ^ String streamContents: [ :stream | self put: object asJsonOnStream: stream ]
+%
+
+category: 'convenience'
+classmethod: STON
+toJsonStringPretty: object
+  ^ String
+    streamContents: [ :stream | self put: object asJsonOnStreamPretty: stream ]
+%
+
+category: 'convenience'
+classmethod: STON
+toString: object
+  ^ String streamContents: [ :stream | self put: object onStream: stream ]
+%
+
+category: 'convenience'
+classmethod: STON
+toStringPretty: object
+  ^ String streamContents: [ :stream | self put: object onStreamPretty: stream ]
+%
+
+category: 'accessing'
+classmethod: STON
+writer
+	^ STONWriter new
+%
+
+! Class implementation for 'STONReader'
+
+!		Class methods for 'STONReader'
+
+category: 'instance creation'
+classmethod: STONReader
+new
+  ^ self basicNew
+    initialize;
+    yourself
+%
+
+category: 'instance creation'
+classmethod: STONReader
+on: readStream
+	^ self new
+		on: readStream;
+		yourself
+%
+
+!		Instance methods for 'STONReader'
+
+category: 'initialize-release'
+method: STONReader
+allowComplexMapKeys: boolean
+	allowComplexMapKeys := boolean
+%
+
+category: 'testing'
+method: STONReader
+atEnd
+	^ readStream atEnd
+%
+
+category: 'initialize-release'
+method: STONReader
+classes
+
+	^ classes
+%
+
+category: 'initialize-release'
+method: STONReader
+close
+	readStream ifNotNil: [
+		readStream close.
+		readStream := nil ]
+%
+
+category: 'private'
+method: STONReader
+consumeWhitespace
+	"Strip whitespaces from the input stream."
+
+	[ readStream atEnd not and: [ readStream peek isSeparator ] ]
+		whileTrue: [ readStream next ]
+%
+
+category: 'error handling'
+method: STONReader
+error: aString
+	| streamPosition |
+	"Remain compatible with streams that don't understand #position"
+	streamPosition := [ readStream position ]
+		on: MessageNotUnderstood do: [ nil ].
+	^ STONReaderError signal: aString streamPosition: streamPosition
+%
+
+category: 'private'
+method: STONReader
+expectChar: character
+	"Expect character and consume input and optional whitespace at the end,
+	 throw an error otherwise."
+
+	(self matchChar: character)
+		ifFalse: [ self error: character asString, ' expected' ]
+%
+
+category: 'initialize-release'
+method: STONReader
+initialize
+  objects := IdentityDictionary new.
+  classes := IdentityDictionary new.
+  allowComplexMapKeys := false.
+  stack := OrderedCollection new.
+  unresolvedReferences := 0
+%
+
+category: 'private'
+method: STONReader
+isClassChar: char
+	^ 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' includes: char
+%
+
+category: 'private'
+method: STONReader
+isClassStartChar: char
+	^ 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' includes: char
+%
+
+category: 'private'
+method: STONReader
+isSimpleSymbolChar: char
+	^ 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_./' includes: char
+%
+
+category: 'private'
+method: STONReader
+lookupClass: name
+	^ (System myUserProfile objectNamed: name asSymbol)
+		ifNil: [ 
+			(((AllUsers userWithId: 'SystemUser') objectNamed: 'RowanTools')
+				ifNotNil: [ :rowanSymbolDictionary | 
+					(rowanSymbolDictionary at: name asSymbol ifAbsent: [  ])
+						ifNotNil: [ :cls | ^ cls ] ])
+				ifNil: [ 
+					classes
+						at: name
+						ifAbsentPut: [ 
+							(ClassOrganizer new allSubclassesOf: Object)
+								detect: [ :cls | cls stonName == name ]
+								ifNone: [ 
+									(((AllUsers userWithId: 'SystemUser') objectNamed: 'Rowan')
+										ifNotNil: [ :rowan | rowan platform serviceClassFor: name ])
+										ifNil: [ self error: 'Cannot resolve class named ' , name printString ] ] ] ] ]
+%
+
+category: 'private'
+method: STONReader
+match: string do: block
+	"Try to read and consume string and execute block if successful.
+	Else do nothing (but do not back up)"
+
+	(string allSatisfy: [ :each | readStream peekFor: each ])
+		ifTrue: [ 
+			self consumeWhitespace.
+			block value ]
+%
+
+category: 'private'
+method: STONReader
+matchChar: character
+	"Tries to match character, consume input and 
+	answer true if successful and consumes whitespace at the end."
+
+	^ (readStream peekFor: character)
+		ifTrue: [ 
+			self consumeWhitespace.
+			true ]
+		ifFalse: [ false ]
+%
+
+category: 'private'
+method: STONReader
+newReference
+	| index reference |
+	index := objects size + 1.
+	reference := STONReference index: index.
+	objects at: index put: reference.
+	^ reference
+%
+
+category: 'public'
+method: STONReader
+next
+	| object |
+	self consumeWhitespace.
+	object := self parseValue.
+	unresolvedReferences > 0
+		ifTrue: [ self processSubObjectsOf: object ].
+	^ object
+%
+
+category: 'initialize-release'
+method: STONReader
+on: aReadStream
+	readStream := aReadStream
+%
+
+category: 'private'
+method: STONReader
+optimizeForLargeStructures
+  "nothing special for GemStone"
+
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseCharacter
+  | char |
+  (char := readStream next) = $\
+    ifFalse: [ ^ char ].
+  (#($' $" $/ $\) includes: (char := readStream next))
+    ifTrue: [ ^ char ].
+  char = $b
+    ifTrue: [ ^ Character backspace ].
+  char = $f
+    ifTrue: [ ^ Character newPage ].
+  char = $n
+    ifTrue: [ ^ Character lf ].
+  char = $r
+    ifTrue: [ ^ Character cr ].
+  char = $t
+    ifTrue: [ ^ Character tab ].
+  char = $u
+    ifTrue: [ ^ self parseCharacterHex ].
+  self error: 'invalid escape character \' , (String with: char)
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseCharacterHex
+  | value |
+  value := self parseCharacterHexDigit.
+  3 timesRepeat: [ value := (value bitShift: 4) + self parseCharacterHexDigit ].
+  ^ Character codePoint: value
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseCharacterHexDigit
+	| digit |
+	readStream atEnd ifFalse: [ 
+		digit := readStream next asInteger.
+		(digit between: "$0" 48 and: "$9" 57)
+			ifTrue: [ ^ digit - 48 ].
+		(digit between: "$A" 65 and: "$F" 70)
+			ifTrue: [ ^ digit - 55 ].
+		(digit between: "$a" 97 and: "$f" 102)
+			ifTrue: [ ^ digit - 87 ] ].
+	self error: 'hex-digit expected'
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseClass
+	| className |
+	className := String new.
+	[ readStream atEnd not and: [ self isClassChar: readStream peek ] ]
+		whileTrue: [ className addAll: readStream next ].
+	self consumeWhitespace.
+	^ self lookupClass: className asSymbol
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseConstantDo: block
+	"Parse and consume either true|false|nil|null and execute block 
+	or else do nothing (but do not back up).
+	Hand written implementation to avoid the use of #position:"
+	
+	(readStream peek = $t)
+		ifTrue: [
+			^ self match: 'true' do: [ block value: true ] ].
+	(readStream peek = $f)
+		ifTrue: [
+			^ self match: 'false' do: [ block value: false ] ].
+	(readStream peek = $n)
+		ifTrue: [
+			readStream next.
+			(readStream peek = $i)
+				ifTrue: [
+					self match: 'il' do: [ block value: nil ] ].
+			(readStream peek = $u)
+				ifTrue: [
+					self match: 'ull' do: [ block value: nil ] ] ]
+%
+
+category: 'parsing'
+method: STONReader
+parseList
+	| reference array |
+	reference := self newReference.
+	array := STON listClass streamContents: [ :stream |
+		self parseListDo: [ :each | stream nextPut: each ] ].
+	self setReference: reference to: array.
+	^ array
+%
+
+category: 'parsing'
+method: STONReader
+parseListDo: block
+	| index |
+	self expectChar: $[.
+	(self matchChar: $]) 
+		ifTrue: [ ^ self ].
+	index := 1.
+	[ readStream atEnd ] whileFalse: [
+		block cull: self parseValue cull: index.
+		(self matchChar: $]) 
+			ifTrue: [ ^ self ].
+		index := index + 1.
+		self expectChar: $, ].
+	self error: 'end of list expected'
+%
+
+category: 'parsing'
+method: STONReader
+parseListSingleton
+	| value |
+	value := nil.
+	self parseListDo: [ :each :index |
+		index = 1 ifTrue: [ value := each ] ].
+	^ value
+%
+
+category: 'parsing'
+method: STONReader
+parseMap
+	| map |
+	map := STON mapClass new.
+	self storeReference: map.
+	self parseMapDo: [ :key :value |
+		map at: key put: value ].
+	^ map
+%
+
+category: 'parsing'
+method: STONReader
+parseMapDo: block
+  self expectChar: ${.
+  (self matchChar: $})
+    ifTrue: [ ^ self ].
+  [ readStream atEnd ] whileFalse: [ | name value |
+      name := self parseSimpleValue.
+      (allowComplexMapKeys
+        or: [ name isString or: [ name isNumber ] ])
+        ifFalse: [ self error: 'unexpected property name type' ].
+      self expectChar: $:.
+      value := self parseValue.
+      block value: name value: value.
+      (self matchChar: $})
+        ifTrue: [ ^ self ].
+      self expectChar: $, ].
+  self error: 'end of map expected'
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseNumber
+	| negated number |
+	negated := readStream peekFor: $-.
+	number := self parseNumberInteger.
+	(readStream peekFor: $/)
+		ifTrue: 
+			[number := Fraction numerator: number denominator: self parseNumberInteger.
+			(readStream peekFor: $s)
+				ifTrue: [ number := ScaledDecimal for: number scale: self parseNumberInteger ] ]
+		ifFalse:
+			[(readStream peekFor: $.)
+				ifTrue: [ number := (number + self parseNumberFraction) asFloat ].
+			((readStream peekFor: $e) or: [ readStream peekFor: $E ])
+				ifTrue: [ number := number * self parseNumberExponent ]].
+	negated
+		ifTrue: [ number := number negated ].
+	self consumeWhitespace.
+	^ number
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseNumberExponent
+	| number negated |
+	number := 0.
+	(negated := readStream peekFor: $-)
+		ifFalse: [ readStream peekFor: $+ ].
+	[ readStream atEnd not and: [ readStream peek isDigit ] ]
+		whileTrue: [ number := 10 * number + readStream next digitValue ].
+	negated
+		ifTrue: [ number := number negated ].
+	^ 10 raisedTo: number
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseNumberFraction
+	| number power |
+	number := 0.
+	power := 1.0.
+	[ readStream atEnd not and: [ readStream peek isDigit ] ] whileTrue: [
+		number := 10 * number + readStream next digitValue.
+		power := power * 10.0 ].
+	^ number / power
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseNumberInteger
+	| number |
+	number := 0.
+	[ readStream atEnd not and: [ readStream peek isDigit ] ] whileTrue: [ 
+		number := 10 * number + readStream next digitValue ].
+	^ number
+%
+
+category: 'parsing'
+method: STONReader
+parseObject
+	| targetClass reference object |
+	targetClass := self parseClass.
+	reference := self newReference.
+	object := targetClass fromSton: self.
+	self setReference: reference to: object.
+	^ object
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseReference
+	| index |
+	self expectChar: $@.
+	index := self parseNumberInteger.
+	self consumeWhitespace.
+	unresolvedReferences := unresolvedReferences + 1.
+	^ STONReference index: index
+%
+
+category: 'parsing'
+method: STONReader
+parseSimpleValue
+	| char |
+	readStream atEnd ifFalse: [ 
+		(self isClassStartChar: (char := readStream peek)) 
+			ifTrue: [ ^ self parseObject ].
+		char = ${
+			ifTrue: [ ^ self parseMap ].
+		char = $[
+			ifTrue: [ ^ self parseList ].
+		(char = $' or: [ char = $" ])
+			ifTrue: [ ^ self parseString ].
+		char = $#
+			ifTrue: [ ^ self parseSymbol ].
+		char = $@
+			ifTrue: [ ^ self parseReference ].
+		(char = $- or: [ char isDigit ])
+			ifTrue: [ ^ self parseNumber ].
+		self parseConstantDo: [ :value | ^ value ] ].
+	self error: 'invalid input'
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseString
+	^ self parseStringInternal
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseStringInternal
+	| result delimiter |
+	delimiter := readStream next.
+	(delimiter = $' or: [ delimiter = $" ])
+		ifFalse: [ self error: ''' or " expected' ].
+	result := String new.
+	[ readStream atEnd or: [ readStream peek = delimiter ] ]
+		whileFalse: [ result addAll: self parseCharacter ].
+	self expectChar: delimiter.
+	^ result
+%
+
+category: 'parsing-internal'
+method: STONReader
+parseSymbol
+	| string |
+	self expectChar: $#.
+	readStream peek = $'
+		ifTrue: [ ^ self parseStringInternal asSymbol ].
+	string := String new.
+	[ readStream atEnd not and: [ self isSimpleSymbolChar: readStream peek ] ]
+		whileTrue: [ string addAll: readStream next ].
+	string isEmpty
+		ifFalse: [ 
+			self consumeWhitespace.
+			^ string asSymbol ].
+	self error: 'unexpected input'
+%
+
+category: 'parsing'
+method: STONReader
+parseValue
+	| value |
+	value := self parseSimpleValue.
+	^ (self matchChar: $:)
+		ifTrue: [ Association new key: value value: self parseValue ]
+		ifFalse: [ value ]
+%
+
+category: 'private'
+method: STONReader
+processSubObjectsOf: object
+  stack addFirst: object.
+  [ stack isEmpty ]
+    whileFalse: [ stack removeFirst stonProcessSubObjects: [ :each | each isStonReference
+            ifTrue: [ self resolveReference: each ]
+            ifFalse: [ each stonContainSubObjects
+                ifTrue: [ stack addFirst: each ]
+                ifFalse: [ each ] ] ] ]
+%
+
+category: 'initialize-release'
+method: STONReader
+reset
+	unresolvedReferences := 0.
+	objects removeAll
+%
+
+category: 'private'
+method: STONReader
+resolveReference: reference
+	^ self resolveReferenceIndex: reference index
+%
+
+category: 'private'
+method: STONReader
+resolveReferenceIndex: index
+	^ objects at: index
+%
+
+category: 'private'
+method: STONReader
+setReference: reference to: object
+	objects at: reference index put: object
+%
+
+category: 'private'
+method: STONReader
+storeReference: object
+	| index |
+	index := objects size + 1.
+	objects at: index put: object.
+	^ index
+%
+
+category: 'private'
+method: STONReader
+stringStreamContents: block
+  stringStream ifNil: [ stringStream := WriteStream on: String new ].
+  stringStream reset.
+  block value: stringStream.
+  ^ stringStream contents
+%
+
+! Class implementation for 'STONReference'
+
+!		Class methods for 'STONReference'
+
+category: 'instance creation'
+classmethod: STONReference
+index: integer
+	^ self new
+		index: integer;
+		yourself
+%
+
+!		Instance methods for 'STONReference'
+
+category: 'comparing'
+method: STONReference
+= anObject
+	^ self class == anObject class and: [ self index = anObject index ]
+%
+
+category: 'comparing'
+method: STONReference
+hash
+	^ index hash
+%
+
+category: 'accessing'
+method: STONReference
+index
+	^ index
+%
+
+category: 'accessing'
+method: STONReference
+index: integer
+	index := integer
+%
+
+category: 'testing'
+method: STONReference
+isStonReference
+	^ true
+%
+
+category: 'printing'
+method: STONReference
+printOn: stream
+	super printOn: stream.
+	stream nextPut: $(; print: index; nextPut: $)
+%
+
+! Class implementation for 'STONStreamWriter'
+
+!		Class methods for 'STONStreamWriter'
+
+category: 'instance creation'
+classmethod: STONStreamWriter
+new
+  ^ self basicNew
+    initialize;
+    yourself
+%
+
+category: 'instance creation'
+classmethod: STONStreamWriter
+on: stonWriter
+	^ self new
+		on: stonWriter;
+		yourself
+%
+
+!		Instance methods for 'STONStreamWriter'
+
+category: 'initialize-release'
+method: STONStreamWriter
+initialize
+  first := true
+%
+
+category: 'initialize-release'
+method: STONStreamWriter
+on: stonWriter
+	writer := stonWriter
+%
+
+! Class implementation for 'STONListWriter'
+
+!		Instance methods for 'STONListWriter'
+
+category: 'accessing'
+method: STONListWriter
+add: anObject
+	first ifTrue: [ first := false ] ifFalse: [ writer listElementSeparator ].
+	writer nextPut: anObject
+%
+
+! Class implementation for 'STONShortListWriter'
+
+!		Instance methods for 'STONShortListWriter'
+
+category: 'accessing'
+method: STONShortListWriter
+add: anObject
+	first ifTrue: [ first := false ] ifFalse: [ writer shortListElementSeparator ].
+	writer nextPut: anObject
+%
+
+! Class implementation for 'STONMapWriter'
+
+!		Instance methods for 'STONMapWriter'
+
+category: 'accessing'
+method: STONMapWriter
+at: key put: value
+	first ifTrue: [ first := false ] ifFalse: [ writer mapElementSeparator ].
+	writer encodeKey: key value: value
+%
+
+! Class implementation for 'STONWriter'
+
+!		Class methods for 'STONWriter'
+
+category: 'private'
+classmethod: STONWriter
+findFirstInString: aString inSet: inclusionMap startingAt: start
+  "Trivial, non-primitive version"
+
+  | i stringSize ascii |
+  inclusionMap size ~= 256
+    ifTrue: [ ^ 0 ].
+  i := start.
+  stringSize := aString size.
+  [ i <= stringSize and: [ ascii := (aString at: i) asciiValue.
+      ascii < 256
+        ifTrue: [ (inclusionMap at: ascii + 1) = 0 ]
+        ifFalse: [ true ] ] ] whileTrue: [ i := i + 1 ].
+  i > stringSize
+    ifTrue: [ ^ 0 ].
+  ^ i
+%
+
+category: 'class initialization'
+classmethod: STONWriter
+initialize
+	self initializeSTONCharacters.
+	self initializeSTONSimpleSymbolCharacters
+%
+
+category: 'class initialization'
+classmethod: STONWriter
+initializeSTONCharacters
+	| escapes |
+	STONCharacters := Array new: 127.
+	32 to: 126 do: [ :each | 
+		STONCharacters at: each + 1 put: #pass ].
+	escapes := #( 8 '\b' 9 '\t' 10 '\n' 12 '\f' 13 '\r' 34 '\"' 39 '\''' 92 '\\' ).
+	1 to: escapes size - 1 by: 2 do: [ :index | 
+		STONCharacters 
+			at: (escapes at: index) + 1
+			put: (escapes at: index + 1) ]
+%
+
+category: 'class initialization'
+classmethod: STONWriter
+initializeSTONSimpleSymbolCharacters
+  "STONSimpleSymbolCharacters asArray collectWithIndex: [ :each :index |
+		each isZero ifTrue: [ (index - 1) asCharacter ] ]."
+
+  STONSimpleSymbolCharacters := (ByteArray new: 256)
+    atAllPut: 1;
+    yourself.
+  1 to: 256 do: [ :each | | char |
+    char := (each - 1) asCharacter.
+    (self isSimpleSymbolChar: char)
+      ifTrue: [ STONSimpleSymbolCharacters at: each put: 0 ] ]
+%
+
+category: 'private'
+classmethod: STONWriter
+isSimpleSymbolChar: char
+	^ 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_./' includes: char
+%
+
+category: 'instance creation'
+classmethod: STONWriter
+new
+  ^ self basicNew
+    initialize;
+    yourself
+%
+
+category: 'instance creation'
+classmethod: STONWriter
+on: writeStream
+	^ self new
+		on: writeStream;
+		yourself
+%
+
+!		Instance methods for 'STONWriter'
+
+category: 'initialize-release'
+method: STONWriter
+close
+	writeStream ifNotNil: [
+		writeStream close.
+		writeStream := nil ]
+%
+
+category: 'writing'
+method: STONWriter
+encodeCharacter: char
+  | code encoding |
+  ((code := char codePoint) < 127
+    and: [ (encoding := STONCharacters at: code + 1) notNil ])
+    ifTrue: [ (encoding = #'pass' or: [ jsonMode and: [ char = $' ] ])
+        ifTrue: [ writeStream nextPut: char ]
+        ifFalse: [ writeStream nextPutAll: encoding ] ]
+    ifFalse: [ | paddedStream padding digits |
+      paddedStream := WriteStream on: String new.
+      code printOn: paddedStream base: 16 showRadix: false.
+      digits := paddedStream contents.
+      padding := 4 - digits size.
+      writeStream nextPutAll: '\u'.
+      encoding := padding > 0
+        ifTrue: [ ((String new: padding)
+            atAllPut: $0;
+            yourself) , digits ]
+        ifFalse: [ digits ].
+      writeStream nextPutAll: encoding ]
+%
+
+category: 'private'
+method: STONWriter
+encodeKey: key value: value
+	self nextPut: key.
+	self prettyPrintSpace.
+	writeStream nextPut: $:.
+	self prettyPrintSpace.
+	self nextPut: value
+%
+
+category: 'writing'
+method: STONWriter
+encodeList: elements
+	writeStream nextPut: $[.
+	elements isEmpty
+		ifTrue: [
+			self prettyPrintSpace ]
+		ifFalse: [
+			self indentedDo: [
+				self newlineIndent.
+				elements 
+					do: [ :each | self nextPut: each ]
+					separatedBy: [ self listElementSeparator ] ].
+			self newlineIndent ].
+	writeStream nextPut: $]
+%
+
+category: 'writing'
+method: STONWriter
+encodeMap: pairs
+	| first |
+	first := true.
+	writeStream nextPut: ${.
+	pairs isEmpty
+		ifTrue: [
+			self prettyPrintSpace ]
+		ifFalse: [
+			self indentedDo: [
+				self newlineIndent.
+				pairs keysAndValuesDo: [ :key :value |
+					first 
+						ifTrue: [ first := false ] 
+						ifFalse: [ self mapElementSeparator ].
+					self encodeKey: key value: value ] ].
+			self newlineIndent ].
+	writeStream nextPut: $}
+%
+
+category: 'private'
+method: STONWriter
+encodeString: string
+  | encodedString |
+  encodedString := string.
+  writeStream
+    nextPut:
+      (jsonMode
+        ifTrue: [ $" ]
+        ifFalse: [ $' ]).
+  encodedString do: [ :each | self encodeCharacter: each ].
+  writeStream
+    nextPut:
+      (jsonMode
+        ifTrue: [ $" ]
+        ifFalse: [ $' ])
+%
+
+category: 'private'
+method: STONWriter
+indentedDo: block
+	level := level + 1.
+	block value.
+	level := level - 1
+%
+
+category: 'initialize-release'
+method: STONWriter
+initialize
+  prettyPrint := false.
+  newLine := String with: Character lf.
+  level := 0.
+  referencePolicy := #'normal'.
+  jsonMode := false.
+  objects := IdentityDictionary new
+%
+
+category: 'private'
+method: STONWriter
+isSimpleSymbol: symbol
+  symbol isEmpty
+    ifTrue: [ ^ false ].
+  ^ (self class
+    findFirstInString: symbol
+    inSet: STONSimpleSymbolCharacters
+    startingAt: 1) = 0
+%
+
+category: 'initialize-release'
+method: STONWriter
+jsonMode: boolean
+	jsonMode := boolean
+%
+
+category: 'private'
+method: STONWriter
+listElementSeparator
+	writeStream nextPut: $,.
+	self newlineIndent
+%
+
+category: 'private'
+method: STONWriter
+mapElementSeparator
+	writeStream nextPut: $,.
+	self newlineIndent
+%
+
+category: 'initialize-release'
+method: STONWriter
+newLine: string
+	newLine := string
+%
+
+category: 'private'
+method: STONWriter
+newlineIndent
+	prettyPrint ifTrue: [ 
+		writeStream nextPutAll: newLine.
+		level timesRepeat: [ writeStream tab ] ]
+%
+
+category: 'public'
+method: STONWriter
+nextPut: anObject
+	anObject stonOn: self
+%
+
+category: 'initialize-release'
+method: STONWriter
+on: aWriteStream
+	writeStream := aWriteStream
+%
+
+category: 'private'
+method: STONWriter
+optimizeForLargeStructures
+  "nothing special for GemStone"
+
+%
+
+category: 'initialize-release'
+method: STONWriter
+prettyPrint: boolean
+	prettyPrint := boolean
+%
+
+category: 'private'
+method: STONWriter
+prettyPrintSpace
+	prettyPrint ifTrue: [ writeStream space ]
+%
+
+category: 'initialize-release'
+method: STONWriter
+referencePolicy: policy
+  (#(#'normal' #'ignore' #'error') includes: policy)
+    ifFalse: [ self error: 'Unknown reference policy: ' , policy printString ].
+  referencePolicy := policy
+%
+
+category: 'initialize-release'
+method: STONWriter
+reset
+	objects removeAll
+%
+
+category: 'private'
+method: STONWriter
+shortListElementSeparator
+	writeStream nextPut: $,.
+	self prettyPrintSpace
+%
+
+category: 'private'
+method: STONWriter
+with: object do: block
+	| index |
+	referencePolicy = #ignore 
+		ifTrue: [ ^ block value ].
+	(index := objects at: object ifAbsent: [ nil ]) notNil
+		ifTrue: [
+			referencePolicy = #error
+				ifTrue: [ ^ STONWriterError signal: 'Shared reference detected' ].
+			self writeReference: index ]
+		ifFalse: [
+			index := objects size + 1.
+			objects at: object put: index.
+			block value ]
+%
+
+category: 'writing'
+method: STONWriter
+writeAssociation: association
+	jsonMode
+		ifTrue: [ self error: 'wrong object class for JSON mode' ].
+	self
+		encodeKey: association key
+		value: association value
+%
+
+category: 'writing'
+method: STONWriter
+writeBoolean: boolean
+	writeStream print: boolean
+%
+
+category: 'writing'
+method: STONWriter
+writeFloat: float
+  writeStream nextPutAll: float asString
+%
+
+category: 'writing'
+method: STONWriter
+writeFraction: fraction
+
+	jsonMode
+		ifTrue: [ self writeFloat: fraction asFloat ]
+		ifFalse: [ writeStream
+				print: fraction numerator;
+				nextPut: $/;
+				print: fraction denominator ]
+%
+
+category: 'writing'
+method: STONWriter
+writeInteger: integer
+	writeStream print: integer
+%
+
+category: 'writing'
+method: STONWriter
+writeList: collection
+	self with: collection do: [ 
+		self encodeList: collection ]
+%
+
+category: 'writing'
+method: STONWriter
+writeMap: hashedCollection
+	self with: hashedCollection do: [ 
+		self encodeMap: hashedCollection ]
+%
+
+category: 'writing'
+method: STONWriter
+writeNull
+	jsonMode
+		ifTrue: [ writeStream nextPutAll: 'null' ]
+		ifFalse: [ writeStream print: nil ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: anObject
+  | instanceVariableNames |
+  (instanceVariableNames := anObject class allInstVarNames) isEmpty
+    ifTrue: [ self writeObject: anObject do: [ self encodeMap: #() ] ]
+    ifFalse: [ self writeObject: anObject streamMap: [ :dictionary | instanceVariableNames
+            do: [ :each | (anObject instVarAt: (instanceVariableNames indexOf: each asSymbol))
+                ifNotNil: [ :value | dictionary at: each asSymbol put: value ]
+                ifNil: [ anObject stonShouldWriteNilInstVars
+                    ifTrue: [ dictionary at: each asSymbol put: nil ] ] ] ] ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: anObject do: block
+	(jsonMode and: [ anObject class ~= STON listClass and: [ anObject class ~= STON mapClass ] ])
+		ifTrue: [ STONWriterError signal: 'Wrong object class for JSON mode' ].
+	self with: anObject do: [
+		writeStream nextPutAll: anObject class stonName.
+		self prettyPrintSpace.
+		block value ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: object listSingleton: element
+	self writeObject: object do: [
+		writeStream nextPut: $[.
+		self 
+			prettyPrintSpace;
+			nextPut: element;
+			prettyPrintSpace.
+		writeStream nextPut: $] ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: anObject named: stonName do: block
+	(jsonMode and: [ anObject class ~= STON listClass and: [ anObject class ~= STON mapClass ] ])
+		ifTrue: [ self error: 'wrong object class for JSON mode' ].
+	self with: anObject do: [
+		writeStream nextPutAll: stonName.
+		self prettyPrintSpace.
+		block value ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: object named: stonName listSingleton: element
+	self writeObject: object named: stonName do: [
+		writeStream nextPut: $[.
+		self
+			prettyPrintSpace;
+			nextPut: element;
+			prettyPrintSpace.
+		writeStream nextPut: $] ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: object streamList: block
+	self writeObject: object do: [ | listWriter |
+		listWriter := STONListWriter on: self.
+		writeStream nextPut: $[.
+		self indentedDo: [
+			self newlineIndent.
+			block value: listWriter ].
+		self newlineIndent.
+		writeStream nextPut: $] ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: object streamMap: block
+	self writeObject: object do: [ | mapWriter |
+		mapWriter := STONMapWriter on: self.
+		writeStream nextPut: ${.
+		self indentedDo: [
+			self newlineIndent.
+			block value: mapWriter ].
+		self newlineIndent.
+		writeStream nextPut: $} ]
+%
+
+category: 'writing'
+method: STONWriter
+writeObject: object streamShortList: block
+	self writeObject: object do: [ | listWriter |
+		listWriter := STONShortListWriter on: self.
+		writeStream nextPut: $[.
+		self indentedDo: [
+			self prettyPrintSpace.
+			block value: listWriter ].
+		self prettyPrintSpace.
+		writeStream nextPut: $] ]
+%
+
+category: 'writing'
+method: STONWriter
+writeReference: index
+	writeStream
+		nextPut: $@;
+		print: index
+%
+
+category: 'writing'
+method: STONWriter
+writeScaledDecimal: scaledDecimal
+
+	jsonMode
+		ifTrue: [ self writeFloat: scaledDecimal asFloat ]
+		ifFalse: [ writeStream
+				print: scaledDecimal numerator;
+				nextPut: $/;
+				print: scaledDecimal denominator;
+				nextPut: $s;
+				print: scaledDecimal scale ]
+%
+
+category: 'writing'
+method: STONWriter
+writeString: string
+	self encodeString: string
+%
+
+category: 'writing'
+method: STONWriter
+writeSymbol: symbol
+	jsonMode
+		ifTrue: [
+			self writeString: symbol ]
+		ifFalse: [
+			writeStream nextPut: $#.
+			(self isSimpleSymbol: symbol)
+				ifTrue: [
+					writeStream nextPutAll: symbol ]
+				ifFalse: [
+					self encodeString: symbol ] ]
+%
+
+! Class extensions for 'AbstractDictionary'
+
+!		Class methods for 'AbstractDictionary'
+
+category: '*ston-gemstonecommon'
+classmethod: AbstractDictionary
+fromSton: stonReader
+	"Instances of STON mapClass will be read directly and won't arrive here.
+	Other (sub)classes will use this method."
+	
+	| dictionary |
+	dictionary := self new.
+	stonReader parseMapDo: [ :key :value |
+		dictionary at: key put: value ].
+	^ dictionary
+%
+
+!		Instance methods for 'AbstractDictionary'
+
+category: '*ston-gemstonecommon'
+method: AbstractDictionary
+stonOn: stonWriter
+	"Instances of STON mapClass will be encoded directly, without a class tag.
+	Other (sub)classes will be encoded with a class tag and will use a map representation. "
+	
+	self class == STON mapClass
+		ifTrue: [ 
+			stonWriter writeMap: self ]
+		ifFalse: [ 
+			stonWriter 
+				writeObject: self 
+				do: [ stonWriter encodeMap: self ] ]
+%
+
+category: '*ston-gemstonecommon'
+method: AbstractDictionary
+stonProcessSubObjects: block
+	"Execute block to (potentially) change each of my subObjects.
+	In general, all instance and indexable variables are processed.
+	Overwrite when necessary. Not used when #stonContainSubObjects returns false."
+	(self class isVariable and: [ self class isBytes not and: [self class isIndexable]])
+		ifTrue: [
+			1 to: self _basicSize do: [ :each | |val|			
+									val:= (block value: (self basicAt: each)).
+									self basicAt: each put: val ] ]"
+							super stonProcessSubObjects: block"
+%
+
+! Class extensions for 'AbstractFraction'
+
+!		Instance methods for 'AbstractFraction'
+
+category: '*ston-gemstone-kernel'
+method: AbstractFraction
+stonOn: stonWriter
+
+	stonWriter writeFraction: self
+%
+
+! Class extensions for 'Association'
+
+!		Instance methods for 'Association'
+
+category: '*ston-gemstone-kernel'
+method: Association
+stonOn: stonWriter
+
+	stonWriter writeAssociation: self
+%
+
+! Class extensions for 'Boolean'
+
+!		Instance methods for 'Boolean'
+
+category: '*ston-gemstone-kernel'
+method: Boolean
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstone-kernel'
+method: Boolean
+stonOn: stonWriter
+	stonWriter writeBoolean: self
+%
+
+! Class extensions for 'ByteArray'
+
+!		Class methods for 'ByteArray'
+
+category: '*ston-gemstone-kernel'
+classmethod: ByteArray
+fromSton: stonReader
+  | singletonString |
+  singletonString := stonReader parseListSingleton.
+  ^ (self new: singletonString size // 2)
+    readHexFrom: singletonString readStream
+%
+
+!		Instance methods for 'ByteArray'
+
+category: '*ston-gemstonebase'
+method: ByteArray
+readHexFrom: aStream
+  "Initialize the receiver from a hexadecimal string representation"
+
+  | map v ch value |
+  map := '0123456789abcdefABCDEF'.
+  1 to: self size do: [ :i | 
+    ch := aStream next.
+    v := (map indexOf: ch) - 1.
+    ((v between: 0 and: 15) or: [ (v := v - 6) between: 0 and: 15 ])
+      ifFalse: [ 
+        ^ self
+          error:
+            'Hex digit 
+expected' ].
+    value := v bitShift: 4.
+    ch := aStream next.
+    v := (map indexOf: ch) - 1.
+    ((v between: 0 and: 15) or: [ (v := v - 6) between: 0 and: 15 ])
+      ifFalse: [ 
+        ^ self
+          error:
+            'Hex digit 
+expected' ].
+    value := value + v.
+    self at: i put: value ]
+%
+
+category: '*ston-gemstone-kernel'
+method: ByteArray
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstonecommon'
+method: ByteArray
+stonOn: stonWriter
+  "Use a hex representation"
+
+  stonWriter writeObject: self listSingleton: self asHexString
+%
+
+! Class extensions for 'Character'
+
+!		Class methods for 'Character'
+
+category: '*ston-gemstone-kernel'
+classmethod: Character
+fromSton: stonReader
+	^ stonReader parseListSingleton first
+%
+
+!		Instance methods for 'Character'
+
+category: '*ston-gemstone-kernel'
+method: Character
+stonOn: stonWriter
+	stonWriter writeObject: self listSingleton: self asString
+%
+
+! Class extensions for 'CharacterCollection'
+
+!		Class methods for 'CharacterCollection'
+
+category: '*ston-gemstonecommon'
+classmethod: CharacterCollection
+findFirstInString: aString inSet: inclusionMap startingAt: start
+
+	"Trivial, non-primitive version"
+
+	| i stringSize ascii |
+	inclusionMap size ~= 256
+		ifTrue: [ ^ 0 ].
+
+	i := start.
+	stringSize := aString size.
+	[ 
+	i <= stringSize
+		and: [ 
+			ascii := (aString at: i) asciiValue.
+			ascii < 256
+				ifTrue: [ (inclusionMap at: ascii + 1) = 0 ]
+				ifFalse: [ true ] ] ]
+		whileTrue: [ i := i + 1 ].
+
+	i > stringSize
+		ifTrue: [ ^ 0 ].
+	^ i
+%
+
+!		Instance methods for 'CharacterCollection'
+
+category: '*ston-gemstonebase'
+method: CharacterCollection
+isString
+  ^ true
+%
+
+category: '*ston-gemstonecommon'
+method: CharacterCollection
+stonContainSubObjects
+  ^ false
+%
+
+category: '*ston-gemstonecommon'
+method: CharacterCollection
+stonOn: stonWriter
+
+        self isSymbol
+                ifTrue: [stonWriter writeSymbol: self]
+                ifFalse: [stonWriter writeString: self]
+%
+
+! Class extensions for 'Class'
+
+!		Class methods for 'Class'
+
+category: '*ston-gemstone-kernel'
+classmethod: Class
+fromSton: stonReader
+	| theClassName symbolList |
+	theClassName := stonReader parseListSingleton.
+	symbolList := System myUserProfile symbolList.
+	^(symbolList resolveSymbol:  theClassName)
+		ifNil: [LookupError signal: theClassName asString, ' was not found']
+		ifNotNil: [:assoc | assoc value]
+%
+
+!		Instance methods for 'Class'
+
+category: '*ston-gemstone-kernel'
+method: Class
+stonName
+	"Override to encode my instances using a different class name."
+	
+	^ self name
+%
+
+category: '*ston-gemstone-kernel'
+method: Class
+stonOn: stonWriter
+	stonWriter
+		writeObject: self
+		listSingleton: self name asSymbol
+%
+
+! Class extensions for 'Collection'
+
+!		Class methods for 'Collection'
+
+category: '*ston-gemstone-kernel'
+classmethod: Collection
+fromSton: stonReader
+	| collection |
+	collection := self new.
+	stonReader parseListDo: [ :each |
+		collection add: each ].
+	^ collection
+%
+
+!		Instance methods for 'Collection'
+
+category: '*ston-gemstone-kernel'
+method: Collection
+stonOn: stonWriter
+	stonWriter writeObject: self do: [
+		stonWriter encodeList: self ]
+%
+
+! Class extensions for 'CollisionBucket'
+
+!		Instance methods for 'CollisionBucket'
+
+category: '*ston-gemstonecommon'
+method: CollisionBucket
+stonContainSubObjects 
+	^false
+%
+
+! Class extensions for 'Date'
+
+!		Class methods for 'Date'
+
+category: '*ston-gemstonecommon'
+classmethod: Date
+fromSton: stonReader
+
+	^ self fromStream: stonReader parseListSingleton readStream usingFormat: #(3 2 1 $- 1 1)
+%
+
+!		Instance methods for 'Date'
+
+category: '*ston-gemstone-kernel'
+method: Date
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstonecommon'
+method: Date
+stonOn: stonWriter
+  "Use an ISO style YYYYMMDD representation"
+
+  stonWriter
+    writeObject: self
+    listSingleton: (self asStringUsingFormat: #(3 2 1 $- 1 1 $: false))
+%
+
+! Class extensions for 'DateAndTime'
+
+!		Class methods for 'DateAndTime'
+
+category: '*ston-gemstone-kernel'
+classmethod: DateAndTime
+fromSton: stonReader
+  ^ DateAndTime fromString: stonReader parseListSingleton
+%
+
+!		Instance methods for 'DateAndTime'
+
+category: '*ston-gemstone-kernel'
+method: DateAndTime
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstonecommon'
+method: DateAndTime
+stonOn: stonWriter
+	"Use an ISO representation with all details"
+	
+	stonWriter writeObject: self listSingleton: 
+		(String streamContents: [ :stream |
+			self printOn: stream ])
+%
+
+! Class extensions for 'FileReference'
+
+!		Instance methods for 'FileReference'
+
+category: '*ston-gemstone-kernel'
+method: FileReference
+stonOn: stonWriter
+
+	self fileSystem isDiskFileSystem
+		ifTrue: [ | diskFilePath |
+			"in order to get $/ as delimiter and $. as working directory on all platforms"
+			diskFilePath := path isWorkingDirectory
+				ifTrue: [ '.' ]
+				ifFalse: [ path pathString ].
+			stonWriter
+				writeObject: self
+				named: STONFileReference stonName
+				listSingleton: diskFilePath ]
+		ifFalse: [
+			super stonOn: stonWriter ]
+%
+
+! Class extensions for 'Integer'
+
+!		Instance methods for 'Integer'
+
+category: '*ston-gemstone-kernel'
+method: Integer
+stonOn: stonWriter
+	stonWriter writeInteger: self
+%
+
+! Class extensions for 'Metaclass3'
+
+!		Class methods for 'Metaclass3'
+
+category: '*ston-gemstone-kernel'
+classmethod: Metaclass3
+fromSton: stonReader
+
+	| theClassName symbolList |
+	theClassName := stonReader parseListSingleton.
+	symbolList := System myUserProfile symbolList.
+	^(symbolList resolveSymbol:  theClassName)
+		ifNil: [LookupError signal: theClassName asString, ' was not found']
+		ifNotNil: [:assoc | assoc value class]
+%
+
+category: '*ston-gemstone-kernel'
+classmethod: Metaclass3
+stonName
+
+	^#Metaclass
+%
+
+!		Instance methods for 'Metaclass3'
+
+category: '*ston-gemstone-kernel'
+method: Metaclass3
+stonName
+
+	^#Class
+%
+
+category: '*ston-gemstone-kernel'
+method: Metaclass3
+stonOn: stonWriter
+	stonWriter
+		writeObject: self
+		listSingleton: self thisClass name asSymbol
+%
+
+! Class extensions for 'Number'
+
+!		Instance methods for 'Number'
+
+category: '*ston-gemstone-kernel'
+method: Number
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstone-kernel'
+method: Number
+stonOn: stonWriter
+	stonWriter writeFloat: self asFloat
+%
+
+! Class extensions for 'Object'
+
+!		Class methods for 'Object'
+
+category: '*ston-gemstone-kernel'
+classmethod: Object
+fromSton: stonReader
+	"Create a new instance and delegate decoding to instance side.
+	Override only when new instance should be created directly (see implementors). "
+	
+	^ self new
+		fromSton: stonReader;
+		yourself
+%
+
+!		Instance methods for 'Object'
+
+category: '*ston-gemstone-kernel'
+method: Object
+fromSton: stonReader
+  "Decode non-variable classes from a map of their instance variables and values.
+	Override to customize and add a matching #toSton: (see implementors)."
+
+  self class isVariable
+    ifTrue: [ self subclassResponsibility ]
+    ifFalse: [ | instanceVariableNames |
+      instanceVariableNames := self class allInstVarNames.
+      stonReader
+        parseMapDo: [ :instVarName :value | self instVarAt: (instanceVariableNames indexOf: instVarName asSymbol) put: value ] ]
+%
+
+category: '*ston-gemstone-kernel'
+method: Object
+isStonReference
+	^ false
+%
+
+category: '*ston-gemstonebase'
+method: Object
+isString
+  ^ false
+%
+
+category: '*ston-gemstone-kernel'
+method: Object
+stonContainSubObjects
+	"Return true if I contain subObjects that should be processed, false otherwise.
+	Overwrite when necessary. See also #stonProcessSubObjects:"
+	
+	^ true
+%
+
+category: '*ston-gemstone-kernel'
+method: Object
+stonOn: stonWriter
+	"Encode non-variable classes with a map of their instance variable and values.
+	Override to customize and add a matching #fromSton: (see implementors)."
+
+	self class isVariable 
+		ifTrue: [
+			self subclassResponsibility ]
+		ifFalse: [
+			stonWriter writeObject: self ]
+%
+
+category: '*ston-gemstonecommon'
+method: Object
+stonProcessSubObjects: block
+  "Execute block to (potentially) change each of my subObjects.
+	In general, all instance and indexable variables are processed.
+	Overwrite when necessary. Not used when #stonContainSubObjects returns false."
+
+  1 to: self class instSize do: [ :each | self instVarAt: each put: (block value: (self instVarAt: each)) ].
+  (self class isVariable and: [ self class isBytes not ])
+    ifTrue: [ 1 to: self _basicSize do: [ :each | self basicAt: each put: (block value: (self basicAt: each)) ] ]
+%
+
+category: '*ston-gemstone-kernel'
+method: Object
+stonShouldWriteNilInstVars
+	"Return true if my instance variables that are nil should be written out, 
+	false otherwise. Overwrite when necessary. By default, return false."
+	
+	^ false
+%
+
+! Class extensions for 'Path'
+
+!		Class methods for 'Path'
+
+category: '*ston-gemstone-kernel'
+classmethod: Path
+fromSton: stonReader
+	| elements |
+	elements := Array streamContents: [ :out |
+		stonReader parseListDo: [ :each | out nextPut: each ] ].
+	^ self withAll: elements
+%
+
+!		Instance methods for 'Path'
+
+category: '*ston-gemstone-kernel'
+method: Path
+stonOn: stonWriter
+
+	stonWriter
+		writeObject: self
+		streamShortList: [ :listWriter |
+			self do: [ :each | listWriter add: each ] ]
+%
+
+! Class extensions for 'ScaledDecimal'
+
+!		Instance methods for 'ScaledDecimal'
+
+category: '*ston-gemstone-kernel'
+method: ScaledDecimal
+stonOn: stonWriter
+
+	stonWriter writeScaledDecimal: self
+%
+
+! Class extensions for 'SequenceableCollection'
+
+!		Class methods for 'SequenceableCollection'
+
+category: '*ston-gemstone-kernel'
+classmethod: SequenceableCollection
+fromSton: stonReader
+	^ self streamContents: [ :stream |
+		stonReader parseListDo: [ :each |
+			stream nextPut: each ] ]
+%
+
+category: '*STON-GemStoneBase'
+classmethod: SequenceableCollection
+new: newSize streamContents: blockWithArg
+  | stream |
+  stream := WriteStreamPortable on: (self new: newSize).
+  blockWithArg value: stream.
+  ^ stream contents
+%
+
+category: '*STON-GemStoneBase'
+classmethod: SequenceableCollection
+streamContents: blockWithArg
+  ^ self new: 100 streamContents: blockWithArg
+%
+
+!		Instance methods for 'SequenceableCollection'
+
+category: '*ston-gemstone-kernel'
+method: SequenceableCollection
+stonOn: stonWriter
+	self class == STON listClass
+		ifTrue: [ stonWriter writeList: self ]
+		ifFalse: [ super stonOn: stonWriter ]
+%
+
+! Class extensions for 'SmallDate'
+
+!		Class methods for 'SmallDate'
+
+category: '*ston-gemstone-kernel36x'
+classmethod: SmallDate
+stonName
+	"Need to use a well-known class name. Instances of Date converted to SmallDate if in range"
+	
+	^ 'Date'
+%
+
+! Class extensions for 'SmallDateAndTime'
+
+!		Class methods for 'SmallDateAndTime'
+
+category: '*ston-gemstone-kernel36x'
+classmethod: SmallDateAndTime
+stonName
+	"Need to use a well-known class name. Instances of DateAndTime converted to SmallDateAndTime if in range"
+	
+	^ 'DateAndTime'
+%
+
+! Class extensions for 'SmallTime'
+
+!		Class methods for 'SmallTime'
+
+category: '*ston-gemstone-kernel36x'
+classmethod: SmallTime
+stonName
+	"Need to use a well-known class name. Instances of Time converted to SmallTime if in range"
+	
+	^ 'Time'
+%
+
+! Class extensions for 'String'
+
+!		Instance methods for 'String'
+
+category: '*ston-gemstone-kernel'
+method: String
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstone-kernel'
+method: String
+stonOn: stonWriter
+	stonWriter writeString: self
+%
+
+! Class extensions for 'Symbol'
+
+!		Instance methods for 'Symbol'
+
+category: '*ston-gemstone-kernel'
+method: Symbol
+stonOn: stonWriter
+	stonWriter writeSymbol: self
+%
+
+! Class extensions for 'Time'
+
+!		Class methods for 'Time'
+
+category: '*ston-gemstonecommon'
+classmethod: Time
+fromSton: stonReader
+  ^ self fromString: stonReader parseListSingleton usingFormat: #($: true false)
+%
+
+!		Instance methods for 'Time'
+
+category: '*ston-gemstone-kernel'
+method: Time
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstonecommon'
+method: Time
+stonOn: stonWriter
+  "Use an ISO style HH:MM:SS representation"
+
+  stonWriter
+    writeObject: self
+    listSingleton: (self asStringUsingFormat: #($: true false))
+%
+
+! Class extensions for 'UndefinedObject'
+
+!		Instance methods for 'UndefinedObject'
+
+category: '*ston-gemstone-kernel'
+method: UndefinedObject
+stonContainSubObjects 
+	^ false
+%
+
+category: '*ston-gemstone-kernel'
+method: UndefinedObject
+stonOn: stonWriter
+	stonWriter writeNull
+%
+
+! Class extensions for 'UnorderedCollection'
+
+!		Instance methods for 'UnorderedCollection'
+
+category: '*ston-gemstonecommon'
+method: UnorderedCollection
+stonProcessSubObjects: block
+	"Execute block to (potentially) change each of my subObjects.
+	In general, all instance and indexable variables are processed.
+	Overwrite when necessary. Not used when #stonContainSubObjects returns false."
+"increase the starting index by 4 because of the private inst vars in UnorderedCollection"
+
+	5 to: self class instSize do: [ :each |
+		self instVarAt: each  put: (block value: (self instVarAt: each)) ].
+	(self class isVariable and: [ self class isBytes not ])
+		ifTrue: [
+			1 to: self _basicSize do: [ :each |
+				self basicAt: each put: (block value: (self basicAt: each)) ] ]
+%
+
+! Class Initialization
+
+run
+STONWriter initialize.
+true
+%

--- a/docs/gtSupport/gt4gemstone.gs
+++ b/docs/gtSupport/gt4gemstone.gs
@@ -1,0 +1,7736 @@
+! Class Declarations
+! Generated file, do not Edit
+
+doit
+(Error
+	subclass: 'GtGemStoneAssertionFailure'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneAssertionFailure
+removeallclassmethods GtGemStoneAssertionFailure
+
+doit
+(Object
+	subclass: 'AkgDebuggerPlay'
+	instVarNames: #(process trace allFrames allFramesString count block)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods AkgDebuggerPlay
+removeallclassmethods AkgDebuggerPlay
+
+doit
+(Object
+	subclass: 'GtGemStoneCompilationContext'
+	instVarNames: #(receiver frame frameIdentifier frameLevel evaluationContext clientBindings frameBindings)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneCompilationContext
+removeallclassmethods GtGemStoneCompilationContext
+
+doit
+(Object
+	subclass: 'GtGemStoneDebuggerState'
+	instVarNames: #(summary isResumable isSuspended isTerminated messageText remoteMetadata callStackSpecification)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		comment: 'GtGemStoneDebuggerInitialState holds the information required to open the GS debugger in GT:
+
+- display information for the call stack
+- exception displayString';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneDebuggerState
+removeallclassmethods GtGemStoneDebuggerState
+
+doit
+(Object
+	subclass: 'GtGemStoneDoubleLocalCallFrame'
+	instVarNames: #(previousCallFrame newCallFrame sender)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneDoubleLocalCallFrame
+removeallclassmethods GtGemStoneDoubleLocalCallFrame
+
+doit
+(Object
+	subclass: 'GtGemStoneDoubleLocalCallStack'
+	instVarNames: #(previousCallStack newCallStack callFrames)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneDoubleLocalCallStack
+removeallclassmethods GtGemStoneDoubleLocalCallStack
+
+doit
+(Object
+	subclass: 'GtGemStoneEvaluationContext'
+	instVarNames: #(exception process semaphore serializationStrategy result evaluationResult completed devMessage evalServer block callStack compilationContext)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneEvaluationContext
+removeallclassmethods GtGemStoneEvaluationContext
+
+doit
+(Object
+	subclass: 'GtGemStoneEvaluationFrameContext'
+	instVarNames: #(frameIdentifier evaluationContext)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneEvaluationFrameContext
+removeallclassmethods GtGemStoneEvaluationFrameContext
+
+doit
+(Object
+	subclass: 'GtGemstoneEvaluationResult'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneEvaluationResult
+removeallclassmethods GtGemstoneEvaluationResult
+
+doit
+(GtGemstoneEvaluationResult
+	subclass: 'GtGemstoneEvaluationCancelledResult'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneEvaluationCancelledResult
+removeallclassmethods GtGemstoneEvaluationCancelledResult
+
+doit
+(GtGemstoneEvaluationResult
+	subclass: 'GtGemstoneEvaluationComputedResult'
+	instVarNames: #(computedResult)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneEvaluationComputedResult
+removeallclassmethods GtGemstoneEvaluationComputedResult
+
+doit
+(GtGemstoneEvaluationResult
+	subclass: 'GtGemstoneEvaluationExceptionResult'
+	instVarNames: #(evaluationContext)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneEvaluationExceptionResult
+removeallclassmethods GtGemstoneEvaluationExceptionResult
+
+doit
+(GtGemstoneEvaluationResult
+	subclass: 'GtGemstoneEvaluationInProgressResult'
+	instVarNames: #(evaluationContext)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneEvaluationInProgressResult
+removeallclassmethods GtGemstoneEvaluationInProgressResult
+
+doit
+(GtGemstoneEvaluationResult
+	subclass: 'GtGemstoneEvaluationResumedResult'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneEvaluationResumedResult
+removeallclassmethods GtGemstoneEvaluationResumedResult
+
+doit
+(Object
+	subclass: 'GtGemStoneExampleObjectForLocalDelegate'
+	instVarNames: #(targetValueOne targetValueTwo anotherDelegate)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneExampleObjectForLocalDelegate
+removeallclassmethods GtGemStoneExampleObjectForLocalDelegate
+
+doit
+(Object
+	subclass: 'GtGemStoneExampleResult'
+	instVarNames: #(example result exception)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneExampleResult
+removeallclassmethods GtGemStoneExampleResult
+
+doit
+(Object
+	subclass: 'GtGemStoneExampleRunner'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneExampleRunner
+removeallclassmethods GtGemStoneExampleRunner
+
+doit
+(Object
+	subclass: 'GtGemstoneHttpClient'
+	instVarNames: #(url contents headers query)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneHttpClient
+removeallclassmethods GtGemstoneHttpClient
+
+doit
+(Object
+	subclass: 'GtGemstoneHttpJsonSerializer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemstoneHttpJsonSerializer
+removeallclassmethods GtGemstoneHttpJsonSerializer
+
+doit
+(Object
+	subclass: 'GtGemStoneLocalCallFrame'
+	instVarNames: #(frameContents homeMethod frameIdentifier)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneLocalCallFrame
+removeallclassmethods GtGemStoneLocalCallFrame
+
+doit
+(Object
+	subclass: 'GtGemStoneLocalCallStack'
+	instVarNames: #(callFrames gsProcess nextFrameIdentifier)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneLocalCallStack
+removeallclassmethods GtGemStoneLocalCallStack
+
+doit
+(Object
+	subclass: 'GtGemStoneLocalCallStackUpdater'
+	instVarNames: #(targetCallStack)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneLocalCallStackUpdater
+removeallclassmethods GtGemStoneLocalCallStackUpdater
+
+doit
+(Object
+	subclass: 'GtGemStoneRemotePhlowCollectionPrinter'
+	instVarNames: #(targetCollection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneRemotePhlowCollectionPrinter
+removeallclassmethods GtGemStoneRemotePhlowCollectionPrinter
+
+doit
+(GtGemStoneRemotePhlowCollectionPrinter
+	subclass: 'GtGemStoneRemotePhlowDictionaryPrinter'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneRemotePhlowDictionaryPrinter
+removeallclassmethods GtGemStoneRemotePhlowDictionaryPrinter
+
+doit
+(Object
+	subclass: 'GtGemStoneSemanticVersionNumber'
+	instVarNames: #(major minor patch iceTag)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneSemanticVersionNumber
+removeallclassmethods GtGemStoneSemanticVersionNumber
+
+doit
+(Object
+	subclass: 'GtGemStoneSerializationExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneSerializationExamples
+removeallclassmethods GtGemStoneSerializationExamples
+
+doit
+(Object
+	subclass: 'GtGemStoneSessionFeature'
+	instVarNames: #(enabled featureId)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneSessionFeature
+removeallclassmethods GtGemStoneSessionFeature
+
+doit
+(Object
+	subclass: 'GtGemStoneSessionFeatures'
+	instVarNames: #(featuresById)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneSessionFeatures
+removeallclassmethods GtGemStoneSessionFeatures
+
+doit
+(Object
+	subclass: 'GtGemStoneSessionTransactionConflictsReport'
+	instVarNames: #(transactionConflicts)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneSessionTransactionConflictsReport
+removeallclassmethods GtGemStoneSessionTransactionConflictsReport
+
+doit
+(Object
+	subclass: 'GtGemStoneSpecification'
+	instVarNames: #(remoteMetadata)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneSpecification
+removeallclassmethods GtGemStoneSpecification
+
+doit
+(GtGemStoneSpecification
+	subclass: 'GtGemStoneCallFrameIdentifier'
+	instVarNames: #(identityIndex)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneCallFrameIdentifier
+removeallclassmethods GtGemStoneCallFrameIdentifier
+
+doit
+(GtGemStoneSpecification
+	subclass: 'GtGemStoneClassBasicDetails'
+	instVarNames: #(targetClassName targetClassIconName)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneClassBasicDetails
+removeallclassmethods GtGemStoneClassBasicDetails
+
+doit
+(GtGemStoneSpecification
+	subclass: 'GtGemStoneFeatureSpecification'
+	instVarNames: #(enabled featureId)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneFeatureSpecification
+removeallclassmethods GtGemStoneFeatureSpecification
+
+doit
+(GtGemStoneSpecification
+	subclass: 'GtGemStoneFeaturesSpecification'
+	instVarNames: #(featureSpecifications)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneFeaturesSpecification
+removeallclassmethods GtGemStoneFeaturesSpecification
+
+doit
+(GtGemStoneSpecification
+	subclass: 'GtGemStoneMethodSpecification'
+	instVarNames: #(coderClassName selector isMeta sourceString protocolName categoryName coderClassIconName explicitProviderBehaviourDetails)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneMethodSpecification
+removeallclassmethods GtGemStoneMethodSpecification
+
+doit
+(GtGemStoneMethodSpecification
+	subclass: 'GtGemStoneContextSpecification'
+	instVarNames: #(isForBlock ipOffset frameIdentifier programCounterMarkers)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneContextSpecification
+removeallclassmethods GtGemStoneContextSpecification
+
+doit
+(GtGemStoneSpecification
+	subclass: 'GtGemStoneMethodsSpecification'
+	instVarNames: #(methodCoderSpecifications)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneMethodsSpecification
+removeallclassmethods GtGemStoneMethodsSpecification
+
+doit
+(GtGemStoneMethodsSpecification
+	subclass: 'GtGemStoneProcessSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneProcessSpecification
+removeallclassmethods GtGemStoneProcessSpecification
+
+doit
+(Object
+	subclass: 'GtGemStoneSpecificationMedatada'
+	instVarNames: #(apiVersion schemaVersion)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneSpecificationMedatada
+removeallclassmethods GtGemStoneSpecificationMedatada
+
+doit
+(Object
+	subclass: 'GtGemStoneTranscript'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-Transcript';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneTranscript
+removeallclassmethods GtGemStoneTranscript
+
+doit
+(GtGemStoneTranscript
+	subclass: 'GtGemStoneInImageTranscript'
+	instVarNames: #(contentStream enabled)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-Transcript';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneInImageTranscript
+removeallclassmethods GtGemStoneInImageTranscript
+
+doit
+(Object
+	subclass: 'GtGemStoneTranscriptHandler'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-Transcript';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneTranscriptHandler
+removeallclassmethods GtGemStoneTranscriptHandler
+
+doit
+(Object
+	subclass: 'GtGsRelease'
+	instVarNames: #(versionString)
+	classVars: #()
+	classInstVars: #(default)
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGsRelease
+removeallclassmethods GtGsRelease
+
+doit
+(Object
+	subclass: 'GtRsrSerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrSerializationStrategy
+removeallclassmethods GtRsrSerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrDirectLocalObjectSerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrDirectLocalObjectSerializationStrategy
+removeallclassmethods GtRsrDirectLocalObjectSerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrLegacySerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrLegacySerializationStrategy
+removeallclassmethods GtRsrLegacySerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrLiteralAndProxySerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		comment: 'GtRsrLiteralAndProxySerializationStrategy answers nil, numbers and booleans by value and everything else by proxy (including strings).';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrLiteralAndProxySerializationStrategy
+removeallclassmethods GtRsrLiteralAndProxySerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrLocalObjectSerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrLocalObjectSerializationStrategy
+removeallclassmethods GtRsrLocalObjectSerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrPrimitiveOnlySerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		comment: 'GtRsrPrimitiveOnlySerializationStrategy will answer anything that RSR regards as a primitive type by value, everything else is will trigger an exception.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrPrimitiveOnlySerializationStrategy
+removeallclassmethods GtRsrPrimitiveOnlySerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrProxyOnlySerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrProxyOnlySerializationStrategy
+removeallclassmethods GtRsrProxyOnlySerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrStonSerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		comment: 'STON serialisation answers everything by value, using STON to serialise the object tree.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrStonSerializationStrategy
+removeallclassmethods GtRsrStonSerializationStrategy
+
+doit
+(GtRsrSerializationStrategy
+	subclass: 'GtRsrWireSerializationStrategy'
+	instVarNames: #(encoder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrWireSerializationStrategy
+removeallclassmethods GtRsrWireSerializationStrategy
+
+doit
+(GtRsrWireSerializationStrategy
+	subclass: 'GtRsrRemoteObjectWireSerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		comment: 'GtRsrWithProxyWireSerializationStrategy provides the same functionality as its parent class, but having the separate name allows clients to choose whether to retrieve objects by value (wire serialisation) or with the object''s associated proxy.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrRemoteObjectWireSerializationStrategy
+removeallclassmethods GtRsrRemoteObjectWireSerializationStrategy
+
+doit
+(Object
+	subclass: 'STONJSON'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods STONJSON
+removeallclassmethods STONJSON
+
+doit
+(Object
+	subclass: 'ZnBase64Encoder'
+	instVarNames: #(alphabet inverse lineLength lineEnd whitespace padding strict)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods ZnBase64Encoder
+removeallclassmethods ZnBase64Encoder
+
+doit
+(RsrService
+	subclass: 'GtRsrEvaluatorFeaturesService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrEvaluatorFeaturesService
+removeallclassmethods GtRsrEvaluatorFeaturesService
+
+doit
+(GtRsrEvaluatorFeaturesService
+	subclass: 'GtRsrEvaluatorFeaturesServiceServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrEvaluatorFeaturesServiceServer
+removeallclassmethods GtRsrEvaluatorFeaturesServiceServer
+
+doit
+(RsrService
+	subclass: 'GtRsrEvaluatorService'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		comment: 'GtRsrEvaluatorService provides the ability to evaluate scripts on a GemStone server from a Gtoolkit client, using GemStone''s RemoteServiceReplicator facility.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrEvaluatorService
+removeallclassmethods GtRsrEvaluatorService
+
+doit
+(GtRsrEvaluatorService
+	subclass: 'GtRsrEvaluatorServiceServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrEvaluatorServiceServer
+removeallclassmethods GtRsrEvaluatorServiceServer
+
+doit
+(RsrService
+	subclass: 'GtRsrProxyService'
+	instVarNames: #(remoteClass)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrProxyService
+removeallclassmethods GtRsrProxyService
+
+doit
+(GtRsrProxyService
+	subclass: 'GtRsrProxyServiceServer'
+	instVarNames: #(object)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrProxyServiceServer
+removeallclassmethods GtRsrProxyServiceServer
+
+doit
+(RsrService
+	subclass: 'GtRsrTestService'
+	instVarNames: #(object)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrTestService
+removeallclassmethods GtRsrTestService
+
+doit
+(GtRsrTestService
+	subclass: 'GtRsrTestServiceClient'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrTestServiceClient
+removeallclassmethods GtRsrTestServiceClient
+
+doit
+(GtRsrTestService
+	subclass: 'GtRsrTestServiceServer'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrTestServiceServer
+removeallclassmethods GtRsrTestServiceServer
+
+doit
+(RsrService
+	subclass: 'GtRsrWireTransferService'
+	instVarNames: #(buffer roots)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrWireTransferService
+removeallclassmethods GtRsrWireTransferService
+
+doit
+(GtRsrWireTransferService
+	subclass: 'GtRsrWireTransferServiceServer'
+	instVarNames: #(object encoder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrWireTransferServiceServer
+removeallclassmethods GtRsrWireTransferServiceServer
+
+doit
+(TestCase
+	subclass: 'GtGemStoneEvaluationContextTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtGemStoneEvaluationContextTest
+removeallclassmethods GtGemStoneEvaluationContextTest
+
+doit
+(TestCase
+	subclass: 'GtRsrEvaluatorServiceTest'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-GemStone-GemStone';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrEvaluatorServiceTest
+removeallclassmethods GtRsrEvaluatorServiceTest
+
+! Class implementation for 'AkgDebuggerPlay'
+
+!		Class methods for 'AkgDebuggerPlay'
+
+category: 'playing'
+classmethod: AkgDebuggerPlay
+two
+	"AkgDebuggerPlay two"
+
+	^ self new initialize two
+%
+
+!		Instance methods for 'AkgDebuggerPlay'
+
+category: 'other'
+method: AkgDebuggerPlay
+createProcess
+
+	process := [ 
+		self evalBlock
+			on: ControlInterrupt
+			do: [ :ex |
+				trace nextPut: #ControlInterrupt -> ex.
+				process suspend.
+				ex resume ] ] newProcess.
+	process
+		priority: Processor activeProcess priority - 1;
+		breakpointLevel: 1.
+	^ process
+%
+
+category: 'rewind'
+method: AkgDebuggerPlay
+doBlock: aBlock
+self halt.
+	^ aBlock value
+%
+
+category: 'other'
+method: AkgDebuggerPlay
+evalBlock
+
+	^ [ trace nextPut: #StartedProcessExecution.
+		self haltMethod.
+		trace nextPut: #AfterHalt1.
+		trace nextPut: self getString. 
+		[ trace nextPut: #AfterHalt3. 
+		trace nextPut: #AfterHalt4. ]
+			value.
+		trace nextPut: #AfterHalt5. 
+		trace nextPut: #AfterHalt6. 
+		#akgDebuggerPlayDone.
+		]
+%
+
+category: 'accessing'
+method: AkgDebuggerPlay
+getString
+
+	^ 'get', 'String'
+%
+
+category: 'other'
+method: AkgDebuggerPlay
+haltMethod
+
+	trace nextPut: #BeforeHalt.
+	self halt.
+	trace nextPut: #AfterHalt.
+%
+
+category: 'initialization'
+method: AkgDebuggerPlay
+initialize
+
+	super initialize.
+	trace := SharedQueue new.
+	count := 0.
+%
+
+category: 'other'
+method: AkgDebuggerPlay
+printOn: aStream
+
+	trace ifNil: [ ^ super printOn: aStream ].
+	trace printOn: aStream.
+%
+
+category: 'other'
+method: AkgDebuggerPlay
+process
+
+	^ process
+%
+
+category: 'other'
+method: AkgDebuggerPlay
+run
+	| whichProc |
+
+	self createProcess.
+	process resume.
+	self waitMS: 100.
+	allFrames := process gtAllFrames.
+	allFramesString := allFrames at: 10.
+	whichProc := Processor activeProcess == process.
+	process setStepOverBreaksAtLevel: 11.
+	process resume.
+	self waitMS: 100.
+	"process resume."
+	"self waitMS: 100."
+	self halt.
+%
+
+category: 'other'
+method: AkgDebuggerPlay
+trace
+
+	^ trace
+%
+
+category: 'rewind'
+method: AkgDebuggerPlay
+two
+
+	count := count + 1.
+	count = 1 ifTrue: [ block := [ ^ 'v 001' ] ].
+	count = 2 ifTrue: 
+		[ self doBlock: block ]
+	ifFalse: 
+		[ count < 2 ifTrue: [ self two ] ].
+	count := count + 1.
+	^ count
+%
+
+category: 'other'
+method: AkgDebuggerPlay
+waitMS: milliseconds
+	(Delay forMilliseconds: milliseconds) wait
+%
+
+! Class implementation for 'GtGemStoneCompilationContext'
+
+!		Class methods for 'GtGemStoneCompilationContext'
+
+category: 'instance creation'
+classmethod: GtGemStoneCompilationContext
+receiver: anObject  frameIdentifierIndex: aFrameIdentifierIndex evaluationContext: aTargetEvaluationContext clientBindings: aDictionary 
+	^ self new 
+			setReceiver: anObject  
+			frameIdentifierIndex: aFrameIdentifierIndex 
+			evaluationContext: aTargetEvaluationContext 
+			clientBindings: aDictionary
+%
+
+!		Instance methods for 'GtGemStoneCompilationContext'
+
+category: 'accessing'
+method: GtGemStoneCompilationContext
+allBindings
+	| allBindings |
+	allBindings := GsCurrentSession currentSession symbolList
+		, (Array with: clientBindings).
+
+	^ frame
+		ifNil: [allBindings ]
+		ifNotNil: [ allBindings, (Array with: frameBindings) ]
+%
+
+category: 'bindings'
+method: GtGemStoneCompilationContext
+createClientBindingsFrom: aDictionary
+	| newBindings |
+
+	newBindings := SymbolDictionary new
+		name: #'Explicit client bindings'.
+	aDictionary keysAndValuesDo: [ :key :value |
+		newBindings at: key put: value asGtGsArgument ].
+
+	^ newBindings
+%
+
+category: 'bindings'
+method: GtGemStoneCompilationContext
+createFrameBindignsForFrame: aCallFrame ofEvaluationContext: aTargetEvaluationContext
+	^ aCallFrame createFrameBindings
+			name: ('Frame bindings for frame index ' 
+				, frame frameIdentifier identityIndex printString
+				,  ' in process with oop '
+				,  aTargetEvaluationContext processOop printString) asSymbol;
+			yourself
+%
+
+category: 'accessing'
+method: GtGemStoneCompilationContext
+currentReceiver
+	^ frame 
+		ifNil: [ receiver ]
+		ifNotNil: [ frame receiver ]
+%
+
+category: 'private'
+method: GtGemStoneCompilationContext
+initializeFrameWithFrameIdentifierIndex: aFrameIdentifierIndex
+	frame := evaluationContext frameForIdentifierIndex: aFrameIdentifierIndex.
+	frameIdentifier := frame frameIdentifier.
+	frameLevel := evaluationContext frameLevelForIdentifier: frameIdentifier.
+	frameBindings := self 
+		createFrameBindignsForFrame: frame 
+		ofEvaluationContext: evaluationContext
+%
+
+category: 'private'
+method: GtGemStoneCompilationContext
+setReceiver: anObject  frameIdentifierIndex: aFrameIdentifierIndex evaluationContext: aTargetEvaluationContext clientBindings: aDictionary
+	receiver := anObject.
+	clientBindings := self createClientBindingsFrom: aDictionary.
+
+	(aFrameIdentifierIndex notNil and: [
+		aTargetEvaluationContext notNil]) ifTrue: [
+			evaluationContext := aTargetEvaluationContext.
+			self initializeFrameWithFrameIdentifierIndex: aFrameIdentifierIndex ]
+%
+
+category: 'updating'
+method: GtGemStoneCompilationContext
+updatedFrameBindings
+	frame ifNil: [ ^ self ].
+
+	evaluationContext 
+			updateBindingsForFrame: frame
+			atLevel: frameLevel
+			with: frameBindings
+%
+
+! Class implementation for 'GtGemStoneDebuggerState'
+
+!		Class methods for 'GtGemStoneDebuggerState'
+
+category: 'instance creation'
+classmethod: GtGemStoneDebuggerState
+fromJsonString: aString
+	^ self new 
+		initializeFromJsonString: aString
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneDebuggerState
+process: aGsProcess exception: anException
+	"Create a new instance of the receiver populated for the supplied process and exception"
+
+	^ self new 
+		initializeProcess: aGsProcess 
+		exception: anException
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneDebuggerState
+process: aGsProcess exception: anException callStack: aCallStack
+	"Create a new instance of the receiver populated for the supplied process and exception"
+
+	^ self new 
+		initializeProcess: aGsProcess 
+		exception: anException
+		callStack: aCallStack
+%
+
+!		Instance methods for 'GtGemStoneDebuggerState'
+
+category: 'converting'
+method: GtGemStoneDebuggerState
+asDictionaryForExport
+
+	^ Dictionary new
+		at: 'messageText' put: messageText;
+		at: 'isSuspended' put: isSuspended;
+		at: 'isResumable' put: isResumable;
+		at: 'isTerminated' put: isTerminated;
+		at: 'summary' put: summary;
+		at: 'callStack' put: callStackSpecification asDictionaryForExport;
+		addAll: self localMetadata asMetadataAttributesForExport;
+		yourself
+%
+
+category: 'converting'
+method: GtGemStoneDebuggerState
+asJsonForExport 
+	"Answer the receiver serialised in JSON format"
+
+	^STON toJsonString: self asDictionaryForExport
+%
+
+category: 'accessing'
+method: GtGemStoneDebuggerState
+callStack
+
+	^ callStackSpecification
+%
+
+category: 'accessing'
+method: GtGemStoneDebuggerState
+callStackSpecification
+
+	^ callStackSpecification
+%
+
+category: 'gt - extensions'
+method: GtGemStoneDebuggerState
+gtViewCallFrameSpecificationsFor: aView 
+	<gtView>
+	
+	^ aView forward 
+		title: 'Frame specifications';
+		object: [ self callStackSpecification ];
+		view: #gtViewCallFrameSpecificationsFor: 
+%
+
+category: 'converting'
+method: GtGemStoneDebuggerState
+initializeFromJSONDictionary: aDictionary
+	
+	messageText := aDictionary at: 'messageText'.
+	isResumable := aDictionary at: 'isResumable'.
+	isSuspended := aDictionary at: 'isSuspended'.
+	isTerminated := aDictionary at: 'isTerminated'.
+	summary := aDictionary at: 'summary'.
+	
+	callStackSpecification := GtGemStoneProcessSpecification 
+		fromJSONDictionary:  (aDictionary at: 'callStack').
+		
+	self initializeMetadataFromJSONDictionary: aDictionary.
+%
+
+category: 'converting'
+method: GtGemStoneDebuggerState
+initializeFromJsonString: aString
+	| dictionary |
+
+	dictionary := STON fromString: aString.
+	
+	self initializeFromJSONDictionary: dictionary.
+%
+
+category: 'converting'
+method: GtGemStoneDebuggerState
+initializeMetadataFromJSONDictionary: aDictionary 
+	remoteMetadata := GtGemStoneSpecificationMedatada 
+		fromObjectDictionary: aDictionary
+%
+
+category: 'initialize'
+method: GtGemStoneDebuggerState
+initializeProcess2: aGsProcess exception: anException
+
+	messageText := [ anException messageText ifNil: [ anException printString ] ]
+		on: Error
+		do: [ :ex | 'Error while attempting to obtain messageText' ].
+	isResumable := anException isResumable.
+	isSuspended := aGsProcess _isSuspended.
+	isTerminated := aGsProcess _isTerminated.
+	summary := aGsProcess _isTerminated
+		ifTrue: [ 'Terminated: ', messageText ]
+		ifFalse: [ messageText ].
+
+	callStackSpecification := aGsProcess gtAllFrames collect: [ :frameArray |
+		| homeMethod |
+		homeMethod := frameArray first homeMethod.
+		{ homeMethod inClass ifNotNil: [ :cls | cls name ].
+		homeMethod selector.
+		frameArray first isMethodForBlock. } ].
+%
+
+category: 'initialize'
+method: GtGemStoneDebuggerState
+initializeProcess: aGsProcess exception: anException
+
+	messageText := [ anException messageText ifNil: [ anException printString ] ]
+		on: Error
+		do: [ :ex | 'Error while attempting to obtain messageText' ].
+	isResumable := anException isResumable.
+	isSuspended := aGsProcess _isSuspended.
+	isTerminated := aGsProcess _isTerminated.
+	summary := aGsProcess _isTerminated
+		ifTrue: [ 'Terminated: ', messageText ]
+		ifFalse: [ messageText ].
+
+	callStackSpecification := (GtGemStoneLocalCallStack forProcess: aGsProcess) createSpecification
+%
+
+category: 'initialize'
+method: GtGemStoneDebuggerState
+initializeProcess: aGsProcess exception: anException callStack: aCallStack
+
+	messageText := [ anException messageText ifNil: [ anException printString ] ]
+		on: Error
+		do: [ :ex | 'Error while attempting to obtain messageText' ].
+	isResumable := anException isResumable.
+	isSuspended := aGsProcess _isSuspended.
+	isTerminated := aGsProcess _isTerminated.
+	summary := aGsProcess _isTerminated
+		ifTrue: [ 'Terminated: ', messageText ]
+		ifFalse: [ messageText ].
+
+	callStackSpecification := aCallStack createSpecification
+%
+
+category: 'accessing'
+method: GtGemStoneDebuggerState
+isResumable
+
+	^ isResumable
+%
+
+category: 'accessing'
+method: GtGemStoneDebuggerState
+isSuspended
+
+	^ isSuspended
+%
+
+category: 'accessing'
+method: GtGemStoneDebuggerState
+isTerminated
+
+	^ isTerminated
+%
+
+category: 'converting'
+method: GtGemStoneDebuggerState
+llmDataViewFor: aDataView
+	<gtLlmDataView>
+	
+	^aDataView jsonData
+			title: 'Exception properties';
+			data: [ 
+				{
+					'summary' -> self summary.
+					'messageText' -> self messageText.
+					'callStack' -> (self callStackSpecification frameSpecifications
+						collect: [ :aStackFrame |
+							String streamContents: [:aStream |
+								aStream 
+									<< aStackFrame printBehaviorName;
+									<< '>>';
+									<< (aStackFrame selector ifNil: [ '<none>' ]) ]])
+				} asDictionary]
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneDebuggerState
+localApiVersion
+	^ GtGemStoneSemanticVersionNumber oneZeroZero
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneDebuggerState
+localMetadata
+	^ GtGemStoneSpecificationMedatada new 
+		apiVersion: self localApiVersion;
+		schemaVersion: self localSchemaVersion
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneDebuggerState
+localSchemaVersion
+	^ GtGemStoneSemanticVersionNumber oneZeroZero
+%
+
+category: 'accessing'
+method: GtGemStoneDebuggerState
+messageText
+
+	^ messageText
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneDebuggerState
+remoteMetadata
+	^ remoteMetadata
+%
+
+category: 'accessing'
+method: GtGemStoneDebuggerState
+summary
+
+	^ summary
+%
+
+! Class implementation for 'GtGemStoneDoubleLocalCallFrame'
+
+!		Class methods for 'GtGemStoneDoubleLocalCallFrame'
+
+category: 'instance creation'
+classmethod: GtGemStoneDoubleLocalCallFrame
+forPreviousCallFrame: aPreviousCallFrame newCallFrame: aNewCallFrame
+	^ self new 
+		initializeForPreviousCallFrame: aPreviousCallFrame 
+		newCallFrame: aNewCallFrame
+%
+
+!		Instance methods for 'GtGemStoneDoubleLocalCallFrame'
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+frameIdentifierDescription
+	^ String streamContents: [ :aStream | 
+		self printFrameIdentifierDescriptionOn: aStream ]
+%
+
+category: 'testing'
+method: GtGemStoneDoubleLocalCallFrame
+hasCallFrames 
+	^ previousCallFrame notNil and: [ newCallFrame notNil ]
+%
+
+category: 'testing'
+method: GtGemStoneDoubleLocalCallFrame
+hasSameProperties
+	^ self hasCallFrames and: [ 
+			previousCallFrame hasSamePropertiesAs: newCallFrame ]
+%
+
+category: 'testing'
+method: GtGemStoneDoubleLocalCallFrame
+hasSamePropertiesSinceTheBeginning
+	| currentContext |
+	currentContext := self.
+	[ currentContext notNil and: [currentContext hasSameProperties ] ]
+		whileTrue: [ currentContext := currentContext sender ].
+		
+	^ currentContext isNil
+%
+
+category: 'initialization'
+method: GtGemStoneDoubleLocalCallFrame
+initializeForPreviousCallFrame: aPreviousCallFrame newCallFrame: aNewCallFrame 
+	previousCallFrame := aPreviousCallFrame.
+	newCallFrame := aNewCallFrame.
+%
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+ipOffsetDescription
+	^ String streamContents: [ :aStream | 
+		self printIpOffsetDescriptionOn: aStream ]
+%
+
+category: 'testing'
+method: GtGemStoneDoubleLocalCallFrame
+isForSameMethodOrBlock
+	^ self hasCallFrames and: [
+			previousCallFrame isForSameMethodOrBlockAs: newCallFrame ]
+%
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+methodDescription
+	^ String streamContents: [ :aStream | 
+		self printMethodDescriptionOn: aStream ]
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+newCallFrame
+	^ newCallFrame
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+newFrameIdentifier
+	^ newCallFrame 
+		ifNil: [ nil ]
+		ifNotNil: [ :aCallFrame | aCallFrame frameIdentifier ]
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+newIpOffset
+	^ newCallFrame 
+		ifNil: [ nil ]
+		ifNotNil: [ :aCallFrame | aCallFrame ipOffset ]
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+phlowBackgroundColor
+	^ nil
+	"| allSendersMatch |
+	allSendersMatch := self sender
+		ifNil: [true] 
+		ifNotNil: [ :aSender | aSender hasSamePropertiesSinceTheBeginning ].
+	
+	^ (self hasSameProperties and: [ allSendersMatch ])
+			ifTrue: [ GtPhlowColor named: #green alpha: 0.4 ]
+			ifFalse: [ 
+				allSendersMatch
+					ifTrue: [ GtPhlowColor named: #orange alpha: 0.4 ]
+					ifFalse: [ GtPhlowColor transparent ]  ]"
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+phlowBackgroundColorInIsolation
+	^ nil
+	"| senderMatches |
+	senderMatches := self sender
+		ifNil: [true] 
+		ifNotNil: [ :aSender | aSender hasSameProperties ].
+	
+	^ self hasSameProperties
+			ifTrue: [ GtPhlowColor named: #green alpha: 0.4 ]
+			ifFalse: [ 
+				senderMatches
+					ifTrue: [ GtPhlowColor named: #orange alpha: 0.4 ]
+					ifFalse: [ GtPhlowColor transparent ]  ]"
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+previousCallFrame
+	^ previousCallFrame
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+previousFrameIdentifier
+	^ previousCallFrame 
+		ifNil: [ nil ]
+		ifNotNil: [ :aCallFrame | aCallFrame frameIdentifier ]
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+previousIpOffset
+	^ previousCallFrame 
+		ifNil: [ nil ]
+		ifNotNil: [ :aCallFrame | aCallFrame ipOffset ]
+%
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+printComparisonBetween: anObject and: anotherObject withFormat: aFormatBlock on: aStream
+	| previousDescription newDescription|
+	previousDescription := anObject
+		ifNil: [ ' - '] ifNotNil: [ :targetObject | aFormatBlock cull: targetObject ].
+	newDescription := anotherObject
+		ifNil: [ ' - '] ifNotNil: [ :targetObject | aFormatBlock cull: targetObject ].
+	
+	anObject = anotherObject
+		ifTrue: [
+			aStream
+				nextPutAll: previousDescription ]
+		ifFalse: [
+			aStream
+				nextPutAll: previousDescription;
+				nextPutAll: ' / ';
+				nextPutAll: newDescription ]
+%
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+printFrameIdentifierDescriptionOn: aStream
+	^ self 
+		printComparisonBetween: self previousFrameIdentifier 
+		and: self newFrameIdentifier 
+		withFormat: [ :anIdentifier | anIdentifier description ] 
+		on: aStream
+%
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+printIpOffsetDescriptionOn: aStream
+	^ self 
+		printComparisonBetween: self previousIpOffset 
+		and: self newIpOffset 
+		withFormat: [ :anOffset | anOffset asString ]
+		on: aStream
+%
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+printMethodDescriptionOn: aStream
+	| previousDescription newDescription|
+	previousDescription := self previousCallFrame
+		ifNil: [ ' - '] ifNotNil: [ :aCallFrame | aCallFrame methodDescription ].
+	newDescription := self newCallFrame
+		ifNil: [ ' - '] ifNotNil: [ :aCallFrame | aCallFrame methodDescription ].
+	
+	self isForSameMethodOrBlock
+		ifTrue: [
+			aStream
+				nextPutAll: previousDescription ]
+		ifFalse: [
+			aStream
+				nextPutAll: previousDescription;
+				nextPutAll: ' / ';
+				nextPutAll: newDescription ]
+%
+
+category: 'printing'
+method: GtGemStoneDoubleLocalCallFrame
+printOn: aStream
+	super printOn: aStream.
+	
+	self isForSameMethodOrBlock ifTrue: [
+		aStream parenthesize: [ 
+			previousCallFrame printMethodDescriptionOn: aStream.
+			aStream 
+				nextPutAll: ' ['.
+			self printIpOffsetDescriptionOn: aStream.
+			aStream
+				nextPutAll: ']; id='.
+			self printFrameIdentifierDescriptionOn: aStream ].
+		^ self ].
+		
+	aStream parenthesize: [ 
+		previousCallFrame
+			ifNil: [ aStream nextPutAll: ' - ']
+			ifNotNil: [ 
+				previousCallFrame printMethodDescriptionOn: aStream.
+				aStream nextPutAll: ' '.
+				previousCallFrame printExtraDetailsOn: aStream. ].
+		aStream nextPutAll: ' / '.
+		newCallFrame
+			ifNil: [ aStream nextPutAll: ' - ']
+			ifNotNil: [ 
+				newCallFrame printMethodDescriptionOn: aStream.
+				aStream nextPutAll: ' '.
+				newCallFrame printExtraDetailsOn: aStream. ] ] 
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+sender
+	^ sender
+%
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallFrame
+sender: aDoubleStackFrame
+	(sender isNil and: [ aDoubleStackFrame notNil ]) ifFalse: [ Error signal] .
+	
+	sender := aDoubleStackFrame
+%
+
+! Class implementation for 'GtGemStoneDoubleLocalCallStack'
+
+!		Class methods for 'GtGemStoneDoubleLocalCallStack'
+
+category: 'instance creation'
+classmethod: GtGemStoneDoubleLocalCallStack
+forPreviousCallStack: aPreviousCallStack newCallStack: aNewCallStack
+	^ self new 
+		initializeForPreviousCallStack: aPreviousCallStack 
+		newCallStack: aNewCallStack
+%
+
+!		Instance methods for 'GtGemStoneDoubleLocalCallStack'
+
+category: 'accessing'
+method: GtGemStoneDoubleLocalCallStack
+firstDivergentContentsIndex
+	"This looks for the first different pair of contexts between the two stack."
+	| currentIndex newIndex |
+	currentIndex := previousCallStack numberOfCallFrames.
+	newIndex := newCallStack numberOfCallFrames.
+
+	[ 
+		(1 <= currentIndex) and: [
+			(1 <= newIndex) and: [
+				(previousCallStack callFramesAt: currentIndex)
+					hasSamePropertiesAs:(newCallStack callFramesAt: newIndex) ] ]
+	] whileTrue: [ 
+		currentIndex := currentIndex - 1.
+		newIndex := newIndex - 1 ].
+	
+	^ {currentIndex . newIndex}
+%
+
+category: 'gt - extensions'
+method: GtGemStoneDoubleLocalCallStack
+gtViewDoubleStackFramesBasicFor: aView
+	"<gtView>"
+	"Create a view where the background color is determined by doing looking
+	only at the context in isolation (ignoring senders)"
+	
+	^ (self 
+		gtViewDoubleStackFramesFor: aView 
+		withBackground:  [ :aDescription :aDoubleFrame |
+			aDoubleFrame phlowBackgroundColorInIsolation ])
+				title: 'Call Frames - in isolation';
+				priority: 15
+%
+
+category: 'gt - extensions'
+method: GtGemStoneDoubleLocalCallStack
+gtViewDoubleStackFramesFor: aView withBackground: aBackgroundBlock
+	
+	^ aView columnedList 
+		items: [ callFrames ];
+		column: 'Index' textDo: [ :aColumn |
+			aColumn
+				format: [ :aDoubleFrame :anIndex | anIndex ];
+				width: 75;
+				background: aBackgroundBlock ];
+		column: 'Identifier' textDo: [ :aColumn | 
+			aColumn
+				format: [ :aDoubleFrame |
+					aDoubleFrame frameIdentifierDescription ];
+				width: 75;
+				background: aBackgroundBlock ];
+		column: 'IP Offset' textDo: [ :aColumn | 
+			aColumn
+				format: [ :aDoubleFrame |
+					aDoubleFrame ipOffsetDescription ];
+				width: 75;
+				background: aBackgroundBlock ];
+		column: 'New Stack'  textDo: [ :aColumn | 
+			aColumn
+				format: [ :aDoubleFrame |
+					aDoubleFrame newCallFrame 
+						ifNil: [ '-' ] ifNotNil: [ :aCallFrame | 
+							aCallFrame methodDescription ] ];
+				background: aBackgroundBlock ];
+		column: 'Previous Stack'  textDo: [ :aColumn | 
+			aColumn
+				format: [ :aDoubleFrame |
+					(aDoubleFrame isForSameMethodOrBlock not and: [
+						aDoubleFrame newCallFrame notNil ])
+							ifFalse: [ ''] 
+							ifTrue: [ 
+								aDoubleFrame newCallFrame methodDescription ] ];
+				background: [ :aDescription :aDoubleFrame |
+					aDoubleFrame isForSameMethodOrBlock 
+						ifTrue: ["GtPhlowColor transparent" nil]
+						ifFalse: [ 
+							aBackgroundBlock cull: aDescription cull: aDoubleFrame ] ] ]
+%
+
+category: 'gt - extensions'
+method: GtGemStoneDoubleLocalCallStack
+gtViewDoubleStackFramesListFor: aView
+	"<gtView>"
+	"Create a view where the background color is determined by doing looking
+	at the full stack."
+	
+	^ (self 
+		gtViewDoubleStackFramesFor: aView 
+		withBackground:  [ :aDescription :aDoubleFrame |
+			aDoubleFrame phlowBackgroundColor ])
+				title: 'Call Frames';
+				priority: 10
+%
+
+category: 'gt - extensions'
+method: GtGemStoneDoubleLocalCallStack
+gtViewNewStackFramesFor: aView
+	<gtView>
+	
+	^ aView forward 
+		title: 'New Call Frames';
+		priority: 41;
+		object: [ newCallStack ];
+		view: #gtViewStackFramesFor: 
+%
+
+category: 'gt - extensions'
+method: GtGemStoneDoubleLocalCallStack
+gtViewPreviousStackFramesFor: aView
+	<gtView>
+	
+	^ aView forward 
+		title: 'Previous Call Frames';
+		priority: 40;
+		object: [ previousCallStack ];
+		view: #gtViewStackFramesFor: 
+%
+
+category: 'initialization'
+method: GtGemStoneDoubleLocalCallStack
+initializeCallStackFrames
+	| previousIndex newIndex reversedCallFrames |
+	
+	previousIndex := previousCallStack numberOfCallFrames.
+	newIndex := newCallStack numberOfCallFrames.
+	reversedCallFrames := OrderedCollection new.
+
+	[ 
+		(1 <= previousIndex) and: [ (1 <= newIndex) ]
+	] whileTrue: [ 
+		reversedCallFrames add: (GtGemStoneDoubleLocalCallFrame
+			forPreviousCallFrame: (previousCallStack callFramesAt: previousIndex)
+			newCallFrame: (newCallStack callFramesAt: newIndex)).
+		previousIndex := previousIndex - 1.
+		newIndex := newIndex - 1 ].
+		
+	[ 1 <= previousIndex ] whileTrue: [
+		reversedCallFrames add: (GtGemStoneDoubleLocalCallFrame
+			forPreviousCallFrame: (previousCallStack callFramesAt: previousIndex)
+			newCallFrame: nil).
+		previousIndex := previousIndex - 1 ].
+	
+	[ 1 <= newIndex ] whileTrue: [
+		reversedCallFrames add: (GtGemStoneDoubleLocalCallFrame
+			forPreviousCallFrame: nil
+			newCallFrame: (newCallStack callFramesAt: newIndex)).
+		newIndex := newIndex - 1 ].
+		
+	callFrames := reversedCallFrames reversed.
+%
+
+category: 'initialization'
+method: GtGemStoneDoubleLocalCallStack
+initializeForPreviousCallStack: aPreviousCallStack newCallStack: aNewCallStack
+	previousCallStack := aPreviousCallStack.
+	newCallStack := aNewCallStack. 
+	
+	self initializeCallStackFrames.
+	self initializeStackFrameSenders
+%
+
+category: 'initialization'
+method: GtGemStoneDoubleLocalCallStack
+initializeStackFrameSenders
+	1 to: callFrames size -1 do: [ :anIndex |
+		(callFrames at: anIndex) sender: (callFrames at: anIndex + 1)  ]
+%
+
+! Class implementation for 'GtGemStoneEvaluationContext'
+
+!		Instance methods for 'GtGemStoneEvaluationContext'
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+assertNotSignalled
+
+	semaphore isLocked ifFalse:
+		[ self error: 'Process semaphore already signalled' ]
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+buildMessageText
+
+	^ exception buildMessageText
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+callStack
+	^ callStack ifNil: [
+			callStack := self createNewCallStack ]
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+compilationContext: aCompilationContext
+	compilationContext := aCompilationContext
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+createNewCallStack
+	^ GtGemStoneLocalCallStack forProcess: process
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+debuggerState
+	callStack := self createNewCallStack.
+	
+	^ GtGemStoneDebuggerState
+		process: process
+		exception: exception
+		callStack: callStack
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+debuggerStateDictionaryForExport
+
+	^ self debuggerState asDictionaryForExport
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+debuggerStateJsonForExport
+
+	^ self debuggerState asJsonForExport
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+devMessage
+	^devMessage
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+devMessage: object
+	devMessage := object
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+evalServer
+	^evalServer
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+evalServer: object
+	evalServer := object
+%
+
+category: 'actions - api'
+method: GtGemStoneEvaluationContext
+evaluateAndWaitBlock: aBlock from: anEvaluationServer
+	"Evaluate the supplied block.
+	If it completes successfully, answer the result.
+	If an exception is raised, suspend the evaluation process and answer the receiver."
+
+	self evaluateBlock: aBlock from: anEvaluationServer priority: Processor userBackgroundPriority.
+	^ self waitForEvaluationResult.
+%
+
+category: 'actions - api'
+method: GtGemStoneEvaluationContext
+evaluateBlock: aBlock from: anEvaluationServer priority: anInteger
+	"Start evaluation of the supplied block.
+	If it completes successfully, result is the return value of aBlock.
+	If an exception is raised, suspend the evaluation process and set result to the receiver."
+
+	block := aBlock.
+	semaphore := Semaphore new.
+	completed := false.
+	evalServer := anEvaluationServer.
+
+	process := [
+		[ | computationResult |
+		computationResult := block value.
+
+		result := self serializationStrategy
+			ifNil: [ computationResult  ]
+			ifNotNil: [ :aSerializationStrategy | 
+				| strategies strategy |
+				strategies := SessionTemps current
+					at: #GtSerializationStrategies
+					ifAbsent: [].
+				strategy := strategies ifNotNil:
+					[ strategies at: aSerializationStrategy ifAbsent: [] ].
+				strategy ifNil:
+					[ strategy := (GsSession currentSession objectNamed: aSerializationStrategy) new ].
+				strategy serialize: computationResult ].
+		evaluationResult := GtGemstoneEvaluationComputedResult new 
+			computedResult: result.
+		completed := true.
+		semaphore signal ]
+			on: Exception
+			do: (self handlerBlock: nil) ] newProcess.
+
+	"Need to figure out the circumstances when the debugActionBlock: is called"
+	process debugActionBlock: (self handlerBlock: 'debugActionBlock:').
+
+	process
+		name: 'GT evaluation';
+		priority: anInteger;
+		breakpointLevel: 1;
+		resume.
+
+	^ GtGemstoneEvaluationInProgressResult new
+		 evaluationContext: self
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+exception
+
+	^ exception
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+exception: anException
+
+	exception := anException
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+frameContentsAtLevel: anInteger
+
+	^ process _frameContentsAt: anInteger
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+frameForIdentifier: aFrameIdentifier
+	callStack ifNil: [ Error signal: 'Call stack not initialized!' ].
+
+	^ callStack frameForIdentifier: aFrameIdentifier
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+frameForIdentifierIndex: aFrameIdentifierIndex
+	^ self frameForIdentifier: (GtGemStoneCallFrameIdentifier forIndex: aFrameIdentifierIndex)
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+frameLevelForIdentifier: aFrameIdentifier
+	callStack ifNil: [ Error signal: 'Call stack not initialized!' ].
+
+	^ callStack frameLevelForIdentifier: aFrameIdentifier
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+frameLevelForIdentifierIndex: aFrameIdentifierIndex
+	^ self frameLevelForIdentifier: (GtGemStoneCallFrameIdentifier forIndex: aFrameIdentifierIndex)
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+handlerBlock: anObject
+	"Answer the block that will be evaluated if an exception occurs.
+	In this case, suspend the evaluation process and answer the receiver.
+	If the user resumes the process it will then resume from where the exception was originally raised."
+
+	^ [ :ex |
+	
+		exception := ex.
+		devMessage := anObject.
+	
+		result := self asGtRsrProxyObjectForConnection: evalServer _connection.
+		evaluationResult := GtGemstoneEvaluationExceptionResult new
+			evaluationContext: self.
+	
+		semaphore signal.
+		process suspend.
+		ex resume ]
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+interruptAsyncComputation
+
+	process suspend.
+
+	self createNewCallStack firstNonCriticalFrameIndex
+		ifNil: [ "Possibly handle the case of processes that we cannot interrupt" ]
+		ifNotNil: [ :anIndex | 
+			process setStepIntoBreaksAtLevel: 	anIndex ].
+	
+	process resume.
+
+	^ #interruptedAsync
+%
+
+category: 'testing'
+method: GtGemStoneEvaluationContext
+isCompleted
+	"Answer a boolean indicating whether the receiver's process has completed and successfully answered a result"
+
+	^ completed
+%
+
+category: 'testing'
+method: GtGemStoneEvaluationContext
+isResumable
+
+	^ exception isResumable
+%
+
+category: 'testing'
+method: GtGemStoneEvaluationContext
+isSuspended
+
+	^ process _isSuspended
+%
+
+category: 'testing'
+method: GtGemStoneEvaluationContext
+isTerminated
+
+	^ process _isTerminated
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+methodAtFrameLevel: anInteger
+
+	^ (process _frameContentsAt: anInteger) first
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+newDebuggerState
+	callStack := self createNewCallStack.
+	
+	^ GtGemStoneDebuggerState
+		process: process
+		exception: exception
+		callStack: callStack
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+newDebuggerStateDictionaryForExport
+
+	^ self newDebuggerState asDictionaryForExport
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+newDebuggerStateJsonForExport
+
+	^ self newDebuggerState asJsonForExport
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+process
+
+	^ process
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+processOop
+	^ process asOop
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+programCounterMarkersAtFrameIdentifierIndex: aFrameIdentifierIndex
+	^ (self frameForIdentifierIndex: aFrameIdentifierIndex) programCounterMarkers
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+restartFrameIdentifierIndex: aFrameIdentifierIndex
+	^ self restartFrameLevel: (self frameLevelForIdentifierIndex: aFrameIdentifierIndex)
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+restartFrameLevel: anInteger
+
+	process _trimStackToLevel: anInteger.
+	^ #restart
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+resume
+
+	self assertNotSignalled.
+	process resume.
+	
+	^ self waitForEvaluationResult asDictionaryForExport
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+resumeAsyncComputation
+
+	self assertNotSignalled.
+	process resume.
+
+	^ GtGemstoneEvaluationResumedResult new asDictionaryForExport
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+serializationStrategy
+	^serializationStrategy
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+serializationStrategy: object
+	serializationStrategy := object
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+sourceCodeAtFrameLevel: anInteger
+
+	^ (self stackFrames at: anInteger) first sourceString
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+sourceInfoAtFrameIdentifierIndex: aFrameIdentifierIndex
+	^ self sourceInfoAtFrameLevel: (self frameLevelForIdentifierIndex: aFrameIdentifierIndex)
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+sourceInfoAtFrameLevel: anInteger
+	| frameContents source ipOffset markers startIndex endIndex i |
+
+	frameContents := self stackFrames at: anInteger.
+	source := frameContents first sourceString.
+	ipOffset := frameContents second.
+	markers := frameContents first _buildIpMarkerArray.
+	startIndex := markers indexOf: ipOffset.
+	startIndex = 0 ifTrue:
+		[ ^ { 1. source size. source } ].
+	i := startIndex + 1.
+
+	[ endIndex isNil and: [ i <= markers size ] ] whileTrue:
+		[ (markers at: i) notNil ifTrue:
+			[ endIndex := i ].
+		i := i + 1 ].
+	endIndex ifNil: [ endIndex := source size ].
+	^ { startIndex. endIndex. source. }
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationContext
+stackFrames
+
+	^ process gtAllFrames
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+stdout
+
+	^ System gemLogFileName asFileReference contents
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+stepIntoFrameIdentifierIndex: aFrameIdentifierIndex
+	^ self stepIntoFrameLevel: (self frameLevelForIdentifierIndex: aFrameIdentifierIndex)
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+stepIntoFrameLevel: anInteger
+
+	process setStepIntoBreaksAtLevel: anInteger.
+	self resume.
+	^ #stepInto
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+stepOverFrameIdentifierIndex: aFrameIdentifierIndex
+	^ self stepOverFrameLevel: (self frameLevelForIdentifierIndex: aFrameIdentifierIndex)
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+stepOverFrameLevel: anInteger
+
+	process setStepOverBreaksAtLevel: anInteger.
+	self resume.
+	^ #stepOver
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+stepThroughFrameIdentifierIndex: aFrameIdentifierIndex
+	^ self stepThroughFrameLevel: (self frameLevelForIdentifierIndex: aFrameIdentifierIndex)
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+stepThroughFrameLevel: anInteger
+
+	process setStepThroughBreaksAtLevel: anInteger.
+	self resume.
+	^ #stepThrough
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+synchronizeCallStack
+	| currentCallStack stackUpdater |
+	currentCallStack := self callStack.
+	stackUpdater := GtGemStoneLocalCallStackUpdater forCallStack: currentCallStack.
+
+	stackUpdater updateBasedOn: self createNewCallStack.
+
+	^ (GtGemStoneDebuggerState
+		process: process
+		exception: exception
+		callStack: currentCallStack) asJsonForExport
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+synchronizeCallStackDictionaryForExport
+	| currentCallStack stackUpdater |
+	currentCallStack := self callStack.
+	stackUpdater := GtGemStoneLocalCallStackUpdater forCallStack: currentCallStack.
+
+	stackUpdater updateBasedOn: self createNewCallStack.
+
+	^ (GtGemStoneDebuggerState
+		process: process
+		exception: exception
+		callStack: currentCallStack) asDictionaryForExport
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+terminateAsyncComputation
+
+	process terminate.
+ 
+	evaluationResult := GtGemstoneEvaluationCancelledResult new.
+	semaphore signal.
+
+	^ #terminatedAsync
+%
+
+category: 'actions - debug'
+method: GtGemStoneEvaluationContext
+terminateProcess
+
+	process terminate
+%
+
+category: 'actions - frame'
+method: GtGemStoneEvaluationContext
+updateBindingsForFrame: aCallFrame atLevel: frameLevel with: frameBindings
+	self callStack 
+		updateBindingsForFrame:aCallFrame
+		atLevel: frameLevel
+		with: frameBindings
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+variable: aSymbol atFrameLevel: anInteger
+	"Answer the variables from the specified frame.
+
+	This method is deprecated in favour of #variableIndex:atFrameLevel: as it doesn't handle instance variables."
+	| frameContents varNames index |
+
+	frameContents := process _frameContentsAt: anInteger.
+	varNames := frameContents at: 9.
+	index := varNames indexOf: aSymbol asSymbol.
+	^ frameContents at: index + 10.
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+variableArrayAtFrameLevel: anInteger
+	"Answer an Array of Associations of the items to be displayed in the Variable pane of the specified frame."
+	| frameContents associations varNames selfObject |
+
+	frameContents := process _frameContentsAt: anInteger.
+	selfObject := frameContents at: 8.
+	associations := SortedCollection sortBlock: [ :a :b | a first < b first ].
+
+	varNames := frameContents at: 9.
+	1 to: varNames size do: [ :i | | object |
+		object := frameContents at: i + 10.
+		associations add: { varNames at: i. object. #frame. object class gtSystemIconName.  } ].
+
+	associations := associations asOrderedCollection.
+
+	(selfObject gtRemoteVariableValuePairsWithSelfIf: false) do:
+		[ :assoc | associations add: { assoc key. assoc value. #instVar.  assoc value class gtSystemIconName. }. ].
+
+	associations addAllFirst:
+		{ { #self. selfObject. #self. selfObject class gtSystemIconName. }.
+			{ #receiver. (frameContents at: 10). #receiver. (frameContents at: 10) class gtSystemIconName } }.
+
+	^ associations asArray.
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+variableIndex: index atFrameIdentifierIndex: aFrameIdentifierIndex
+	^ self variableIndex: index atFrameLevel: (self frameLevelForIdentifierIndex: aFrameIdentifierIndex)
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+variableIndex: index atFrameLevel: anInteger
+	"Answer the variable from the specified frame"
+
+	^ ((self variableArrayAtFrameLevel: anInteger) at: index) second
+%
+
+category: 'actions - debug (identifier)'
+method: GtGemStoneEvaluationContext
+variableInfoAtFrameIdentifierIndex: aFrameIdentifierIndex
+	^ self variableInfoAtFrameLevel: (self frameLevelForIdentifierIndex: aFrameIdentifierIndex)
+%
+
+category: 'actions - debug (level)'
+method: GtGemStoneEvaluationContext
+variableInfoAtFrameLevel: anInteger
+	"Answer the variables from the specified frame, including self's instance variables"
+
+	^ (self variableArrayAtFrameLevel: anInteger) collect: [ :each | | displayData |
+		displayData := each copy.
+		displayData at: 2 put: each second gtDisplayString.
+		displayData ]
+%
+
+category: 'actions - api'
+method: GtGemStoneEvaluationContext
+wait
+
+	^ self waitForEvaluationResult asDictionaryForExport
+%
+
+category: 'actions - api'
+method: GtGemStoneEvaluationContext
+waitForComputationResult
+
+	semaphore wait.
+	^ result
+%
+
+category: 'actions - api'
+method: GtGemStoneEvaluationContext
+waitForEvaluationResult
+
+	semaphore wait.
+	^ evaluationResult
+%
+
+category: 'private'
+method: GtGemStoneEvaluationContext
+waitMS: milliseconds
+	(Delay forMilliseconds: milliseconds) wait
+%
+
+! Class implementation for 'GtGemStoneEvaluationFrameContext'
+
+!		Class methods for 'GtGemStoneEvaluationFrameContext'
+
+category: 'instance creation'
+classmethod: GtGemStoneEvaluationFrameContext
+frameIdentifier: aFrameIdentifier evaluationContext: anEvaluationContext
+	^ self new 
+		initializeWithFrameIdentifier: aFrameIdentifier 
+		evaluationContext: anEvaluationContext
+%
+
+!		Instance methods for 'GtGemStoneEvaluationFrameContext'
+
+category: 'accessing'
+method: GtGemStoneEvaluationFrameContext
+evaluationContext
+	^ evaluationContext
+%
+
+category: 'accessing'
+method: GtGemStoneEvaluationFrameContext
+frameIdentifier
+	^ frameIdentifier
+%
+
+category: 'initialization'
+method: GtGemStoneEvaluationFrameContext
+initializeWithFrameIdentifier: aFrameIdentifier evaluationContext: anEvaluationContext
+	frameIdentifier := aFrameIdentifier.
+	evaluationContext := anEvaluationContext.
+%
+
+! Class implementation for 'GtGemstoneEvaluationResult'
+
+!		Class methods for 'GtGemstoneEvaluationResult'
+
+category: 'instance creation'
+classmethod: GtGemstoneEvaluationResult
+fromJSONDictionary: aDictionary
+	^ self new  
+		initializeFromJSONDictionary: aDictionary
+%
+
+category: 'testing'
+classmethod: GtGemstoneEvaluationResult
+isSerializedData: aValue
+	^ self subclasses anySatisfy: [ :aClass |
+		aClass isSerializedDataForCurrentClass: aValue ]
+%
+
+category: 'testing'
+classmethod: GtGemstoneEvaluationResult
+isSerializedDataForCurrentClass: aValue
+	^ (aValue class = Dictionary and: [
+		aValue 
+			at: '__typeName'
+			ifPresent: [ :aClassName | 
+				aClassName = self name ] 
+			ifAbsent: [ false ] ])
+%
+
+!		Instance methods for 'GtGemstoneEvaluationResult'
+
+category: 'accessing'
+method: GtGemstoneEvaluationResult
+computedResult
+	"The value that will be returned to the called as the result of the evaluation"
+	^ self subclassResponsibility
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationResult
+hasEvaluationException
+	^ false
+%
+
+category: 'initialization '
+method: GtGemstoneEvaluationResult
+initializeFromJSONDictionary: aDictionary
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationResult
+isEvaluationCancelledResult
+	^ false
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationResult
+isEvaluationComputedResult
+	^ false
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationResult
+isResumedExecutionResult
+	^ false
+%
+
+! Class implementation for 'GtGemstoneEvaluationCancelledResult'
+
+!		Instance methods for 'GtGemstoneEvaluationCancelledResult'
+
+category: 'accessing'
+method: GtGemstoneEvaluationCancelledResult
+computedResult
+	^ nil
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationCancelledResult
+isEvaluationCancelledResult
+	^ true
+%
+
+! Class implementation for 'GtGemstoneEvaluationComputedResult'
+
+!		Instance methods for 'GtGemstoneEvaluationComputedResult'
+
+category: 'accessing'
+method: GtGemstoneEvaluationComputedResult
+computedResult
+	^ computedResult
+%
+
+category: 'accessing'
+method: GtGemstoneEvaluationComputedResult
+computedResult: anObject
+	computedResult := anObject
+%
+
+category: 'initialization '
+method: GtGemstoneEvaluationComputedResult
+gtPharoProxyInitializeWithSession: aGemStoneSession
+	computedResult gtPharoProxyInitializeWithSession: aGemStoneSession
+%
+
+category: 'initialization '
+method: GtGemstoneEvaluationComputedResult
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	aDictionary 
+		at: 'computedResult' 
+		ifPresent: [ :anObject |
+			computedResult := anObject ]
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationComputedResult
+isEvaluationComputedResult
+	^ true
+%
+
+! Class implementation for 'GtGemstoneEvaluationExceptionResult'
+
+!		Instance methods for 'GtGemstoneEvaluationExceptionResult'
+
+category: 'testing'
+method: GtGemstoneEvaluationExceptionResult
+canHandleSpecificDebugger
+	^ true
+%
+
+category: 'accessing'
+method: GtGemstoneEvaluationExceptionResult
+computedResult
+	^ self evaluationContext
+%
+
+category: 'accessing'
+method: GtGemstoneEvaluationExceptionResult
+evaluationContext
+	^ evaluationContext
+%
+
+category: 'accessing'
+method: GtGemstoneEvaluationExceptionResult
+evaluationContext: aGemStoneEvaluationContext
+	evaluationContext := aGemStoneEvaluationContext
+%
+
+category: 'initialization '
+method: GtGemstoneEvaluationExceptionResult
+gtPharoProxyInitializeWithSession: aGemStoneSession
+	evaluationContext gtPharoProxyInitializeWithSession: aGemStoneSession
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationExceptionResult
+hasEvaluationException
+	^ true
+%
+
+category: 'initialization '
+method: GtGemstoneEvaluationExceptionResult
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	aDictionary 
+		at: 'evaluationContextProxy' 
+		ifPresent: [ :anObject |
+			evaluationContext := anObject ]
+%
+
+! Class implementation for 'GtGemstoneEvaluationInProgressResult'
+
+!		Instance methods for 'GtGemstoneEvaluationInProgressResult'
+
+category: 'accessing'
+method: GtGemstoneEvaluationInProgressResult
+computedResult
+	^ self evaluationContext
+%
+
+category: 'accessing'
+method: GtGemstoneEvaluationInProgressResult
+evaluationContext
+	^ evaluationContext
+%
+
+category: 'accessing'
+method: GtGemstoneEvaluationInProgressResult
+evaluationContext: aGemStoneEvaluationContext
+	evaluationContext := aGemStoneEvaluationContext
+%
+
+category: 'initialization '
+method: GtGemstoneEvaluationInProgressResult
+gtPharoProxyInitializeWithSession: aGemStoneSession
+	evaluationContext gtPharoProxyInitializeWithSession: aGemStoneSession
+%
+
+category: 'initialization '
+method: GtGemstoneEvaluationInProgressResult
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	aDictionary 
+		at: 'evaluationContextProxy' 
+		ifPresent: [ :anObject |
+			evaluationContext := anObject ]
+%
+
+! Class implementation for 'GtGemstoneEvaluationResumedResult'
+
+!		Instance methods for 'GtGemstoneEvaluationResumedResult'
+
+category: 'accessing'
+method: GtGemstoneEvaluationResumedResult
+computedResult
+	^ nil
+%
+
+category: 'testing'
+method: GtGemstoneEvaluationResumedResult
+isResumedExecutionResult
+	^ true
+%
+
+! Class implementation for 'GtGemStoneExampleObjectForLocalDelegate'
+
+!		Instance methods for 'GtGemStoneExampleObjectForLocalDelegate'
+
+category: 'accessing'
+method: GtGemStoneExampleObjectForLocalDelegate
+anotherDelegate
+	^ anotherDelegate
+%
+
+category: 'accessing'
+method: GtGemStoneExampleObjectForLocalDelegate
+anotherDelegate: anObject
+	anotherDelegate := anObject
+%
+
+category: 'accessing'
+method: GtGemStoneExampleObjectForLocalDelegate
+targetValueOne
+	^ targetValueOne
+%
+
+category: 'accessing'
+method: GtGemStoneExampleObjectForLocalDelegate
+targetValueOne: anObject
+	targetValueOne := anObject
+%
+
+category: 'accessing'
+method: GtGemStoneExampleObjectForLocalDelegate
+targetValueTwo
+	^ targetValueTwo
+%
+
+category: 'accessing'
+method: GtGemStoneExampleObjectForLocalDelegate
+targetValueTwo: anObject
+	targetValueTwo := anObject
+%
+
+! Class implementation for 'GtGemStoneExampleResult'
+
+!		Instance methods for 'GtGemStoneExampleResult'
+
+category: 'other'
+method: GtGemStoneExampleResult
+example
+	^ example
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+example: anExample
+	example := anExample
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+exception
+	^ exception
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+exception: anException
+	exception := anException
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+gtSourceFor: aView
+	<gtView>
+	^ aView textEditor
+		title: 'Source';
+		priority: 10;
+		text: [ self example fullSource ]
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+isError
+	^ exception isNotNil
+		and: [ (exception isKindOf: GtGemStoneAssertionFailure) not ]
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+isFailure
+	^ exception isNotNil and: [ exception isKindOf: GtGemStoneAssertionFailure ]
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+isSuccess
+	^ result isNotNil
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+result
+	^ result
+%
+
+category: 'other'
+method: GtGemStoneExampleResult
+result: aValue
+	result := aValue
+%
+
+! Class implementation for 'GtGemStoneExampleRunner'
+
+!		Instance methods for 'GtGemStoneExampleRunner'
+
+category: 'other'
+method: GtGemStoneExampleRunner
+newResultFor: anExample
+	^ GtGemStoneExampleResult new example: anExample
+%
+
+category: 'other'
+method: GtGemStoneExampleRunner
+runExample: anExample in: aClass
+	| result |
+	[ 
+	result := (self newResultFor: anExample)
+		result: (aClass new perform: anExample selector) ]
+		on: self signalableExceptions
+		do: [ :anException | 
+			result := (self newResultFor: anExample) exception: anException ].
+	System abortTransaction.
+	^ result
+%
+
+category: 'other'
+method: GtGemStoneExampleRunner
+runExampleClass: aClass
+	^ self
+		runExamples:
+			((Pragma allNamed: #'gtExample' from: aClass to: Object)
+				collect: [ :aPragma | aPragma method ])
+		in: aClass
+%
+
+category: 'other'
+method: GtGemStoneExampleRunner
+runExamples: aListOfExamples in: aClass
+	^ aListOfExamples collect: [:anExample | self runExample: anExample in: aClass ]
+%
+
+category: 'other'
+method: GtGemStoneExampleRunner
+signalableExceptions
+	^ ExceptionSet new ,
+		Halt ,
+		Error ,
+		TestFailure,
+		GtGemStoneAssertionFailure
+%
+
+! Class implementation for 'GtGemstoneHttpClient'
+
+!		Class methods for 'GtGemstoneHttpClient'
+
+category: 'other'
+classmethod: GtGemstoneHttpClient
+new
+	^ self basicNew initialize
+%
+
+!		Instance methods for 'GtGemstoneHttpClient'
+
+category: 'other'
+method: GtGemstoneHttpClient
+authorization: aString
+	headers at: 'Authorization' put: aString
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+beOneShot
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+contents
+	^ contents
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+contents: aDict
+	contents := aDict
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+contentType: aString
+	headers at: 'Content-Type' put: aString
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+defaultContentType
+	^ 'application/json'
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+entity: aDict
+	contents := aDict
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+get
+	^ STONJSON fromString: (self performMethod: 'GET')
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+headerAt: aKey put: aValue
+	headers at: aKey put: aValue
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+initialize
+	super initialize.
+	headers := Dictionary new.
+	query := Dictionary new.
+	self contentType: self defaultContentType
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+performMethod: aMethod
+	| callUrl curlArguments dataFile |
+	callUrl := self url , '?'.
+
+	query
+		keysAndValuesDo: [ :aKey :aValue | callUrl := callUrl , aKey , '=' , aValue , '&' ].
+
+	callUrl := callUrl allButLast.
+
+	curlArguments := {'curl'.
+	'-s'.
+	'--post301'.
+	'-L'.
+	'''', callUrl, ''''.
+	'-X'.
+	aMethod} asOrderedCollection.
+
+	headers
+		keysAndValuesDo: [ :aKey :aValue | 
+			curlArguments
+				addAll:
+					{'-H'.
+					('''' , aKey , ': ' , aValue , '''')} ].
+
+	^ [ self contents ifNotNil: [ :aContents |
+		dataFile := FileReference newTempFilePrefix: self class name asString, '-' suffix: '.json'.
+		dataFile writeStreamDo: [ :stream |
+			stream nextPutAll: (GtGemstoneHttpJsonSerializer serialize: aContents) ].
+		curlArguments addAll:
+			{'--data'.
+			('@', dataFile fullName)} ].
+
+		System performOnServer: (' ' join: curlArguments) ]
+			ensure: [ dataFile ifNotNil: [ dataFile ensureDelete ] ].
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+post
+	^ STONJSON fromString: (self performMethod: 'POST')
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+postStreaming
+	^ (Character cr split: (self performMethod: 'POST')) collect: [:aLine | STONJSON fromString: aLine]
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+queryAt: aKey put: aValue
+	query at: aKey put: aValue asString
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+url
+	^ url
+%
+
+category: 'other'
+method: GtGemstoneHttpClient
+url: aString
+	url := aString
+%
+
+! Class implementation for 'GtGemstoneHttpJsonSerializer'
+
+!		Class methods for 'GtGemstoneHttpJsonSerializer'
+
+category: 'other'
+classmethod: GtGemstoneHttpJsonSerializer
+serialize: anObject
+	^ STONJSON toString: (self serializeObject: anObject)
+%
+
+category: 'other'
+classmethod: GtGemstoneHttpJsonSerializer
+serializeCollection: aCollection
+	^ (aCollection collect: [:aValue | self serializeObject: aValue]) asArray
+%
+
+category: 'other'
+classmethod: GtGemstoneHttpJsonSerializer
+serializeDict: anObject
+	^ anObject collect: [:aValue | self serializeObject: aValue]
+%
+
+category: 'other'
+classmethod: GtGemstoneHttpJsonSerializer
+serializeObject: anObject
+	(anObject isKindOf: Dictionary)
+		ifTrue: [ ^ self serializeDict: anObject ].
+	(anObject isKindOf: String)
+		ifTrue: [ ^ anObject ].
+	(anObject isKindOf: Collection)
+		ifTrue: [ ^ self serializeCollection: anObject ].
+	^ anObject
+%
+
+! Class implementation for 'GtGemStoneLocalCallFrame'
+
+!		Class methods for 'GtGemStoneLocalCallFrame'
+
+category: 'accessing'
+classmethod: GtGemStoneLocalCallFrame
+forFrameContents: aFrameArray 
+	^ self 
+		forFrameContents: aFrameArray 
+		withIdentifier: nil
+%
+
+category: 'accessing'
+classmethod: GtGemStoneLocalCallFrame
+forFrameContents: aFrameArray withIdentifier: aFrameIdentifier
+	^ self new 
+		initializeForFrameContents: aFrameArray 
+		withIdentifier: aFrameIdentifier
+%
+
+!		Instance methods for 'GtGemStoneLocalCallFrame'
+
+category: 'bindings'
+method: GtGemStoneLocalCallFrame
+createFrameBindings
+	| frameBindings |
+
+	frameBindings := SymbolDictionary new.
+
+	1 to: (frameContents at: 9) size do: [ :index | 
+				((frameContents at: 9) at: index) first = $.
+					ifFalse: [ 
+						frameBindings
+							at: ((frameContents at: 9) at: index) asSymbol
+							put: (frameContents at: 11 + index - 1) ] ].
+
+	^ frameBindings
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallFrame
+description
+	^ String streamContents: [ :aStream |
+		self printDescriptionOn: aStream]
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+frameIdentifier
+	^ frameIdentifier
+%
+
+category: 'gt - extensions'
+method: GtGemStoneLocalCallFrame
+gtFrameArrayItemsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Frame Contents';
+		priority: 25;
+		items: [ frameContents ];
+		column: 'Index' 
+			text: [ :eachItem :eachIndex | eachIndex  ]
+			width: 45;
+		column: 'Item' 
+			text: [ :eachItem | eachItem gtDisplayString ].
+%
+
+category: 'testing'
+method: GtGemStoneLocalCallFrame
+hasSamePropertiesAs: anotherContext
+	^ (self isForSameMethodOrBlockAs: anotherContext) and: [
+		self ipOffset = anotherContext ipOffset ] 
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+homeMethod
+	^ homeMethod
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+homeMethodOop
+	^ self homeMethod asOop
+%
+
+category: 'initialization'
+method: GtGemStoneLocalCallFrame
+initializeForFrameContents: aFrameArray withIdentifier: aFrameIdentifier 
+	frameIdentifier := aFrameIdentifier.
+	self updateWithFrameContents: aFrameArray
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+ipOffset
+	^ frameContents at: 2
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+isForBlock
+	^ frameContents first isMethodForBlock
+%
+
+category: 'testing'
+method: GtGemStoneLocalCallFrame
+isForCriticalMethod
+	^ ProcessorScheduler scheduler _criticalMethods 
+		includes: self homeMethod
+%
+
+category: 'testing'
+method: GtGemStoneLocalCallFrame
+isForSameMethodOrBlockAs: anotherContext
+	"This amims to detect of two contexts are different"
+	^ self methodClassName = anotherContext methodClassName and: [
+		self selector = anotherContext selector and: [
+			self homeMethodOop = anotherContext homeMethodOop  ] ]
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+methodClass
+	^ homeMethod inClass
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+methodClassName
+	^ self methodClass ifNotNil: [ :aClass | 
+		aClass name ]
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallFrame
+methodDescription
+	^ String streamContents: [ :aStream |
+	 	self printMethodDescriptionOn: aStream ]
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallFrame
+printClassLabelOn: aStream
+	self selfObjectClass ~= self methodClass
+		ifTrue: [
+			aStream 
+				nextPutAll: self selfObjectClassName;
+				nextPutAll: '('; 
+				nextPutAll: (self methodClassName ifNil: [ '<unknown>']);
+				nextPutAll: ')' ]
+		ifFalse: [
+			aStream nextPutAll: (self methodClassName ifNil: [ '<unknown>']) ]
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallFrame
+printDescriptionOn: aStream
+	self printMethodDescriptionOn:  aStream.
+	aStream nextPutAll: ' '.
+	self printExtraDetailsOn: aStream. 
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallFrame
+printExtraDetailsOn: aStream
+	aStream 
+		nextPutAll: '[';
+		nextPutAll: self ipOffset asString;
+		nextPutAll: ']; id=';
+		nextPutAll: self frameIdentifier description 
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallFrame
+printMethodDescriptionOn: aStream
+	self isForBlock ifTrue: [
+		aStream nextPutAll: '[] in ' ].
+	self printClassLabelOn: aStream.
+	aStream 
+		nextPutAll: '>>#'.
+	self selector 
+		ifNil: [ aStream nextPutAll: '<none>']
+		ifNotNil: [ :aSelector | 
+			aStream nextPutAll: aSelector ]
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallFrame
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize:  [
+		self printDescriptionOn: aStream ]
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+programCounterMarkers
+	| currentSourceInfo |
+	currentSourceInfo := self sourceInfo.
+	^ { currentSourceInfo first . currentSourceInfo second }
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+receiver
+	^ frameContents at: 10
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+receiverClass
+	^ self receiver class
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+receiverClassName
+	^ self receiverClass name
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+selector
+	^ homeMethod selector.
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+selfObject
+	^ frameContents at: 8
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+selfObjectClass
+	^ self selfObject class
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+selfObjectClassName
+	^ self selfObjectClass name
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallFrame
+sourceInfo
+	| source ipOffset markers startIndex endIndex i |
+
+	source := frameContents first sourceString.
+	ipOffset := frameContents second.
+	markers := frameContents first _buildIpMarkerArray.
+	startIndex := markers indexOf: ipOffset.
+	startIndex = 0 ifTrue:
+		[ ^ { 1. source size. source } ].
+	i := startIndex + 1.
+
+	[ endIndex isNil and: [ i <= markers size ] ] whileTrue:
+		[ (markers at: i) notNil ifTrue:
+			[ endIndex := i ].
+		i := i + 1 ].
+	endIndex ifNil: [ endIndex := source size ].
+	^ { startIndex. endIndex. source. }
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallFrame
+updateBindingsWith: frameBindings  forFrameAtLevel: aFrameLevel inProcess: gsProcess
+	
+	1 to: (frameContents at: 9) size do: [ :index | 
+				| argsAndTemps |
+				argsAndTemps := frameContents at: 9.
+				(argsAndTemps at: index) first = $.
+					ifFalse: [ 
+						gsProcess
+							_frameAt: aFrameLevel
+							tempAt: index
+							put: (frameBindings at: (argsAndTemps at: index))  ] ].
+
+	"After updating the bindings in the process, reinitialize the contents of the frame"
+	self updateWithFrameContents: (gsProcess _frameContentsAt: aFrameLevel).
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallFrame
+updateIdentifierBasedOn: aCallFrame
+	self updateIdentifierTo:  aCallFrame frameIdentifier
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallFrame
+updateIdentifierTo: anIdentifier
+	frameIdentifier := anIdentifier
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallFrame
+updateWithFrameContents: aFrameArray 
+	frameContents := aFrameArray.
+	homeMethod := frameContents first homeMethod.
+%
+
+! Class implementation for 'GtGemStoneLocalCallStack'
+
+!		Class methods for 'GtGemStoneLocalCallStack'
+
+category: 'instance creation'
+classmethod: GtGemStoneLocalCallStack
+forProcess: aGsProcess 
+	^ self new 
+		initializeForProcess: aGsProcess 
+%
+
+!		Instance methods for 'GtGemStoneLocalCallStack'
+
+category: 'updating'
+method: GtGemStoneLocalCallStack
+appendCallFramesFromIndex: anIndex from: aNewCallStack 
+	(aNewCallStack callFrames copyFrom: 1 to: anIndex) 
+		reverseDo: [ :aNewCallFrame |
+			self appendFirstNewCallFrame: aNewCallFrame ]
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStack
+appendFirstNewCallFrame: aNewCallFrame 
+	aNewCallFrame updateIdentifierTo: self generateIdentifier.
+	callFrames addFirst: aNewCallFrame
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+callFrames
+	^ callFrames
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+callFramesAt: anIndex
+	^ self callFrames at: anIndex
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+createSpecification
+	^ GtGemStoneProcessSpecification forGsCallStack: self
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+firstNonCriticalFrameIndex
+	1 to: self numberOfCallFrames do: [ :anIndex |
+		(self callFrames at: anIndex) isForCriticalMethod 
+			ifFalse: [ ^ anIndex ] ].
+		
+	^ nil
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+frameForIdentifier: aFrameIdentifier 
+	| frameLevel |
+	frameLevel := self frameLevelForIdentifier: aFrameIdentifier.
+	^ self callFrames at: frameLevel
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+frameLevelForIdentifier: aFrameIdentifier
+	aFrameIdentifier ifNil: [
+		Error signal: 'aFrameIdentifier cannot be nil' ].
+
+	1 to: self callFrames size do: [ :anIndex |
+		(self callFrames at: anIndex) frameIdentifier = aFrameIdentifier
+			ifTrue: [ ^ anIndex ] ].
+
+	Error signal: 'Could not find frame with identifier: ', aFrameIdentifier printString
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+generateIdentifier
+	| currentIdentifier |
+	currentIdentifier := nextFrameIdentifier.
+	nextFrameIdentifier := currentIdentifier nextIdentifier.
+	^ currentIdentifier
+%
+
+category: 'gt - extensions'
+method: GtGemStoneLocalCallStack
+gtViewStackFramesFor: aView 
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Call frames';
+		items: [ self callFrames ];
+		column: 'Index' 
+			text: [ :aStackFrame :anIndex |
+				anIndex ]
+			width: 75;
+		column: 'Identifier' 
+			text: [ :aStackFrame |
+				aStackFrame frameIdentifier identityIndex ]
+			width: 75;
+		column: 'IP Offset' 
+			text: [ :aStackFrame |
+				aStackFrame ipOffset ]
+			width: 75;
+		column: 'Method' text: [ :aStackFrame |
+			aStackFrame methodDescription ]
+%
+
+category: 'initialization'
+method: GtGemStoneLocalCallStack
+initializeForProcess: aGsProcess 
+	nextFrameIdentifier := GtGemStoneCallFrameIdentifier initialIdentifier.
+
+	gsProcess := aGsProcess.
+	callFrames := OrderedCollection withAll: (aGsProcess gtAllFrames 
+		collect: [ :aFrameArray |
+			GtGemStoneLocalCallFrame 
+				forFrameContents: aFrameArray 
+				withIdentifier: self generateIdentifier ]).
+%
+
+category: 'testing'
+method: GtGemStoneLocalCallStack
+isEmpty
+	^ self numberOfCallFrames = 0
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+numberOfCallFrames
+	^ self callFrames size
+%
+
+category: 'printing'
+method: GtGemStoneLocalCallStack
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		aStream print: self numberOfCallFrames.
+		aStream nextPutAll: ' frames' ]
+%
+
+category: 'accessing'
+method: GtGemStoneLocalCallStack
+removeAllCallFrames
+	callFrames := OrderedCollection new
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStack
+removeCallFramesUpwardsFromIndex: anIndex 
+	"Remove all call frames upwards starting from the given 1-based index"
+	
+	anIndex = 0 ifTrue: [ ^ self ].
+	callFrames := callFrames 
+		copyFrom: anIndex + 1 
+		to: callFrames size
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStack
+replaceFrameAt: anIndex with: aNewContext
+	self callFrames at: anIndex put: aNewContext
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStack
+updateBindingsForFrame: aCallFrame atLevel: aFrameLevel with: frameBindings
+	aCallFrame 
+		updateBindingsWith: frameBindings 
+		forFrameAtLevel: aFrameLevel 
+		inProcess: gsProcess
+%
+
+! Class implementation for 'GtGemStoneLocalCallStackUpdater'
+
+!		Class methods for 'GtGemStoneLocalCallStackUpdater'
+
+category: 'instance creation'
+classmethod: GtGemStoneLocalCallStackUpdater
+forCallStack: aCallStack
+	^ self new 
+		initializeForCallStack: aCallStack
+%
+
+!		Instance methods for 'GtGemStoneLocalCallStackUpdater'
+
+category: 'updating'
+method: GtGemStoneLocalCallStackUpdater
+appendCallFramesFromIndexPair: anIndexPair from: aNewCallStack 
+	targetCallStack 
+		appendCallFramesFromIndex: anIndexPair second
+		from: aNewCallStack 
+%
+
+category: 'testing'
+method: GtGemStoneLocalCallStackUpdater
+hasCommonMethodContextAtIndex: anIndexPair with: aNewCallStack 
+	^ (anIndexPair first >= 1) and: [
+			(anIndexPair second >= 1) and: [
+				(targetCallStack callFramesAt: anIndexPair first)
+					isForSameMethodOrBlockAs:(aNewCallStack 
+						callFramesAt: anIndexPair second) ] ]
+%
+
+category: 'initialization'
+method: GtGemStoneLocalCallStackUpdater
+initializeForCallStack: aCallStack 
+	targetCallStack := aCallStack
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStackUpdater
+removeCallFramesFromIndexPair: anIndexPair 
+	targetCallStack removeCallFramesUpwardsFromIndex: anIndexPair first
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStackUpdater
+updateBasedOn: aNewCallStack
+	| firstDifferentIndexes doubleCallStack |
+	
+	aNewCallStack isEmpty ifTrue: [
+		^ self updateBasedOnEmptyStack ].
+		
+	doubleCallStack := GtGemStoneDoubleLocalCallStack 
+		forPreviousCallStack: targetCallStack 
+		newCallStack: aNewCallStack.
+	
+	firstDifferentIndexes := doubleCallStack firstDivergentContentsIndex.
+	^ self 
+		updateStackFromIndex: firstDifferentIndexes
+		basedOn: aNewCallStack
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStackUpdater
+updateBasedOnEmptyStack
+	targetCallStack removeAllCallFrames.
+	^ targetCallStack
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStackUpdater
+updateStackFromIndex: anIndexPair basedOn: aNewCallStack 
+	| currentIndexPair |
+	currentIndexPair := anIndexPair.
+	(self hasCommonMethodContextAtIndex: currentIndexPair with: aNewCallStack)
+		ifTrue: [
+			self 
+				updateTopCommonContextAtIndexPair: currentIndexPair 
+				basedOn: aNewCallStack.
+			currentIndexPair := {
+				currentIndexPair first - 1.
+				currentIndexPair second - 1 } ].
+	
+	self removeCallFramesFromIndexPair: currentIndexPair.
+	self appendCallFramesFromIndexPair: currentIndexPair from: aNewCallStack.
+	
+	^ targetCallStack
+%
+
+category: 'updating'
+method: GtGemStoneLocalCallStackUpdater
+updateTopCommonContextAtIndexPair: anIndexPair basedOn: aNewCallStack 
+	| existingContext newContext |
+	existingContext := targetCallStack callFramesAt: anIndexPair first.
+	newContext := aNewCallStack callFramesAt: anIndexPair second.
+	
+	newContext updateIdentifierBasedOn: existingContext.
+	targetCallStack replaceFrameAt: anIndexPair first with: newContext.
+%
+
+! Class implementation for 'GtGemStoneRemotePhlowCollectionPrinter'
+
+!		Class methods for 'GtGemStoneRemotePhlowCollectionPrinter'
+
+category: 'api'
+classmethod: GtGemStoneRemotePhlowCollectionPrinter
+displayStringFor: aCollection on: aStream
+	^ (self forTargetCollection: aCollection)
+		writeDisplayStringOn: aStream
+%
+
+category: 'api'
+classmethod: GtGemStoneRemotePhlowCollectionPrinter
+forTargetCollection: aCollection
+	^ self new 
+		targetCollection: aCollection
+%
+
+!		Instance methods for 'GtGemStoneRemotePhlowCollectionPrinter'
+
+category: 'enumerating'
+method: GtGemStoneRemotePhlowCollectionPrinter
+elementsDo: aBlock
+	targetCollection do: aBlock
+%
+
+category: 'accessing'
+method: GtGemStoneRemotePhlowCollectionPrinter
+targetCollection: aCollection
+	targetCollection := aCollection
+%
+
+category: 'printing'
+method: GtGemStoneRemotePhlowCollectionPrinter
+writeClassDescriptionOn: aStream 
+	aStream nextPutAll: targetCollection class name describeClassName 
+%
+
+category: 'api'
+method: GtGemStoneRemotePhlowCollectionPrinter
+writeCollectionItemsOn: aStream
+	| maxPrint count collectionSize |
+	
+	aStream 
+		space;
+		nextPutAll: '(' .
+	maxPrint := 180.
+	count := 1 .
+	collectionSize := targetCollection size .
+	self elementsDo: [ :anElement |
+	  aStream position > maxPrint ifTrue:[
+		aStream nextPutAll: '...)' .
+		^ self ].
+	  anElement printOn: aStream.
+	  count < collectionSize ifTrue:[ aStream space ].
+	  count := count + 1 ].
+	aStream nextPut: $).
+%
+
+category: 'printing'
+method: GtGemStoneRemotePhlowCollectionPrinter
+writeCollectionSizeOn: aStream
+	| collectionSize |
+	collectionSize := targetCollection size. 
+	aStream
+		space;
+		nextPut: $[;
+		print: collectionSize;
+		space;
+		nextPutAll: (collectionSize = 1 
+			ifTrue: [ 'item' ]
+			ifFalse: [ 'items' ]);
+		nextPut: $].
+%
+
+category: 'api'
+method: GtGemStoneRemotePhlowCollectionPrinter
+writeDisplayStringOn: aStream
+	"Put a displayable representation of the receiver on the given stream."
+	
+	self writeClassDescriptionOn: aStream.
+	self writeCollectionSizeOn: aStream.
+	self writeCollectionItemsOn: aStream.
+%
+
+! Class implementation for 'GtGemStoneRemotePhlowDictionaryPrinter'
+
+!		Instance methods for 'GtGemStoneRemotePhlowDictionaryPrinter'
+
+category: 'enumerating'
+method: GtGemStoneRemotePhlowDictionaryPrinter
+elementsDo: aBlock
+	targetCollection associationsDo: aBlock
+%
+
+! Class implementation for 'GtGemStoneSemanticVersionNumber'
+
+!		Class methods for 'GtGemStoneSemanticVersionNumber'
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+major: majorNumber minor: minorNumber patch: patchNumber
+	^ self new 
+		initializeMajor: majorNumber
+		minor: minorNumber
+		patch: patchNumber
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+oneZeroZero
+	^ self major: 1 minor: 0 patch: 0
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+pointOne
+	^ self major: 0 minor: 0 patch: 1
+%
+
+category: 'converting'
+classmethod: GtGemStoneSemanticVersionNumber
+readFromString: aString
+	| tokens |
+	tokens := (aString trimBoth trimLeft: [:char | char = $v]) findTokens: '.'.
+	^ self 
+		major: tokens first asInteger
+		minor: tokens second asInteger
+		patch: tokens third asInteger. 
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+v1_0_1098
+	"Support for v1.0.1098 was dropped on 2025-06-06"
+
+	^ self major: 1 minor: 0 patch: 1098
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+v1_0_1501
+
+	^ self major: 1 minor: 0 patch: 1501
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+v1_0_1502
+
+	^ self major: 1 minor: 0 patch: 1502
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+v1_1_199
+
+	^ self major: 1 minor: 1 patch: 199
+%
+
+category: 'accessing'
+classmethod: GtGemStoneSemanticVersionNumber
+versionNumberRegexString
+	^ 'v[0-9]+\.[0-9]+\.[0-9]+'
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSemanticVersionNumber
+zero
+	^ self major: 0 minor: 0 patch: 0
+%
+
+!		Instance methods for 'GtGemStoneSemanticVersionNumber'
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+< aSemanticVersionNumber
+	self major < aSemanticVersionNumber major ifTrue: [ ^ true ].
+		self major = aSemanticVersionNumber major ifTrue: [ 
+			self minor < aSemanticVersionNumber minor ifTrue: [ ^ true ].
+			self minor = aSemanticVersionNumber minor ifTrue: [ 
+				self patch < aSemanticVersionNumber patch ifTrue: [ ^ true ]]].
+	^ false.
+%
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+<= aSemanticVersionNumber
+	"Answer whether the receiver is less than or equal to the given version number."
+	^ (self > aSemanticVersionNumber) not
+%
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+= anObject
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	^ self major = anObject major and: [ 
+		 self minor = anObject minor and: [ 
+			self patch = anObject patch ] ]
+%
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+> aSemanticVersionNumber 
+	"Answer whether the receiver is greater than the argument."
+
+	^aSemanticVersionNumber < self
+%
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+>= aSemanticVersionNumber 
+	"Answer whether the receiver is greater than or equal to the argument."
+
+	^ aSemanticVersionNumber <= self
+%
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+between: min and: max
+	"Answer whether the receiver is less than or equal to the argument, max,
+	and greater than or equal to the argument, min."
+
+	^self >= min and: [self <= max]
+%
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+exBetween: min and: max
+	"Answer whether the receiver is less than or equal to the argument, max,
+	and greater than or equal to the argument, min."
+
+	^self > min and: [self < max]
+%
+
+category: 'comparing'
+method: GtGemStoneSemanticVersionNumber
+hash
+	^ ((self species hash
+		bitXor: self major hash)
+		bitXor: self minor hash)
+		bitXor: self patch hash
+%
+
+category: 'initialization'
+method: GtGemStoneSemanticVersionNumber
+initializeMajor: aMajorNumber minor: aMinorNumber patch: aPatchNumber
+	 (aMajorNumber notNil and: [ aMinorNumber notNil and: [ aPatchNumber notNil ] ])
+	 	ifFalse: [ 
+	 		Error signal: 'The components of a semantic version cannot be null' ].
+	(aMajorNumber >= 0 and: [ aMinorNumber >= 0 and: [ aPatchNumber >= 0 ] ])
+		ifFalse: [ 
+			Error signal: 'The components of a semantic version should not be negative' ].
+	(major isNil and: [ minor isNil and: [ patch isNil ] ]) 
+		ifFalse: [
+			Error signal: 'Semantic version numbers are immutable' ].
+	
+	major := aMajorNumber.
+	minor := aMinorNumber.
+	patch := aPatchNumber.
+%
+
+category: 'testing'
+method: GtGemStoneSemanticVersionNumber
+isZero
+	^ self = self class zero
+%
+
+category: 'accessing'
+method: GtGemStoneSemanticVersionNumber
+major
+	^ major
+%
+
+category: 'accessing'
+method: GtGemStoneSemanticVersionNumber
+minor
+	^ minor
+%
+
+category: 'accessing'
+method: GtGemStoneSemanticVersionNumber
+patch
+	^ patch 
+%
+
+category: 'printing'
+method: GtGemStoneSemanticVersionNumber
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream 
+		nextPut: $(;
+		nextPutAll: self versionString;
+		nextPut: $)
+%
+
+category: 'accessing'
+method: GtGemStoneSemanticVersionNumber
+tag
+	^ iceTag
+%
+
+category: 'accessing'
+method: GtGemStoneSemanticVersionNumber
+tag: anIceTag
+	iceTag := anIceTag 
+%
+
+category: 'accessing'
+method: GtGemStoneSemanticVersionNumber
+versionString
+	^ String streamContents: [ :aStream |
+		aStream 
+			<< 'v';
+			<< self major printString;
+			<< '.';
+			<< self minor printString;
+			<< '.';
+			<< self patch printString ]
+%
+
+! Class implementation for 'GtGemStoneSerializationExamples'
+
+!		Instance methods for 'GtGemStoneSerializationExamples'
+
+category: 'examples'
+method: GtGemStoneSerializationExamples
+gbsMaxDepthToWireExample
+	"Demonstrate `max` and `min` keywords in a replication spec"
+	<gtExample>
+	| replicationSpec object encoder byteArray next array currentArray transferService |
+
+	replicationSpec := {GtWireEncodingExampleInstVarObject -> #(#(var1 max 2))}
+			asDictionary.
+	array := Array new: 2.
+	currentArray := array.
+	1 to: 10 do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	object := GtWireEncodingExampleInstVarObject new var1: array.
+	encoder := GtWireEncoder onByteArray.
+	GtWireGbsReplicationSpecConverter new update: encoder from: replicationSpec.
+	transferService := GtRsrWireTransferService gtClientGsServer new
+		encoder: encoder;
+		object: object.
+	byteArray := transferService buffer.
+	transferService := GtRsrWireTransferService gtClientGsServer new
+		buffer: byteArray.
+	next := transferService object.
+
+	self assert: next class equals: GtWireEncodingExampleInstVarObject.
+	self assert: next var1 class equals: Array.
+	self assert: next var1 first equals: 1.
+	next := next var1 second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next equals: #(3 nil)
+%
+
+! Class implementation for 'GtGemStoneSessionFeature'
+
+!		Class methods for 'GtGemStoneSessionFeature'
+
+category: 'instance creation'
+classmethod: GtGemStoneSessionFeature
+fromFeatureSpecification: aFeatureSpecification 
+	^ self new 
+		initializeFromFeatureSpecification: aFeatureSpecification 
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSessionFeature
+withId: anSymbol
+	^ self basicNew initialize 
+		featureId: anSymbol
+%
+
+!		Instance methods for 'GtGemStoneSessionFeature'
+
+category: 'converting'
+method: GtGemStoneSessionFeature
+createSpecification
+	^ GtGemStoneFeatureSpecification forFeature: self
+%
+
+category: 'actions'
+method: GtGemStoneSessionFeature
+disable
+	enabled := false
+%
+
+category: 'actions'
+method: GtGemStoneSessionFeature
+enable
+	enabled := true
+%
+
+category: 'accessing'
+method: GtGemStoneSessionFeature
+featureId
+	^ featureId
+%
+
+category: 'accessing'
+method: GtGemStoneSessionFeature
+featureId: anSymbol
+	featureId := anSymbol
+%
+
+category: 'initialization'
+method: GtGemStoneSessionFeature
+initializeFromFeatureSpecification: aFeatureSpecification 
+	enabled := aFeatureSpecification enabled.
+	featureId := aFeatureSpecification featureId.
+%
+
+category: 'testing'
+method: GtGemStoneSessionFeature
+isEnabled
+	^ enabled ifNil: [ false ]
+%
+
+category: 'printing'
+method: GtGemStoneSessionFeature
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		aStream 
+			nextPutAll: 'id: ';
+			nextPutAll: featureId;
+			nextPutAll: '; enabled: ';
+			print: enabled ]
+%
+
+category: 'accessing'
+method: GtGemStoneSessionFeature
+statusDescription
+	^ self isEnabled
+		ifTrue: [ 'Enabled' ] 
+		ifFalse: [ 'Disabled' ]
+%
+
+! Class implementation for 'GtGemStoneSessionFeatures'
+
+!		Class methods for 'GtGemStoneSessionFeatures'
+
+category: 'accessing'
+classmethod: GtGemStoneSessionFeatures
+collectFeaturesDefinitions
+	| featureSelectors |
+	featureSelectors := ((Pragma 
+		allNamed: #gtGemStoneFeature
+		from: self  class
+		to: self  class ) collect: [ :each | each method selector ]) asSet asArray.
+	
+	^ featureSelectors collect: [ :aSelector |
+		self perform: aSelector asSymbol ]
+%
+
+category: 'accessing'
+classmethod: GtGemStoneSessionFeatures
+currentFeatures
+	^ SessionTemps current 
+		at: self featuresKeyName
+		ifAbsentPut: [ self forCurrentDefinitions ]
+%
+
+category: 'features'
+classmethod: GtGemStoneSessionFeatures
+exampleFeatureV1
+	<gtGemStoneFeature>
+	
+	^ (GtGemStoneSessionFeature
+		withId: #exampleFeatureV1)
+			enable
+%
+
+category: 'accessing'
+classmethod: GtGemStoneSessionFeatures
+featuresKeyName
+	^#GT_FEATURES_LIST_NAME
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSessionFeatures
+forCurrentDefinitions
+	^ self withAll: self collectFeaturesDefinitions
+%
+
+category: 'views'
+classmethod: GtGemStoneSessionFeatures
+gtViewCurrentFeaturesFor: aView
+	<gtView>
+	<gtClassView>
+	
+	^ self 
+		gtDo: [ aView empty ] 
+		gemstoneDo: [
+			aView forward
+				title: 'Current Features';
+				priority: 30;
+				object: [ self currentFeatures ];
+				view: #gtViewFeaturesFor: ]
+%
+
+category: 'views'
+classmethod: GtGemStoneSessionFeatures
+gtViewDefinedFeaturesFor: aView
+	<gtView>
+	<gtClassView>
+	
+	^ aView forward
+		title: 'Defined Features';
+		priority: 31;
+		object: [ self forCurrentDefinitions ];
+		view: #gtViewFeaturesFor:
+%
+
+category: 'accessing'
+classmethod: GtGemStoneSessionFeatures
+resetFeatures
+	^ SessionTemps current 
+		removeKey: self featuresKeyName
+		ifAbsent: [  ]
+%
+
+category: 'features'
+classmethod: GtGemStoneSessionFeatures
+spawnPrimitiveTypeAsProxyExampleFeature
+	<gtGemStoneFeature>
+	"Only needed to indicate if GtRemotePhlowDeclarativeTestInspectable>>#gtColumnedListSpawnTextFor: has a column for spawning primitive types"
+	^ (GtGemStoneSessionFeature
+		withId: #spawnPrimitiveTypeAsProxyExampleFeature)
+			enable
+%
+
+category: 'features'
+classmethod: GtGemStoneSessionFeatures
+transcriptV1
+	<gtGemStoneFeature>
+	
+	^ (GtGemStoneSessionFeature
+		withId: #transcriptV1)
+			enable
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSessionFeatures
+withAll: aCollection
+	^ self new 
+		initializeWithFeatures: aCollection
+%
+
+!		Instance methods for 'GtGemStoneSessionFeatures'
+
+category: 'adding'
+method: GtGemStoneSessionFeatures
+addFeature: aFeature
+	featuresById at: aFeature featureId put: aFeature
+%
+
+category: 'converting'
+method: GtGemStoneSessionFeatures
+createSpecification
+	^ GtGemStoneFeaturesSpecification forFeatures: self
+%
+
+category: 'actions'
+method: GtGemStoneSessionFeatures
+disableFeatureWithId: aFeatureId 
+	self
+		featureWithId: aFeatureId
+		ifPresent: [ :aFeature | aFeature disable ] 
+		ifAbsent: [ Error signal: 'Feature not found' ] 
+%
+
+category: 'actions'
+method: GtGemStoneSessionFeatures
+enableFeatureWithId: aFeatureId 
+	self
+		featureWithId: aFeatureId
+		ifPresent: [ :aFeature | aFeature enable ] 
+		ifAbsent: [ Error signal: 'Feature not found' ] 
+%
+
+category: 'enumerating'
+method: GtGemStoneSessionFeatures
+featureWithId: aFeatureId 
+	^ featuresById
+		at: aFeatureId
+%
+
+category: 'enumerating'
+method: GtGemStoneSessionFeatures
+featureWithId: aFeatureId ifPresent: aPresentBlock 
+	^ featuresById
+		at: aFeatureId
+		ifPresent: aPresentBlock
+%
+
+category: 'enumerating'
+method: GtGemStoneSessionFeatures
+featureWithId: aFeatureId ifPresent: aPresentBlock ifAbsent: anAbsentBlock
+	| feature |
+	feature := featuresById
+		at: aFeatureId
+		ifAbsent: [ ^ anAbsentBlock value ].
+		
+	^ aPresentBlock cull: feature
+%
+
+category: 'views'
+method: GtGemStoneSessionFeatures
+gtViewFeaturesFor: aView
+	<gtView>
+	
+	featuresById ifNil: [ ^ aView empty ].
+	
+	^ aView columnedList
+		title: 'Features';
+		items: [ (self 
+			gtDo: [ featuresById associations ] 
+			gemstoneDo: [ featuresById associationsAsArray ] )
+				sort: [ :a :b | a value featureId < b value featureId ] ];
+		column: 'Id' text: [ :assoc | assoc key ];
+		column: 'Status' text: [ :assoc | assoc value statusDescription ];
+		send: [ :assoc | assoc value ]
+%
+
+category: 'initialization'
+method: GtGemStoneSessionFeatures
+initializeWithFeatures: aCollection 
+	featuresById := Dictionary new.
+	
+	aCollection do: [ :aFeature |
+		self addFeature: aFeature ]
+%
+
+category: 'testing'
+method: GtGemStoneSessionFeatures
+isFeatureEnabledWithId: aFeatureId
+	^ self
+		featureWithId: aFeatureId
+		ifPresent: [ :aFeature | aFeature isEnabled ] 
+		ifAbsent: [ false ] 
+%
+
+category: 'accessing'
+method: GtGemStoneSessionFeatures
+items
+	^ featuresById values
+%
+
+category: 'accessing'
+method: GtGemStoneSessionFeatures
+numberOfFeatures
+	^ featuresById size
+%
+
+category: 'printing'
+method: GtGemStoneSessionFeatures
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream 
+		<< ' [';
+		print: self numberOfFeatures;
+		<< ' ';
+		<< (self numberOfFeatures = 1 
+			ifTrue: [ 'feature' ]
+			ifFalse: [ 'features' ]);
+		<< ']'
+%
+
+! Class implementation for 'GtGemStoneSessionTransactionConflictsReport'
+
+!		Class methods for 'GtGemStoneSessionTransactionConflictsReport'
+
+category: 'instance - creation'
+classmethod: GtGemStoneSessionTransactionConflictsReport
+forCurrentConflicts
+	^ self new initializeFromCurrentConflicts
+%
+
+!		Instance methods for 'GtGemStoneSessionTransactionConflictsReport'
+
+category: 'accessing'
+method: GtGemStoneSessionTransactionConflictsReport
+commitResult 
+	^ transactionConflicts  
+		at: #commitResult
+		ifAbsent: [ 'unknown' ]
+%
+
+category: 'gt - extensions'
+method: GtGemStoneSessionTransactionConflictsReport
+gtViewTransactionConflictsFor: aView 
+	<gtView>
+	
+	^ aView forward
+		title: 'Transaction Conflicts';
+		priority: 5;
+		object: [ transactionConflicts ];
+		view: #gtItemsFor:
+%
+
+category: 'initialization'
+method: GtGemStoneSessionTransactionConflictsReport
+initializeFromCurrentConflicts
+	transactionConflicts := System transactionConflicts
+%
+
+category: 'printing'
+method: GtGemStoneSessionTransactionConflictsReport
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		aStream << self commitResult asString ]
+%
+
+category: 'converting'
+method: GtGemStoneSessionTransactionConflictsReport
+reportDictionaryForExport
+	^ Dictionary new
+		at: 'commitResult' put: self commitResult;
+		at: 'conflictsReport'
+			put: (self asGtRsrProxyObjectForConnection: nil);
+		yourself
+%
+
+category: 'accessing'
+method: GtGemStoneSessionTransactionConflictsReport
+transactionConflicts
+	^ transactionConflicts
+%
+
+! Class implementation for 'GtGemStoneSpecification'
+
+!		Class methods for 'GtGemStoneSpecification'
+
+category: 'instance creation'
+classmethod: GtGemStoneSpecification
+fromJSONDictionary: aDictionary
+	^ self new  
+		initializeFromJSONDictionary: aDictionary
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSpecification
+fromJsonString: aString
+	| dictionary |
+
+	dictionary := STON fromString: aString.
+	^ self fromJSONDictionary: dictionary
+%
+
+!		Instance methods for 'GtGemStoneSpecification'
+
+category: 'converting'
+method: GtGemStoneSpecification
+asDictionaryForExport
+
+	^ Dictionary new
+		addAll: self localMetadata asMetadataAttributesForExport;
+		yourself
+%
+
+category: 'converting'
+method: GtGemStoneSpecification
+asJsonForExport 
+	"Answer the receiver serialised in JSON format"
+
+	^STON toJsonString: self asDictionaryForExport
+%
+
+category: 'initialization'
+method: GtGemStoneSpecification
+initializeFromJSONDictionary: aDictionary
+	self initializeMetadataFromJSONDictionary: aDictionary.
+%
+
+category: 'initialization'
+method: GtGemStoneSpecification
+initializeMetadataFromJSONDictionary: aDictionary 
+	remoteMetadata := GtGemStoneSpecificationMedatada 
+		fromObjectDictionary: aDictionary
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneSpecification
+localApiVersion
+	^ GtGemStoneSemanticVersionNumber oneZeroZero
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneSpecification
+localMetadata
+	^ GtGemStoneSpecificationMedatada new 
+		apiVersion: self localApiVersion;
+		schemaVersion: self localSchemaVersion
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneSpecification
+localSchemaVersion
+	^ GtGemStoneSemanticVersionNumber oneZeroZero
+%
+
+category: 'accessing - metadata'
+method: GtGemStoneSpecification
+remoteMetadata
+	^ remoteMetadata
+%
+
+! Class implementation for 'GtGemStoneCallFrameIdentifier'
+
+!		Class methods for 'GtGemStoneCallFrameIdentifier'
+
+category: 'instance creation'
+classmethod: GtGemStoneCallFrameIdentifier
+forIndex: anIndex
+	^ self new 
+		initializeForIndex: anIndex
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneCallFrameIdentifier
+initialIdentifier
+	^ self forIndex: 1
+%
+
+!		Instance methods for 'GtGemStoneCallFrameIdentifier'
+
+category: 'comparing'
+method: GtGemStoneCallFrameIdentifier
+= anObject
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	
+	^ self identityIndex = anObject identityIndex
+%
+
+category: 'converting'
+method: GtGemStoneCallFrameIdentifier
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'identityIndex' put: identityIndex;
+		yourself
+%
+
+category: 'accessing'
+method: GtGemStoneCallFrameIdentifier
+description
+	^ self identityIndex asString
+%
+
+category: 'comparing'
+method: GtGemStoneCallFrameIdentifier
+hash
+	^ self identityIndex hash
+%
+
+category: 'accessing'
+method: GtGemStoneCallFrameIdentifier
+identityIndex
+	^ identityIndex
+%
+
+category: 'initialization'
+method: GtGemStoneCallFrameIdentifier
+initializeForIndex: anIndex
+	identityIndex := anIndex
+%
+
+category: 'initialization'
+method: GtGemStoneCallFrameIdentifier
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	identityIndex := aDictionary at: 'identityIndex'.
+%
+
+category: 'accessing'
+method: GtGemStoneCallFrameIdentifier
+nextIdentifier
+	^ self class forIndex: self identityIndex + 1
+%
+
+category: 'printing'
+method: GtGemStoneCallFrameIdentifier
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		aStream
+			nextPutAll: self description ]
+%
+
+! Class implementation for 'GtGemStoneClassBasicDetails'
+
+!		Class methods for 'GtGemStoneClassBasicDetails'
+
+category: 'instance creation'
+classmethod: GtGemStoneClassBasicDetails
+forClass: aGsClass
+	^ self new 
+		intializeForClass: aGsClass
+%
+
+!		Instance methods for 'GtGemStoneClassBasicDetails'
+
+category: 'converting'
+method: GtGemStoneClassBasicDetails
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'targetClassName' put: targetClassName;
+		at: 'targetClassIconName' put: targetClassIconName;
+		yourself
+%
+
+category: 'initialization'
+method: GtGemStoneClassBasicDetails
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	targetClassName := aDictionary at: 'targetClassName'.
+	targetClassIconName := aDictionary at: 'targetClassIconName'.
+%
+
+category: 'initialization'
+method: GtGemStoneClassBasicDetails
+intializeForClass: aGsClass 
+	"We should handle here metaclasses through an explicit isMetaclass flag"
+	targetClassName := aGsClass name.
+	targetClassIconName := aGsClass gtSystemIconName.
+%
+
+category: 'accessing'
+method: GtGemStoneClassBasicDetails
+targetClassIconName
+	^ targetClassIconName
+%
+
+category: 'accessing'
+method: GtGemStoneClassBasicDetails
+targetClassName
+	^ targetClassName
+%
+
+! Class implementation for 'GtGemStoneFeatureSpecification'
+
+!		Class methods for 'GtGemStoneFeatureSpecification'
+
+category: 'instance creation'
+classmethod: GtGemStoneFeatureSpecification
+forFeature: aFeature
+	^ self new 
+		initializeForFeature: aFeature
+%
+
+!		Instance methods for 'GtGemStoneFeatureSpecification'
+
+category: 'converting'
+method: GtGemStoneFeatureSpecification
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'enabled' put: enabled;
+		at: 'featureId' put: featureId;
+		yourself
+%
+
+category: 'accessing'
+method: GtGemStoneFeatureSpecification
+enabled
+	^ enabled
+%
+
+category: 'accessing'
+method: GtGemStoneFeatureSpecification
+enabled: anObject
+	enabled := anObject
+%
+
+category: 'accessing'
+method: GtGemStoneFeatureSpecification
+featureId
+	^ featureId
+%
+
+category: 'accessing'
+method: GtGemStoneFeatureSpecification
+featureId: anObject
+	featureId := anObject
+%
+
+category: 'initialization'
+method: GtGemStoneFeatureSpecification
+initializeForFeature: aFeature 
+	enabled := aFeature isEnabled.
+	featureId := aFeature featureId.
+%
+
+category: 'initialization'
+method: GtGemStoneFeatureSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	enabled := aDictionary at: 'enabled'.
+	featureId := aDictionary at: 'featureId'.
+%
+
+! Class implementation for 'GtGemStoneFeaturesSpecification'
+
+!		Class methods for 'GtGemStoneFeaturesSpecification'
+
+category: 'instance creation'
+classmethod: GtGemStoneFeaturesSpecification
+forFeatures: aFeaturesObject
+	^ self new 
+		initializeFromFeatures: aFeaturesObject
+%
+
+!		Instance methods for 'GtGemStoneFeaturesSpecification'
+
+category: 'converting'
+method: GtGemStoneFeaturesSpecification
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'featureSpecifications' put: (featureSpecifications collect: [ :each |
+			each asDictionaryForExport ]);
+		yourself
+%
+
+category: 'instance creation'
+method: GtGemStoneFeaturesSpecification
+initializeFromFeatures: aFeaturesObject 
+	featureSpecifications := (aFeaturesObject items collect: [ :each |
+		each createSpecification ]) asArray
+%
+
+category: 'initialization'
+method: GtGemStoneFeaturesSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	featureSpecifications := (aDictionary at: 'featureSpecifications') collect: [ :each |
+		GtGemStoneFeatureSpecification fromJSONDictionary: each ].
+%
+
+! Class implementation for 'GtGemStoneMethodSpecification'
+
+!		Class methods for 'GtGemStoneMethodSpecification'
+
+category: 'instance creation'
+classmethod: GtGemStoneMethodSpecification
+forClass: aClass selector: aSelector
+	| gsMethod | 
+	gsMethod := (aClass methodDictForEnv: 0) at: aSelector.
+	^ self forGsMethod: gsMethod.
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneMethodSpecification
+forGsMethod: aGsMethod 
+	"Creation method on the GemStone side starting from a GemStone method"
+	
+	^ self new 
+		initializeForGsMethod: aGsMethod 
+%
+
+!		Instance methods for 'GtGemStoneMethodSpecification'
+
+category: 'converting'
+method: GtGemStoneMethodSpecification
+asDictionaryForExport
+
+	| exportData| 
+	exportData := super asDictionaryForExport.
+	exportData
+		at: 'coderClassName' put: coderClassName;
+		at: 'coderClassIconName' put: coderClassIconName;
+		at: 'isMeta' put: isMeta;
+		at: 'categoryName' put: categoryName;
+		at: 'sourceString' put: sourceString;
+		at: 'protocolName' put: protocolName;
+		at: 'selector' put: selector.
+		
+	self explicitProviderBehaviourDetails ifNotNil: [ :anObject | 
+		exportData 
+			at: 'explicitProviderBehaviourDetails'
+			put: anObject asDictionaryForExport ].
+	
+	^ exportData
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+categoryName
+	^categoryName
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+coderClassIconName
+	^ coderClassIconName
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+coderClassName
+	^ coderClassName
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+explicitProviderBehaviourDetails
+	^ explicitProviderBehaviourDetails
+%
+
+category: 'gt - extensions'
+method: GtGemStoneMethodSpecification
+gtViewSourceStringFor: aView 
+	<gtView>
+	
+	^ aView textEditor 
+		title: 'Source string';
+		priority: 25;
+		text: [ self sourceString ]
+%
+
+category: 'initialization'
+method: GtGemStoneMethodSpecification
+initializeForBehaviour: aMethodBehaviour ofMethod: aGsMethod
+	self 
+		initializeForClassName: aMethodBehaviour theNonMetaClass name
+		iconName: aMethodBehaviour gtSystemIconName
+		isMeta: aMethodBehaviour isMeta  
+		categoryName: aMethodBehaviour category 
+		protocolName: (aMethodBehaviour 
+			categoryOfSelector: aGsMethod selector )
+%
+
+category: 'initialization'
+method: GtGemStoneMethodSpecification
+initializeForClassName: aClassName iconName: aClassIconName isMeta: aBoolean categoryName: aCategoryName protocolName: aProtocolName
+	coderClassName := aClassName.
+	coderClassIconName := aClassIconName.
+	isMeta := aBoolean.
+	categoryName := aCategoryName.
+	protocolName := aProtocolName.
+%
+
+category: 'initialization'
+method: GtGemStoneMethodSpecification
+initializeForClassName: aClassName iconName: aClassIconName isMeta: aBoolean categoryName: aCategoryName selector: aSelector sourceString: aSourceCode protocolName: aProtocolName explicitProvider: aProviderDetails
+	self 
+		initializeForClassName: aClassName 
+		iconName: aClassIconName 
+		isMeta: aBoolean 
+		categoryName: aCategoryName 
+		protocolName: aProtocolName.
+	
+	sourceString := aSourceCode.
+	selector := aSelector.
+	explicitProviderBehaviourDetails := aProviderDetails.
+%
+
+category: 'initialization'
+method: GtGemStoneMethodSpecification
+initializeForGsMethod: aGsMethod 
+	| methodBehavior |
+	selector := aGsMethod selector.
+	sourceString := aGsMethod sourceString.
+	
+	methodBehavior := aGsMethod inClass.
+	methodBehavior ifNotNil: [
+		self 
+			initializeForBehaviour: methodBehavior 
+			ofMethod: aGsMethod ]
+%
+
+category: 'initialization'
+method: GtGemStoneMethodSpecification
+initializeForSelector: aSelector sourceString: aSourceString 
+	selector := aSelector.
+	sourceString := aSourceString.
+%
+
+category: 'initialization'
+method: GtGemStoneMethodSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+
+	self
+		initializeForClassName: (aDictionary at: #coderClassName)
+		iconName: (aDictionary at: #coderClassIconName ifAbsent: [ nil ])
+		isMeta: (aDictionary at: #isMeta)
+		categoryName: (aDictionary at: #categoryName)
+		selector: (aDictionary at: #selector)
+		sourceString: (aDictionary at: #sourceString)
+		protocolName: (aDictionary at: #protocolName)
+		explicitProvider: ((aDictionary includesKey: #explicitProviderBehaviourDetails)
+			ifTrue: [ GtGemStoneClassBasicDetails  fromJSONDictionary: (
+				aDictionary at: #explicitProviderBehaviourDetails)]
+			ifFalse: [ nil ])
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+isMeta
+	^ isMeta ifNil: [ false ]
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+packageName
+	^ categoryName
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+printBehaviorName
+	self coderClassName ifNil: [ ^ '<none>' ].
+	^ self isMeta 
+		ifTrue: [ self coderClassName, ' class' ] 
+		ifFalse: [ self coderClassName ]
+%
+
+category: 'printing'
+method: GtGemStoneMethodSpecification
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		aStream 
+			<< self printBehaviorName;
+			<< '>>';
+			<< (self selector ifNil: [ ^ '<none>' ]) ]
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+protocol
+	^ protocolName
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+protocolName
+	^protocolName
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+selector
+	^ selector
+%
+
+category: 'accessing'
+method: GtGemStoneMethodSpecification
+sourceString
+	^ sourceString
+%
+
+! Class implementation for 'GtGemStoneContextSpecification'
+
+!		Class methods for 'GtGemStoneContextSpecification'
+
+category: 'instance creation'
+classmethod: GtGemStoneContextSpecification
+forGsCallFrame: aGsCallFrame
+	^ self new 
+		initializeForGsCallFrame: aGsCallFrame 
+%
+
+!		Instance methods for 'GtGemStoneContextSpecification'
+
+category: 'converting'
+method: GtGemStoneContextSpecification
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: #isForBlock put: isForBlock;
+		at: #ipOffset put: ipOffset;
+		at: #frameIdentifier put: frameIdentifier asDictionaryForExport;
+		at: #programCounterMarkers put: programCounterMarkers;
+		yourself
+%
+
+category: 'accessing'
+method: GtGemStoneContextSpecification
+frameIdentifier
+	^ frameIdentifier
+%
+
+category: 'initialization'
+method: GtGemStoneContextSpecification
+initializeForGsCallFrame: aGsCallFrame 
+	self initializeForGsMethod: aGsCallFrame homeMethod.
+	self initializeProviderBehaviorFromFrame: aGsCallFrame.
+	
+	isForBlock := aGsCallFrame isForBlock.
+	ipOffset := aGsCallFrame ipOffset.
+	frameIdentifier := aGsCallFrame frameIdentifier. 
+	programCounterMarkers := aGsCallFrame programCounterMarkers. 
+%
+
+category: 'initialization'
+method: GtGemStoneContextSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	isForBlock := aDictionary at: #isForBlock.
+	ipOffset := aDictionary at: #ipOffset ifAbsent: [ nil ].
+	programCounterMarkers := aDictionary at: #programCounterMarkers ifAbsent: [ nil ].
+	
+	(aDictionary includesKey: #frameIdentifier) ifTrue: [
+		frameIdentifier := GtGemStoneCallFrameIdentifier 
+			fromJSONDictionary: (aDictionary at: #frameIdentifier) ]
+%
+
+category: 'initialization'
+method: GtGemStoneContextSpecification
+initializeProviderBehaviorFromFrame: aGsCallFrame 
+	| selfObjectClass |
+	selfObjectClass := aGsCallFrame selfObjectClass.
+	aGsCallFrame methodClass ~= selfObjectClass ifTrue: [
+		explicitProviderBehaviourDetails := GtGemStoneClassBasicDetails 
+			forClass: selfObjectClass ]
+%
+
+category: 'accessing'
+method: GtGemStoneContextSpecification
+ipOffset
+	^ ipOffset
+%
+
+category: 'accessing'
+method: GtGemStoneContextSpecification
+isForBlock
+	^ isForBlock ifNil: [ false ]
+%
+
+category: 'accessing'
+method: GtGemStoneContextSpecification
+programCounterMarkers
+	^ programCounterMarkers
+%
+
+! Class implementation for 'GtGemStoneMethodsSpecification'
+
+!		Class methods for 'GtGemStoneMethodsSpecification'
+
+category: 'instance creation'
+classmethod: GtGemStoneMethodsSpecification
+forGsMethods: aCollection 
+	^ self new 
+		initializeForGsMethods: aCollection 
+%
+
+!		Instance methods for 'GtGemStoneMethodsSpecification'
+
+category: 'accessing'
+method: GtGemStoneMethodsSpecification
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'methodCoderSpecifications' put: (methodCoderSpecifications
+			collect: [ :aMethodCoderSpecification |
+				aMethodCoderSpecification asDictionaryForExport]);
+		yourself
+%
+
+category: 'accessing'
+method: GtGemStoneMethodsSpecification
+at: anInteger
+
+	^ methodCoderSpecifications at: anInteger
+%
+
+category: 'accessing'
+method: GtGemStoneMethodsSpecification
+initializeForGsMethods: aCollectionOfGsMethods
+	methodCoderSpecifications := aCollectionOfGsMethods asArray 
+		collect: [ :aGsMethod |
+			GtGemStoneMethodSpecification forGsMethod: aGsMethod ]
+%
+
+category: 'initialization'
+method: GtGemStoneMethodsSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	methodCoderSpecifications := (aDictionary at: #methodCoderSpecifications)
+		collect: [ :aCoderJsonData  |
+			self instantiateCoderSpecificationFromJsonData: aCoderJsonData ]
+%
+
+category: 'initialization'
+method: GtGemStoneMethodsSpecification
+instantiateCoderSpecificationFromJsonData: aCoderJsonData 
+	^ GtGemStoneMethodSpecification  fromJSONDictionary: aCoderJsonData
+%
+
+category: 'accessing'
+method: GtGemStoneMethodsSpecification
+methodCoderSpecifications
+	^ methodCoderSpecifications
+%
+
+category: 'accessing'
+method: GtGemStoneMethodsSpecification
+size
+
+	^ methodCoderSpecifications size
+%
+
+! Class implementation for 'GtGemStoneProcessSpecification'
+
+!		Class methods for 'GtGemStoneProcessSpecification'
+
+category: 'instance creation'
+classmethod: GtGemStoneProcessSpecification
+forGsCallStack: aCallStack
+	^ self new 
+		initializeForGsCallStack: aCallStack
+%
+
+!		Instance methods for 'GtGemStoneProcessSpecification'
+
+category: 'accessing'
+method: GtGemStoneProcessSpecification
+frameSpecifications
+	^ self methodCoderSpecifications
+%
+
+category: 'gt - extensions'
+method: GtGemStoneProcessSpecification
+gtViewCallFrameSpecificationsFor: aView 
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Frame specifications';
+		priority: 50;
+		items: [ self frameSpecifications ];
+		actionUpdateButtonTooltip: 'Update item list';
+		column: 'Index' 
+			text: [ :eachItem :eachIndex | eachIndex  ]
+			width: 45;
+		column: 'ID' 
+			text: [ :eachItem | eachItem frameIdentifier description  ]
+			width: 45;
+		column: 'Ip Offset' 
+			text: [ :eachItem | eachItem ipOffset ]
+			width: 45;
+		column: 'Item' 
+			text: [ :eachItem | eachItem gtDisplayText ]
+%
+
+category: 'accessing'
+method: GtGemStoneProcessSpecification
+initializeForGsCallStack: aCallStack
+	methodCoderSpecifications := (aCallStack callFrames 
+		collect: [ :aGsCallFrame |
+			GtGemStoneContextSpecification forGsCallFrame: aGsCallFrame ]) asArray
+%
+
+category: 'accessing'
+method: GtGemStoneProcessSpecification
+instantiateCoderSpecificationFromJsonData: aCoderJsonData 
+	^ GtGemStoneContextSpecification  fromJSONDictionary: aCoderJsonData
+%
+
+! Class implementation for 'GtGemStoneSpecificationMedatada'
+
+!		Class methods for 'GtGemStoneSpecificationMedatada'
+
+category: 'instance creation'
+classmethod: GtGemStoneSpecificationMedatada
+fromJSONDictionary: aDictionary
+	^ self new  
+		initializeFromJSONDictionary: aDictionary
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSpecificationMedatada
+fromJsonString: aString
+	| dictionary |
+
+	dictionary := STON fromString: aString.
+	^ self fromJSONDictionary: dictionary
+%
+
+category: 'instance creation'
+classmethod: GtGemStoneSpecificationMedatada
+fromObjectDictionary: aDictionary 
+	^ self fromJSONDictionary: (aDictionary 
+		at: '__metadata' 
+		ifAbsent: [ ^ self new
+			apiVersion: GtGemStoneSemanticVersionNumber zero;
+			schemaVersion: GtGemStoneSemanticVersionNumber zero ])
+%
+
+!		Instance methods for 'GtGemStoneSpecificationMedatada'
+
+category: 'accessing'
+method: GtGemStoneSpecificationMedatada
+apiVersion
+	^ apiVersion
+%
+
+category: 'accessing'
+method: GtGemStoneSpecificationMedatada
+apiVersion: anObject
+	apiVersion := anObject
+%
+
+category: 'converting'
+method: GtGemStoneSpecificationMedatada
+asDictionaryForExport
+	^ {
+		'apiVersion' -> self apiVersion versionString.
+		'schemaVersion' -> self schemaVersion versionString
+	} asDictionary
+%
+
+category: 'converting'
+method: GtGemStoneSpecificationMedatada
+asMetadataAttributesForExport
+	^ {'__metadata' -> self asDictionaryForExport} asDictionary
+%
+
+category: 'initialization'
+method: GtGemStoneSpecificationMedatada
+initializeFromJSONDictionary: aDictionary
+	apiVersion := GtGemStoneSemanticVersionNumber 
+		readFromString: (aDictionary at: 'apiVersion').
+	schemaVersion := GtGemStoneSemanticVersionNumber 
+		readFromString: (aDictionary at: 'schemaVersion').
+%
+
+category: 'accessing'
+method: GtGemStoneSpecificationMedatada
+schemaVersion
+	^ schemaVersion
+%
+
+category: 'accessing'
+method: GtGemStoneSpecificationMedatada
+schemaVersion: anObject
+	schemaVersion := anObject
+%
+
+! Class implementation for 'GtGemStoneTranscript'
+
+!		Class methods for 'GtGemStoneTranscript'
+
+category: 'accessing'
+classmethod: GtGemStoneTranscript
+current
+	^ GtGemStoneTranscriptHandler currentTranscript
+%
+
+category: 'accessing'
+classmethod: GtGemStoneTranscript
+registerAsCurrentTranscript
+	^ GtGemStoneTranscriptHandler registerTranscriptClass: self
+%
+
+category: 'accessing'
+classmethod: GtGemStoneTranscript
+reset
+	^ GtGemStoneTranscriptHandler resetTranscript
+%
+
+!		Instance methods for 'GtGemStoneTranscript'
+
+category: 'actions'
+method: GtGemStoneTranscript
+clearContent
+	self subclassResponsibility
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+cr
+	self nextPut: Character cr
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+crShow: anObject
+	self 
+		cr; 
+		show: anObject 
+%
+
+category: 'actions'
+method: GtGemStoneTranscript
+disable
+	self subclassResponsibility
+%
+
+category: 'actions'
+method: GtGemStoneTranscript
+enable
+	self subclassResponsibility
+%
+
+category: 'testing'
+method: GtGemStoneTranscript
+isEnabled
+	^ self subclassResponsibility
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+lf
+	self nextPut: Character lf
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+lfShow: anObject
+	self 
+		lf; 
+		show: anObject
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+newLine
+	self lf
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+nextPut: aCharacter
+	self subclassResponsibility
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+nextPutAll: aString
+	self subclassResponsibility
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+print: anObject
+	self nextPutAll: anObject asString 
+%
+
+category: 'api - streaming'
+method: GtGemStoneTranscript
+show: anObject
+	self print: anObject
+%
+
+category: 'accessing'
+method: GtGemStoneTranscript
+statusDescription
+	^ self isEnabled
+		ifTrue: [ 'Enabled' ] 
+		ifFalse: [ 'Disabled' ]
+%
+
+category: 'actions'
+method: GtGemStoneTranscript
+toggleStatus
+	self isEnabled 
+		ifTrue: [ self disable ]	
+		ifFalse: [ self enable ].
+	
+	^ self isEnabled 
+%
+
+category: 'actions'
+method: GtGemStoneTranscript
+toggleStatusWithLogging
+	self isEnabled 
+		ifTrue: [ 
+			self lfShow: 'Deactivate GemStone transcript on current session'.
+			self disable]
+		ifFalse: [ 
+			self enable.
+			self lfShow: 'Activate GemStone transcript on current session' ].
+	^ self isEnabled
+%
+
+category: 'utils'
+method: GtGemStoneTranscript
+whenEnabledDo: aBlock
+	self isEnabled ifTrue: [
+		aBlock value ]
+%
+
+! Class implementation for 'GtGemStoneInImageTranscript'
+
+!		Instance methods for 'GtGemStoneInImageTranscript'
+
+category: 'configuration'
+method: GtGemStoneInImageTranscript
+clearContent
+	contentStream := PrintStream printingOn: String new.
+%
+
+category: 'accessing'
+method: GtGemStoneInImageTranscript
+contents
+	^ contentStream contents
+%
+
+category: 'configuration'
+method: GtGemStoneInImageTranscript
+disable
+	enabled := false
+%
+
+category: 'configuration'
+method: GtGemStoneInImageTranscript
+enable
+	enabled := true
+%
+
+category: 'gt - extensions'
+method: GtGemStoneInImageTranscript
+gtViewContentsFor: aView
+	<gtView>
+	
+	^ aView text 
+		title: 'Contents';
+		priority: 10;
+		text: [ contentStream contents ]
+%
+
+category: 'initialization'
+method: GtGemStoneInImageTranscript
+initialize
+	super initialize.
+	
+	self clearContent.
+	self disable.
+%
+
+category: 'testing'
+method: GtGemStoneInImageTranscript
+isEnabled
+	^ enabled
+%
+
+category: 'api - streaming'
+method: GtGemStoneInImageTranscript
+nextPut: aCharacter
+	self whenEnabledDo: [  
+		contentStream nextPut: aCharacter ]
+%
+
+category: 'api - streaming'
+method: GtGemStoneInImageTranscript
+nextPutAll: aString
+	self whenEnabledDo: [  
+		contentStream nextPutAll: aString ]
+%
+
+! Class implementation for 'GtGemStoneTranscriptHandler'
+
+!		Class methods for 'GtGemStoneTranscriptHandler'
+
+category: 'utils'
+classmethod: GtGemStoneTranscriptHandler
+createNewTranscript
+	^ ((System myUserProfile objectNamed: self transcriptClassName asSymbol)
+		ifNil: [ GtGemStoneInImageTranscript  ]
+		ifNotNil: [ :aClass | aClass ]) basicNew initialize
+%
+
+category: 'transcript - api'
+classmethod: GtGemStoneTranscriptHandler
+currentTranscript
+	^ SessionTemps current 
+		at: self transcriptInstanceKeyName
+		ifAbsentPut: [ self createNewTranscript  ]
+%
+
+category: 'transcript - api'
+classmethod: GtGemStoneTranscriptHandler
+registerTranscriptClass: aClass
+	^ SessionTemps current 
+		at: self transcriptClassKeyName
+		put: aClass name
+%
+
+category: 'transcript - api'
+classmethod: GtGemStoneTranscriptHandler
+resetTranscript
+	"Remove the current transcript instance.
+	If called from the GT side, the caller should ensure
+	that the old instance is no longer used on the GT side."
+	
+	SessionTemps current 
+		removeKey: self transcriptInstanceKeyName
+		ifAbsent: [ ]
+%
+
+category: 'accessing'
+classmethod: GtGemStoneTranscriptHandler
+transcriptClassKeyName
+	^#GT_TRANSCRIPT_INSTANCE
+%
+
+category: 'accessing'
+classmethod: GtGemStoneTranscriptHandler
+transcriptClassName
+	^ SessionTemps current 
+		at: self transcriptClassKeyName
+		ifAbsent: [ GtGemStoneInImageTranscript name ]
+%
+
+category: 'accessing'
+classmethod: GtGemStoneTranscriptHandler
+transcriptInstanceKeyName
+	^#GT_TRANSCRIPT_CLASS_NAME
+%
+
+! Class implementation for 'GtGsRelease'
+
+!		Class methods for 'GtGsRelease'
+
+category: 'accessing'
+classmethod: GtGsRelease
+default
+	^ default ifNil: [ 
+		default := self new ]
+%
+
+category: 'accessing'
+classmethod: GtGsRelease
+versionString
+	^ default
+		ifNil: [ '<none>' ]
+		ifNotNil: [
+			self default versionString ]
+%
+
+category: 'accessing'
+classmethod: GtGsRelease
+versionString: aString
+	self default versionString: aString
+%
+
+!		Instance methods for 'GtGsRelease'
+
+category: 'accessing'
+method: GtGsRelease
+versionString
+
+	^ versionString
+%
+
+category: 'accessing'
+method: GtGsRelease
+versionString: aString
+
+	versionString := aString
+%
+
+! Class implementation for 'GtRsrSerializationStrategy'
+
+!		Class methods for 'GtRsrSerializationStrategy'
+
+category: 'accessing'
+classmethod: GtRsrSerializationStrategy
+strategyLabel
+	^ ((self className
+		withoutPrefix: 'GtRsr')
+		withoutSuffix: 'SerializationStrategy class')
+			ifEmpty: [ 'SerializationStrategy' ]
+%
+
+!		Instance methods for 'GtRsrSerializationStrategy'
+
+category: 'converting'
+method: GtRsrSerializationStrategy
+deserialize: anObject
+	"Deserialize the supplied object"
+	
+	^ self subclassResponsibility
+%
+
+category: 'converting'
+method: GtRsrSerializationStrategy
+serialize: anObject
+	"Serialize the object to something that RSR can return"
+	
+	^ self subclassResponsibility
+%
+
+! Class implementation for 'GtRsrDirectLocalObjectSerializationStrategy'
+
+!		Instance methods for 'GtRsrDirectLocalObjectSerializationStrategy'
+
+category: 'converting'
+method: GtRsrDirectLocalObjectSerializationStrategy
+serialize: anObject 
+	| names instVarDictionary |
+	
+	"This code that sets the attributes be delegated through the class of the object"
+	names := anObject class allInstVarNames.
+	instVarDictionary := Dictionary new.
+	1 to: names size do: [ :i |
+		instVarDictionary at: (names at: i) put: (self instVarAt: i) ].
+	
+	^ Dictionary new 	
+		at: 'instanceVariables' put: instVarDictionary;
+		at: 'remoteInstance' put: (anObject asGtRsrProxyObjectForConnection: nil);
+		at: 'remoteClassName' put: anObject class name;
+		yourself
+%
+
+! Class implementation for 'GtRsrLegacySerializationStrategy'
+
+!		Instance methods for 'GtRsrLegacySerializationStrategy'
+
+category: 'converting'
+method: GtRsrLegacySerializationStrategy
+deserialize: anObject
+	"Deserialize the supplied object"
+	
+	^ anObject
+%
+
+category: 'converting'
+method: GtRsrLegacySerializationStrategy
+serialize: anObject 
+	^ anObject asGtRsrProxyObjectForConnection: nil
+%
+
+! Class implementation for 'GtRsrLiteralAndProxySerializationStrategy'
+
+!		Instance methods for 'GtRsrLiteralAndProxySerializationStrategy'
+
+category: 'converting'
+method: GtRsrLiteralAndProxySerializationStrategy
+deserialize: anObject
+	"Deserialize the supplied object"
+	
+	^ anObject
+%
+
+! Class implementation for 'GtRsrLocalObjectSerializationStrategy'
+
+!		Instance methods for 'GtRsrLocalObjectSerializationStrategy'
+
+category: 'converting'
+method: GtRsrLocalObjectSerializationStrategy
+deserialize: anObject
+	"Deserialize the supplied object"
+	
+	^ anObject asGtBareProxyObject asGtpoLocalObject
+%
+
+category: 'converting'
+method: GtRsrLocalObjectSerializationStrategy
+serialize: anObject 
+	^ anObject asGtRsrProxyObjectForConnection: nil
+%
+
+! Class implementation for 'GtRsrPrimitiveOnlySerializationStrategy'
+
+!		Instance methods for 'GtRsrPrimitiveOnlySerializationStrategy'
+
+category: 'converting'
+method: GtRsrPrimitiveOnlySerializationStrategy
+deserialize: anObject
+	"Deserialize the supplied object"
+	
+	^ anObject
+%
+
+category: 'converting'
+method: GtRsrPrimitiveOnlySerializationStrategy
+serialize: anObject
+	"Serialize the object to something that RSR can return.
+	In this case we're requiring that the object can be returned as an RSR primitive.  If it can't RSR will raise an exception."
+	
+	^ anObject
+%
+
+! Class implementation for 'GtRsrProxyOnlySerializationStrategy'
+
+!		Instance methods for 'GtRsrProxyOnlySerializationStrategy'
+
+category: 'converting'
+method: GtRsrProxyOnlySerializationStrategy
+deserialize: anObject
+	"Deserialize the supplied object"
+	
+	^ anObject
+%
+
+! Class implementation for 'GtRsrStonSerializationStrategy'
+
+!		Instance methods for 'GtRsrStonSerializationStrategy'
+
+category: 'converting'
+method: GtRsrStonSerializationStrategy
+deserialize: anObject
+	"Deserialize the supplied object"
+
+	anObject isString ifFalse: [ ^ anObject ].
+
+	^ self stonClass fromString: anObject
+%
+
+category: 'converting'
+method: GtRsrStonSerializationStrategy
+serialize: anObject
+	"Serialize the object to a String, except RSR services"
+
+	(anObject isKindOf: RsrService) ifTrue: [ ^ anObject ].
+	^ self stonClass toString: anObject
+%
+
+category: 'private'
+method: GtRsrStonSerializationStrategy
+stonClass
+	| stonClass |
+
+	stonClass := self
+		gtDo: [ self class environment at: #STON ifAbsent: [ nil ] ]
+		gemstoneDo: [ GsCurrentSession currentSession symbolList objectNamed: #STON ].
+	stonClass ifNil: [ self error: 'STON not installed' ].
+
+	^ stonClass
+%
+
+! Class implementation for 'GtRsrWireSerializationStrategy'
+
+!		Instance methods for 'GtRsrWireSerializationStrategy'
+
+category: 'converting'
+method: GtRsrWireSerializationStrategy
+deserialize: aGtRsrWireTransferService
+	"Deserialize the supplied object"
+	
+	^ aGtRsrWireTransferService object
+%
+
+category: 'accessing'
+method: GtRsrWireSerializationStrategy
+encoder
+
+	^ encoder
+%
+
+category: 'accessing'
+method: GtRsrWireSerializationStrategy
+encoder: aGtWireEncoder
+
+	"self assert: aGtWireEncoder hasValidConfiguration
+		description: 'Supplied wire encoder has invalid configuration'."
+	encoder := aGtWireEncoder
+%
+
+category: 'converting'
+method: GtRsrWireSerializationStrategy
+serialize: anObject
+	"Serialize the object to something that RSR can return"
+	
+	^ (self gtDo: [ GtRsrWireTransferService clientClass ] gemstoneDo: [ GtRsrWireTransferService serverClass ]) new 
+		encoder: encoder copy;
+		object: anObject
+%
+
+! Class implementation for 'STONJSON'
+
+!		Class methods for 'STONJSON'
+
+category: 'other'
+classmethod: STONJSON
+fromString: aString
+	^ JsonParser parse: aString
+%
+
+category: 'other'
+classmethod: STONJSON
+toString: object
+	^ STON toJsonString: object
+%
+
+category: 'other'
+classmethod: STONJSON
+toStringPretty: object
+	^ STON toJsonStringPretty: object
+%
+
+! Class implementation for 'ZnBase64Encoder'
+
+!		Class methods for 'ZnBase64Encoder'
+
+category: 'other'
+classmethod: ZnBase64Encoder
+new
+	^ self basicNew initialize
+%
+
+!		Instance methods for 'ZnBase64Encoder'
+
+category: 'other'
+method: ZnBase64Encoder
+beStrict
+	"Configure me to enforce padding when decoding"
+
+	strict := true
+%
+
+category: 'other'
+method: ZnBase64Encoder
+characterCountFor: bytes
+	| n characterCount |
+	"This assumes that padding is used"
+	n := bytes size.
+	characterCount := (n // 3 + (n \\ 3) sign) * 4.
+	^ lineLength
+		ifNil: [ characterCount ]
+		ifNotNil: [ characterCount + (characterCount // lineLength * lineEnd size) ]
+%
+
+category: 'other'
+method: ZnBase64Encoder
+characterForValue: value
+	^ alphabet at: value + 1
+%
+
+category: 'other'
+method: ZnBase64Encoder
+defaultAlphabet
+	^ 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+%
+
+category: 'other'
+method: ZnBase64Encoder
+defaultInverse
+	| defaultInverse |
+	defaultInverse := Array new: 128.
+	0 to: 127 do: [ :each | 
+		| offset |
+		offset := self defaultAlphabet indexOf: each asCharacter ifAbsent: [ nil ].
+		defaultInverse at: each + 1 put: (offset ifNotNil: [ offset - 1 ]) ].
+	^ defaultInverse
+%
+
+category: 'other'
+method: ZnBase64Encoder
+encode: byteArray
+	"Encode byteArray using Base64 encoding and return the resulting string"
+
+	^ String
+		new: (self characterCountFor: byteArray)
+		streamContents: [ :stringStream |
+			self encode: byteArray readStream to: stringStream ]
+%
+
+category: 'other'
+method: ZnBase64Encoder
+encode: byte1 and: byte2 and: byte3 to: stream
+	stream nextPut: (self characterForValue: (byte1 bitShift: -2)).
+	byte2
+		ifNil: [
+			stream nextPut: (self characterForValue: ((byte1 bitAnd: 2r11) bitShift: 4)).
+			padding ifNotNil: [ stream nextPut: padding; nextPut: padding ] ]
+		ifNotNil: [
+			stream nextPut: (self characterForValue: (((byte1 bitAnd: 2r11) bitShift: 4) + (byte2 bitShift: -4))).
+			byte3
+				ifNil: [
+					stream nextPut: (self characterForValue: ((byte2 bitAnd: 2r1111) bitShift: 2)).
+					padding ifNotNil: [ stream nextPut: $= ] ]
+				ifNotNil: [
+					stream nextPut: (self characterForValue: (((byte2 bitAnd: 2r1111) bitShift: 2) + (byte3 bitShift: -6))).
+					stream nextPut: (self characterForValue: (byte3 bitAnd: 2r111111)) ] ]
+%
+
+category: 'other'
+method: ZnBase64Encoder
+encode: byteStream to: stringStream
+	| byte1 byte2 byte3 count |
+	lineLength
+		ifNil: [
+			[ byteStream atEnd ] whileFalse: [
+				byte1 := byteStream next.
+				byte2 := byteStream next.
+				byte3 := byteStream next.
+				self encode: byte1 and: byte2 and: byte3 to: stringStream ] ]
+		ifNotNil: [
+			count := 0.
+			[ byteStream atEnd ] whileFalse: [
+				byte1 := byteStream next.
+				byte2 := byteStream next.
+				byte3 := byteStream next.
+				self encode: byte1 and: byte2 and: byte3 to: stringStream.
+				(count := count + 4) = lineLength
+					ifTrue: [
+						stringStream nextPutAll: lineEnd.
+						count := 0 ] ] ]
+%
+
+category: 'other'
+method: ZnBase64Encoder
+initialize
+	super initialize.
+	alphabet := self defaultAlphabet.
+	inverse := self defaultInverse.
+	self padding: $=.
+	self whitespace: #any.
+	self beStrict
+%
+
+category: 'other'
+method: ZnBase64Encoder
+padding: character
+	"Configure me to use character as padding.
+	One or two padding character might be needed to complete each quad.
+	Use nil to disable padding."
+
+	padding := character
+%
+
+category: 'other'
+method: ZnBase64Encoder
+whitespace: mode
+	"Set the whitespace mode:
+	nil is no whitespace allowed,
+	#separator is CR, LF, FF, SPACE, TAB allowed,
+	#any is all non-alphabet characters allowed (the default)"
+
+	whitespace := mode
+%
+
+! Class implementation for 'GtRsrEvaluatorFeaturesService'
+
+!		Class methods for 'GtRsrEvaluatorFeaturesService'
+
+category: 'accessing'
+classmethod: GtRsrEvaluatorFeaturesService
+templateClassName
+
+	^ #GtRsrEvaluatorFeaturesService
+%
+
+! Class implementation for 'GtRsrEvaluatorFeaturesServiceServer'
+
+!		Instance methods for 'GtRsrEvaluatorFeaturesServiceServer'
+
+category: 'accessing'
+method: GtRsrEvaluatorFeaturesServiceServer
+featuresDictionary
+	"Answer a dictionary of primitives defining the server's evaluation features."
+
+	^ Dictionary new
+		at: #gtRsrEvaluator put: (Dictionary new
+			at: #version put: '0.1.0';
+			yourself);
+		yourself.
+%
+
+! Class implementation for 'GtRsrEvaluatorService'
+
+!		Class methods for 'GtRsrEvaluatorService'
+
+category: 'testing'
+classmethod: GtRsrEvaluatorService
+isRsrImmediate: anObject
+	"Answer a boolean indicating whether the supplied object is considered a primitive type, meaining:
+	- it has an RSR service mapping, or
+	- it is a service object"
+
+	^ (RsrReference referenceMapping includesKey: anObject class) or:
+		[ anObject isKindOf: RsrService ]
+%
+
+category: 'accessing'
+classmethod: GtRsrEvaluatorService
+templateClassName
+
+	^ #GtRsrEvaluatorService
+%
+
+! Class implementation for 'GtRsrEvaluatorServiceServer'
+
+!		Class methods for 'GtRsrEvaluatorServiceServer'
+
+category: 'logging'
+classmethod: GtRsrEvaluatorServiceServer
+stdout
+	"Cache stdout in the session temps as in a large database reflection is very slow,
+	so the initial call could take 10 - 20 seconds."
+
+	^ SessionTemps current
+		at: #stdout
+		ifAbsentPut: [ FsFileDescriptor stdout ].
+%
+
+category: 'logging'
+classmethod: GtRsrEvaluatorServiceServer
+stdoutLog: aMessage
+	| msgStream |
+
+	msgStream := WriteStream on: String new.
+	msgStream
+		nextPutAll: Time now printString;
+		nextPutAll: ': ';
+		nextPutAll: (aMessage isString
+			ifTrue: [ aMessage asString ]
+			ifFalse: [ aMessage printString ]);
+		lf.
+	self stdout write: msgStream contents utf8Encoded.
+%
+
+!		Instance methods for 'GtRsrEvaluatorServiceServer'
+
+category: 'actions'
+method: GtRsrEvaluatorServiceServer
+evaluate: aString for: anObject bindings: aDictionary
+	"Evaluate the receiver's script, answering the result.
+	On the server this is a synchronous operation."
+
+	^ self 
+			evaluate: aString 
+			for: anObject 
+			bindings: aDictionary 
+			serializationStrategy: #GtRsrLegacySerializationStrategy
+%
+
+category: 'actions'
+method: GtRsrEvaluatorServiceServer
+evaluate: aString for: anObject bindings: aDictionary serializationStrategy: aSymbol
+	"Evaluate the receiver's script, answering the serialized result.
+	On the server this is a synchronous operation."
+	
+	| evaluationResult |
+
+	evaluationResult := self 
+		gsEvaluate: aString 
+		for: anObject 
+		bindings: aDictionary 
+		serializationStrategy: aSymbol.
+
+	^ evaluationResult ifNotNil: [ :anEvaluationResult |  
+		anEvaluationResult asDictionaryForExport ]
+%
+
+category: 'actions'
+method: GtRsrEvaluatorServiceServer
+evaluate: aString for: anObject inFrameIdentifierIndex: aFrameIndex ofEvaluationContext: aTargetEvaluationContext bindings: aDictionary serializationStrategy: aSymbol
+	"Evaluate the receiver's script, answering the serialized result.
+	On the server this is a synchronous operation."
+	
+	| evaluationResult |
+
+	evaluationResult := self 
+		gsEvaluate: aString 
+		for: anObject 
+		inFrameIdentifierIndex: aFrameIndex 
+		ofEvaluationContext: aTargetEvaluationContext
+		bindings: aDictionary 
+		serializationStrategy: aSymbol.
+
+	^ evaluationResult ifNotNil: [ :anEvaluationResult |  
+		anEvaluationResult asDictionaryForExport ]
+%
+
+category: 'actions'
+method: GtRsrEvaluatorServiceServer
+evaluateReturnProxy: aString for: anObject bindings: aDictionary
+	"Evaluate the receiver's script, answering the result as a proxy.
+	On the server this is a synchronous operation."
+
+	^ self 
+			evaluate: aString 
+			for: anObject 
+			bindings: aDictionary 
+			serializationStrategy: #GtRsrProxyOnlySerializationStrategy
+%
+
+category: 'private - GemStone'
+method: GtRsrEvaluatorServiceServer
+gsEvaluate: aString for: anObject bindings: aDictionary
+	^ self gsEvaluate: aString for: anObject bindings: aDictionary serializationStrategy: nil
+%
+
+category: 'private - GemStone'
+method: GtRsrEvaluatorServiceServer
+gsEvaluate: aString for: anObject bindings: aDictionary serializationStrategy: aSymbol
+	"Evaluate the receiver's script, answering the result"
+	| receiver symbolDictionary bindings |
+
+	SessionTemps current at: #GtRsrServer put: self.
+	receiver := anObject asGtGsArgument.
+	symbolDictionary := SymbolDictionary new.
+	aDictionary asGtGsArgument keysAndValuesDo: [ :key :value |
+		symbolDictionary at: key put: value asGtGsArgument ].
+	bindings := GsCurrentSession currentSession symbolList, (Array with: symbolDictionary).
+
+	^ GtGemStoneEvaluationContext new
+		serializationStrategy: aSymbol;
+		evaluateAndWaitBlock: 
+			[ | method |
+			method := aString _compileInContext: receiver symbolList: bindings.
+			method _executeInContext: receiver ]
+		from: self.
+%
+
+category: 'private - GemStone'
+method: GtRsrEvaluatorServiceServer
+gsEvaluate: aString for: anObject  inFrameIdentifierIndex: aFrameIdentifierIndex ofEvaluationContext: aTargetEvaluationContext bindings: aDictionary serializationStrategy: aSymbol
+	"Evaluate the receiver's script, answering the result"
+	| compilationContext receiver  allBindings  |
+
+	SessionTemps current at: #GtRsrServer put: self.
+	compilationContext := GtGemStoneCompilationContext 
+		receiver: anObject asGtGsArgument
+		frameIdentifierIndex: aFrameIdentifierIndex 
+		evaluationContext: aTargetEvaluationContext asGtGsArgument
+		clientBindings: aDictionary asGtGsArgument.
+
+	receiver := compilationContext currentReceiver.
+	allBindings := compilationContext allBindings.
+
+	^ GtGemStoneEvaluationContext new
+		serializationStrategy: aSymbol;
+		compilationContext: compilationContext;
+		evaluateAndWaitBlock: 
+			[ | method |
+			method := aString _compileInContext: receiver symbolList: allBindings.
+			[ method _executeInContext: receiver] ensure: [
+				compilationContext updatedFrameBindings ] ]
+		from: self
+%
+
+category: 'private - GemStone'
+method: GtRsrEvaluatorServiceServer
+gsStartEvaluate: aString for: anObject bindings: aDictionary serializationStrategy: aSymbol
+	"Evaluate the receiver's script, answering the result"
+	| receiver symbolDictionary bindings |
+
+	SessionTemps current at: #GtRsrServer put: self.
+	receiver := anObject asGtGsArgument.
+	symbolDictionary := SymbolDictionary new.
+	aDictionary asGtGsArgument keysAndValuesDo: [ :key :value |
+		symbolDictionary at: key put: value asGtGsArgument ].
+	bindings := GsCurrentSession currentSession symbolList, (Array with: symbolDictionary).
+
+	^ GtGemStoneEvaluationContext new
+		serializationStrategy: aSymbol;
+		evaluateBlock: 
+			[ | method |
+			method := aString _compileInContext: receiver symbolList: bindings.
+			method _executeInContext: receiver ]
+		from: self
+		priority: Processor userBackgroundPriority - 2
+%
+
+category: 'actions'
+method: GtRsrEvaluatorServiceServer
+startEvaluate: aString for: anObject bindings: aDictionary serializationStrategy: aSymbol
+	"Start the receiver's script, answering the result."
+	| evaluationResult |
+
+	evaluationResult := self gsStartEvaluate: aString for: anObject bindings: aDictionary serializationStrategy: aSymbol.
+	^ evaluationResult asDictionaryForExport
+			asGtRsrProxyObjectForConnection: nil
+%
+
+! Class implementation for 'GtRsrProxyService'
+
+!		Class methods for 'GtRsrProxyService'
+
+category: 'accessing'
+classmethod: GtRsrProxyService
+templateClassName
+
+	^ #GtRsrProxyService
+%
+
+!		Instance methods for 'GtRsrProxyService'
+
+category: 'testing'
+method: GtRsrProxyService
+isGtGemStoneRsrProxy
+
+	^ true
+%
+
+category: 'testing'
+method: GtRsrProxyService
+isGtProxyObject
+
+	^ true
+%
+
+category: 'testing'
+method: GtRsrProxyService
+isProxyObjectActive
+	"Answer a boolean indicating whether the receiver is expected to be functioning,
+	i.e. it has a connection that is open, and it's connection is the current one."
+
+	_connection ifNil: [ ^ false ].
+	_connection isOpen ifFalse: [ ^ false ].
+	^ true
+%
+
+category: 'accessing'
+method: GtRsrProxyService
+remoteClass
+	"Answer the name of the class of the remote object"
+
+	^ remoteClass
+%
+
+category: 'accessing'
+method: GtRsrProxyService
+remoteClass: aSymbol
+	"Set the name of the class of the remote object"
+
+	remoteClass := aSymbol
+%
+
+! Class implementation for 'GtRsrProxyServiceServer'
+
+!		Class methods for 'GtRsrProxyServiceServer'
+
+category: 'other'
+classmethod: GtRsrProxyServiceServer
+object: anObject
+
+	^ self new object: anObject
+%
+
+!		Instance methods for 'GtRsrProxyServiceServer'
+
+category: 'accessing'
+method: GtRsrProxyServiceServer
+asGtGsArgument
+	"Answer the the local object of the receiver"
+
+	^ object
+%
+
+category: 'private'
+method: GtRsrProxyServiceServer
+basicPerform: aSymbol withArguments: anArray  serializationStrategy: aSerialisationStrategySymbol
+	"Perform the requested operation, catching errors and returning exception information"
+
+	SessionTemps current at: #GtRsrServer put: self.
+
+	^ (GtGemStoneEvaluationContext new
+		serializationStrategy: aSerialisationStrategySymbol)
+			evaluateAndWaitBlock: [ 
+				object perform: aSymbol withArguments: anArray asGtGsArgument ]
+			from: self.
+%
+
+category: 'accessing'
+method: GtRsrProxyServiceServer
+object
+	"Answer the object being proxied"
+
+	^ object
+%
+
+category: 'accessing'
+method: GtRsrProxyServiceServer
+object: anObject
+	"Set the object being proxied"
+
+	object := anObject.
+	remoteClass := anObject class name.
+%
+
+category: 'performing'
+method: GtRsrProxyServiceServer
+proxyPerform: aSymbol
+	^ self proxyPerform: aSymbol withArguments: #()
+%
+
+category: 'performing'
+method: GtRsrProxyServiceServer
+proxyPerform: aSymbol serializationStrategy: serializationSymbol
+	^ self 
+		proxyPerform: aSymbol 
+		withArguments: #() 
+		serializationStrategy: serializationSymbol
+%
+
+category: 'performing'
+method: GtRsrProxyServiceServer
+proxyPerform: aSymbol withArguments: anArray
+	^ self 
+		proxyPerform: aSymbol 
+		withArguments: anArray
+		serializationStrategy: #GtRsrLegacySerializationStrategy
+%
+
+category: 'performing'
+method: GtRsrProxyServiceServer
+proxyPerform: aSymbol withArguments: anArray serializationStrategy: aSerializationStrategySymbol
+	| evaluationResult |
+
+	evaluationResult := self 
+		basicPerform: aSymbol 
+		withArguments: anArray 
+		serializationStrategy: aSerializationStrategySymbol.
+
+	^ evaluationResult ifNotNil: [ :anEvaluationResult |  
+		anEvaluationResult asDictionaryForExport ]
+%
+
+category: 'performing'
+method: GtRsrProxyServiceServer
+proxyPerformReturnProxy: aSymbol
+	^ self proxyPerformReturnProxy: aSymbol withArguments: #()
+%
+
+category: 'performing'
+method: GtRsrProxyServiceServer
+proxyPerformReturnProxy: aSymbol withArguments: anArray
+	^ self 
+		proxyPerform: aSymbol 
+		withArguments: anArray
+		serializationStrategy: #GtRsrProxyOnlySerializationStrategy
+%
+
+! Class implementation for 'GtRsrTestService'
+
+!		Class methods for 'GtRsrTestService'
+
+category: 'accessing'
+classmethod: GtRsrTestService
+templateClassName
+
+	^ #GtRsrTestService
+%
+
+!		Instance methods for 'GtRsrTestService'
+
+category: 'testing'
+method: GtRsrTestService
+isGtGemStoneRsrProxy
+
+	^ true
+%
+
+category: 'accessing'
+method: GtRsrTestService
+object
+	^ object
+%
+
+category: 'accessing'
+method: GtRsrTestService
+object: anObject
+	object := anObject
+%
+
+! Class implementation for 'GtRsrWireTransferService'
+
+!		Class methods for 'GtRsrWireTransferService'
+
+category: 'accessing'
+classmethod: GtRsrWireTransferService
+templateClassName
+
+	^ #GtRsrWireTransferService
+%
+
+!		Instance methods for 'GtRsrWireTransferService'
+
+category: 'private'
+method: GtRsrWireTransferService
+addRoot: anObject
+	"Hold on to the supplied object so it is included in the RSR analysis."
+
+	roots add: anObject.
+%
+
+category: 'accessing'
+method: GtRsrWireTransferService
+buffer
+	^ buffer
+%
+
+category: 'accessing'
+method: GtRsrWireTransferService
+buffer: anObject
+	buffer := anObject
+%
+
+category: 'accessing'
+method: GtRsrWireTransferService
+bufferObject
+	"Answer the object.
+	nil should never be passed using the wire transfer service, it should use RsrNilObject"
+	| decoder |
+
+		buffer class = ByteArray ifFalse:
+			[ self error: 'buffer not set' ].
+		decoder := GtWireDecoder on: (ReadStream on: buffer).
+		^ decoder next
+%
+
+category: 'accessing'
+method: GtRsrWireTransferService
+bufferObject: anObject
+	| encoder |
+
+	encoder := self encoder.
+	roots := IdentitySet new.
+	encoder nextPut: anObject.
+	buffer := encoder contents.
+	"IdentitySets can't be replicated"
+	roots := roots asArray.
+%
+
+category: 'accessing'
+method: GtRsrWireTransferService
+encoder
+
+	^ GtWireEncoder onByteArray
+%
+
+! Class implementation for 'GtRsrWireTransferServiceServer'
+
+!		Instance methods for 'GtRsrWireTransferServiceServer'
+
+category: 'accessing'
+method: GtRsrWireTransferServiceServer
+asGtGsArgument
+
+	^ self object
+%
+
+category: 'accessing'
+method: GtRsrWireTransferServiceServer
+encoder
+
+	^ encoder ifNil: [ super encoder ]
+%
+
+category: 'accessing'
+method: GtRsrWireTransferServiceServer
+encoder: aGtWireEncoder
+
+	encoder := aGtWireEncoder
+%
+
+category: 'accessing'
+method: GtRsrWireTransferServiceServer
+object
+	"Answer the object.
+	nil should never be passed using the wire transfer service, it should use RsrNilObject"
+
+	^ object ifNil: [ object := self bufferObject ]
+%
+
+category: 'accessing'
+method: GtRsrWireTransferServiceServer
+object: anObject
+
+	object := anObject.
+	SessionTemps current at: #GtRsrCurrentWireService put: self.
+	self bufferObject: object.
+%
+
+! Class implementation for 'GtGemStoneEvaluationContextTest'
+
+!		Instance methods for 'GtGemStoneEvaluationContextTest'
+
+category: 'tests'
+method: GtGemStoneEvaluationContextTest
+testSourceInfoAtFrameLevel
+	| context allFrames info |
+
+	context := (GtGemStoneEvaluationContext new
+		evaluateAndWaitBlock: [ AkgDebuggerPlay new initialize evalBlock value ]
+		from: GtRsrEvaluatorServiceServer new) object.
+	allFrames := context process gtAllFrames.
+	
+	info := context sourceInfoAtFrameLevel: 10.
+
+	self assert: info first = 48.
+	"This is wrong, but let the test pass for now"
+	self assert: info second = 61.
+	self assert: info third size = 80.
+	context process terminate.
+%
+
+category: 'tests'
+method: GtGemStoneEvaluationContextTest
+testVariableInfoAtFrameLevel
+	| context variables |
+
+	context := (GtGemStoneEvaluationContext new
+		evaluateAndWaitBlock: [ AkgDebuggerPlay new initialize evalBlock value ]
+		from: GtRsrEvaluatorServiceServer new) object.
+	variables := context variableInfoAtFrameLevel: 10.
+
+	self assert: variables first first = #self.
+	self assert: variables first second class = String.
+	context process terminate.
+%
+
+! Class implementation for 'GtRsrEvaluatorServiceTest'
+
+!		Instance methods for 'GtRsrEvaluatorServiceTest'
+
+category: 'private'
+method: GtRsrEvaluatorServiceTest
+gsErrorClass
+
+	^ CompileError
+%
+
+category: 'private'
+method: GtRsrEvaluatorServiceTest
+should: testBlock raise: anErrorClass withExceptionDo: exceptionBlock
+
+	testBlock
+		on: anErrorClass
+		do: [ :ex | 
+			exceptionBlock value: ex.
+			^ self ].
+	self error: anErrorClass printString, ' not raised'.
+%
+
+category: 'tests'
+method: GtRsrEvaluatorServiceTest
+testCompilationError
+	"Confirm that a compilation error is caught and returned in"
+	| script evaluator context |
+
+	evaluator := GtRsrEvaluatorServiceServer new.
+	script := 'self error:'. 
+	context := (evaluator evaluate: script for: nil bindings: Dictionary new) object.
+	self deny: context isCompleted.
+	self assert: context isSuspended.
+	self assert: context exception class = CompileError.
+	self assert: context exception messageText = 'a CompileError occurred (error 1001), expected a primary expression '.
+%
+
+category: 'tests'
+method: GtRsrEvaluatorServiceTest
+testInitialState
+	"Check that the initial state answers the expected information"
+	| process exception state encodedState deserializedState contextSpecification |
+
+	process := [ [ self halt ]
+		on: Exception
+		do: [ :ex | 
+			exception := ex.
+			process suspend ] ] fork.
+	(Delay forMilliseconds: 100) wait.
+	self assert: process _isSuspended.
+	self assert: exception notNil.
+	state := GtGemStoneDebuggerState
+		process: process
+		exception: exception.
+
+	self assert: state summary = 'a Halt occurred (error 2709)'.
+	self assert: state callStackSpecification size = 15.
+	contextSpecification := state callStackSpecification at: 10.
+	self assert: contextSpecification coderClassName = #GtRsrEvaluatorServiceTest.
+	self assert: contextSpecification selector = #testInitialState.
+	self assert: contextSpecification isForBlock.
+	self assert: state messageText = 'a Halt occurred (error 2709)'.
+	self assert: state isResumable.
+	self assert: state isSuspended.
+	self deny: state isTerminated.
+
+	encodedState := state asJsonForExport.
+	self assert: encodedState isString.
+	deserializedState := GtGemStoneDebuggerState fromJsonString: encodedState.
+	self assert: deserializedState summary = 'a Halt occurred (error 2709)'.
+	self assert: deserializedState callStackSpecification size = 15.
+	contextSpecification := deserializedState callStackSpecification at: 10.
+	self assert: contextSpecification coderClassName = 'GtRsrEvaluatorServiceTest'.
+	self assert: contextSpecification selector = 'testInitialState'.
+	self assert: contextSpecification isForBlock.
+	self assert: deserializedState messageText = 'a Halt occurred (error 2709)'.
+	self assert: deserializedState isResumable.
+	self assert: deserializedState isSuspended.
+	self deny: deserializedState isTerminated.
+%
+
+category: 'tests'
+method: GtRsrEvaluatorServiceTest
+testProxiedObjectScript
+	"Test answering a complex object.
+	Assumes that Associations are not immediate"
+	| script evaluator result dict proxy |
+
+	evaluator := GtRsrEvaluatorServiceServer new.
+	script := 
+'| resultDict aDict anArray |
+
+aDict := Dictionary new.
+aDict at: #a put: 1.
+aDict at: #b put: #c -> 2.
+anArray := Array new: 3.
+anArray at: 1 put: 3.
+anArray at: 2 put: aDict.
+anArray at: 3 put: #d -> 4.
+anArray.'. 
+	result := evaluator evaluate: script for: nil bindings: Dictionary new.
+	self assert: result class equals: Array.
+	self assert: result size equals: 3.
+	self assert: (result at: 1) equals: 3.
+	dict := result at: 2.
+	self assert: (dict at: #a) equals: 1.
+	proxy := dict at: #b.
+	proxy := result at: 3.
+	self assert: proxy class equals: GtRsrProxyServiceServer.
+	self assert: proxy object equals: #d -> 4.
+	^ result.
+%
+
+category: 'tests'
+method: GtRsrEvaluatorServiceTest
+testRuntimeErrorScript
+	| script evaluator result object |
+
+	evaluator := GtRsrEvaluatorServiceServer new.
+	script := 'self + ''NaN'''.
+	"'4 + ''NaN''' raises a MNU which is trapped, resulting in a GtGemStoneEvaluationContext being returned"
+	result := evaluator evaluate: script for: 4 bindings: Dictionary new.
+	self assert: result class = GtRsrProxyServiceServer.
+	object := result object.
+	self assert: object class = GtGemStoneEvaluationContext.
+	"Pharo raises #adaptToNumber:andSend:, GemStone raises #_generality"
+	self assert: (#(#adaptToNumber:andSend: #'_generality') includes: object exception message selector).
+%
+
+category: 'tests'
+method: GtRsrEvaluatorServiceTest
+testSelfScript
+	| script evaluator result |
+
+	evaluator := GtRsrEvaluatorServiceServer new.
+	script := 'self + 3'. 
+	result := evaluator evaluate: script for: 4 bindings: Dictionary new.
+	self assert: result equals: 7.
+%
+
+category: 'tests'
+method: GtRsrEvaluatorServiceTest
+testSimpleScript
+	| script evaluator result |
+
+	evaluator := GtRsrEvaluatorServiceServer new.
+	script := '4+3'. 
+	result := evaluator evaluate: script for: nil bindings: Dictionary new.
+	self assert: result equals: 7.
+%
+
+! Class extensions for 'AbstractCollisionBucket'
+
+!		Instance methods for 'AbstractCollisionBucket'
+
+category: '*GToolkit-GemStone-GemStone'
+method: AbstractCollisionBucket
+asGtRsrProxyObjectForConnection: aRsrConnection
+	"Answer the receiver with unsupported objects converted to GtRsrProxyServiceServers.
+	Ideally we would look up objects in the connection and use the same proxy, but that isn't happening yet."
+
+	(GtRsrEvaluatorService isRsrImmediate: self) ifFalse: 
+		[ ^ GtRsrProxyServiceServer object: self ].
+	^ self
+%
+
+! Class extensions for 'AbstractDictionary'
+
+!		Instance methods for 'AbstractDictionary'
+
+category: '*GToolkit-GemStone-GemStone'
+method: AbstractDictionary
+isDictionary
+	^ true
+%
+
+! Class extensions for 'Array'
+
+!		Instance methods for 'Array'
+
+category: '*GToolkit-GemStone'
+method: Array
+asGtRsrProxyObjectForConnection: aRsrConnection
+	"Answer the receiver with unsupported objects converted to GtRsrProxyServiceServers.
+	Ideally we would look up objects in the connection and use the same proxy, but that isn't happening yet."
+
+	^ self collect: [ :each | each asGtRsrProxyObjectForConnection: aRsrConnection ]
+%
+
+! Class extensions for 'Association'
+
+!		Class methods for 'Association'
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: Association
+key: aKey value: aValue
+
+	^ self new key: aKey value: aValue
+%
+
+! Class extensions for 'ByteArray'
+
+!		Instance methods for 'ByteArray'
+
+category: '*GToolkit-GemStone-GemStone'
+method: ByteArray
+base64Encoded
+	"Encode the receiver using Base64, returning a String.
+	Base64 encoding is a technique to represent binary data as ASCII text.
+	The inverse operation is String>>#base64Decoded"
+
+	"(0 to: 255) asByteArray base64Encoded"
+	"(Integer primesUpTo: 255) asByteArray base64Encoded"
+	"'Hello World!' utf8Encoded base64Encoded"
+
+	^ ZnBase64Encoder new encode: self
+%
+
+! Class extensions for 'Character'
+
+!		Class methods for 'Character'
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: Character
+null
+
+	^ self value: 0
+%
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: Character
+value: aCodePointInteger
+
+	^ self withValue: aCodePointInteger
+%
+
+!		Instance methods for 'Character'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Character
+join: aSequenceableCollection
+	^ self asString join: aSequenceableCollection
+%
+
+! Class extensions for 'CharacterCollection'
+
+!		Instance methods for 'CharacterCollection'
+
+category: '*GToolkit-GemStone-GemStone'
+method: CharacterCollection
+asGtGsArgument
+	"Answer the the local object of the receiver"
+
+	^ self
+%
+
+! Class extensions for 'Collection'
+
+!		Instance methods for 'Collection'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Collection
+anyOne
+
+	self do: [ :each | ^ each ].
+	self error: 'Receiver is empty'.
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Collection
+detect: aBlock ifFound: foundBlock ifNone: exceptionBlock
+	self
+		do: [ :each |
+			(aBlock value: each)
+				ifTrue: [ ^ foundBlock cull: each ] ].
+	^ exceptionBlock value
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Collection
+isNotEmpty
+
+"Returns true if the receiver is not empty.  Returns false otherwise."
+
+^self size ~~ 0
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Collection
+max
+	"Answer the maximum value of the receiver"
+
+	^ self inject: self anyOne into: [ :max :each | max max: each ]
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Collection
+select: selectBlock thenCollect: collectBlock
+	^ (self select: selectBlock) collect: collectBlock
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Collection
+sorted: aBlock
+	^ self sortWithBlock: aBlock
+%
+
+! Class extensions for 'DateAndTime'
+
+!		Class methods for 'DateAndTime'
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: DateAndTime
+fromUnixTime: anInteger
+	^ self posixSeconds: anInteger offset: Duration new
+%
+
+! Class extensions for 'DateAndTimeANSI'
+
+!		Class methods for 'DateAndTimeANSI'
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: DateAndTimeANSI
+readFrom: aStream
+	"Basic compatibility with Pharo DateAndTime>>readFrom:.	
+	Assumes that the DateAndTime is the last thing in the stream."
+
+	^ self fromString: aStream upToEnd
+%
+
+! Class extensions for 'Dictionary'
+
+!		Instance methods for 'Dictionary'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Dictionary
+, aCollection
+	^self copy addAll: aCollection; yourself
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Dictionary
+asGtGsArgument
+	"Answer the the local object of the receiver"
+	| local |
+
+	local := self copy.
+	local associationsDo: [ :assoc |
+		assoc value: assoc value asGtGsArgument ].
+	^ local
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Dictionary
+asGtRsrProxyObjectForConnection: aRsrConnection
+	"Answer the receiver with unsupported (non-immediate) objects converted to GtRsrProxyServiceServers.
+	Ideally we would look up objects in the connection and use the same proxy, but that isn't happening yet.
+	If not all keys are immediate, answer the entire dictionary as a proxy."
+
+	| proxyDict |
+
+	(self keys allSatisfy: [ :key | GtRsrEvaluatorService isRsrImmediate: key ]) ifFalse:
+		[ ^ GtRsrProxyServiceServer object: self ].
+	proxyDict := self class new: self size.
+	self keysAndValuesDo: [ :key :value |
+		proxyDict
+			at: key 
+			put: (value asGtRsrProxyObjectForConnection: aRsrConnection) ].
+	^ proxyDict
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Dictionary
+associations
+	^Array new: self size streamContents: [ :stream |
+		self associationsDo: [ :each | stream nextPut: each ] ]
+%
+
+! Class extensions for 'Duration'
+
+!		Class methods for 'Duration'
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: Duration
+nanoSeconds: nanoSeconds
+	^ self seconds: nanoSeconds / 1000000000
+%
+
+!		Instance methods for 'Duration'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Duration
+asDelay
+	^ Delay forSeconds: seconds
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Duration
+wait
+	^ self asDelay wait
+%
+
+! Class extensions for 'ExecBlock'
+
+!		Instance methods for 'ExecBlock'
+
+category: '*GToolkit-GemStone-GemStone'
+method: ExecBlock
+gtSourceFor: aView
+	<gtView>
+
+	^ aView textEditor
+		title: 'Source';
+		priority: 10;
+		text: [ self _sourceString ].
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: ExecBlock
+isClean
+
+	^ self _isCopyingBlock not and: [ self _cost = 1 ]
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: ExecBlock
+timeToRun
+	| start end |
+
+	start := Time millisecondClockValue.
+	self value.
+	end := Time millisecondClockValue.
+	^ Duration seconds: (end - start) / 1000
+%
+
+! Class extensions for 'GsProcess'
+
+!		Instance methods for 'GsProcess'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GsProcess
+gtAllFrames
+
+	^ (1 to: self stackDepth) collect: [ :i |
+		self _frameContentsAt: i ]
+%
+
+! Class extensions for 'GsStackBuffer'
+
+!		Instance methods for 'GsStackBuffer'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GsStackBuffer
+asGtRsrProxyObjectForConnection: aRsrConnection
+	"Answer the receiver with unsupported objects converted to GtRsrProxyServiceServers.
+	Ideally we would look up objects in the connection and use the same proxy, but that isn't happening yet."
+
+	(GtRsrEvaluatorService isRsrImmediate: self) ifFalse: 
+		[ ^ GtRsrProxyServiceServer object: self ].
+	^ self
+%
+
+! Class extensions for 'GtGemstoneEvaluationComputedResult'
+
+!		Instance methods for 'GtGemstoneEvaluationComputedResult'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtGemstoneEvaluationComputedResult
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+			at: 'computedResult' put: computedResult;
+			yourself
+%
+
+! Class extensions for 'GtGemstoneEvaluationExceptionResult'
+
+!		Instance methods for 'GtGemstoneEvaluationExceptionResult'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtGemstoneEvaluationExceptionResult
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+			at: 'evaluationContextProxy' put: (GtRsrProxyServiceServer object: evaluationContext);
+			yourself
+%
+
+! Class extensions for 'GtGemstoneEvaluationInProgressResult'
+
+!		Instance methods for 'GtGemstoneEvaluationInProgressResult'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtGemstoneEvaluationInProgressResult
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+			at: 'evaluationContextProxy' put: (GtRsrProxyServiceServer object: evaluationContext);
+			yourself
+%
+
+! Class extensions for 'GtGemstoneEvaluationResult'
+
+!		Instance methods for 'GtGemstoneEvaluationResult'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtGemstoneEvaluationResult
+asDictionaryForExport
+	^ Dictionary new 
+			at: '__typeName' put: self class name;
+			yourself.
+%
+
+! Class extensions for 'GtGemStoneSerializationExamples'
+
+!		Instance methods for 'GtGemStoneSerializationExamples'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtGemStoneSerializationExamples
+assert: aBoolean description: aString
+
+	aBoolean == true ifFalse:
+		[ TestResult failure signal: aString value ]
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtGemStoneSerializationExamples
+assert: actual equals: expected
+
+	self
+		assert: actual = expected
+		description: actual printString, ' is not equal to ', expected printString.
+%
+
+! Class extensions for 'GtRsrLiteralAndProxySerializationStrategy'
+
+!		Instance methods for 'GtRsrLiteralAndProxySerializationStrategy'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtRsrLiteralAndProxySerializationStrategy
+serialize: anObject
+	"Serialize the object to something that RSR can return.
+	In this case we're requiring that the object can be returned as an RSR primitive.  If it can't RSR will raise an exception."
+	
+	(anObject isNil or: 
+		[ anObject isNumber or: 
+		[ anObject isKindOf: Boolean ] ]) 
+			ifTrue: [ ^ anObject ].
+	^ self
+		gtDo: [ anObject ]
+		gemstoneDo: [ GtRsrProxyServiceServer object: anObject ]
+%
+
+! Class extensions for 'GtRsrProxyOnlySerializationStrategy'
+
+!		Instance methods for 'GtRsrProxyOnlySerializationStrategy'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtRsrProxyOnlySerializationStrategy
+serialize: anObject
+	 ^ GtRsrProxyServiceServer object: anObject
+%
+
+! Class extensions for 'GtRsrSerializationStrategy'
+
+!		Class methods for 'GtRsrSerializationStrategy'
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: GtRsrSerializationStrategy
+serializationStrategies
+	"Answer the session specific dictionary of serialisation strategies"
+
+	^ SessionTemps current
+		at: #GtSerializationStrategies
+		ifAbsentPut: [ Dictionary new ].
+%
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: GtRsrSerializationStrategy
+serializationStrategyNamed: aSymbol
+	"Answer the session specific strategy, creating it if required"
+
+	^ self serializationStrategies
+		at: aSymbol
+		ifAbsentPut: [ (GsSession currentSession objectNamed: aSymbol) new ]
+%
+
+! Class extensions for 'GtRsrWireTransferService'
+
+!		Instance methods for 'GtRsrWireTransferService'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtRsrWireTransferService
+serialize: anObject
+
+	^ GtRsrWireTransferServiceServer new object: anObject
+%
+
+! Class extensions for 'GtWireGemStoneRsrEncoder'
+
+!		Instance methods for 'GtWireGemStoneRsrEncoder'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtWireGemStoneRsrEncoder
+encode: anObject with: aGtWireEncoderContext
+	"It is up to the user to ensure that anObject isn't GCd during transfer and decoding
+	(which would allow the oop to be reused and the wrong object returned), or that the
+	session is aborted."
+	| rsrService |
+
+	rsrService := anObject isGtGemStoneRsrProxy
+		ifTrue: [ anObject ]
+		ifFalse: [ GtRsrProxyServiceServer object: anObject ].
+	"Ensure that the service is at least registered so that it has an _id
+	and has a reference in the service.
+	Remaining set up will be done during snapshot analysis."
+
+	self connection _ensureRegistered: rsrService.
+	self currentWireService addRoot: rsrService.
+	aGtWireEncoderContext
+		putTypeIdentifier: self class typeIdentifier;
+		nextPut: rsrService _id
+%
+
+! Class extensions for 'GtWireGemStoneWithRsrEncoder'
+
+!		Instance methods for 'GtWireGemStoneWithRsrEncoder'
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtWireGemStoneWithRsrEncoder
+encode: anObject with: aGtWireEncoderContext
+
+	self error: self class name asString, '>>encode:with: should not be reached'
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: GtWireGemStoneWithRsrEncoder
+encode: anObject with: aGtWireEncoderContext objectEncoder: objectEncoder
+	| rsrService |
+
+	anObject isGtGemStoneRsrProxy ifTrue: 
+		[ self error: 'Proxies should not be encoded with RSR encoder' ].
+
+	"Put the proxy object on the wire first"
+	rsrService := GtRsrProxyServiceServer object: anObject.
+	"Ensure that the service is at least registered so that it has an _id
+	and has a reference in the service.
+	Remaining set up will be done during snapshot analysis."
+	self connection _ensureRegistered: rsrService.
+	self currentWireService addRoot: rsrService.
+	aGtWireEncoderContext putTypeIdentifier: self class typeIdentifier.
+	"To avoid attempting to create a proxy for the service ID,
+	instead of passing back to the GtWireEncoder, call the integer object encoder directly."
+	GtWireIntegerEncoder new encode: rsrService _id with: aGtWireEncoderContext.
+
+	"Then put the object itself"
+	objectEncoder encode: anObject with: aGtWireEncoderContext.
+%
+
+! Class extensions for 'Integer'
+
+!		Instance methods for 'Integer'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Integer
+isInteger
+
+	^ true
+%
+
+! Class extensions for 'MultiByteString'
+
+!		Instance methods for 'MultiByteString'
+
+category: '*GToolkit-GemStone-GemStone'
+method: MultiByteString
+utf8Encoded
+	"Answer a ByteArray of the receiver in UTF8 format"
+
+	^ self encodeAsUTF8 asByteArray
+%
+
+! Class extensions for 'Number'
+
+!		Instance methods for 'Number'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Number
+nanoSeconds
+	^ Duration nanoSeconds: self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Number
+seconds
+	^ Duration seconds: self
+%
+
+! Class extensions for 'Object'
+
+!		Instance methods for 'Object'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+asGtGsArgument
+	"Answer the the local object of the receiver"
+
+	^ self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+asGtRsrProxyObjectForConnection: aRsrConnection
+	"Answer the receiver with unsupported objects converted to GtRsrProxyServiceServers.
+	Ideally we would look up objects in the connection and use the same proxy, but that isn't happening yet."
+
+	(GtRsrEvaluatorService isRsrImmediate: self) ifFalse: 
+		[ ^ GtRsrProxyServiceServer object: self ].
+	^ self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+gtDo: gtoolkitBlock gemstoneDo: gemstoneBlock
+	"Evaluate the supplied platform specific block"
+
+	^ gemstoneBlock value
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+instVarNamed: instVarName
+	| index |
+
+	index := self class allInstVarNames indexOf: instVarName.
+	index = 0 ifTrue: [ self error: 'Unknown instance variable: ', instVarName printString ].
+	^ self instVarAt: index
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+instVarNamed: instVarName put: anObject
+	| index |
+
+	index := self class allInstVarNames indexOf: instVarName.
+	index = 0 ifTrue: [ self error: 'Unknown instance variable: ', instVarName printString ].
+	self instVarAt: index put: anObject
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+isDictionary
+	^ false
+%
+
+category: '*GToolkit-GemStone'
+method: Object
+isGtGemStoneRsrProxy
+
+	^ false
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+isInteger
+
+	^ false
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Object
+isNotNil
+	^ self ~~ nil
+%
+
+! Class extensions for 'OrderedCollection'
+
+!		Instance methods for 'OrderedCollection'
+
+category: '*GToolkit-GemStone-GemStone'
+method: OrderedCollection
+asGtRsrProxyObjectForConnection: aRsrConnection
+	"Answer the receiver with unsupported objects converted to GtRsrProxyServiceServers.
+	Ideally we would look up objects in the connection and use the same proxy, but that isn't happening yet."
+
+	^ self collect: [ :each | 
+			each asGtRsrProxyObjectForConnection: aRsrConnection ]
+   "^ GtRsrProxyServiceServer object: self"
+%
+
+! Class extensions for 'Pragma'
+
+!		Instance methods for 'Pragma'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Pragma
+methodSelector
+	"Answer the selector of the method containing the pragma."
+
+	^ method selector.
+%
+
+! Class extensions for 'RsrService'
+
+!		Class methods for 'RsrService'
+
+category: '*GToolkit-GemStone'
+classmethod: RsrService
+gtClientGsServer
+	"Answer the receiver's client class on GT and server class on GS"
+
+	^ self
+		gtDo: [ self clientClass] 
+		gemstoneDo: [ self serverClass ]
+%
+
+! Class extensions for 'SequenceableCollection'
+
+!		Instance methods for 'SequenceableCollection'
+
+category: '*GToolkit-GemStone-GemStone'
+method: SequenceableCollection
+allButFirstDo: block
+
+	2 to: self size do:
+		[ :index | block value: (self at: index) ]
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: SequenceableCollection
+asGtGsArgument
+	"Answer the the local object of the receiver"
+
+	^ self collect: [ :each | each asGtGsArgument ]
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: SequenceableCollection
+flatCollect: aBlock
+	"Evaluate aBlock for each of the receiver's elements and answer the
+	list of all resulting values flatten one level. Assumes that aBlock returns some kind
+	of collection for each element. optimized version for Sequencable Collection and subclasses
+	implementing #writeStream"
+
+	"(#( (2 -3) (4 -5) #(-6)) flatCollect: [ :e | e abs  ]) >>> #(2 3 4 5 6)"
+
+	"(#( (2 -3) #((4 -5)) #(-6)) flatCollect: [ :e | e abs  ]) >>> #(2 3 #(4 5) 6)"
+
+	self isEmpty
+		ifTrue: [ ^ self copy ].
+	^ self class 
+		new: 0
+		streamContents: [ :stream | self do: [ :each | stream nextPutAll: (aBlock value: each) ] ]
+%
+
+! Class extensions for 'Set'
+
+!		Instance methods for 'Set'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Set
+asGtRsrProxyObjectForConnection: aRsrConnection
+	"Answer the receiver as a proxy object.
+	To avoid dealing with equality at the moment, always answer as a proxy object.
+	Ideally we would look up objects in the connection and use the same proxy, but that isn't happening yet."
+
+	^ GtRsrProxyServiceServer object: self
+%
+
+! Class extensions for 'String'
+
+!		Class methods for 'String'
+
+category: '*GToolkit-GemStone-GemStone'
+classmethod: String
+cr
+	^ self with: Character cr
+%
+
+!		Instance methods for 'String'
+
+category: '*GToolkit-GemStone-GemStone'
+method: String
+/ anotherString
+	^ self , '/', anotherString
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: String
+asZnUrl
+	^ self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: String
+repeat: aNumber
+	"Returns a new string concatenated by itself repeated n times"
+	"('abc' repeat: 3) >>> 'abcabcabc'"
+
+	aNumber < 0 ifTrue: [ self error: 'aNumber cannot be negative' ].
+	^ self species
+		new: self size * aNumber
+		streamContents: [ :stringStream |
+			1 to: aNumber do: [ :idx | stringStream nextPutAll: self ] ]
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: String
+utf8Encoded
+	"Answer a ByteArray of the receiver in UTF8 format"
+
+	^ self encodeAsUTF8 asByteArray
+%
+
+! Class extensions for 'Symbol'
+
+!		Instance methods for 'Symbol'
+
+category: '*GToolkit-GemStone-GemStone'
+method: Symbol
+asMutator
+	^ self, ':'
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Symbol
+cull: anObject
+
+	^ anObject perform: self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Symbol
+cull: anObject cull: arg2
+
+	^ anObject perform: self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Symbol
+cull: anObject cull: arg2 cull: arg3
+
+	^ anObject perform: self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Symbol
+cull: anObject cull: arg2 cull: arg3 cull: arg4
+
+	^ anObject perform: self
+%
+
+category: '*GToolkit-GemStone-GemStone'
+method: Symbol
+value: anObject
+
+	^ anObject perform: self
+%
+

--- a/docs/gtSupport/gtoolkit-remote.gs
+++ b/docs/gtSupport/gtoolkit-remote.gs
@@ -1,0 +1,15347 @@
+! Class Declarations
+! Generated file, do not Edit
+
+doit
+(Object
+	subclass: 'GtPhlowBasicRun'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowBasicRun
+removeallclassmethods GtPhlowBasicRun
+
+doit
+(GtPhlowBasicRun
+	subclass: 'GtPhlowRun'
+	instVarNames: #(attributes startIndex endIndex)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowRun
+removeallclassmethods GtPhlowRun
+
+doit
+(Object
+	subclass: 'GtPhlowColor'
+	instVarNames: #(name red green blue alpha)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowColor
+removeallclassmethods GtPhlowColor
+
+doit
+(Object
+	subclass: 'GtPhlowDeclarativeListingType'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowDeclarativeListingType
+removeallclassmethods GtPhlowDeclarativeListingType
+
+doit
+(GtPhlowDeclarativeListingType
+	subclass: 'GtPhlowNumberDeclarativeListingType'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowNumberDeclarativeListingType
+removeallclassmethods GtPhlowNumberDeclarativeListingType
+
+doit
+(GtPhlowDeclarativeListingType
+	subclass: 'GtPhlowTextDeclarativeListingType'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextDeclarativeListingType
+removeallclassmethods GtPhlowTextDeclarativeListingType
+
+doit
+(GtPhlowDeclarativeListingType
+	subclass: 'GtPhlowTextLinkDeclarativeListingType'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextLinkDeclarativeListingType
+removeallclassmethods GtPhlowTextLinkDeclarativeListingType
+
+doit
+(GtPhlowDeclarativeListingType
+	subclass: 'GtPhlowThemeIconNameDeclarativeListingType'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowThemeIconNameDeclarativeListingType
+removeallclassmethods GtPhlowThemeIconNameDeclarativeListingType
+
+doit
+(GtPhlowDeclarativeListingType
+	subclass: 'GtPhlowUnknownDeclarativeListingType'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowUnknownDeclarativeListingType
+removeallclassmethods GtPhlowUnknownDeclarativeListingType
+
+doit
+(Object
+	subclass: 'GtPhlowDeclarativeSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeSpecification';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowDeclarativeSpecification
+removeallclassmethods GtPhlowDeclarativeSpecification
+
+doit
+(GtPhlowDeclarativeSpecification
+	subclass: 'GtPhlowActionSpecification'
+	instVarNames: #(id priority tooltipText methodSelector phlowDataSource)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowActionSpecification
+removeallclassmethods GtPhlowActionSpecification
+
+doit
+(GtPhlowActionSpecification
+	subclass: 'GtPhlowButtonActionSpecification'
+	instVarNames: #(label iconStencil)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowButtonActionSpecification
+removeallclassmethods GtPhlowButtonActionSpecification
+
+doit
+(GtPhlowActionSpecification
+	subclass: 'GtPhlowErrorActionSpecification'
+	instVarNames: #(errorMessage)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowErrorActionSpecification
+removeallclassmethods GtPhlowErrorActionSpecification
+
+doit
+(GtPhlowDeclarativeSpecification
+	subclass: 'GtPhlowIconStencil'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Icons';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowIconStencil
+removeallclassmethods GtPhlowIconStencil
+
+doit
+(GtPhlowIconStencil
+	subclass: 'GtPhlowNamedIconStencil'
+	instVarNames: #(iconName)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Icons';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowNamedIconStencil
+removeallclassmethods GtPhlowNamedIconStencil
+
+doit
+(GtPhlowNamedIconStencil
+	subclass: 'GtPhlowBasicGlamorousIconNameStencil'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Icons';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowBasicGlamorousIconNameStencil
+removeallclassmethods GtPhlowBasicGlamorousIconNameStencil
+
+doit
+(GtPhlowBasicGlamorousIconNameStencil
+	subclass: 'GtPhlowGlamorousIconNameStencil'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Icons';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowGlamorousIconNameStencil
+removeallclassmethods GtPhlowGlamorousIconNameStencil
+
+doit
+(GtPhlowBasicGlamorousIconNameStencil
+	subclass: 'GtPhlowGlamorousVectorIconNameStencil'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Icons';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowGlamorousVectorIconNameStencil
+removeallclassmethods GtPhlowGlamorousVectorIconNameStencil
+
+doit
+(GtPhlowNamedIconStencil
+	subclass: 'GtPhlowThemeIconNameStencil'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Icons';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowThemeIconNameStencil
+removeallclassmethods GtPhlowThemeIconNameStencil
+
+doit
+(GtPhlowDeclarativeSpecification
+	subclass: 'GtRemotePhlowNavigationAction'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowNavigationAction
+removeallclassmethods GtRemotePhlowNavigationAction
+
+doit
+(GtRemotePhlowNavigationAction
+	subclass: 'GtRemotePhlowSpawnObjectAction'
+	instVarNames: #(targetObject)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowSpawnObjectAction
+removeallclassmethods GtRemotePhlowSpawnObjectAction
+
+doit
+(GtPhlowDeclarativeSpecification
+	subclass: 'GtRemotePhlowViewedObjectClassSpecification'
+	instVarNames: #(viewObjectClassName viewObjectInstanceVariableNames)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-InspectorCore';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowViewedObjectClassSpecification
+removeallclassmethods GtRemotePhlowViewedObjectClassSpecification
+
+doit
+(Object
+	subclass: 'GtPhlowRuns'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowRuns
+removeallclassmethods GtPhlowRuns
+
+doit
+(GtPhlowRuns
+	subclass: 'GtPhlowRunsGroup'
+	instVarNames: #(items)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowRunsGroup
+removeallclassmethods GtPhlowRunsGroup
+
+doit
+(Object
+	subclass: 'GtPhlowText'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowText
+removeallclassmethods GtPhlowText
+
+doit
+(GtPhlowText
+	subclass: 'GtPhlowRunBasedText'
+	instVarNames: #(sourceString attributeRuns)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowRunBasedText
+removeallclassmethods GtPhlowRunBasedText
+
+doit
+(GtPhlowText
+	subclass: 'GtPhlowSubText'
+	instVarNames: #(parentText startIndex endIndex)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowSubText
+removeallclassmethods GtPhlowSubText
+
+doit
+(Object
+	subclass: 'GtPhlowTextAttribute'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextAttribute
+removeallclassmethods GtPhlowTextAttribute
+
+doit
+(GtPhlowTextAttribute
+	subclass: 'GtPhlowFontEmphasisAttribute'
+	instVarNames: #(emphasis)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowFontEmphasisAttribute
+removeallclassmethods GtPhlowFontEmphasisAttribute
+
+doit
+(GtPhlowTextAttribute
+	subclass: 'GtPhlowFontNameAttribute'
+	instVarNames: #(fontName)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowFontNameAttribute
+removeallclassmethods GtPhlowFontNameAttribute
+
+doit
+(GtPhlowTextAttribute
+	subclass: 'GtPhlowFontSizeAttribute'
+	instVarNames: #(sizeValue)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowFontSizeAttribute
+removeallclassmethods GtPhlowFontSizeAttribute
+
+doit
+(GtPhlowTextAttribute
+	subclass: 'GtPhlowFontWeightAttribute'
+	instVarNames: #(weight)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowFontWeightAttribute
+removeallclassmethods GtPhlowFontWeightAttribute
+
+doit
+(GtPhlowTextAttribute
+	subclass: 'GtPhlowTextColorAttribute'
+	instVarNames: #(color)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextColorAttribute
+removeallclassmethods GtPhlowTextColorAttribute
+
+doit
+(GtPhlowTextColorAttribute
+	subclass: 'GtPhlowTextForegroundAttribute'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextForegroundAttribute
+removeallclassmethods GtPhlowTextForegroundAttribute
+
+doit
+(GtPhlowTextColorAttribute
+	subclass: 'GtPhlowTextHighlightAttribute'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextHighlightAttribute
+removeallclassmethods GtPhlowTextHighlightAttribute
+
+doit
+(GtPhlowTextAttribute
+	subclass: 'GtPhlowTextDecorationAttribute'
+	instVarNames: #(decoration)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextDecorationAttribute
+removeallclassmethods GtPhlowTextDecorationAttribute
+
+doit
+(GtPhlowTextAttribute
+	subclass: 'GtPhlowTextUnknownAttribute'
+	instVarNames: #(rawData)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextUnknownAttribute
+removeallclassmethods GtPhlowTextUnknownAttribute
+
+doit
+(Object
+	subclass: 'GtPhlowTextDecoration'
+	instVarNames: #(thickness color styleName typeNames)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextDecoration
+removeallclassmethods GtPhlowTextDecoration
+
+doit
+(Object
+	subclass: 'GtPhlowTextHighlight'
+	instVarNames: #(color startPosition endPosition)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextHighlight
+removeallclassmethods GtPhlowTextHighlight
+
+doit
+(Object
+	subclass: 'GtPhlowViewSpecification'
+	instVarNames: #(phlowDataSource methodSelector title priority dataTransport)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		comment: '{{gtClass:GtPhlowViewSpecification}} provides a declarative UI specification for presenting data that can be easily serialised and sent over the wire, including between applications written in different languages.
+
+A specification contains basic data about the view, like its title and priority, and a data source that handles the actual data of the view.
+####Local and and remote instances
+
+An instance of the specification is created remotely based on the remote view. That specification is serialized by sending it {{gtMethod:GtPhlowViewSpecification>>asJSONForExport|label=#selector}}, and based on it a new instance is created locally with the same data using {{gtMethod:GtPhlowViewSpecification class>>fromJSONString:|label=#selector}}. So there will be two instances of the specification, one remotely and one locally.
+
+####Initializing the local instance
+
+The initialisation of the local version of the specification is done in two steps. First, an instance is created and initialized using the initial JSON data. Second, on this instance the inspector calls {{gtMethod:GtPhlowViewSpecification>>initializeFromInspector:|label=#selector}}. 
+
+This call exists so that the specification can initialize the `phlowDataSource` attributes. Views can initialize it with a local object, if all the data of the view was retrieved, or with a proxy to the remote data source.  
+
+So while the local and remote instances of the specification have the same attributes, for the data source attribute the local version can have a proxy, and the remote version the actual object.
+
+dataTransport is an emumerated value indicating whether the data to be displayed will be included with the specification or is available via reference or by key.]
+
+- 1: data is included in the response
+- 2: data is available by reference
+- 3: data is available by reference and key (tbc)
+
+####Creating local views
+
+Subclasses should override {{gtMethod:GtPhlowViewSpecification>>viewFor:|label=#selector}}  for creating a  local views from a specification.
+
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowViewSpecification
+removeallclassmethods GtPhlowViewSpecification
+
+doit
+(GtPhlowViewSpecification
+	subclass: 'GtPhlowEmptyViewSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowEmptyViewSpecification
+removeallclassmethods GtPhlowEmptyViewSpecification
+
+doit
+(GtPhlowViewSpecification
+	subclass: 'GtPhlowForwardViewSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowForwardViewSpecification
+removeallclassmethods GtPhlowForwardViewSpecification
+
+doit
+(GtPhlowViewSpecification
+	subclass: 'GtPhlowListingViewSpecification'
+	instVarNames: #(totalItemsCount)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		comment: '{{gtClass:GtPhlowListingViewSpecification}} provides support for instantiating local list, tree and column views used to show the items in remote list, tree and column views.
+
+When the remote side is in a different environment, in the local instance of the specification,  `phlowDataSource` is going to be a proxy providing the required API for accessing items in the view. 
+
+When the remote side is Glamorous Toolkit, Pharo and GemStone, the data source is of type {{gtClass:GtRemotePhlowDeclarativeViewListingDataSource}} in the remote instance of the specification.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowListingViewSpecification
+removeallclassmethods GtPhlowListingViewSpecification
+
+doit
+(GtPhlowListingViewSpecification
+	subclass: 'GtPhlowBasicColumnedViewSpecification'
+	instVarNames: #(columnSpecifications)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowBasicColumnedViewSpecification
+removeallclassmethods GtPhlowBasicColumnedViewSpecification
+
+doit
+(GtPhlowBasicColumnedViewSpecification
+	subclass: 'GtPhlowColumnedListViewSpecification'
+	instVarNames: #(horizontalScrollingEnabled)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		comment: 'GtDeclarativeColumnedList supports a subset of the possible configurations of {{gtClass:name=GtPhlowColumnedListView}}.
+
+Current limitations:
+
+- Only matchParent and fixed column widths are supported
+
+# Internal Representation and Key Implementation Points.
+
+
+## Instance Variables
+
+	columnTitles:	<Array of String>
+	columnWidths:	<Array of Integer|nil>
+	items:				<Array of Array>	These are the formatted values to display, not the raw values to send
+
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowColumnedListViewSpecification
+removeallclassmethods GtPhlowColumnedListViewSpecification
+
+doit
+(GtPhlowBasicColumnedViewSpecification
+	subclass: 'GtPhlowColumnedTreeViewSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowColumnedTreeViewSpecification
+removeallclassmethods GtPhlowColumnedTreeViewSpecification
+
+doit
+(GtPhlowListingViewSpecification
+	subclass: 'GtPhlowListViewSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		comment: '{{gtClass:GtPhlowListViewSpecification}}  provides the data needed to instantiate a local {{gtClass:name=GtPhlowListView}} used to show the items in a remote list view.
+
+The `phlowDataSource` for a list view should provide the following API:
+	- `retrieveItems:fromIndex:` returns  the concrete data for displaying a number of items from a certain index
+	- `retrieveSentItemAt:` returns a proxy to the item at the given position
+
+When the remote side is Glamorous Toolkit, GemStone or Pharo, in the local instane of the specification `phlowDataSource` is a proxy to an instance of type {{gtClass:GtRemotePhlowDeclarativeViewListDataSource}}. When using the simulation we get directly an instance of type {{gtClass:GtRemotePhlowDeclarativeViewListDataSource}} as the data source.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowListViewSpecification
+removeallclassmethods GtPhlowListViewSpecification
+
+doit
+(GtPhlowListingViewSpecification
+	subclass: 'GtPhlowTreeViewSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTreeViewSpecification
+removeallclassmethods GtPhlowTreeViewSpecification
+
+doit
+(GtPhlowViewSpecification
+	subclass: 'GtPhlowTextualViewSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextualViewSpecification
+removeallclassmethods GtPhlowTextualViewSpecification
+
+doit
+(GtPhlowTextualViewSpecification
+	subclass: 'GtPhlowTextEditorViewSpecification'
+	instVarNames: #(string dataSource textStylerSpecification)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextEditorViewSpecification
+removeallclassmethods GtPhlowTextEditorViewSpecification
+
+doit
+(GtPhlowTextualViewSpecification
+	subclass: 'GtPhlowTextViewSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowTextViewSpecification
+removeallclassmethods GtPhlowTextViewSpecification
+
+doit
+(GtPhlowViewSpecification
+	subclass: 'GtPhlowViewErrorViewSpecification'
+	instVarNames: #(errorMessage)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtPhlowViewErrorViewSpecification
+removeallclassmethods GtPhlowViewErrorViewSpecification
+
+doit
+(Object
+	subclass: 'GtRemotePhlowAction'
+	instVarNames: #(id priority tooltipText definingSelector definingClass)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowAction
+removeallclassmethods GtRemotePhlowAction
+
+doit
+(GtRemotePhlowAction
+	subclass: 'GtRemotePhlowButtonAction'
+	instVarNames: #(actionBlock label iconStencil)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowButtonAction
+removeallclassmethods GtRemotePhlowButtonAction
+
+doit
+(GtRemotePhlowAction
+	subclass: 'GtRemotePhlowErrorAction'
+	instVarNames: #(errorMessage)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowErrorAction
+removeallclassmethods GtRemotePhlowErrorAction
+
+doit
+(GtRemotePhlowAction
+	subclass: 'GtRemotePhlowNoAction'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowNoAction
+removeallclassmethods GtRemotePhlowNoAction
+
+doit
+(Object
+	subclass: 'GtRemotePhlowApiWrapper'
+	instVarNames: #(currentAction)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowApiWrapper
+removeallclassmethods GtRemotePhlowApiWrapper
+
+doit
+(Object
+	subclass: 'GtRemotePhlowCollectionIterator'
+	instVarNames: #(targetCollection)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowCollectionIterator
+removeallclassmethods GtRemotePhlowCollectionIterator
+
+doit
+(GtRemotePhlowCollectionIterator
+	subclass: 'GtRemotePhlowSequenceableCollectionIterator'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowSequenceableCollectionIterator
+removeallclassmethods GtRemotePhlowSequenceableCollectionIterator
+
+doit
+(GtRemotePhlowCollectionIterator
+	subclass: 'GtRemotePhlowUnindexedCollectionIterator'
+	instVarNames: #(iterationSelector)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowUnindexedCollectionIterator
+removeallclassmethods GtRemotePhlowUnindexedCollectionIterator
+
+doit
+(GtRemotePhlowUnindexedCollectionIterator
+	subclass: 'GtRemotePhlowDictionaryAssociationsIterator'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDictionaryAssociationsIterator
+removeallclassmethods GtRemotePhlowDictionaryAssociationsIterator
+
+doit
+(GtRemotePhlowUnindexedCollectionIterator
+	subclass: 'GtRemotePhlowDictionaryKeysIterator'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDictionaryKeysIterator
+removeallclassmethods GtRemotePhlowDictionaryKeysIterator
+
+doit
+(GtRemotePhlowUnindexedCollectionIterator
+	subclass: 'GtRemotePhlowGenericCollectionIterator'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowGenericCollectionIterator
+removeallclassmethods GtRemotePhlowGenericCollectionIterator
+
+doit
+(GtRemotePhlowUnindexedCollectionIterator
+	subclass: 'GtRemotePhlowPluggableCollectionIterator'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowPluggableCollectionIterator
+removeallclassmethods GtRemotePhlowPluggableCollectionIterator
+
+doit
+(Object
+	subclass: 'GtRemotePhlowColumn'
+	instVarNames: #(index title width itemComputation backgroundComputation)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowColumn
+removeallclassmethods GtRemotePhlowColumn
+
+doit
+(GtRemotePhlowColumn
+	subclass: 'GtRemotePhlowExplicitColumn'
+	instVarNames: #(spawnObjectComputation type)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowExplicitColumn
+removeallclassmethods GtRemotePhlowExplicitColumn
+
+doit
+(GtRemotePhlowColumn
+	subclass: 'GtRemotePhlowTypedColumn'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTypedColumn
+removeallclassmethods GtRemotePhlowTypedColumn
+
+doit
+(GtRemotePhlowTypedColumn
+	subclass: 'GtRemotePhlowIconNameColumn'
+	instVarNames: #(iconNameComputation)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowIconNameColumn
+removeallclassmethods GtRemotePhlowIconNameColumn
+
+doit
+(GtRemotePhlowIconNameColumn
+	subclass: 'GtRemotePhlowThemeIconNameColumn'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowThemeIconNameColumn
+removeallclassmethods GtRemotePhlowThemeIconNameColumn
+
+doit
+(GtRemotePhlowTypedColumn
+	subclass: 'GtRemotePhlowNumberColumn'
+	instVarNames: #(formatComputation)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowNumberColumn
+removeallclassmethods GtRemotePhlowNumberColumn
+
+doit
+(GtRemotePhlowTypedColumn
+	subclass: 'GtRemotePhlowTextColumn'
+	instVarNames: #(formatComputation)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextColumn
+removeallclassmethods GtRemotePhlowTextColumn
+
+doit
+(Object
+	subclass: 'GtRemotePhlowColumnSpecification'
+	instVarNames: #(title cellWidth type spawnsObjects properties)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowColumnSpecification
+removeallclassmethods GtRemotePhlowColumnSpecification
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDataNode'
+	instVarNames: #(targetObject nodeId nodeValue)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDataNode
+removeallclassmethods GtRemotePhlowDataNode
+
+doit
+(GtRemotePhlowDataNode
+	subclass: 'GtRemotePhlowTreeNode'
+	instVarNames: #(childNodes parentNode)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTreeNode
+removeallclassmethods GtRemotePhlowTreeNode
+
+doit
+(GtRemotePhlowTreeNode
+	subclass: 'GtRemotePhlowColumnedTreeNode'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowColumnedTreeNode
+removeallclassmethods GtRemotePhlowColumnedTreeNode
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeActionDataSource'
+	instVarNames: #(phlowAction)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeActionDataSource
+removeallclassmethods GtRemotePhlowDeclarativeActionDataSource
+
+doit
+(GtRemotePhlowDeclarativeActionDataSource
+	subclass: 'GtRemotePhlowDeclarativeBlockActionDataSource'
+	instVarNames: #(targetBlock)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeBlockActionDataSource
+removeallclassmethods GtRemotePhlowDeclarativeBlockActionDataSource
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeErrorTestInspectable'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeErrorTestInspectable
+removeallclassmethods GtRemotePhlowDeclarativeErrorTestInspectable
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeExamples'
+	instVarNames: #(server)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeExamples
+removeallclassmethods GtRemotePhlowDeclarativeExamples
+
+doit
+(GtRemotePhlowDeclarativeExamples
+	subclass: 'GtRemotePhlowDeclarativeActionsExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeActionsExamples
+removeallclassmethods GtRemotePhlowDeclarativeActionsExamples
+
+doit
+(GtRemotePhlowDeclarativeActionsExamples
+	subclass: 'GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples
+removeallclassmethods GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples
+
+doit
+(GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples
+	subclass: 'GtRemotePhlowDeclarativeActionsLocalViewedObjectExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeActionsLocalViewedObjectExamples
+removeallclassmethods GtRemotePhlowDeclarativeActionsLocalViewedObjectExamples
+
+doit
+(GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples
+	subclass: 'GtRemotePhlowDeclarativeActionsRemoteViewedObjectExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeActionsRemoteViewedObjectExamples
+removeallclassmethods GtRemotePhlowDeclarativeActionsRemoteViewedObjectExamples
+
+doit
+(GtRemotePhlowDeclarativeActionsExamples
+	subclass: 'GtRemotePhlowDeclarativeActionsProxySimulationExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeActionsProxySimulationExamples
+removeallclassmethods GtRemotePhlowDeclarativeActionsProxySimulationExamples
+
+doit
+(GtRemotePhlowDeclarativeExamples
+	subclass: 'GtRemotePhlowDeclarativeViewsExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		comment: 'GtRemoteDeclarativeGtExamples demonstrates the use of declarative views in Gtoolkit.
+
+This class runs the examples within the one image, and thus can be run without any external server setup.  Subclasses overwrite various methods to run the examples connecting to the remote server.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewsExamples
+removeallclassmethods GtRemotePhlowDeclarativeViewsExamples
+
+doit
+(GtRemotePhlowDeclarativeViewsExamples
+	subclass: 'GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples
+removeallclassmethods GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples
+
+doit
+(GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples
+	subclass: 'GtRemotePhlowDeclarativeViewsLocalViewedObjectExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewsLocalViewedObjectExamples
+removeallclassmethods GtRemotePhlowDeclarativeViewsLocalViewedObjectExamples
+
+doit
+(GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples
+	subclass: 'GtRemotePhlowDeclarativeViewsRemoteViewedObjectExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewsRemoteViewedObjectExamples
+removeallclassmethods GtRemotePhlowDeclarativeViewsRemoteViewedObjectExamples
+
+doit
+(GtRemotePhlowDeclarativeViewsExamples
+	subclass: 'GtRemotePhlowDeclarativeViewsProxySimulationExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewsProxySimulationExamples
+removeallclassmethods GtRemotePhlowDeclarativeViewsProxySimulationExamples
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeTestForCustomProxyInspectable'
+	instVarNames: #(collectionOfObjects)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeTestForCustomProxyInspectable
+removeallclassmethods GtRemotePhlowDeclarativeTestForCustomProxyInspectable
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeTestInspectable'
+	instVarNames: #(string collectionOfObjects)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		comment: 'GtDeclarativeTestInspectable is a simple object that can be used to test the Gt declarative views. 
+
+ 
+## Internal Representation and Key Implementation Points.
+
+### Instance Variables
+
+	collectionOfObjects:		<Array>  a collection of objects for displaying in lists
+	string:		<String> for displaying in a text view
+
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeTestInspectable
+removeallclassmethods GtRemotePhlowDeclarativeTestInspectable
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeTestWithViewIncrement'
+	instVarNames: #(counter)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeTestWithViewIncrement
+removeallclassmethods GtRemotePhlowDeclarativeTestWithViewIncrement
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeTextTestInspectable'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeTextTestInspectable
+removeallclassmethods GtRemotePhlowDeclarativeTextTestInspectable
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeTreeExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeTreeExamples
+removeallclassmethods GtRemotePhlowDeclarativeTreeExamples
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDeclarativeViewDataSource'
+	instVarNames: #(phlowView)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewDataSource
+removeallclassmethods GtRemotePhlowDeclarativeViewDataSource
+
+doit
+(GtRemotePhlowDeclarativeViewDataSource
+	subclass: 'GtRemotePhlowDeclarativeForwardViewDataSource'
+	instVarNames: #(cachedViewSpecification)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeForwardViewDataSource
+removeallclassmethods GtRemotePhlowDeclarativeForwardViewDataSource
+
+doit
+(GtRemotePhlowDeclarativeViewDataSource
+	subclass: 'GtRemotePhlowDeclarativeTextualViewDataSource'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeTextualViewDataSource
+removeallclassmethods GtRemotePhlowDeclarativeTextualViewDataSource
+
+doit
+(GtRemotePhlowDeclarativeViewDataSource
+	subclass: 'GtRemotePhlowDeclarativeViewListingDataSource'
+	instVarNames: #(itemsIterator cachedNodes cachedValueBuilder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewListingDataSource
+removeallclassmethods GtRemotePhlowDeclarativeViewListingDataSource
+
+doit
+(GtRemotePhlowDeclarativeViewListingDataSource
+	subclass: 'GtRemotePhlowDeclarativeViewColumnedListDataSource'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewColumnedListDataSource
+removeallclassmethods GtRemotePhlowDeclarativeViewColumnedListDataSource
+
+doit
+(GtRemotePhlowDeclarativeViewListingDataSource
+	subclass: 'GtRemotePhlowDeclarativeViewListDataSource'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewListDataSource
+removeallclassmethods GtRemotePhlowDeclarativeViewListDataSource
+
+doit
+(GtRemotePhlowDeclarativeViewListingDataSource
+	subclass: 'GtRemotePhlowDeclarativeViewTreeDataSource'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewTreeDataSource
+removeallclassmethods GtRemotePhlowDeclarativeViewTreeDataSource
+
+doit
+(GtRemotePhlowDeclarativeViewTreeDataSource
+	subclass: 'GtRemotePhlowDeclarativeViewColumnedTreeDataSource'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDeclarativeViewColumnedTreeDataSource
+removeallclassmethods GtRemotePhlowDeclarativeViewColumnedTreeDataSource
+
+doit
+(Object
+	subclass: 'GtRemotePhlowDummyTextStyler'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowDummyTextStyler
+removeallclassmethods GtRemotePhlowDummyTextStyler
+
+doit
+(Object
+	subclass: 'GtRemotePhlowNodeValue'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowNodeValue
+removeallclassmethods GtRemotePhlowNodeValue
+
+doit
+(GtRemotePhlowNodeValue
+	subclass: 'GtRemotePhlowItemValue'
+	instVarNames: #(background)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowItemValue
+removeallclassmethods GtRemotePhlowItemValue
+
+doit
+(GtRemotePhlowItemValue
+	subclass: 'GtRemotePhlowItemTextualValue'
+	instVarNames: #(itemText)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowItemTextualValue
+removeallclassmethods GtRemotePhlowItemTextualValue
+
+doit
+(GtRemotePhlowItemTextualValue
+	subclass: 'GtRemotePhlowItemErrorValue'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		comment: 'I am a node modeling an error that happened during the computation';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowItemErrorValue
+removeallclassmethods GtRemotePhlowItemErrorValue
+
+doit
+(GtRemotePhlowNodeValue
+	subclass: 'GtRemotePhlowRowValue'
+	instVarNames: #(columnValues)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowRowValue
+removeallclassmethods GtRemotePhlowRowValue
+
+doit
+(Object
+	subclass: 'GtRemotePhlowNodeValueBuilder'
+	instVarNames: #(phlowView)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowNodeValueBuilder
+removeallclassmethods GtRemotePhlowNodeValueBuilder
+
+doit
+(GtRemotePhlowNodeValueBuilder
+	subclass: 'GtRemotePhlowItemBuilder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowItemBuilder
+removeallclassmethods GtRemotePhlowItemBuilder
+
+doit
+(GtRemotePhlowNodeValueBuilder
+	subclass: 'GtRemotePhlowRowBuilder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowRowBuilder
+removeallclassmethods GtRemotePhlowRowBuilder
+
+doit
+(Object
+	subclass: 'GtRemotePhlowProtoView'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowProtoView
+removeallclassmethods GtRemotePhlowProtoView
+
+doit
+(GtRemotePhlowProtoView
+	subclass: 'GtRemotePhlowView'
+	instVarNames: #(title priority definingSelector definingClass)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		comment: 'GtDeclarativeView provides a declarative UI specification for presenting data that can be easily serialised and sent over the wire, including between applications written in different languages.
+
+dataTransport is an emumerated value indicating whether the data to be displayed will be included with the specification or is available via reference or by key.]
+
+- 1: data is included in the response
+- 2: data is available by reference
+- 3: data is available by reference and key (tbc)
+
+
+Public API and Key Messages
+
+- message one   
+- message two 
+- (for bonus points) how to create instances.
+
+   One simple example is simply gorgeous.
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	dataTransport:		<Object>
+
+
+    Implementation Points';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowView
+removeallclassmethods GtRemotePhlowView
+
+doit
+(GtRemotePhlowView
+	subclass: 'GtRemotePhlowEmptyView'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowEmptyView
+removeallclassmethods GtRemotePhlowEmptyView
+
+doit
+(GtRemotePhlowView
+	subclass: 'GtRemotePhlowForwarderView'
+	instVarNames: #(viewSelector objectComputation transformation isDeclarative)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowForwarderView
+removeallclassmethods GtRemotePhlowForwarderView
+
+doit
+(GtRemotePhlowView
+	subclass: 'GtRemotePhlowListingView'
+	instVarNames: #(itemsProviderComputation transformation)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowListingView
+removeallclassmethods GtRemotePhlowListingView
+
+doit
+(GtRemotePhlowListingView
+	subclass: 'GtRemotePhlowBasicColumnedView'
+	instVarNames: #(columns)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		comment: 'I provide functionality for working with columns.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowBasicColumnedView
+removeallclassmethods GtRemotePhlowBasicColumnedView
+
+doit
+(GtRemotePhlowBasicColumnedView
+	subclass: 'GtRemotePhlowColumnedListView'
+	instVarNames: #(horizontalScrollingEnabled)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		comment: 'I support a subset of the possible configurations of {{gtClass:name=GtPhlowColumnedListView}}.
+
+Current limitations:
+
+- Only matchParent and fixed column widths are supported';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowColumnedListView
+removeallclassmethods GtRemotePhlowColumnedListView
+
+doit
+(GtRemotePhlowBasicColumnedView
+	subclass: 'GtRemotePhlowColumnedTreeView'
+	instVarNames: #(itemTextBlock childrenBuilder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		comment: 'I support a subset of the possible configurations of {{gtClass:name=GtPhlowColumnedTreeView}}.
+
+I subclass from {{gtClass:GtRemotePhlowBasicColumnedView}} to reuse the functionality for working with columns and duplicate the API for working with trees from {{gtClass:GtRemotePhlowTreeView}}. This happens in order to also work in GemStone where traits are not available.  Views in the Phlow version targeting the standard GT image  (subclassing {{gtClass:GtPhlowViewDecorator}}) use traits so share a common API. Since traits are not available in GemStone we rely on inheritance. We share the columns API through inheritance instead of the tree api, as the tree API is simpler and does not result in that much duplication.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowColumnedTreeView
+removeallclassmethods GtRemotePhlowColumnedTreeView
+
+doit
+(GtRemotePhlowListingView
+	subclass: 'GtRemotePhlowListView'
+	instVarNames: #(itemTextBlock)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		comment: 'GtDeclarativeList supports a subset of the possible configurations of {{gtClass:name=GtPhlowListView}}.
+
+ 
+## Internal Representation and Key Implementation Points.
+
+### Instance Variables
+	itemsBuilder: 	{{gtClass:BlockClosure}} - A BlockClosure that will return the (unformatted) list of items to be displayed.
+	items:				{{gtClass:Array}} - The formatted items to display (not the raw values held in the list)
+	itemTextBlock: 	{{gtClass:BlockClosure}} - A BlockClosure (or Symbol) that converts each item to its displayed format.  The result of the BlockClosure must be a JSON primitive type, effectively a string or number.
+
+
+### Implementation Points
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowListView
+removeallclassmethods GtRemotePhlowListView
+
+doit
+(GtRemotePhlowListingView
+	subclass: 'GtRemotePhlowTreeView'
+	instVarNames: #(itemTextBlock childrenBuilder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		comment: 'GtPharoDeclarativeTree maps to GtPhlowTreeView in Gt.
+
+When transporting the data, each node in the tree is represented as an Array with three slots:
+1. The item''s textual representation
+2. The index.  This is an array of indices to the nodes location.
+3. An Array of child nodes.
+';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTreeView
+removeallclassmethods GtRemotePhlowTreeView
+
+doit
+(GtRemotePhlowView
+	subclass: 'GtRemotePhlowTextualView'
+	instVarNames: #(textBuilder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextualView
+removeallclassmethods GtRemotePhlowTextualView
+
+doit
+(GtRemotePhlowTextualView
+	subclass: 'GtRemotePhlowTextEditorView'
+	instVarNames: #(stylerSpecification)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextEditorView
+removeallclassmethods GtRemotePhlowTextEditorView
+
+doit
+(GtRemotePhlowTextualView
+	subclass: 'GtRemotePhlowTextView'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextView
+removeallclassmethods GtRemotePhlowTextView
+
+doit
+(GtRemotePhlowView
+	subclass: 'GtRemotePhlowViewErrorView'
+	instVarNames: #(errorMessage)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowViewErrorView
+removeallclassmethods GtRemotePhlowViewErrorView
+
+doit
+(Object
+	subclass: 'GtRemotePhlowSendObjectTransformation'
+	instVarNames: #(valuable)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-PhlowViews';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowSendObjectTransformation
+removeallclassmethods GtRemotePhlowSendObjectTransformation
+
+doit
+(Object
+	subclass: 'GtRemotePhlowSpawnObjectWrapper'
+	instVarNames: #(targetObject)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-DeclarativeActions';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowSpawnObjectWrapper
+removeallclassmethods GtRemotePhlowSpawnObjectWrapper
+
+doit
+(Object
+	subclass: 'GtRemotePhlowSpecificationConversionExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowSpecificationConversionExamples
+removeallclassmethods GtRemotePhlowSpecificationConversionExamples
+
+doit
+(GtRemotePhlowSpecificationConversionExamples
+	subclass: 'GtRemotePhlowActionSpecificationConversionExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowActionSpecificationConversionExamples
+removeallclassmethods GtRemotePhlowActionSpecificationConversionExamples
+
+doit
+(GtRemotePhlowSpecificationConversionExamples
+	subclass: 'GtRemotePhlowViewSpecificationConversionExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowViewSpecificationConversionExamples
+removeallclassmethods GtRemotePhlowViewSpecificationConversionExamples
+
+doit
+(Object
+	subclass: 'GtRemotePhlowStylableText'
+	instVarNames: #(string stylerSpecification highlight)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowStylableText
+removeallclassmethods GtRemotePhlowStylableText
+
+doit
+(Object
+	subclass: 'GtRemotePhlowTextStylerSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextStylerSpecification
+removeallclassmethods GtRemotePhlowTextStylerSpecification
+
+doit
+(GtRemotePhlowTextStylerSpecification
+	subclass: 'GtRemotePhlowTextAttributeRunsStylerSpecification'
+	instVarNames: #(attributeRuns)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextAttributeRunsStylerSpecification
+removeallclassmethods GtRemotePhlowTextAttributeRunsStylerSpecification
+
+doit
+(GtRemotePhlowTextStylerSpecification
+	subclass: 'GtRemotePhlowTextNamedStylerSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextNamedStylerSpecification
+removeallclassmethods GtRemotePhlowTextNamedStylerSpecification
+
+doit
+(GtRemotePhlowTextNamedStylerSpecification
+	subclass: 'GtRemotePhlowTextClassStylerSpecification'
+	instVarNames: #(stylerClassName)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextClassStylerSpecification
+removeallclassmethods GtRemotePhlowTextClassStylerSpecification
+
+doit
+(GtRemotePhlowTextNamedStylerSpecification
+	subclass: 'GtRemotePhlowTextParserStylerSpecification'
+	instVarNames: #(parserClassName)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextParserStylerSpecification
+removeallclassmethods GtRemotePhlowTextParserStylerSpecification
+
+doit
+(GtRemotePhlowTextStylerSpecification
+	subclass: 'GtRemotePhlowTextNullStylerSpecification'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowTextNullStylerSpecification
+removeallclassmethods GtRemotePhlowTextNullStylerSpecification
+
+doit
+(GtRemotePhlowTextStylerSpecification
+	subclass: 'GtRemoteTextStylerComputableSpecification'
+	instVarNames: #(stylerComputation)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-Text';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemoteTextStylerComputableSpecification
+removeallclassmethods GtRemoteTextStylerComputableSpecification
+
+doit
+(Object
+	subclass: 'GtRemotePhlowViewedObject'
+	instVarNames: #(object actionSpecificationsBySelector viewSpecificationsBySelector)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-InspectorCore';
+		comment: '{{gtClass:GtRemotePhlowViewedObject}} is responsible for serving serialized views to the client inspector.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemotePhlowViewedObject
+removeallclassmethods GtRemotePhlowViewedObject
+
+doit
+(Object
+	subclass: 'GtRmGeoGpsGroup'
+	instVarNames: #(items cache)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeoGpsGroup
+removeallclassmethods GtRmGeoGpsGroup
+
+doit
+(GtRmGeoGpsGroup
+	subclass: 'GtRmGeoGpsRecordsGroup'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeoGpsRecordsGroup
+removeallclassmethods GtRmGeoGpsRecordsGroup
+
+doit
+(GtRmGeoGpsGroup
+	subclass: 'GtRmGeoGpsTrajectoriesGroup'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeoGpsTrajectoriesGroup
+removeallclassmethods GtRmGeoGpsTrajectoriesGroup
+
+doit
+(GtRmGeoGpsGroup
+	subclass: 'GtRmGeoGpsUsersGroup'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeoGpsUsersGroup
+removeallclassmethods GtRmGeoGpsUsersGroup
+
+doit
+(Object
+	subclass: 'GtRmGeoGpsRecord'
+	instVarNames: #(timestamp latitude longitude)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeoGpsRecord
+removeallclassmethods GtRmGeoGpsRecord
+
+doit
+(Object
+	subclass: 'GtRmGeoGpsTrajectory'
+	instVarNames: #(records targetFolderName)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeoGpsTrajectory
+removeallclassmethods GtRmGeoGpsTrajectory
+
+doit
+(Object
+	subclass: 'GtRmGeolife'
+	instVarNames: #(users)
+	classVars: #(DEFAULT)
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeolife
+removeallclassmethods GtRmGeolife
+
+doit
+(Object
+	subclass: 'GtRmGeolifeBaseImporter'
+	instVarNames: #(currentDirectory usersCount)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeolifeBaseImporter
+removeallclassmethods GtRmGeolifeBaseImporter
+
+doit
+(GtRmGeolifeBaseImporter
+	subclass: 'GtRmGeolifeLocalImporter'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeolifeLocalImporter
+removeallclassmethods GtRmGeolifeLocalImporter
+
+doit
+(Object
+	subclass: 'GtRmGeoUser'
+	instVarNames: #(trajectories id)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-GeolifeDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmGeoUser
+removeallclassmethods GtRmGeoUser
+
+doit
+(Object
+	subclass: 'GtRmMovie'
+	instVarNames: #(rawData propertyNames)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-MoviesDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmMovie
+removeallclassmethods GtRmMovie
+
+doit
+(Object
+	subclass: 'GtRmMovieCollection'
+	instVarNames: #(rawData propertyNames)
+	classVars: #(DEFAULT)
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-MoviesDemo';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRmMovieCollection
+removeallclassmethods GtRmMovieCollection
+
+doit
+(Object
+	subclass: 'GtRsrInspectorProxySerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-InspectorCore';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrInspectorProxySerializationStrategy
+removeallclassmethods GtRsrInspectorProxySerializationStrategy
+
+doit
+(GtRsrInspectorProxySerializationStrategy
+	subclass: 'GtRsrInspectorProxyDataSerializationStrategy'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-RemotePhlow-InspectorCore';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRsrInspectorProxyDataSerializationStrategy
+removeallclassmethods GtRsrInspectorProxyDataSerializationStrategy
+
+! Class implementation for 'GtPhlowBasicRun'
+
+!		Class methods for 'GtPhlowBasicRun'
+
+category: 'instance creation'
+classmethod: GtPhlowBasicRun
+from: aStartIndex to: aEndIndex attributes: aCollectionOfAttributes
+	^ self new 
+		initializeFrom: aStartIndex to: aEndIndex attributes: aCollectionOfAttributes
+%
+
+category: 'instance creation'
+classmethod: GtPhlowBasicRun
+fromJSONDictionary: aTextStylerData 
+	| typeLabel attributesClass |
+ 	typeLabel := aTextStylerData at: '__typeLabel'.
+			
+	typeLabel = GtPhlowRun typeLabel ifTrue: [
+ 		attributesClass :=  GtPhlowRun ].
+		
+	^ attributesClass 
+		ifNil: [ nil ]
+		ifNotNil: [
+			attributesClass new  
+				initializeFromJSONDictionary: aTextStylerData ]
+%
+
+category: 'accessing'
+classmethod: GtPhlowBasicRun
+typeLabel
+	^ '<missing>'
+%
+
+!		Instance methods for 'GtPhlowBasicRun'
+
+category: 'styling'
+method: GtPhlowBasicRun
+applyStyleToText: aText
+	self subclassResponsibility
+%
+
+category: 'accessing'
+method: GtPhlowBasicRun
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ Dictionary new 
+		at: '__typeLabel' put: self class typeLabel;
+		yourself
+%
+
+category: 'initialization'
+method: GtPhlowBasicRun
+initializeFrom: aStartIndex to: aEndIndex attributes: aCollectionOfAttributes 
+	self subclassResponsibility
+%
+
+! Class implementation for 'GtPhlowRun'
+
+!		Class methods for 'GtPhlowRun'
+
+category: 'instance creation'
+classmethod: GtPhlowRun
+fromJSONDictionary: anAttributeData 
+	^ self new  
+		initializeFromJSONDictionary: anAttributeData
+%
+
+category: 'accessing'
+classmethod: GtPhlowRun
+typeLabel
+	^ 'phlowRun'
+%
+
+!		Instance methods for 'GtPhlowRun'
+
+category: 'comparing'
+method: GtPhlowRun
+= anObject
+	
+	self == anObject
+		ifTrue: [ ^ true ].
+	(anObject class = self class)
+		ifFalse: [ ^ false ].
+
+	^ (self startIndex = anObject startIndex) and: [
+		self endIndex = anObject endIndex and: [ 
+			self attributes = anObject attributes ] ]
+%
+
+category: 'accessing'
+method: GtPhlowRun
+addAttribute: anAttribute
+	self attributes add: anAttribute
+%
+
+category: 'styling'
+method: GtPhlowRun
+applyStyleToText: aText
+	| subText |
+	subText := aText from: startIndex to: endIndex.
+	attributes do: [ :anAttribute |
+		anAttribute applyStyleToText: subText ]
+%
+
+category: 'converting'
+method: GtPhlowRun
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'startIndex' put: startIndex;
+		at: 'endIndex' put: endIndex;
+		at: 'attributes' put: (attributes collect: [ :anAttribute |
+			anAttribute asDictionaryForExport ]) asArray;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowRun
+attributes
+	^ attributes
+%
+
+category: 'accessing'
+method: GtPhlowRun
+attributes: aCollection
+	attributes := aCollection asOrderedCollection
+%
+
+category: 'printing'
+method: GtPhlowRun
+attributesDescription
+	^ String streamContents: [ :aStream |
+		self attributesDescriptionOn: aStream ]
+%
+
+category: 'printing'
+method: GtPhlowRun
+attributesDescriptionOn: aStream 
+	self attributes 
+		do: [ :anAttribute |
+			aStream << anAttribute printString ] 
+		separatedBy: [ aStream << ' ']
+%
+
+category: 'copying'
+method: GtPhlowRun
+copyFrom: aStartIndex to: anEndIndex
+	^ self class
+		from: (aStartIndex max: startIndex) - aStartIndex + 1
+		to: (anEndIndex min: endIndex) - aStartIndex + 1
+		attributes: attributes  copy
+%
+
+category: 'accessing'
+method: GtPhlowRun
+endIndex
+	^ endIndex
+%
+
+category: 'accessing'
+method: GtPhlowRun
+gtViewAttributesFor: aView 
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Attributes';
+		items: [ self attributes ];
+		column: 'Attribute' text: [ :anAttribute | anAttribute printString];
+		column: 'Range ' text: [ :_ | self rangeDescription ]
+%
+
+category: 'comparing'
+method: GtPhlowRun
+hash
+
+	^ (self startIndex hash 
+		bitXor: self endIndex hash)
+		bitXor: self attributes hash
+%
+
+category: 'initialization'
+method: GtPhlowRun
+initializeFrom: aStartIndex to: aEndIndex attributes: aCollectionOfAttributes 
+	startIndex := aStartIndex.
+	endIndex := aEndIndex.
+	self attributes: aCollectionOfAttributes.
+%
+
+category: 'initialization'
+method: GtPhlowRun
+initializeFromJSONDictionary: aRunData
+	self 
+		initializeFrom: (aRunData at: 'startIndex')
+		to: (aRunData at: 'endIndex')
+		attributes: ((aRunData at: 'attributes') collect: [ :anAttributeData |
+			GtPhlowTextAttribute fromJSONDictionary: anAttributeData ]) 
+%
+
+category: 'printing'
+method: GtPhlowRun
+printOn: aStream
+	self rangeDescriptionOn:  aStream.
+	aStream << ': '.
+	self attributesDescriptionOn: aStream 
+%
+
+category: 'printing'
+method: GtPhlowRun
+rangeDescription
+	^ String streamContents: [ :aStream |
+		 self rangeDescriptionOn: aStream ]
+%
+
+category: 'printing'
+method: GtPhlowRun
+rangeDescriptionOn: aStream
+	aStream 
+		print: startIndex;
+		<< '-';
+		print: endIndex
+%
+
+category: 'accessing'
+method: GtPhlowRun
+startIndex
+	^ startIndex
+%
+
+! Class implementation for 'GtPhlowColor'
+
+!		Class methods for 'GtPhlowColor'
+
+category: 'instance creation'
+classmethod: GtPhlowColor
+fromJSONDictionary: aDictionary
+	"Answer an instance of the receiver from the supplied dictionary."
+
+	^self new 
+		named: (aDictionary at: #name ifAbsent: [ nil ]);
+		r: (aDictionary at: #r ifAbsent: [ nil ])
+			g: (aDictionary at: #g ifAbsent: [ nil ])
+			b: (aDictionary at: #b ifAbsent: [ nil ])
+			alpha: (aDictionary at: #a ifAbsent: [ nil ]);
+		yourself
+%
+
+category: 'instance creation'
+classmethod: GtPhlowColor
+named: aColorName
+	^ self new 
+		named: aColorName
+%
+
+category: 'instance creation'
+classmethod: GtPhlowColor
+named: aColorName alpha: anAlpha
+	^ self new 
+		named: aColorName alpha: anAlpha
+%
+
+category: 'instance creation'
+classmethod: GtPhlowColor
+r: r g: g b: b 
+	^ self new 
+		r: r g: g b: b alpha: nil
+%
+
+category: 'instance creation'
+classmethod: GtPhlowColor
+r: r g: g b: b alpha: alpha
+	^ self new 
+		r: r g: g b: b alpha: alpha
+%
+
+category: 'accessing - defaults'
+classmethod: GtPhlowColor
+transparent
+	^ self named: #transparent
+%
+
+!		Instance methods for 'GtPhlowColor'
+
+category: 'comparing'
+method: GtPhlowColor
+= anObject
+	"For now make this equal only to instances of other phlow colors"
+	<return: #Boolean>
+	
+	self == anObject
+		ifTrue: [ ^ true ].
+	(anObject class = self class)
+		ifFalse: [ ^ false ].
+
+	^ self red = anObject red and: [
+		self green = anObject green and: [
+			self blue = anObject blue and: [
+				self alpha = anObject alpha and: [
+					self name = anObject name ] ] ] ]
+%
+
+category: 'accessing'
+method: GtPhlowColor
+alpha
+	^ alpha ifNil: [ 0 ]
+%
+
+category: 'accessing'
+method: GtPhlowColor
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation"
+
+	| data| 
+	data := Dictionary new 
+		yourself.
+		
+	name ifNotNil: [ :aValue |
+		data at: #name put: aValue ].
+	red ifNotNil: [ :aValue |
+		data at: #r put: aValue ].
+	green ifNotNil: [ :aValue |
+		data at: #g put: aValue ].
+	blue ifNotNil: [ :aValue |
+		data at: #b put: aValue ].
+	alpha ifNotNil: [ :aValue |
+		data at: #a put: aValue ].
+	
+	^ data
+%
+
+category: 'accessing'
+method: GtPhlowColor
+blue
+	^ blue
+%
+
+category: 'accessing'
+method: GtPhlowColor
+green
+	^ green
+%
+
+category: 'comparing'
+method: GtPhlowColor
+hash
+
+	^ self red hash 
+		bitXor: (self green hash 
+		bitXor: (self blue hash 
+		bitXor: (self alpha hash 
+		bitXor: self name hash )))
+%
+
+category: 'testing'
+method: GtPhlowColor
+isColor
+	^ true
+%
+
+category: 'testing'
+method: GtPhlowColor
+isTransparent
+	^ alpha = 0 or: [ name= #transparent ]
+%
+
+category: 'accessing'
+method: GtPhlowColor
+name
+	^ name
+%
+
+category: 'accessing'
+method: GtPhlowColor
+named: aColorName
+	name := aColorName
+%
+
+category: 'accessing'
+method: GtPhlowColor
+named: aColorName alpha: anAlpha
+	name := aColorName.
+	alpha := anAlpha
+%
+
+category: 'printing'
+method: GtPhlowColor
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		self isTransparent ifTrue: [ 
+			^ aStream nextPutAll: 'transparent' ].
+		name ifNotNil: [
+			^ aStream nextPutAll: name ].
+			
+	aStream
+		nextPutAll: ' r: ';
+		print: red;
+		nextPutAll: ' g: ';
+		print: green;
+		nextPutAll: ' b: ';
+		print: blue;
+		nextPutAll: ' alpha: ';
+		print: alpha]
+%
+
+category: 'accessing'
+method: GtPhlowColor
+r: r g: g b: b alpha: anAlpha
+	red := r.
+	green := g.
+	blue := b.
+	alpha := anAlpha
+%
+
+category: 'accessing'
+method: GtPhlowColor
+red
+	^ red
+%
+
+! Class implementation for 'GtPhlowDeclarativeListingType'
+
+!		Class methods for 'GtPhlowDeclarativeListingType'
+
+category: 'instance creation'
+classmethod: GtPhlowDeclarativeListingType
+forTypeLabel: aValue 
+	^ self allSubclasses
+		detect: [ :aSubclass |
+			aSubclass typeLabel = aValue ]
+		ifFound: [ :aSubclass | aSubclass new ]
+		ifNone: [ self unknown ]
+%
+
+category: 'types creation'
+classmethod: GtPhlowDeclarativeListingType
+iconName
+	^ GtPhlowThemeIconNameDeclarativeListingType new
+%
+
+category: 'types creation'
+classmethod: GtPhlowDeclarativeListingType
+number
+	^ GtPhlowNumberDeclarativeListingType new
+%
+
+category: 'types creation'
+classmethod: GtPhlowDeclarativeListingType
+text
+	^ GtPhlowTextDeclarativeListingType new
+%
+
+category: 'types creation'
+classmethod: GtPhlowDeclarativeListingType
+textLink
+	^ GtPhlowTextLinkDeclarativeListingType new
+%
+
+category: 'accessing'
+classmethod: GtPhlowDeclarativeListingType
+typeLabel
+	^ 'listing type'
+%
+
+category: 'types creation'
+classmethod: GtPhlowDeclarativeListingType
+unknown
+	^ GtPhlowUnknownDeclarativeListingType new
+%
+
+!		Instance methods for 'GtPhlowDeclarativeListingType'
+
+category: 'testing'
+method: GtPhlowDeclarativeListingType
+isTextLinkListingType
+	^ false
+%
+
+category: 'testing'
+method: GtPhlowDeclarativeListingType
+isUnknown
+	^ false
+%
+
+category: 'accessing'
+method: GtPhlowDeclarativeListingType
+typeLabel
+	^ self class typeLabel
+%
+
+! Class implementation for 'GtPhlowNumberDeclarativeListingType'
+
+!		Class methods for 'GtPhlowNumberDeclarativeListingType'
+
+category: 'accessing'
+classmethod: GtPhlowNumberDeclarativeListingType
+typeLabel
+	^ #number
+%
+
+! Class implementation for 'GtPhlowTextDeclarativeListingType'
+
+!		Class methods for 'GtPhlowTextDeclarativeListingType'
+
+category: 'accessing'
+classmethod: GtPhlowTextDeclarativeListingType
+typeLabel
+	^ #text
+%
+
+! Class implementation for 'GtPhlowTextLinkDeclarativeListingType'
+
+!		Class methods for 'GtPhlowTextLinkDeclarativeListingType'
+
+category: 'accessing'
+classmethod: GtPhlowTextLinkDeclarativeListingType
+typeLabel
+	^ #textLink
+%
+
+!		Instance methods for 'GtPhlowTextLinkDeclarativeListingType'
+
+category: 'testing'
+method: GtPhlowTextLinkDeclarativeListingType
+isTextLinkListingType
+	^ true
+%
+
+! Class implementation for 'GtPhlowThemeIconNameDeclarativeListingType'
+
+!		Class methods for 'GtPhlowThemeIconNameDeclarativeListingType'
+
+category: 'accessing'
+classmethod: GtPhlowThemeIconNameDeclarativeListingType
+typeLabel
+	^ #icon
+%
+
+! Class implementation for 'GtPhlowUnknownDeclarativeListingType'
+
+!		Class methods for 'GtPhlowUnknownDeclarativeListingType'
+
+category: 'accessing'
+classmethod: GtPhlowUnknownDeclarativeListingType
+typeLabel
+	^ #unknown
+%
+
+!		Instance methods for 'GtPhlowUnknownDeclarativeListingType'
+
+category: 'testing'
+method: GtPhlowUnknownDeclarativeListingType
+isUnknown
+	^ true
+%
+
+! Class implementation for 'GtPhlowDeclarativeSpecification'
+
+!		Class methods for 'GtPhlowDeclarativeSpecification'
+
+category: 'instance creation'
+classmethod: GtPhlowDeclarativeSpecification
+fromJSONDictionary: aDictionary
+	"Answer an instance of the receiver from the supplied dictionary."
+
+	^self new 
+		initializeFromJSONDictionary: aDictionary
+%
+
+category: 'accessing'
+classmethod: GtPhlowDeclarativeSpecification
+typeLabel
+	^ nil
+%
+
+!		Instance methods for 'GtPhlowDeclarativeSpecification'
+
+category: 'converting'
+method: GtPhlowDeclarativeSpecification
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+	| dictionaryForExport |
+	
+	dictionaryForExport :=  Dictionary new 
+		at: '__typeName' put: self class name;
+		yourself.
+	
+	self class typeLabel ifNotNil: [ :aLabel |
+		dictionaryForExport at: '__typeLabel' put: aLabel ].
+		
+	^ dictionaryForExport
+%
+
+category: 'initialization'
+method: GtPhlowDeclarativeSpecification
+initializeFromJSONDictionary: aDictionary
+%
+
+! Class implementation for 'GtPhlowActionSpecification'
+
+!		Instance methods for 'GtPhlowActionSpecification'
+
+category: 'converting'
+method: GtPhlowActionSpecification
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ super asDictionaryForExport
+		at: 'priority' put: priority;
+		at: 'methodSelector' put: methodSelector;
+		yourself
+%
+
+category: 'initialization'
+method: GtPhlowActionSpecification
+initializeFromInspector: anInspector
+%
+
+category: 'initialization'
+method: GtPhlowActionSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+
+	self
+		priority: (aDictionary at: 'priority' ifAbsent: [ nil ]);
+		methodSelector: (aDictionary at: 'methodSelector' ifAbsent: [ nil ]);
+		tooltipText: (aDictionary  at: 'tooltipText' ifAbsent: [ nil ]);
+		phlowDataSource: (aDictionary 
+			at: 'phlowDataSource' ifAbsent: [ nil ])
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+methodSelector
+	^ methodSelector
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+methodSelector: aSelector
+	methodSelector := aSelector
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+phlowDataSource
+	^ phlowDataSource
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+phlowDataSource: aDataSource
+	phlowDataSource := aDataSource
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+priority
+	^ priority
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+priority: aNumber
+	priority := aNumber
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+tooltipText
+	^ tooltipText
+%
+
+category: 'accessing'
+method: GtPhlowActionSpecification
+tooltipText: aTextOrString
+	tooltipText := aTextOrString
+%
+
+! Class implementation for 'GtPhlowButtonActionSpecification'
+
+!		Class methods for 'GtPhlowButtonActionSpecification'
+
+category: 'accessing'
+classmethod: GtPhlowButtonActionSpecification
+typeLabel
+	^ 'phlowButtonActionSpecification'
+%
+
+!		Instance methods for 'GtPhlowButtonActionSpecification'
+
+category: 'converting'
+method: GtPhlowButtonActionSpecification
+asDictionaryForExport
+	| dictionaryForExport|
+	dictionaryForExport := super asDictionaryForExport.
+	
+	label ifNotNil: [ :aText |
+		dictionaryForExport at: 'label' put: aText ].
+	iconStencil ifNotNil: [ :anIconStencil |
+		dictionaryForExport 
+			at: 'iconStencil' 
+			put: anIconStencil asDictionaryForExport ].
+	tooltipText ifNotNil: [ :aText |
+		dictionaryForExport at: 'tooltipText' put: aText ].
+
+	^ dictionaryForExport
+%
+
+category: 'accessing'
+method: GtPhlowButtonActionSpecification
+iconStencil
+	^ iconStencil
+%
+
+category: 'accessing'
+method: GtPhlowButtonActionSpecification
+iconStencil: anIconStencil
+	iconStencil := anIconStencil
+%
+
+category: 'initialization'
+method: GtPhlowButtonActionSpecification
+initializeFromInspector: anInspector
+	self phlowDataSource ifNil: [
+		self phlowDataSource: (anInspector 
+			getDeclarativeActionDataSourceFor: self methodSelector) ]
+%
+
+category: 'initialization'
+method: GtPhlowButtonActionSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	aDictionary 
+		at: 'label' 
+		ifPresent: [ :aText |
+			self label: aText ].
+	aDictionary 
+		at: 'tooltipText' 
+		ifPresent: [ :aText |
+			self tooltipText: aText ].
+	aDictionary 
+		at: 'iconStencil' 
+		ifPresent: [ :anIconStencilData |
+			anIconStencilData ifNotNil: [
+				self iconStencil: (GtPhlowIconStencil 
+					phlowIconStencilFromDictionary: anIconStencilData) ] ].
+%
+
+category: 'accessing'
+method: GtPhlowButtonActionSpecification
+label
+	^ label
+%
+
+category: 'accessing'
+method: GtPhlowButtonActionSpecification
+label: aLabel
+	label := aLabel
+%
+
+! Class implementation for 'GtPhlowErrorActionSpecification'
+
+!		Class methods for 'GtPhlowErrorActionSpecification'
+
+category: 'accessing'
+classmethod: GtPhlowErrorActionSpecification
+typeLabel
+	^ 'phlowErrorActionSpecification'
+%
+
+!		Instance methods for 'GtPhlowErrorActionSpecification'
+
+category: 'converting'
+method: GtPhlowErrorActionSpecification
+asDictionaryForExport
+	| dictionaryForExport|
+	dictionaryForExport := super asDictionaryForExport.
+	
+	errorMessage ifNotNil: [ :aText |
+		dictionaryForExport at: 'errorMessage' put: aText ].
+	tooltipText ifNotNil: [ :aText |
+		dictionaryForExport at: 'tooltipText' put: aText ].
+
+	^ dictionaryForExport
+%
+
+category: 'accessing'
+method: GtPhlowErrorActionSpecification
+errorMessage
+	^ errorMessage
+%
+
+category: 'accessing'
+method: GtPhlowErrorActionSpecification
+errorMessage: aStringMessage
+	errorMessage := aStringMessage
+%
+
+category: 'accessing'
+method: GtPhlowErrorActionSpecification
+iconStencil 
+	^ nil
+%
+
+category: 'accessing'
+method: GtPhlowErrorActionSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	aDictionary 
+		at: 'errorMessage' 
+		ifPresent: [ :aText |
+			self errorMessage: aText ].
+	aDictionary 
+		at: 'tooltipText' 
+		ifPresent: [ :aText |
+			self tooltipText: aText ].
+%
+
+category: 'accessing'
+method: GtPhlowErrorActionSpecification
+label
+	^ 'Error'
+%
+
+! Class implementation for 'GtPhlowNamedIconStencil'
+
+!		Class methods for 'GtPhlowNamedIconStencil'
+
+category: 'instance creation'
+classmethod: GtPhlowNamedIconStencil
+forIconName: anIconName
+	^ self new 
+		iconName: anIconName
+%
+
+!		Instance methods for 'GtPhlowNamedIconStencil'
+
+category: 'comparing'
+method: GtPhlowNamedIconStencil
+= anObject
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject
+		ifTrue: [ ^ true ].
+	self class = anObject class
+		ifFalse: [ ^ false ].
+		
+	^ self iconName = anObject iconName
+%
+
+category: 'accessing'
+method: GtPhlowNamedIconStencil
+asDictionaryForExport
+	^ super asDictionaryForExport
+		at: 'iconName' put: self iconName;
+		yourself
+%
+
+category: 'comparing'
+method: GtPhlowNamedIconStencil
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ self iconName hash
+%
+
+category: 'accessing'
+method: GtPhlowNamedIconStencil
+iconName
+	^ iconName
+%
+
+category: 'accessing'
+method: GtPhlowNamedIconStencil
+iconName: anIconName
+	iconName := anIconName
+%
+
+category: 'accessing'
+method: GtPhlowNamedIconStencil
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+	
+	aDictionary 
+		at: 'iconName' 
+		ifPresent: [ :anIconName | 
+			anIconName ifNotNil: [ 
+				self iconName: anIconName ] ]
+%
+
+! Class implementation for 'GtPhlowGlamorousIconNameStencil'
+
+!		Class methods for 'GtPhlowGlamorousIconNameStencil'
+
+category: 'accessing'
+classmethod: GtPhlowGlamorousIconNameStencil
+typeLabel
+	^ 'phlowGlamorousIconNameStencil'
+%
+
+! Class implementation for 'GtPhlowGlamorousVectorIconNameStencil'
+
+!		Class methods for 'GtPhlowGlamorousVectorIconNameStencil'
+
+category: 'accessing'
+classmethod: GtPhlowGlamorousVectorIconNameStencil
+typeLabel
+	^ 'phlowGlamorousVectorIconNameStencil'
+%
+
+! Class implementation for 'GtPhlowThemeIconNameStencil'
+
+!		Class methods for 'GtPhlowThemeIconNameStencil'
+
+category: 'accessing'
+classmethod: GtPhlowThemeIconNameStencil
+typeLabel
+	^ 'phlowThemeIconNameStencil'
+%
+
+! Class implementation for 'GtRemotePhlowSpawnObjectAction'
+
+!		Class methods for 'GtRemotePhlowSpawnObjectAction'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowSpawnObjectAction
+forObject: anObject 
+	^ self new 
+		targetObject: anObject 
+%
+
+!		Instance methods for 'GtRemotePhlowSpawnObjectAction'
+
+category: 'converting'
+method: GtRemotePhlowSpawnObjectAction
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation"
+
+	^ super asDictionaryForExport
+		at: 'objectWrapper' put: (GtRemotePhlowSpawnObjectWrapper new
+				targetObject: targetObject);
+		yourself
+%
+
+category: 'initialization'
+method: GtRemotePhlowSpawnObjectAction
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+
+	aDictionary at: 'objectWrapper' ifPresent: [ :anObjectWrapper |
+		self
+			targetObject: (aDictionary 
+				at: 'objectWrapper') targetObject asGtBareProxyObject ].
+%
+
+category: 'accessing'
+method: GtRemotePhlowSpawnObjectAction
+targetObject
+	^ targetObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowSpawnObjectAction
+targetObject: anObject 
+	targetObject := anObject 
+%
+
+! Class implementation for 'GtRemotePhlowViewedObjectClassSpecification'
+
+!		Class methods for 'GtRemotePhlowViewedObjectClassSpecification'
+
+category: 'accessing'
+classmethod: GtRemotePhlowViewedObjectClassSpecification
+forClass: aClass
+	^ self new 
+		initializeFromClass: aClass
+%
+
+category: 'accessing'
+classmethod: GtRemotePhlowViewedObjectClassSpecification
+typeLabel
+	^ 'phlowViewedObjectClassSpecification'
+%
+
+!		Instance methods for 'GtRemotePhlowViewedObjectClassSpecification'
+
+category: 'converting'
+method: GtRemotePhlowViewedObjectClassSpecification
+asDictionaryForExport
+	| dictionaryForExport|
+	dictionaryForExport := super asDictionaryForExport.
+	
+	dictionaryForExport at: 'viewObjectClassName' put: viewObjectClassName.
+	dictionaryForExport 
+		at: 'viewObjectInstanceVariableNames' 
+		put: viewObjectInstanceVariableNames.
+	
+	^ dictionaryForExport
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObjectClassSpecification
+initializeFromClass: aClass
+	self viewObjectClassName: aClass name.
+	self viewObjectInstanceVariableNames: aClass allInstVarNames
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObjectClassSpecification
+initializeFromJSONDictionary: aDictionary
+	super initializeFromJSONDictionary: aDictionary.
+
+	self
+		viewObjectClassName: (aDictionary 
+			at: 'viewObjectClassName' 
+			ifAbsent: [ nil ]);
+		viewObjectInstanceVariableNames: (aDictionary 
+			at: 'viewObjectInstanceVariableNames' 
+			ifAbsent: [ nil ])
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewedObjectClassSpecification
+viewObjectClassName
+	^ viewObjectClassName
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewedObjectClassSpecification
+viewObjectClassName: anObject
+	viewObjectClassName := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewedObjectClassSpecification
+viewObjectInstanceVariableNames
+	^ viewObjectInstanceVariableNames
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewedObjectClassSpecification
+viewObjectInstanceVariableNames: anObject
+	viewObjectInstanceVariableNames := anObject
+%
+
+! Class implementation for 'GtPhlowRuns'
+
+!		Class methods for 'GtPhlowRuns'
+
+category: 'instance creation'
+classmethod: GtPhlowRuns
+fromJSONDictionary: aRunsData 
+	| typeLabel runsClass |
+ 	typeLabel := aRunsData at: '__typeLabel'.
+			
+	typeLabel = GtPhlowRunsGroup typeLabel ifTrue: [
+ 		runsClass := GtPhlowRunsGroup ].
+		
+	^ runsClass 
+		ifNil: [ nil ]
+		ifNotNil: [
+			runsClass new  
+				initializeFromJSONDictionary: aRunsData ]
+%
+
+category: 'accessing'
+classmethod: GtPhlowRuns
+typeLabel
+	^ '<missing>'
+%
+
+!		Instance methods for 'GtPhlowRuns'
+
+category: 'styling'
+method: GtPhlowRuns
+applyStyleToText: aText
+	self runsDo: [ :aRun |
+		aRun applyStyleToText: aText ]
+%
+
+category: 'converting'
+method: GtPhlowRuns
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ Dictionary new 
+		at: '__typeLabel' put: self class typeLabel;
+		yourself
+%
+
+category: 'gt - extensions'
+method: GtPhlowRuns
+gtViewIntervalsFor: aView
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Intervals';
+		priority: 10;
+		items: [ 
+			| collectedRuns |
+			collectedRuns := OrderedCollection new.
+			self runsDo: [ :aRun |
+				collectedRuns add: aRun ].
+			collectedRuns ];
+		column: 'Interval' 
+			text: [ :aRun | aRun rangeDescription ]
+			width: 150;
+		column: 'Attributes' 
+			text: [ :aRun | aRun attributesDescription ]
+%
+
+category: 'initialization '
+method: GtPhlowRuns
+initializeFromJSONDictionary: aRunsData
+%
+
+category: 'testing'
+method: GtPhlowRuns
+isEmpty
+	^ self subclassResponsibility
+%
+
+category: 'testing'
+method: GtPhlowRuns
+notEmpty
+	^ self isEmpty not
+%
+
+category: 'enumerating'
+method: GtPhlowRuns
+runsDo: aBlock
+	self subclassResponsibility 
+%
+
+! Class implementation for 'GtPhlowRunsGroup'
+
+!		Class methods for 'GtPhlowRunsGroup'
+
+category: 'accessing'
+classmethod: GtPhlowRunsGroup
+typeLabel
+	^ 'phlowRunsGroup'
+%
+
+category: 'initialization'
+classmethod: GtPhlowRunsGroup
+withRuns: aCollectionOfRuns
+	^ self new 
+		initializeWithRuns: aCollectionOfRuns
+%
+
+!		Instance methods for 'GtPhlowRunsGroup'
+
+category: 'accessing'
+method: GtPhlowRunsGroup
+= anObject
+	
+	self == anObject
+		ifTrue: [ ^ true ].
+	(anObject class = self class)
+		ifFalse: [ ^ false ].
+
+	^ self items = anObject items
+%
+
+category: 'adding'
+method: GtPhlowRunsGroup
+add: aRun
+	self addRun: aRun
+%
+
+category: 'adding'
+method: GtPhlowRunsGroup
+addRun: aRun
+	self items add: aRun
+%
+
+category: 'converting'
+method: GtPhlowRunsGroup
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'items' put: (self items collect: [ :aRun |
+			aRun asDictionaryForExport ]) asArray;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowRunsGroup
+copyFrom: aStartIndex to: anEndIndex
+	^ self class withRuns: ((self items 
+		reject: [ :aRun |
+			(anEndIndex < aRun startIndex) or: [ aStartIndex > aRun endIndex]])
+		collect: [ :aRun |
+			aRun copyFrom: aStartIndex to: anEndIndex ])
+%
+
+category: 'enumerating'
+method: GtPhlowRunsGroup
+detect: aBlock ifNone: exceptionBlock
+	^ self items detect: aBlock ifNone: exceptionBlock
+%
+
+category: 'accessing'
+method: GtPhlowRunsGroup
+hash
+
+	^ self items hash
+%
+
+category: 'initialization'
+method: GtPhlowRunsGroup
+initializeFromJSONDictionary: aRunsData
+	items := ((aRunsData at: 'items') collect: [ :aRunData |
+		GtPhlowBasicRun fromJSONDictionary:  aRunData ]) asOrderedCollection
+%
+
+category: 'initialization'
+method: GtPhlowRunsGroup
+initializeWithRuns: aCollectionOfRuns
+	items := aCollectionOfRuns
+%
+
+category: 'testing'
+method: GtPhlowRunsGroup
+isEmpty
+	^ items isNil or: [ items isEmpty ]
+%
+
+category: 'accessing'
+method: GtPhlowRunsGroup
+items
+	^ items ifNil: [
+		items := OrderedCollection new ]	
+%
+
+category: 'enumerating'
+method: GtPhlowRunsGroup
+itemsDo: aBlock
+	items ifNil: [ ^ self ].
+	
+	items do: aBlock
+%
+
+category: 'printing'
+method: GtPhlowRunsGroup
+printOn: aStream
+	super printOn:  aStream.
+	aStream parenthesize: [
+		aStream
+			print: items size;
+			<< ' runs' ]
+%
+
+category: 'enumerating'
+method: GtPhlowRunsGroup
+reject: aBlock
+	^ self class 
+		withRuns: (self items reject: aBlock)
+%
+
+category: 'enumerating'
+method: GtPhlowRunsGroup
+runsDo: aBlock
+	self itemsDo: aBlock
+%
+
+category: 'accessing'
+method: GtPhlowRunsGroup
+size
+	^ self isEmpty 
+		ifTrue: [0] 
+		ifFalse: [ self items size ]
+%
+
+! Class implementation for 'GtPhlowText'
+
+!		Class methods for 'GtPhlowText'
+
+category: 'accessing'
+classmethod: GtPhlowText
+forString: aString
+	^ GtPhlowRunBasedText new 
+		initializeWithString: aString
+%
+
+!		Instance methods for 'GtPhlowText'
+
+category: 'attributes'
+method: GtPhlowText
+addAttribute: aPhlowAttribute
+	 self  
+	 	addAttribute: aPhlowAttribute 
+	 	from: self startIndex
+	 	to: self endIndex
+%
+
+category: 'attributes'
+method: GtPhlowText
+addAttribute: aPhlowAttribute from: aStartIndex to: anEndIndex 
+	self subclassResponsibility
+%
+
+category: 'api - text style'
+method: GtPhlowText
+bold
+	^ self addAttribute: GtPhlowFontWeightAttribute bold
+%
+
+category: 'api - text style'
+method: GtPhlowText
+decorationDo: aBlock
+	| anAttribute |
+	
+	anAttribute := GtPhlowTextDecorationAttribute new.
+	aBlock value: anAttribute.
+	self addAttribute: anAttribute
+%
+
+category: 'accessing'
+method: GtPhlowText
+endIndex
+	^ self subclassResponsibility
+%
+
+category: 'api - text style'
+method: GtPhlowText
+fontName: aName
+	self addAttribute: (GtPhlowFontNameAttribute new 
+		fontName: aName)
+%
+
+category: 'api - text style'
+method: GtPhlowText
+fontSize: aNumber
+	self addAttribute: (GtPhlowFontSizeAttribute new 
+		sizeValue: aNumber)
+%
+
+category: 'api - text style'
+method: GtPhlowText
+foreground: aPhlowColor
+	self addAttribute: (GtPhlowTextForegroundAttribute new 
+		color: aPhlowColor)
+%
+
+category: 'test - accessing'
+method: GtPhlowText
+from: aStart to: anEnd
+	"Create and return a subtext of this text form aStart to anEnd."
+	<return: #GtPhlowSubText>
+	
+	^ self subclassResponsibility
+%
+
+category: 'api - text style'
+method: GtPhlowText
+glamorousCodeFont
+	self fontName: 'Source Code Pro'
+%
+
+category: 'api - text style'
+method: GtPhlowText
+glamorousRegularFont
+	self fontName: 'Source Sans Pro'
+%
+
+category: 'gt - extensions'
+method: GtPhlowText
+gtDisplayText
+	^ self asRopedText
+%
+
+category: 'gt - extensions'
+method: GtPhlowText
+gtStringFor: aView
+	<gtView>
+	self isEmpty ifTrue: [ ^ aView empty ].
+	
+	^ aView forward 
+		title: 'String';
+		priority: 5;
+		object: [ self asString ];
+		view: #gtStringFor:
+%
+
+category: 'gt - extensions'
+method: GtPhlowText
+gtTextFor: aView
+	<gtView>
+	
+	^ aView text
+		title: 'Text';
+		priority: 2;
+		text: [ self ]
+%
+
+category: 'api - text style'
+method: GtPhlowText
+highlight: aColor
+	self addAttribute: (GtPhlowTextHighlightAttribute new 
+		color: aColor)
+%
+
+category: 'testing'
+method: GtPhlowText
+isEmpty
+	^ self size = 0
+%
+
+category: 'api - text style'
+method: GtPhlowText
+italic
+	^ self addAttribute: GtPhlowFontEmphasisAttribute italic
+%
+
+category: 'api - text style'
+method: GtPhlowText
+normal
+	^ self addAttribute: GtPhlowFontEmphasisAttribute normal
+%
+
+category: 'testing'
+method: GtPhlowText
+notEmpty
+	^ self isEmpty not
+%
+
+category: 'api - text style'
+method: GtPhlowText
+oblique
+	^ self addAttribute: GtPhlowFontEmphasisAttribute oblique
+%
+
+category: 'test - accessing'
+method: GtPhlowText
+size
+	^ self subclassResponsibility
+%
+
+category: 'accessing'
+method: GtPhlowText
+startIndex
+	^ self subclassResponsibility
+%
+
+category: 'api - text style'
+method: GtPhlowText
+thin
+	^ self addAttribute: GtPhlowFontWeightAttribute thin
+%
+
+! Class implementation for 'GtPhlowRunBasedText'
+
+!		Class methods for 'GtPhlowRunBasedText'
+
+category: 'instance creation'
+classmethod: GtPhlowRunBasedText
+fromJSONDictionary: aDictionary
+	^ self new
+		initializeFromJSONDictionary: aDictionary
+%
+
+category: 'accessing'
+classmethod: GtPhlowRunBasedText
+typeLabel
+	^ 'gtPhlowRunBasedText'
+%
+
+!		Instance methods for 'GtPhlowRunBasedText'
+
+category: 'comparing'
+method: GtPhlowRunBasedText
+= anObject
+	
+	self == anObject
+		ifTrue: [ ^ true ].
+	(anObject class = self class)
+		ifFalse: [ ^ false ].
+
+	^ self asString = anObject asString and: [
+		self attributeRuns = anObject attributeRuns ]
+%
+
+category: 'attributes'
+method: GtPhlowRunBasedText
+addAttribute: aPhlowAttribute from: aStartIndex to: anEndIndex
+	| targetRun | 
+	targetRun := attributeRuns 
+		detect: [ :aRunWithAttributes |
+			aRunWithAttributes startIndex = aStartIndex and: [
+				aRunWithAttributes endIndex = anEndIndex ] ] 
+		ifNone: [
+			| newRun |
+			newRun := (GtPhlowRun 
+				from: aStartIndex
+				to: anEndIndex
+				attributes: OrderedCollection new).
+			attributeRuns addRun: newRun.
+			newRun ].
+	targetRun addAttribute: aPhlowAttribute
+%
+
+category: 'converting'
+method: GtPhlowRunBasedText
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+	| dataForExport|
+	dataForExport := Dictionary new.
+	dataForExport
+		at: '__typeLabel' put: self class typeLabel;
+		at: 'sourceString' put: sourceString.
+	attributeRuns ifNotNil: [ :currentAttributeRuns | 
+		dataForExport
+			at: 'attributeRuns' 
+			put: currentAttributeRuns asDictionaryForExport ].
+
+	^ dataForExport
+%
+
+category: 'converting'
+method: GtPhlowRunBasedText
+asRopedText
+	^ self 
+		gtDo: [ 
+			(#GtRemotePhlowLocalTextAttributeRunsStyler asClass new 
+				attributeRuns: attributeRuns)
+					style: sourceString asRopedText]
+		gemstoneDo: [ self ]
+%
+
+category: 'converting'
+method: GtPhlowRunBasedText
+asString
+	^ sourceString
+%
+
+category: 'accessing'
+method: GtPhlowRunBasedText
+attributeRuns
+	^ attributeRuns
+%
+
+category: 'accessing'
+method: GtPhlowRunBasedText
+attributeRuns: anAttributeRuns
+	attributeRuns := anAttributeRuns
+%
+
+category: 'test - accessing'
+method: GtPhlowRunBasedText
+copyFrom: aStartIndex to: anEndIndex
+	"Create a copy of this text within a given indices interval.
+	Note: I am different from ==#from:to:== in a sense that I don't create a sub-text that points
+	to the original text, I create an independent copy which can be safely used in text editors and other tools."
+
+	<return: #BlText>
+	| result |
+	aStartIndex > anEndIndex ifTrue: [ 
+		^ self empty].
+	
+	result := self class
+		forString: (sourceString copyFrom: aStartIndex to: anEndIndex).
+		
+	self attributeRuns size > 0 ifTrue: [ 
+		result
+			attributeRuns: (self attributeRuns 
+				copyFrom: aStartIndex
+				to: anEndIndex) ].
+	^ result
+%
+
+category: 'test - accessing'
+method: GtPhlowRunBasedText
+empty
+	"Return a similar (the same backend data structure) but empty text"
+	<return: #BlText>
+	
+	^ self class forString: ''
+%
+
+category: 'accessing'
+method: GtPhlowRunBasedText
+endIndex
+	^ sourceString size
+%
+
+category: 'accessing'
+method: GtPhlowRunBasedText
+extractRemotePhlowRuns
+	^ self attributeRuns
+%
+
+category: 'accessing'
+method: GtPhlowRunBasedText
+forString: aString
+	^ self
+		initializeWithString: aString
+%
+
+category: 'test - accessing'
+method: GtPhlowRunBasedText
+from: aStart to: anEnd
+	"Create and return a subtext of this text form aStart to anEnd."
+	<return: #GtPhlowSubText>
+	
+	aStart <= (anEnd + 1) 
+		ifFalse: [ Error signal: 'Start must not exceed end' ].
+		
+	(self notEmpty or: [ aStart = 1 and: [ anEnd isZero ] ]) 
+		ifFalse: [ Error signal: 'If I am empty then start must be 1 and end must be zero' ].
+
+	^ GtPhlowSubText text: self from: aStart to: anEnd
+%
+
+category: 'gt - extensions'
+method: GtPhlowRunBasedText
+gtAttributeTreeFor: aView
+	<gtView>
+	| attributes |
+	attributes := Dictionary new.
+	attributeRuns runsDo: [ :aRun | 
+			aRun attributes
+				do: [ :each | 
+					| locations |
+					locations := attributes at: each ifAbsentPut: [ OrderedCollection new ].
+					(locations notEmpty and: [ locations last last + 1 = aRun startIndex ])
+						ifTrue: [ locations at: locations size put: (locations last first to: aRun endIndex) ]
+						ifFalse: [ locations add: (aRun startIndex to: aRun endIndex) ] ] ].
+	^ aView columnedTree
+		title: 'All attributes';
+		priority: 20;
+		items: [ attributes keys
+				asSortedCollection: [ :a :b | (attributes at: a) first first < (attributes at: b) first first ] ];
+		children: [ :each | attributes at: each ifAbsent: [ #() ] ];
+		column: 'Text'
+			text: [ :each | 
+				each class = Interval
+					ifTrue: [ (self copyFrom: each first to: each last) asRopedText ]
+					ifFalse: [ each printString ] ];
+		column: 'Interval'
+			text: [ :each | 
+				each class = Interval
+					ifTrue: [ each first printString , '-' , each last printString ]
+					ifFalse: [ '' ] ]
+			width: 80;
+		send: [ :each | 
+			each class = Interval
+				ifTrue: [ self from: (each first max: 1) to: each last ]
+				ifFalse: [ each ] ]
+%
+
+category: 'gt - extensions'
+method: GtPhlowRunBasedText
+gtViewIntervalsFor: aView
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Intervals';
+		priority: 10;
+		items: [ 
+			| collectedRuns |
+			collectedRuns := OrderedCollection new.
+			attributeRuns runsDo: [ :aRun |
+				collectedRuns add: aRun ].
+			collectedRuns ];
+		column: 'Interval' 
+			text: [ :aRun | aRun rangeDescription ]
+			width: 150;
+		column: 'Text' 
+			text: [ :aRun | 
+				self 
+					copyFrom: aRun startIndex
+					to: aRun endIndex ];
+		column: 'Attributes' 
+			text: [ :aRun | aRun attributesDescription ]
+%
+
+category: 'gt - extensions'
+method: GtPhlowRunBasedText
+gtViewPlainRunsFor: aView
+	<gtView>
+	
+	^ aView forward 
+		title: 'Plain Runs';
+		priority: 11;
+		object: [ attributeRuns ];
+		view: #gtViewIntervalsFor: 
+%
+
+category: 'comparing'
+method: GtPhlowRunBasedText
+hash
+	^ self asString hash 
+		bitXor: self attributeRuns hash
+%
+
+category: 'initialization'
+method: GtPhlowRunBasedText
+initializeFromJSONDictionary: aDictionary
+	self initializeWithString: (aDictionary at: 'sourceString').
+		
+	(aDictionary includesKey: 'attributeRuns') ifTrue: [
+		self attributeRuns: (GtPhlowRuns
+				fromJSONDictionary: (aDictionary at: 'attributeRuns')) ]
+%
+
+category: 'initialization'
+method: GtPhlowRunBasedText
+initializeWithString: aString 
+	sourceString := aString.
+	attributeRuns := GtPhlowRunsGroup new
+%
+
+category: 'printing'
+method: GtPhlowRunBasedText
+printOn: aStream
+	aStream 
+		<< 'Phlow Rope: ';
+		<< sourceString
+%
+
+category: 'test - accessing'
+method: GtPhlowRunBasedText
+size
+	^ sourceString size
+%
+
+category: 'accessing'
+method: GtPhlowRunBasedText
+startIndex
+	^ 1
+%
+
+! Class implementation for 'GtPhlowSubText'
+
+!		Class methods for 'GtPhlowSubText'
+
+category: 'instance creation'
+classmethod: GtPhlowSubText
+text: aPhlowText from: aStartIndex to: anEndIndex
+	(aPhlowText isKindOf: self) ifTrue: [
+		Error signal: 'Can not create sub text of a subtext' ].
+
+	^ self new
+		text: aPhlowText from: aStartIndex to: anEndIndex;
+		yourself
+%
+
+!		Instance methods for 'GtPhlowSubText'
+
+category: 'attributes'
+method: GtPhlowSubText
+addAttribute: aPhlowAttribute from: aStartIndex to: anEndIndex 
+	parentText 
+		addAttribute: aPhlowAttribute from: aStartIndex to: anEndIndex 
+%
+
+category: 'copy'
+method: GtPhlowSubText
+asRopedText
+	^ parentText copyFrom: startIndex to: endIndex
+%
+
+category: 'assertions'
+method: GtPhlowSubText
+assertInvariant
+	self assertStart: startIndex end: endIndex
+%
+
+category: 'assertions'
+method: GtPhlowSubText
+assertStart: aStartIndex end: anEndIndex
+	
+	aStartIndex = 0
+		ifTrue: [ Error signal: 'Start index must not be zero' ].
+
+	(aStartIndex between: 1 and: (parentText size + 1))
+		ifFalse: [Error signal: 'Sub-text start index is out of bounds'] .
+	(anEndIndex between: 0 and: parentText size) ifFalse: [ Error signal: 'Sub-text end index is out of bounds!'].
+	
+	(parentText notEmpty or: [ aStartIndex = 1 and: [ anEndIndex = 0 ] ]) 
+		ifFalse: [ Error signal: 'If text is empty, start must be 1 and end index must be Zero!' ].
+
+	(anEndIndex ~= 0  or: [ aStartIndex = 1 ])
+		ifFalse: [ Error signal: 'If end index is zero then start index must be 1' ]
+%
+
+category: 'copy'
+method: GtPhlowSubText
+asString
+	^ self asRopedText asString
+%
+
+category: 'accessing'
+method: GtPhlowSubText
+endIndex
+	^ endIndex
+%
+
+category: 'test - accessing'
+method: GtPhlowSubText
+from: aStart to: anEnd
+	self assertInvariant.
+	
+	(self notEmpty or: [ aStart = 1 and: [ anEnd isZero ] ])
+		ifFalse: [ Error signal: 'If I am empty then start must be 1 and end must be zero' ].
+	
+	^ parentText
+		from: ((aStart + startIndex - 1) max: 0)
+		to: ((anEnd + startIndex - 1) max: 0)
+%
+
+category: 'gt - extensions'
+method: GtPhlowSubText
+gtAttributeTreeFor: aView
+	<gtView>
+	
+	^ aView forward 
+		title: 'All attributes';
+		priority: 20;
+		object: [ self asRopedText ];
+		view: #gtAttributeTreeFor: 
+%
+
+category: 'accessing'
+method: GtPhlowSubText
+printOn: aStream
+	aStream 
+		<< 'Phlow SubText: ';
+		<< self asString
+%
+
+category: 'test - accessing'
+method: GtPhlowSubText
+size
+	self assertInvariant.
+
+	^ (startIndex = endIndex and: [ startIndex = 0 ])
+		ifTrue: [ 0 ]
+		ifFalse: [ endIndex - startIndex + 1 ]
+%
+
+category: 'accessing'
+method: GtPhlowSubText
+startIndex
+	^ startIndex
+%
+
+category: 'initialization'
+method: GtPhlowSubText
+text: aPhlowText from: aStartIndex to: anEndIndex 
+	startIndex := aStartIndex.
+	endIndex := anEndIndex.
+	parentText := aPhlowText.
+	
+	self assertInvariant
+%
+
+! Class implementation for 'GtPhlowTextAttribute'
+
+!		Class methods for 'GtPhlowTextAttribute'
+
+category: 'instance creation'
+classmethod: GtPhlowTextAttribute
+attibuteClassForType: aTypeLabel
+	self
+		allSubclassesDo: [ :each | each typeLabel = aTypeLabel ifTrue: [ ^ each ] ].
+	^ GtPhlowTextUnknownAttribute
+%
+
+category: 'instance creation'
+classmethod: GtPhlowTextAttribute
+fromJSONDictionary: aTextAttributeData 
+	| attributeType attributeClass |
+	attributeType :=  aTextAttributeData at: '__typeLabel'.
+ 	
+	attributeClass := self attibuteClassForType: attributeType.
+		
+	^ attributeType 
+		ifNil: [ 
+			GtPhlowTextUnknownAttribute new
+				rawData: aTextAttributeData ]
+		ifNotNil: [
+			attributeClass new
+				initializeFromJSONDictionary: aTextAttributeData  ]
+%
+
+category: 'accessing'
+classmethod: GtPhlowTextAttribute
+typeLabel
+	^ 'unknown'
+%
+
+!		Instance methods for 'GtPhlowTextAttribute'
+
+category: 'comparing'
+method: GtPhlowTextAttribute
+= anObject
+	"Return true if I am equal to a given object"
+	<return: #Boolean>
+	
+	self == anObject
+		ifTrue: [ ^ true ].
+	(anObject class = self class)
+		ifFalse: [ ^ false ].
+
+	^ self equals: anObject
+%
+
+category: 'styling'
+method: GtPhlowTextAttribute
+applyStyleToText: aText
+	self subclassResponsibility
+%
+
+category: 'converting'
+method: GtPhlowTextAttribute
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ Dictionary new 
+		at: '__typeLabel' put: self class typeLabel;
+		yourself
+%
+
+category: 'comparing'
+method: GtPhlowTextAttribute
+equals: anAttribute
+	^ anAttribute class = self class
+%
+
+category: 'comparing'
+method: GtPhlowTextAttribute
+hash
+	"Should be overriden by subclasses"
+	^ 31 hash
+%
+
+category: 'initialization'
+method: GtPhlowTextAttribute
+initializeFromJSONDictionary: aTextAttributeData 
+%
+
+! Class implementation for 'GtPhlowFontEmphasisAttribute'
+
+!		Class methods for 'GtPhlowFontEmphasisAttribute'
+
+category: 'instance creation'
+classmethod: GtPhlowFontEmphasisAttribute
+italic
+	^ self new 
+		emphasis: #italic
+%
+
+category: 'instance creation'
+classmethod: GtPhlowFontEmphasisAttribute
+normal
+	^ self new 
+		emphasis: #normal
+%
+
+category: 'instance creation'
+classmethod: GtPhlowFontEmphasisAttribute
+oblique
+	^ self new 
+		emphasis: #oblique
+%
+
+category: 'accessing'
+classmethod: GtPhlowFontEmphasisAttribute
+typeLabel
+	^ 'phlowFontEmphasisAttribute'
+%
+
+!		Instance methods for 'GtPhlowFontEmphasisAttribute'
+
+category: 'styling'
+method: GtPhlowFontEmphasisAttribute
+applyStyleToText: aText
+	aText perform: emphasis asSymbol
+%
+
+category: 'converting'
+method: GtPhlowFontEmphasisAttribute
+asDictionaryForExport
+	^ super asDictionaryForExport
+		at: 'emphasis' put: emphasis;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowFontEmphasisAttribute
+emphasis
+	^ emphasis
+%
+
+category: 'accessing'
+method: GtPhlowFontEmphasisAttribute
+emphasis: anObject
+	emphasis := anObject
+%
+
+category: 'comparing'
+method: GtPhlowFontEmphasisAttribute
+equals: anAnotherAttribute
+	^ self emphasis = anAnotherAttribute emphasis
+%
+
+category: 'comparing'
+method: GtPhlowFontEmphasisAttribute
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ super hash bitXor: self emphasis hash
+%
+
+category: 'initialization'
+method: GtPhlowFontEmphasisAttribute
+initializeFromJSONDictionary: aTextAttributeData
+	super initializeFromJSONDictionary: aTextAttributeData.
+	emphasis := aTextAttributeData at: 'emphasis'
+%
+
+category: 'printing'
+method: GtPhlowFontEmphasisAttribute
+printOn: aStream
+	aStream
+		nextPutAll: 'phlow font-emphasis: ';
+		nextPutAll: emphasis
+%
+
+! Class implementation for 'GtPhlowFontNameAttribute'
+
+!		Class methods for 'GtPhlowFontNameAttribute'
+
+category: 'accessing'
+classmethod: GtPhlowFontNameAttribute
+typeLabel
+	^ 'phlowFontNameAttribute'
+%
+
+!		Instance methods for 'GtPhlowFontNameAttribute'
+
+category: 'styling'
+method: GtPhlowFontNameAttribute
+applyStyleToText: aText
+	aText fontName: fontName
+%
+
+category: 'converting'
+method: GtPhlowFontNameAttribute
+asDictionaryForExport
+	^ super asDictionaryForExport
+		at: 'name' put: fontName;
+		yourself
+%
+
+category: 'comparing'
+method: GtPhlowFontNameAttribute
+equals: anAnotherAttribute
+	^ self fontName = anAnotherAttribute fontName
+%
+
+category: 'accessing'
+method: GtPhlowFontNameAttribute
+fontName
+	^ fontName
+%
+
+category: 'accessing'
+method: GtPhlowFontNameAttribute
+fontName: aString
+	fontName := aString
+%
+
+category: 'comparing'
+method: GtPhlowFontNameAttribute
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ super hash bitXor: self fontName hash
+%
+
+category: 'initialization'
+method: GtPhlowFontNameAttribute
+initializeFromJSONDictionary: aTextAttributeData
+	super initializeFromJSONDictionary: aTextAttributeData.
+	fontName := aTextAttributeData at: 'name'
+%
+
+category: 'printing'
+method: GtPhlowFontNameAttribute
+printOn: aStream
+	aStream
+		nextPutAll: 'phlow font-name: ';
+		nextPutAll: fontName
+%
+
+! Class implementation for 'GtPhlowFontSizeAttribute'
+
+!		Class methods for 'GtPhlowFontSizeAttribute'
+
+category: 'accessing'
+classmethod: GtPhlowFontSizeAttribute
+typeLabel
+	^ 'phlowFontSizeAttribute'
+%
+
+!		Instance methods for 'GtPhlowFontSizeAttribute'
+
+category: 'styling'
+method: GtPhlowFontSizeAttribute
+applyStyleToText: aText
+	aText fontSize: self sizeValue
+%
+
+category: 'converting'
+method: GtPhlowFontSizeAttribute
+asDictionaryForExport
+
+	^ super asDictionaryForExport
+		at: 'size' put: self sizeValue;
+		yourself
+%
+
+category: 'comparing'
+method: GtPhlowFontSizeAttribute
+equals: anAnotherAttribute
+	^ self sizeValue = anAnotherAttribute sizeValue
+%
+
+category: 'comparing'
+method: GtPhlowFontSizeAttribute
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ super hash bitXor: self sizeValue hash
+%
+
+category: 'initialization'
+method: GtPhlowFontSizeAttribute
+initializeFromJSONDictionary: aTextAttributeData 
+	super initializeFromJSONDictionary: aTextAttributeData .
+	
+	sizeValue := aTextAttributeData at: 'size'
+%
+
+category: 'printing'
+method: GtPhlowFontSizeAttribute
+printOn: aStream
+	aStream
+		nextPutAll: 'phlow font-size: ';
+		nextPutAll: self sizeValue asString
+%
+
+category: 'accessing'
+method: GtPhlowFontSizeAttribute
+sizeValue
+	^ sizeValue
+%
+
+category: 'accessing'
+method: GtPhlowFontSizeAttribute
+sizeValue: anInteger
+	sizeValue := anInteger
+%
+
+! Class implementation for 'GtPhlowFontWeightAttribute'
+
+!		Class methods for 'GtPhlowFontWeightAttribute'
+
+category: 'instance creation'
+classmethod: GtPhlowFontWeightAttribute
+bold
+	^ self new 
+		weight: #bold
+%
+
+category: 'instance creation'
+classmethod: GtPhlowFontWeightAttribute
+thin
+	^ self new 
+		weight: #thin
+%
+
+category: 'accessing'
+classmethod: GtPhlowFontWeightAttribute
+typeLabel
+	^ 'phlowFontWeightAttribute'
+%
+
+!		Instance methods for 'GtPhlowFontWeightAttribute'
+
+category: 'styling'
+method: GtPhlowFontWeightAttribute
+applyStyleToText: aText
+	aText perform: weight asSymbol
+%
+
+category: 'converting'
+method: GtPhlowFontWeightAttribute
+asDictionaryForExport
+	^ super asDictionaryForExport
+		at: 'weight' put: weight;
+		yourself
+%
+
+category: 'comparing'
+method: GtPhlowFontWeightAttribute
+equals: anAnotherAttribute
+	^ self weight = anAnotherAttribute weight
+%
+
+category: 'comparing'
+method: GtPhlowFontWeightAttribute
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ super hash bitXor: self weight hash
+%
+
+category: 'initialization'
+method: GtPhlowFontWeightAttribute
+initializeFromJSONDictionary: aTextAttributeData
+	super initializeFromJSONDictionary: aTextAttributeData.
+	weight := aTextAttributeData at: 'weight'
+%
+
+category: 'printing'
+method: GtPhlowFontWeightAttribute
+printOn: aStream
+	aStream
+		nextPutAll: 'phlow font-weight: ';
+		nextPutAll: weight
+%
+
+category: 'accessing'
+method: GtPhlowFontWeightAttribute
+weight
+	^ weight
+%
+
+category: 'accessing'
+method: GtPhlowFontWeightAttribute
+weight: anObject
+	weight := anObject
+%
+
+! Class implementation for 'GtPhlowTextColorAttribute'
+
+!		Instance methods for 'GtPhlowTextColorAttribute'
+
+category: 'styling'
+method: GtPhlowTextColorAttribute
+applyStyleToText: aText
+	aText highlight: self color
+%
+
+category: 'accessing'
+method: GtPhlowTextColorAttribute
+asDictionaryForExport
+	^ super asDictionaryForExport
+		at: 'color' put: self color asDictionaryForExport;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowTextColorAttribute
+color
+	^ color
+%
+
+category: 'accessing'
+method: GtPhlowTextColorAttribute
+color: anObject
+	color := anObject
+%
+
+category: 'comparing'
+method: GtPhlowTextColorAttribute
+equals: anAnotherAttribute
+	^ self color = anAnotherAttribute color
+%
+
+category: 'comparing'
+method: GtPhlowTextColorAttribute
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ super hash bitXor: self color hash
+%
+
+category: 'initialization'
+method: GtPhlowTextColorAttribute
+initializeFromJSONDictionary: aTextAttributeData
+	super initializeFromJSONDictionary: aTextAttributeData.
+	color := GtPhlowColor fromJSONDictionary: (aTextAttributeData at: 'color')
+%
+
+! Class implementation for 'GtPhlowTextForegroundAttribute'
+
+!		Class methods for 'GtPhlowTextForegroundAttribute'
+
+category: 'accessing'
+classmethod: GtPhlowTextForegroundAttribute
+typeLabel
+	^ 'phlowTextForegroundAttribute'
+%
+
+!		Instance methods for 'GtPhlowTextForegroundAttribute'
+
+category: 'styling'
+method: GtPhlowTextForegroundAttribute
+applyStyleToText: aText
+	aText foreground: self color asColor 
+%
+
+category: 'printing'
+method: GtPhlowTextForegroundAttribute
+printOn: aStream
+	aStream
+		nextPutAll: 'phlow text-foreground: ';
+		nextPutAll: self color printString
+%
+
+! Class implementation for 'GtPhlowTextHighlightAttribute'
+
+!		Class methods for 'GtPhlowTextHighlightAttribute'
+
+category: 'accessing'
+classmethod: GtPhlowTextHighlightAttribute
+typeLabel
+	^ 'phlowTextHighlightAttribute'
+%
+
+!		Instance methods for 'GtPhlowTextHighlightAttribute'
+
+category: 'styling'
+method: GtPhlowTextHighlightAttribute
+applyStyleToText: aText
+	aText highlight: self color asColor 
+%
+
+category: 'printing'
+method: GtPhlowTextHighlightAttribute
+printOn: aStream
+	aStream
+		nextPutAll: 'phlow text-background: ';
+		nextPutAll: self color printString
+%
+
+! Class implementation for 'GtPhlowTextDecorationAttribute'
+
+!		Class methods for 'GtPhlowTextDecorationAttribute'
+
+category: 'accessing'
+classmethod: GtPhlowTextDecorationAttribute
+new
+	^ self basicNew initialize
+%
+
+category: 'accessing'
+classmethod: GtPhlowTextDecorationAttribute
+typeLabel
+	^ #phlowTextDecorationAttribute
+%
+
+!		Instance methods for 'GtPhlowTextDecorationAttribute'
+
+category: 'styling'
+method: GtPhlowTextDecorationAttribute
+applyStyleToText: aText
+	aText decorationDo: [ :aTextDecorationAttribute |
+		decoration applyPropertiesTo: aTextDecorationAttribute ]
+%
+
+category: 'converting'
+method: GtPhlowTextDecorationAttribute
+asDictionaryForExport
+	^ super asDictionaryForExport
+		at: 'decoration' put: decoration asDictionaryForExport;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowTextDecorationAttribute
+color
+	^ decoration color
+%
+
+category: 'accessing'
+method: GtPhlowTextDecorationAttribute
+color: aColor
+	decoration color: aColor
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+dashed
+	decoration dashed
+%
+
+category: 'accessing'
+method: GtPhlowTextDecorationAttribute
+decoration
+	<return: #GtPhlowTextDecoration>
+
+	^ decoration
+%
+
+category: 'accessing'
+method: GtPhlowTextDecorationAttribute
+decoration: aGTPhlowTextDecoration
+	decoration := aGTPhlowTextDecoration
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+dotted
+	decoration dotted
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+double
+	decoration double
+%
+
+category: 'comparing'
+method: GtPhlowTextDecorationAttribute
+equals: anAnotherAttribute
+	^ self decoration = anAnotherAttribute decoration
+%
+
+category: 'initialization'
+method: GtPhlowTextDecorationAttribute
+initialize
+	super initialize.
+	
+	decoration := GtPhlowTextDecoration new
+%
+
+category: 'initialization'
+method: GtPhlowTextDecorationAttribute
+initializeFromJSONDictionary: aTextAttributeData
+	super initializeFromJSONDictionary: aTextAttributeData.
+	
+	decoration := GtPhlowTextDecoration 
+		fromJSONDictionary: (aTextAttributeData at: 'decoration')
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+lineThrough
+	decoration withLineThrough
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+overline
+	decoration withOverline
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+solid
+	decoration solid
+%
+
+category: 'accessing'
+method: GtPhlowTextDecorationAttribute
+thickness
+	^ decoration thickness
+%
+
+category: 'accessing'
+method: GtPhlowTextDecorationAttribute
+thickness: aNumber
+	decoration thickness: aNumber
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+underline
+	decoration withUnderline
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecorationAttribute
+wavy
+	decoration wavy
+%
+
+! Class implementation for 'GtPhlowTextUnknownAttribute'
+
+!		Class methods for 'GtPhlowTextUnknownAttribute'
+
+category: 'accessing'
+classmethod: GtPhlowTextUnknownAttribute
+typeLabel
+	^ 'phlowTextUnknownAttribute'
+%
+
+!		Instance methods for 'GtPhlowTextUnknownAttribute'
+
+category: 'styling'
+method: GtPhlowTextUnknownAttribute
+applyStyleToText: aText
+%
+
+category: 'comparing'
+method: GtPhlowTextUnknownAttribute
+equals: anAnotherAttribute
+	^ self rawData = anAnotherAttribute rawData
+%
+
+category: 'comparing'
+method: GtPhlowTextUnknownAttribute
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ super hash bitXor: self rawData hash
+%
+
+category: 'accessing'
+method: GtPhlowTextUnknownAttribute
+rawData
+	^ rawData
+%
+
+category: 'accessing'
+method: GtPhlowTextUnknownAttribute
+rawData: aTextStylerData 
+	rawData := aTextStylerData
+%
+
+! Class implementation for 'GtPhlowTextDecoration'
+
+!		Class methods for 'GtPhlowTextDecoration'
+
+category: 'instance creation'
+classmethod: GtPhlowTextDecoration
+fromJSONDictionary: aTextAttributeData 
+	^ self new
+		initializeFromJSONDictionary: aTextAttributeData  
+%
+
+category: 'accessing'
+classmethod: GtPhlowTextDecoration
+new
+	^ self basicNew initialize
+%
+
+!		Instance methods for 'GtPhlowTextDecoration'
+
+category: 'comparing'
+method: GtPhlowTextDecoration
+= anObject
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject
+		ifTrue: [ ^ true ].
+	self class = anObject class
+		ifFalse: [ ^ false ].
+		
+	^ color = anObject color
+		and: [ styleName = anObject styleName
+				and: [ thickness = anObject thickness 
+					and: [ typeNames = anObject typeNames ]  ] ]
+%
+
+category: 'styling'
+method: GtPhlowTextDecoration
+applyPropertiesTo: aBlTextDecorationAttribute
+	styleName ifNotNil: [
+		aBlTextDecorationAttribute perform: styleName asSymbol ].
+	typeNames do: [ :aTypeName | 
+		aBlTextDecorationAttribute perform: aTypeName asSymbol ].
+	color ifNotNil: [ :aColor |
+		aBlTextDecorationAttribute color: aColor asColor ].
+	thickness ifNotNil: [ :aNumber |
+		aBlTextDecorationAttribute thickness: aNumber ].
+%
+
+category: 'converting'
+method: GtPhlowTextDecoration
+asDictionaryForExport
+	| dictionaryForExport |
+	dictionaryForExport := Dictionary new.
+	
+	dictionaryForExport
+		at: 'styleName' put: self styleName;
+		at: 'typeNames' put: self typeNames asArray.
+		
+	self color ifNotNil: [
+		dictionaryForExport 
+			at: 'color' 
+			put: self color asDictionaryForExport ].
+	self thickness ifNotNil: [
+		dictionaryForExport 
+			at: 'thickness' 
+			put: self thickness ].
+		
+	^ dictionaryForExport
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+color
+	^ color
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+color: anObject
+	color := anObject
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+dashed
+	styleName := #dashed
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+dotted
+	styleName := #dotted
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+double
+	styleName := #double
+%
+
+category: 'gt - extensions'
+method: GtPhlowTextDecoration
+gtPreviewFor: aView
+	<gtView>
+
+	^ aView text
+		title: 'Preview';
+		priority: 1;
+		text: [
+			'Decoration' asRopedText
+				fontSize: 20;
+				decorationDo: [ :aTextDecorationAttribute | 
+					self applyPropertiesTo: aTextDecorationAttribute ] ]
+%
+
+category: 'comparing'
+method: GtPhlowTextDecoration
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ color hash
+		bitXor: (styleName hash 
+			bitXor: (thickness hash 
+				bitXor: typeNames hash))
+%
+
+category: 'initialization'
+method: GtPhlowTextDecoration
+initialize
+	super initialize.
+	
+	typeNames := Set new.
+	self solid.
+	thickness := 1.
+%
+
+category: 'initialization'
+method: GtPhlowTextDecoration
+initializeFromJSONDictionary: aTextDecorationData 
+	styleName := aTextDecorationData at: 'styleName'.
+	typeNames := (aTextDecorationData at: 'typeNames') asSet.
+	
+	aTextDecorationData at: 'color' ifPresent: [ :aColorData |
+		color := GtPhlowColor fromJSONDictionary: aColorData ].
+	aTextDecorationData at: 'thickness' ifPresent: [ :aNumber |
+		thickness := aNumber ].
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+solid
+	styleName := #solid
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+styleName
+	^ styleName
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+styleName: anObject
+	styleName := anObject
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+thickness
+	^ thickness
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+thickness: anObject
+	thickness := anObject
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+typeNames
+	^ typeNames
+%
+
+category: 'accessing'
+method: GtPhlowTextDecoration
+typeNames: anObject
+	typeNames := anObject
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+wavy
+	styleName := #wavy
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+withLineThrough
+	typeNames add: #lineThrough
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+withOverline
+	typeNames add: #overline
+%
+
+category: 'api - decoration'
+method: GtPhlowTextDecoration
+withUnderline
+	typeNames add: #underline
+%
+
+! Class implementation for 'GtPhlowTextHighlight'
+
+!		Class methods for 'GtPhlowTextHighlight'
+
+category: 'instance creation'
+classmethod: GtPhlowTextHighlight
+from: start to: end
+	^ self new
+		startPosition: start;
+		endPosition: end;
+		yourself
+%
+
+category: 'instance creation'
+classmethod: GtPhlowTextHighlight
+from: start to: end with: aColor
+	^ self new
+		startPosition: start;
+		endPosition: end;
+		color: aColor;
+		yourself
+%
+
+category: 'instance creation'
+classmethod: GtPhlowTextHighlight
+fromJSONDictionary: aDictionary
+	^ self new
+		startPosition: (aDictionary at: 'startPosition');
+		endPosition: (aDictionary at: 'endPosition');
+		color: (aDictionary
+				at: 'color'
+				ifPresent: [ :dict | (GtPhlowColor fromJSONDictionary: dict) asColor ]
+				ifAbsent: [  ]);
+		yourself
+%
+
+!		Instance methods for 'GtPhlowTextHighlight'
+
+category: 'accessing'
+method: GtPhlowTextHighlight
+asDictionaryForExport
+	| dict |
+	dict := Dictionary new.
+	dict at: 'startPosition' put: self startPosition.
+	dict at: 'endPosition' put: self endPosition.
+	color
+		ifNotNil: [ dict
+				at: 'color'
+				put: (GtPhlowColor
+						r: color red
+						g: color green
+						b: color blue
+						alpha: color alpha) asDictionaryForExport ].
+	^ dict
+%
+
+category: 'accessing'
+method: GtPhlowTextHighlight
+color
+	^ color
+%
+
+category: 'accessing'
+method: GtPhlowTextHighlight
+color: anObject
+	color := anObject
+%
+
+category: 'accessing'
+method: GtPhlowTextHighlight
+endPosition
+	^ endPosition
+%
+
+category: 'accessing'
+method: GtPhlowTextHighlight
+endPosition: anObject
+	endPosition := anObject
+%
+
+category: 'accessing'
+method: GtPhlowTextHighlight
+startPosition
+	^ startPosition
+%
+
+category: 'accessing'
+method: GtPhlowTextHighlight
+startPosition: anObject
+	startPosition := anObject
+%
+
+! Class implementation for 'GtPhlowViewSpecification'
+
+!		Class methods for 'GtPhlowViewSpecification'
+
+category: 'data transport'
+classmethod: GtPhlowViewSpecification
+dataIncluded
+	"Answer the enumerated value for the display data being included with the specification"
+
+	^1
+%
+
+category: 'data transport'
+classmethod: GtPhlowViewSpecification
+dataLazy
+	"Answer the enumerated value for the display data accessor name being included with the specification.  This can then be used to retrieve the data at a later time"
+
+	^2
+%
+
+category: 'instance creation'
+classmethod: GtPhlowViewSpecification
+fromJSONDictionary: aDictionary
+	"Answer an instance of the receiver from the supplied dictionary.
+	Subclasses will override this to add their specific attributes"
+
+	^self new 
+		title: (aDictionary at: 'title');
+		priority: (aDictionary at: 'priority');
+		dataTransport: (aDictionary at: 'dataTransport');
+		methodSelector: (aDictionary at: 'methodSelector');
+		phlowDataSource: (aDictionary 
+			at: 'phlowDataSource' ifAbsent: [ nil ]);
+		yourself
+%
+
+!		Instance methods for 'GtPhlowViewSpecification'
+
+category: 'converting'
+method: GtPhlowViewSpecification
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ Dictionary new 
+		at: 'viewName' put: self viewName;
+		at: '__typeName' put: self class name;
+		at: 'title' put: title;
+		at: 'priority' put: priority;
+		at: 'dataTransport' put: dataTransport;
+		at: 'methodSelector' put: methodSelector;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+dataTransport
+	^ dataTransport
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+dataTransport: anObject
+	dataTransport := anObject
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+definingMethod
+	^ phlowDataSource ifNotNil: [ :aDataSource | 
+		aDataSource definingMethod ]
+%
+
+category: 'initialization'
+method: GtPhlowViewSpecification
+initializeFromInspector: anInspector
+%
+
+category: 'testing'
+method: GtPhlowViewSpecification
+isWithLazyLoading
+	^ self dataTransport = self class dataLazy
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+methodSelector
+	^ methodSelector
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+methodSelector: aSelector
+	methodSelector := aSelector
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+phlowDataSource
+	^ phlowDataSource
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+phlowDataSource: aDataSource
+	phlowDataSource := aDataSource
+%
+
+category: 'printing'
+method: GtPhlowViewSpecification
+printOn: aStream
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' (';
+		nextPutAll: self title;
+		nextPutAll: ', ';
+		nextPutAll: self priority asString;
+		nextPutAll: ')'
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+priority
+	^ priority
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+priority: anObject
+	priority := anObject
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+title
+	^ title
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+title: anObject
+	title := anObject
+%
+
+category: 'accessing'
+method: GtPhlowViewSpecification
+viewName
+	"Answer the name of the receivers view"
+
+	^self class name
+%
+
+! Class implementation for 'GtPhlowEmptyViewSpecification'
+
+!		Class methods for 'GtPhlowEmptyViewSpecification'
+
+category: 'as yet unclassified'
+classmethod: GtPhlowEmptyViewSpecification
+fromJSONDictionary: aDictionary
+	"Answer an instance of the receiver from the supplied dictionary.
+	Subclasses will override this to add their specific attributes"
+
+	^ self new
+%
+
+!		Instance methods for 'GtPhlowEmptyViewSpecification'
+
+category: 'as yet unclassified'
+method: GtPhlowEmptyViewSpecification
+viewFor: aView
+	"Answer the GtPhlowView for the receiver. We use a forwarder view as
+	a way to delegate the creation of the remote view back to this specification."
+
+	^ aView empty
+%
+
+! Class implementation for 'GtPhlowForwardViewSpecification'
+
+!		Instance methods for 'GtPhlowForwardViewSpecification'
+
+category: 'api - accessing'
+method: GtPhlowForwardViewSpecification
+getDeclarativeViewFor: aViewSelector
+	"This provides the same API as the inspector proxy, so that view 
+	specifications can define a single method for initializing the link 
+	between the local and the remote instance of the specification."
+	
+	^ self phlowDataSource
+		getDeclarativeViewFor: aViewSelector
+%
+
+category: 'initialization'
+method: GtPhlowForwardViewSpecification
+initializeFromInspector: anInspector
+	self phlowDataSource ifNil: [
+		self phlowDataSource: (anInspector 
+			getDeclarativeViewFor: self methodSelector) ]
+%
+
+category: 'api - accessing'
+method: GtPhlowForwardViewSpecification
+loadViewSpecificationForForwarding
+	| declarativeViewData declarativeView |
+	
+	declarativeViewData := self retrieveViewSpecificationForForwarding.
+	declarativeView := GtPhlowViewSpecification fromDictionary: declarativeViewData.
+	
+	"At this point we need to configure the specification for new view
+	just like the inspector does it when retrieveing views. This links the
+	local instance of the specification with a proxy to the remote instance."
+	declarativeView
+		initializeFromInspector: self.
+				
+	^ declarativeView
+%
+
+category: 'api - accessing'
+method: GtPhlowForwardViewSpecification
+retrieveForwardTargetDataSource
+	"This retrieves directly the datasource for the forwarded view."
+	^ self phlowDataSource
+		retrieveForwardTargetDataSource
+%
+
+category: 'api - accessing'
+method: GtPhlowForwardViewSpecification
+retrieveViewSpecificationForForwarding
+	^ self phlowDataSource
+		retrieveViewSpecificationForForwarding
+%
+
+! Class implementation for 'GtPhlowListingViewSpecification'
+
+!		Instance methods for 'GtPhlowListingViewSpecification'
+
+category: 'api - accessing'
+method: GtPhlowListingViewSpecification
+flushItemsIterator 
+
+	phlowDataSource flushItemsIterator
+%
+
+category: 'initialization'
+method: GtPhlowListingViewSpecification
+initializeFromInspector: anInspector
+	self phlowDataSource ifNil: [
+		self phlowDataSource: (anInspector 
+			getDeclarativeViewFor: self methodSelector) ]
+%
+
+category: 'accessing'
+method: GtPhlowListingViewSpecification
+retrieveFormattedItems
+	^ self phlowDataSource 
+		retrieveItems: self totalItemsCount fromIndex: 1
+%
+
+category: 'api - accessing'
+method: GtPhlowListingViewSpecification
+retrieveItems: anItemsCount fromIndex: anIndex
+	^ self phlowDataSource 
+		retrieveItems: anItemsCount fromIndex: anIndex
+%
+
+category: 'accessing'
+method: GtPhlowListingViewSpecification
+retrieveItemsFromIndex: anIndex
+	^ self retrieveItems: 100 fromIndex: anIndex
+%
+
+category: 'api - accessing'
+method: GtPhlowListingViewSpecification
+retrieveSentItemAt: aSelectionIndex
+	^ self phlowDataSource retrieveSentItemAt: aSelectionIndex
+%
+
+category: 'api - accessing'
+method: GtPhlowListingViewSpecification
+retrieveTotalItemsCount
+	^ self phlowDataSource retrieveTotalItemsCount
+%
+
+category: 'accessing'
+method: GtPhlowListingViewSpecification
+retriveFormattedItems
+	^ self phlowDataSource 
+		retrieveItems: self totalItemsCount fromIndex: 1
+%
+
+category: 'api - accessing'
+method: GtPhlowListingViewSpecification
+retriveSentItemAt: aSelectionIndex
+	^ self phlowDataSource retriveSentItemAt: aSelectionIndex
+%
+
+category: 'accessing'
+method: GtPhlowListingViewSpecification
+totalItemsCount
+	^ totalItemsCount ifNil: [ 
+		totalItemsCount := self phlowDataSource retrieveTotalItemsCount ]
+%
+
+! Class implementation for 'GtPhlowBasicColumnedViewSpecification'
+
+!		Class methods for 'GtPhlowBasicColumnedViewSpecification'
+
+category: 'instance creation'
+classmethod: GtPhlowBasicColumnedViewSpecification
+fromJSONDictionary: aDictionary
+
+	| list |
+
+	list := super fromJSONDictionary: aDictionary.
+	list
+		columnSpecifications: ((aDictionary at: 'columnSpecifications')
+			collect: [ :aColumnSpecificationJson |
+				GtRemotePhlowColumnSpecification 
+					fromJSONDictionary: aColumnSpecificationJson ]).
+	
+	^list
+%
+
+!		Instance methods for 'GtPhlowBasicColumnedViewSpecification'
+
+category: 'converting'
+method: GtPhlowBasicColumnedViewSpecification
+asDictionaryForExport 
+	^ super asDictionaryForExport 
+		at: 'columnSpecifications' put: (self columnSpecifications
+			collect: [ :aColumnSpecification |
+				aColumnSpecification asDictionaryForExport ]);
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowBasicColumnedViewSpecification
+columnSpecifications
+	^ columnSpecifications
+%
+
+category: 'accessing'
+method: GtPhlowBasicColumnedViewSpecification
+columnSpecifications: anObject
+	columnSpecifications := anObject
+%
+
+category: 'accessing'
+method: GtPhlowBasicColumnedViewSpecification
+columnTitles
+	^ self columnSpecifications collect: [ :aColumnSpecification |
+		aColumnSpecification title ]
+%
+
+category: 'accessing'
+method: GtPhlowBasicColumnedViewSpecification
+columnTypes
+	^ self columnSpecifications collect: [ :aColumnSpecification |
+		aColumnSpecification type ]
+%
+
+category: 'accessing'
+method: GtPhlowBasicColumnedViewSpecification
+columnWidths
+	^ self columnSpecifications collect: [ :aColumnSpecification |
+		aColumnSpecification cellWidth ]
+%
+
+category: 'gt - extensions'
+method: GtPhlowBasicColumnedViewSpecification
+gtViewColumnSpecificationFor: aView
+	<gtView>
+	
+	self columnSpecifications ifNil:  [
+		^ aView empty ].
+	
+	^ aView columnedList
+		title: 'Column Specifications';
+		priority: 20;
+		items: [ self columnSpecifications ];
+		column: 'Title' text: [ :aColumnSpecification | 
+			aColumnSpecification title ];
+		column: 'Type' text: [ :aColumnSpecification | 
+			aColumnSpecification type ]
+%
+
+category: 'api - accessing'
+method: GtPhlowBasicColumnedViewSpecification
+retriveSpawnedObjectAtRow: aRowIndex column: aColumnIndex	
+	^ self phlowDataSource 
+		retriveSpawnedObjectAtRow: aRowIndex column: aColumnIndex
+%
+
+! Class implementation for 'GtPhlowColumnedListViewSpecification'
+
+!		Class methods for 'GtPhlowColumnedListViewSpecification'
+
+category: 'instance creation'
+classmethod: GtPhlowColumnedListViewSpecification
+fromJSONDictionary: aDictionary
+	^ (super fromJSONDictionary: aDictionary)
+		horizontalScrollingEnabled: (aDictionary 
+			at: 'horizontalScrollingEnabled' 
+			ifAbsent: [ nil ])
+%
+
+!		Instance methods for 'GtPhlowColumnedListViewSpecification'
+
+category: 'converting'
+method: GtPhlowColumnedListViewSpecification
+asDictionaryForExport 
+	^ super asDictionaryForExport 
+		at: 'horizontalScrollingEnabled' put: horizontalScrollingEnabled;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowColumnedListViewSpecification
+horizontalScrollingEnabled
+	^ horizontalScrollingEnabled
+%
+
+category: 'accessing'
+method: GtPhlowColumnedListViewSpecification
+horizontalScrollingEnabled: aBoolean
+	horizontalScrollingEnabled := aBoolean
+%
+
+category: 'accessing'
+method: GtPhlowColumnedListViewSpecification
+isHorizontalScrollingEnabled
+	^ self horizontalScrollingEnabled ifNil: [ false ]
+%
+
+! Class implementation for 'GtPhlowColumnedTreeViewSpecification'
+
+!		Instance methods for 'GtPhlowColumnedTreeViewSpecification'
+
+category: 'api - accessing'
+method: GtPhlowColumnedTreeViewSpecification
+retrieveChildrenForNodeAtPath: aNodePath
+	^ self phlowDataSource 
+		retrieveChildrenForNodeAtPath: aNodePath
+%
+
+category: 'api - accessing'
+method: GtPhlowColumnedTreeViewSpecification
+retrieveSentItemAtPath: aNodePath
+	^ self phlowDataSource 
+		retrieveSentItemAtPath:aNodePath
+%
+
+category: 'api - accessing'
+method: GtPhlowColumnedTreeViewSpecification
+retriveSentItemAtPath: aNodePath
+	^ self phlowDataSource 
+		retriveSentItemAtPath:aNodePath
+%
+
+! Class implementation for 'GtPhlowListViewSpecification'
+
+!		Class methods for 'GtPhlowListViewSpecification'
+
+category: 'instance creation'
+classmethod: GtPhlowListViewSpecification
+fromJSONDictionary: aDictionary
+	| list |
+
+	list := super fromJSONDictionary: aDictionary.
+	^list
+%
+
+!		Instance methods for 'GtPhlowListViewSpecification'
+
+category: 'converting'
+method: GtPhlowListViewSpecification
+asDictionaryForExport 
+
+	| dictionary |
+
+	dictionary := super asDictionaryForExport.
+	"self dataTransport = self class dataIncluded ifTrue: [ 
+		dictionary at: #items put: self retriveFormattedItems ]."
+	^dictionary
+%
+
+! Class implementation for 'GtPhlowTreeViewSpecification'
+
+!		Instance methods for 'GtPhlowTreeViewSpecification'
+
+category: 'api - accessing'
+method: GtPhlowTreeViewSpecification
+retrieveChildrenForNodeAtPath: aNodePath
+	^ self phlowDataSource 
+		retrieveChildrenForNodeAtPath: aNodePath
+%
+
+category: 'api - accessing'
+method: GtPhlowTreeViewSpecification
+retrieveSentItemAtPath: aNodePath
+	^ self phlowDataSource 
+		retrieveSentItemAtPath: aNodePath
+%
+
+category: 'api - accessing'
+method: GtPhlowTreeViewSpecification
+retriveSentItemAtPath: aNodePath
+	^ self phlowDataSource 
+		retriveSentItemAtPath: aNodePath
+%
+
+! Class implementation for 'GtPhlowTextualViewSpecification'
+
+!		Instance methods for 'GtPhlowTextualViewSpecification'
+
+category: 'api - accessing'
+method: GtPhlowTextualViewSpecification
+getText
+	^ self phlowDataSource getText
+%
+
+category: 'initialization'
+method: GtPhlowTextualViewSpecification
+initializeFromInspector: anInspector
+	self dataTransport = self class dataIncluded ifTrue: [ ^ self ].
+	
+	self phlowDataSource ifNil: [
+		self phlowDataSource: (anInspector 
+			getDeclarativeViewFor: self methodSelector) ]
+%
+
+category: 'api - accessing'
+method: GtPhlowTextualViewSpecification
+retrieveStylableText
+	^ self phlowDataSource retrieveStylableText
+%
+
+! Class implementation for 'GtPhlowTextEditorViewSpecification'
+
+!		Class methods for 'GtPhlowTextEditorViewSpecification'
+
+category: 'instance creation'
+classmethod: GtPhlowTextEditorViewSpecification
+fromJSONDictionary: aDictionary
+	| editorViewSpecification |
+	
+	editorViewSpecification := super fromJSONDictionary: aDictionary.
+	
+	editorViewSpecification dataTransport = self dataIncluded
+		ifTrue: [ 
+			editorViewSpecification string: (aDictionary at: 'string').
+			aDictionary
+				at: 'textStylerSpecification'
+				ifPresent: [ :aTextStylerSpecificationData | 
+					editorViewSpecification
+						textStylerSpecification: (#GtRemotePhlowTextStylerSpecification asClass
+								fromJSONDictionary: aTextStylerSpecificationData) ] ]
+		ifFalse: [ 
+			(aDictionary includesKey: 'dataSource') ifTrue: [
+				editorViewSpecification phlowDataSource: (aDictionary at: 'dataSource')] ].
+	
+	^ editorViewSpecification
+%
+
+!		Instance methods for 'GtPhlowTextEditorViewSpecification'
+
+category: 'converting'
+method: GtPhlowTextEditorViewSpecification
+asDictionaryForExport 
+	| dictionary |
+
+	dictionary := super asDictionaryForExport.
+	self dataTransport = self class dataIncluded ifTrue: [ 
+		dictionary at: 'string' put: string.
+		textStylerSpecification ifNotNil: [
+			dictionary 
+				at: 'textStylerSpecification'
+				put: textStylerSpecification asDictionaryForExport ] ].
+	
+	^ dictionary
+%
+
+category: 'accessing'
+method: GtPhlowTextEditorViewSpecification
+string
+
+	^ string "ifNil: [ 
+		(string isNil and: [ dataTransport = self class dataLazy ]) ifTrue: 
+			[ string := accessor data ] ]."
+%
+
+category: 'accessing'
+method: GtPhlowTextEditorViewSpecification
+string: anObject
+	string := anObject
+%
+
+category: 'accessing'
+method: GtPhlowTextEditorViewSpecification
+textStylerSpecification: aTextAttributeRuns
+	textStylerSpecification := aTextAttributeRuns
+%
+
+! Class implementation for 'GtPhlowTextViewSpecification'
+
+!		Class methods for 'GtPhlowTextViewSpecification'
+
+category: 'instance creation'
+classmethod: GtPhlowTextViewSpecification
+fromJSONDictionary: aDictionary
+	| textViewSpecification |
+	
+	textViewSpecification := super fromJSONDictionary: aDictionary.
+	
+	textViewSpecification dataTransport = self dataLazy
+		ifTrue: [ 
+			(aDictionary includesKey: 'dataSource') ifTrue: [
+				textViewSpecification phlowDataSource: (aDictionary at: 'dataSource')] ].
+	
+	^ textViewSpecification
+%
+
+! Class implementation for 'GtPhlowViewErrorViewSpecification'
+
+!		Class methods for 'GtPhlowViewErrorViewSpecification'
+
+category: 'instance creation'
+classmethod: GtPhlowViewErrorViewSpecification
+fromJSONDictionary: aDictionary
+
+	^ (super fromJSONDictionary: aDictionary)
+		errorMessage: (aDictionary at: 'errorMessage' ifAbsent: [ nil ])
+%
+
+!		Instance methods for 'GtPhlowViewErrorViewSpecification'
+
+category: 'converting'
+method: GtPhlowViewErrorViewSpecification
+asDictionaryForExport 
+	^ super asDictionaryForExport
+		at: 'errorMessage' put: errorMessage;
+		yourself
+%
+
+category: 'accessing'
+method: GtPhlowViewErrorViewSpecification
+errorMessage
+	^ errorMessage
+%
+
+category: 'accessing'
+method: GtPhlowViewErrorViewSpecification
+errorMessage: anObject
+	errorMessage := anObject
+%
+
+! Class implementation for 'GtRemotePhlowAction'
+
+!		Class methods for 'GtRemotePhlowAction'
+
+category: 'accessing'
+classmethod: GtRemotePhlowAction
+handledExceptions
+	"Explicitly catch here Halt and Warning as in case an action raising 
+	those exceptions is embedded in the debugger it will trigger an
+	infinite chain of debuggers.
+	https://github.com/feenkcom/gtoolkit/issues/4383"
+	
+	^ Error, Halt, Warning
+%
+
+!		Instance methods for 'GtRemotePhlowAction'
+
+category: 'accessing'
+method: GtRemotePhlowAction
+asGtDeclarativeAction
+	^ nil
+%
+
+category: 'message performing'
+method: GtRemotePhlowAction
+basicOn: anObject perform: aMessageSymbol withArguments: aCollectionOfArguments 
+	^ anObject  
+		perform: aMessageSymbol
+		with: aCollectionOfArguments first
+%
+
+category: 'decorating'
+method: GtRemotePhlowAction
+button
+	^ GtRemotePhlowButtonAction new
+%
+
+category: 'testing'
+method: GtRemotePhlowAction
+canBeGtDeclarativeAction
+	^ true
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+definingClass
+	^ definingClass
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+definingClass: aClass
+	definingClass := aClass
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+definingMethod
+	^ (self definingClass whichClassIncludesSelector: self definingSelector) 
+		ifNil: [ nil ]
+		ifNotNil: [ :aClass | aClass compiledMethodAt: self definingSelector ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+definingSelector
+
+	^ definingSelector
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+definingSelector: aSelector
+
+	definingSelector := aSelector
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+id
+	^ id
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+id: anId
+	id := anId
+%
+
+category: 'decorating'
+method: GtRemotePhlowAction
+noAction
+	^ GtRemotePhlowNoAction new
+%
+
+category: 'message performing'
+method: GtRemotePhlowAction
+on: anObject perform: aMessageSymbol 
+	<return: #GtRemotePhlowAction>
+	
+	^ self 
+		on: anObject 
+		perform: aMessageSymbol 
+		withArguments: { self }
+%
+
+category: 'message performing'
+method: GtRemotePhlowAction
+on: anObject perform: aMessageSymbol withArguments: aCollectionOfArguments
+	<return: #GtRemotePhlowAction>
+	
+	^ [ 
+			self 
+				basicOn: anObject 
+				perform: aMessageSymbol 
+				withArguments: aCollectionOfArguments
+		
+	] 
+		on: self class handledExceptions do: [ :anException |
+			self 
+				phlowErrorActionWithException: anException 
+				forBuildContext: nil "(GtPhlowBuildContext new 
+					object: anObject; 
+					arguments: aCollectionOfArguments) "
+				andSelector: aMessageSymbol ]
+%
+
+category: 'error handling'
+method: GtRemotePhlowAction
+phlowErrorActionWithException: anException 
+	^ GtRemotePhlowErrorAction new
+		errorMessage: anException description
+%
+
+category: 'error handling'
+method: GtRemotePhlowAction
+phlowErrorActionWithException: anException forBuildContext: aContext andSelector: aMessageSymbol
+	| phlowErrorAction | 
+
+	phlowErrorAction := self phlowErrorActionWithException: anException.
+	
+	"aPhlow buildContext: aContext.
+	aPhlow failedComputation: aFailedComputation."
+
+	^ phlowErrorAction
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+priority
+	^ priority
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+priority: aNumber
+	priority := aNumber
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+tooltip: aTextOrString
+	self tooltipText: aTextOrString
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+tooltipText
+	^ tooltipText
+%
+
+category: 'accessing'
+method: GtRemotePhlowAction
+tooltipText: aTextOrString
+	tooltipText := aTextOrString
+%
+
+! Class implementation for 'GtRemotePhlowButtonAction'
+
+!		Instance methods for 'GtRemotePhlowButtonAction'
+
+category: 'accessing'
+method: GtRemotePhlowButtonAction
+action: aValuable
+	actionBlock := aValuable
+%
+
+category: 'accessing'
+method: GtRemotePhlowButtonAction
+actionBlock
+	^ actionBlock
+%
+
+category: 'converting'
+method: GtRemotePhlowButtonAction
+asGtDeclarativeAction
+	^ GtPhlowButtonActionSpecification new
+		priority: self priority;
+		tooltipText: self tooltipText;
+		label: self label;
+		iconStencil: self iconStencil;
+		phlowDataSource: (GtRemotePhlowDeclarativeBlockActionDataSource new
+			phlowAction: self;
+			targetBlock: self actionBlock)
+%
+
+category: 'accessing'
+method: GtRemotePhlowButtonAction
+icon: anIconStencil
+	iconStencil := anIconStencil
+%
+
+category: 'accessing'
+method: GtRemotePhlowButtonAction
+iconStencil
+	^ iconStencil
+%
+
+category: 'initialization'
+method: GtRemotePhlowButtonAction
+initialize
+	super initialize.
+
+	actionBlock := [ :aButton | 
+		"do nothing" ].
+%
+
+category: 'accessing'
+method: GtRemotePhlowButtonAction
+label
+	^ label
+%
+
+category: 'accessing'
+method: GtRemotePhlowButtonAction
+label: aStringOrText
+	label := aStringOrText
+%
+
+! Class implementation for 'GtRemotePhlowErrorAction'
+
+!		Instance methods for 'GtRemotePhlowErrorAction'
+
+category: 'converting'
+method: GtRemotePhlowErrorAction
+asGtDeclarativeAction
+	^ GtPhlowErrorActionSpecification new
+		priority: self priority;
+		errorMessage: self errorMessage;
+		tooltipText: self tooltipText
+%
+
+category: 'accessing'
+method: GtRemotePhlowErrorAction
+errorMessage
+	^ errorMessage
+%
+
+category: 'accessing'
+method: GtRemotePhlowErrorAction
+errorMessage: aStringMessage
+	errorMessage := aStringMessage
+%
+
+! Class implementation for 'GtRemotePhlowApiWrapper'
+
+!		Instance methods for 'GtRemotePhlowApiWrapper'
+
+category: 'accessing'
+method: GtRemotePhlowApiWrapper
+currentAction
+	^ currentAction
+%
+
+category: 'accessing'
+method: GtRemotePhlowApiWrapper
+phlow 
+	^ self
+%
+
+category: 'accessing'
+method: GtRemotePhlowApiWrapper
+spawnObject: anObject
+	currentAction := GtRemotePhlowSpawnObjectAction forObject: anObject
+%
+
+! Class implementation for 'GtRemotePhlowCollectionIterator'
+
+!		Class methods for 'GtRemotePhlowCollectionIterator'
+
+category: 'as yet unclassified'
+classmethod: GtRemotePhlowCollectionIterator
+forCollection: aCollection
+	^ self new
+		targetCollection: aCollection
+%
+
+!		Instance methods for 'GtRemotePhlowCollectionIterator'
+
+category: 'converting'
+method: GtRemotePhlowCollectionIterator
+asGPhlowItemsIterator
+	^ self
+%
+
+category: 'iterating'
+method: GtRemotePhlowCollectionIterator
+forElementsFrom: startIndex to: endIndex withIndexDo: aBlock
+	self subclassResponsibility
+%
+
+category: 'iterating'
+method: GtRemotePhlowCollectionIterator
+retrieveAllItems
+	^ self 
+		retrieveItems: self totalItemsCount
+		fromIndex: 1
+%
+
+category: 'iterating'
+method: GtRemotePhlowCollectionIterator
+retrieveItems: anItemsCount fromIndex: startIndex
+	| computedElements endIndex |
+
+	computedElements := OrderedCollection new: anItemsCount.
+	endIndex := startIndex + anItemsCount - 1.
+	
+	self 
+		forElementsFrom: startIndex 
+		to: endIndex 
+		withIndexDo: [ :anItem :anIndex |
+			computedElements add: anItem ].
+	
+	^ computedElements asArray
+%
+
+category: 'accessing'
+method: GtRemotePhlowCollectionIterator
+targetCollection: aCollection
+	targetCollection := aCollection
+%
+
+category: 'accessing'
+method: GtRemotePhlowCollectionIterator
+totalItemsCount
+	^ targetCollection 
+		ifNil: [ 0 ] 
+		ifNotNil:  [ :aCollection | aCollection size ]
+%
+
+! Class implementation for 'GtRemotePhlowSequenceableCollectionIterator'
+
+!		Instance methods for 'GtRemotePhlowSequenceableCollectionIterator'
+
+category: 'iterating'
+method: GtRemotePhlowSequenceableCollectionIterator
+forElementsFrom: startIndex to: endIndex withIndexDo: aBlock
+	| limitedStartIndex limitedEndIndex |
+	
+	limitedStartIndex := 1 max: startIndex.
+	limitedEndIndex := targetCollection size min: endIndex.
+	limitedStartIndex to: limitedEndIndex do: [ :anIndex |
+		aBlock value: (targetCollection at: anIndex) value: anIndex ]
+%
+
+! Class implementation for 'GtRemotePhlowUnindexedCollectionIterator'
+
+!		Instance methods for 'GtRemotePhlowUnindexedCollectionIterator'
+
+category: 'iterating'
+method: GtRemotePhlowUnindexedCollectionIterator
+forElementsFrom: startIndex to: endIndex withIndexDo: aBlock
+	| limitedStartIndex limitedEndIndex iterationIndex|
+	
+	limitedStartIndex := 1 max: startIndex.
+	limitedEndIndex := targetCollection size min: endIndex.
+	
+	iterationIndex := 1.
+	targetCollection perform: self iterationSelector with: [ :anElement |
+		"Terminate the iteration if the last element was visited."
+		iterationIndex > limitedEndIndex ifTrue: [ ^ self ].
+		
+		"While between the start and stop indexes visit each element."
+		iterationIndex >= limitedStartIndex ifTrue: [ aBlock value: anElement value: iterationIndex ].
+		iterationIndex := iterationIndex + 1 ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowUnindexedCollectionIterator
+iterationSelector
+	self subclassResponsibility
+%
+
+! Class implementation for 'GtRemotePhlowDictionaryAssociationsIterator'
+
+!		Instance methods for 'GtRemotePhlowDictionaryAssociationsIterator'
+
+category: 'accessing'
+method: GtRemotePhlowDictionaryAssociationsIterator
+iterationSelector
+	^ #associationsDo:
+%
+
+! Class implementation for 'GtRemotePhlowDictionaryKeysIterator'
+
+!		Instance methods for 'GtRemotePhlowDictionaryKeysIterator'
+
+category: 'accessing'
+method: GtRemotePhlowDictionaryKeysIterator
+iterationSelector
+	^ #keysDo:
+%
+
+! Class implementation for 'GtRemotePhlowGenericCollectionIterator'
+
+!		Instance methods for 'GtRemotePhlowGenericCollectionIterator'
+
+category: 'accessing'
+method: GtRemotePhlowGenericCollectionIterator
+iterationSelector
+	^ #do:
+%
+
+! Class implementation for 'GtRemotePhlowPluggableCollectionIterator'
+
+!		Instance methods for 'GtRemotePhlowPluggableCollectionIterator'
+
+category: 'accessing'
+method: GtRemotePhlowPluggableCollectionIterator
+iterationSelector
+	^ iterationSelector
+%
+
+category: 'accessing'
+method: GtRemotePhlowPluggableCollectionIterator
+iterationSelector: aSelector
+	iterationSelector := aSelector
+%
+
+! Class implementation for 'GtRemotePhlowColumn'
+
+!		Class methods for 'GtRemotePhlowColumn'
+
+category: 'testing'
+classmethod: GtRemotePhlowColumn
+isAbstract
+	^ self name = #GtRemotePhlowColumn
+%
+
+!		Instance methods for 'GtRemotePhlowColumn'
+
+category: 'converting'
+method: GtRemotePhlowColumn
+asGtDeclarativeColumnDataType
+	^ self subclassResponsibility
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowColumn
+background: aComputation
+	backgroundComputation := aComputation
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+backgroundComputation
+	^ backgroundComputation
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+cellWidth
+	^ width
+%
+
+category: 'computation'
+method: GtRemotePhlowColumn
+computeItemValuesFor: anObject rowIndex: rowIndex columnIndex: columnIndex
+	| cellValue itemValue |
+	cellValue := self createRemotePhlowCellValue.
+	
+	itemValue := self itemComputation 
+		cull: anObject cull: rowIndex cull: columnIndex.
+		
+	self 
+		updateValue: cellValue 
+		forComputedItem: itemValue 
+		rowIndex: rowIndex 
+		columnIndex: columnIndex.
+	
+	self hasBackgroundComputation ifTrue: [
+		cellValue 
+			background: (self backgroundComputation
+				cull: itemValue cull: anObject cull: rowIndex cull: columnIndex) ].
+	
+	^ cellValue
+%
+
+category: 'computation'
+method: GtRemotePhlowColumn
+createRemotePhlowCellValue
+	^ GtRemotePhlowItemTextualValue new
+%
+
+category: 'testing'
+method: GtRemotePhlowColumn
+hasBackgroundComputation
+	^ backgroundComputation notNil
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+index
+	^ index
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+index: aColumnIndex
+	index := aColumnIndex
+%
+
+category: 'testing'
+method: GtRemotePhlowColumn
+isSpawningObject
+	^ false
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+item: anItemComputation
+	itemComputation := anItemComputation
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+itemComputation
+	^ itemComputation ifNil: [ 
+		itemComputation := [ :item | item ] ]
+%
+
+category: 'computation'
+method: GtRemotePhlowColumn
+phlowTextOrStringFrom: aComputedItem 
+	^ aComputedItem isString
+		ifTrue: [ aComputedItem ]
+		ifFalse: [ aComputedItem gtDisplayText ]
+%
+
+category: 'private - accessing'
+method: GtRemotePhlowColumn
+rowStencil
+	^ nil
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+title
+	^ title
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowColumn
+title: anObject
+	title := anObject
+%
+
+category: 'computation'
+method: GtRemotePhlowColumn
+updateValue: aCellValue forComputedItem: aComputedItem rowIndex: rowIndex columnIndex: columnIndex
+	aCellValue 
+		itemText: (self phlowTextOrStringFrom: aComputedItem).
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumn
+width: aCellWidth
+	width := aCellWidth
+%
+
+! Class implementation for 'GtRemotePhlowExplicitColumn'
+
+!		Instance methods for 'GtRemotePhlowExplicitColumn'
+
+category: 'converting'
+method: GtRemotePhlowExplicitColumn
+asGtDeclarativeColumnDataType
+	^ type ifNil: [
+		GtPhlowDeclarativeListingType unknown ]
+%
+
+category: 'configuration'
+method: GtRemotePhlowExplicitColumn
+iconName: aBlock
+	self item: aBlock.
+	type := GtPhlowDeclarativeListingType iconName
+%
+
+category: 'testing'
+method: GtRemotePhlowExplicitColumn
+isSpawningObject
+	^ self asGtDeclarativeColumnDataType isTextLinkListingType
+%
+
+category: 'accessing'
+method: GtRemotePhlowExplicitColumn
+spawnObjectComputation
+	"If nil, the cell does not spawn an object"
+
+	^ spawnObjectComputation
+%
+
+category: 'configuration'
+method: GtRemotePhlowExplicitColumn
+text: aBlock
+	self item: aBlock.
+	type := GtPhlowDeclarativeListingType text
+%
+
+category: 'configuration'
+method: GtRemotePhlowExplicitColumn
+text: aBlock spawn: aSpawnObjectComputation
+	"aSpawnObjectComputation should return an Object that should be spawned when clicked on:
+		- a link button if the column data type is #text
+		- a link icon if the column data type is #icon.
+
+	Setting a spawnObject influences how a cell is rendered"
+	
+	self item: aBlock.
+	spawnObjectComputation := aSpawnObjectComputation.
+	type := GtPhlowDeclarativeListingType textLink
+%
+
+! Class implementation for 'GtRemotePhlowTypedColumn'
+
+!		Class methods for 'GtRemotePhlowTypedColumn'
+
+category: 'testing'
+classmethod: GtRemotePhlowTypedColumn
+isAbstract
+	^ self name = #GtRemotePhlowTypedColumn
+%
+
+! Class implementation for 'GtRemotePhlowIconNameColumn'
+
+!		Class methods for 'GtRemotePhlowIconNameColumn'
+
+category: 'testing'
+classmethod: GtRemotePhlowIconNameColumn
+isAbstract
+	^ self name = #GtRemotePhlowIconNameColumn
+%
+
+!		Instance methods for 'GtRemotePhlowIconNameColumn'
+
+category: 'accessing'
+method: GtRemotePhlowIconNameColumn
+iconName: anIconNameComputation
+	iconNameComputation := anIconNameComputation
+%
+
+category: 'accessing'
+method: GtRemotePhlowIconNameColumn
+iconNameComputation
+	^ iconNameComputation
+%
+
+category: 'computation'
+method: GtRemotePhlowIconNameColumn
+updateValue: aCellValue forComputedItem: aComputedItem rowIndex: rowIndex columnIndex: columnIndex
+	| itemText |
+	
+	itemText := self iconNameComputation 
+		ifNil: [ aComputedItem ]
+		ifNotNil: [ :anIconNameComputation |
+			anIconNameComputation
+				cull: aComputedItem
+				cull: rowIndex 
+				cull: columnIndex ].
+				
+	aCellValue 
+		itemText: itemText gtDisplayString.
+%
+
+! Class implementation for 'GtRemotePhlowThemeIconNameColumn'
+
+!		Instance methods for 'GtRemotePhlowThemeIconNameColumn'
+
+category: 'accessing'
+method: GtRemotePhlowThemeIconNameColumn
+asGtDeclarativeColumnDataType
+	^ GtPhlowDeclarativeListingType iconName
+%
+
+! Class implementation for 'GtRemotePhlowNumberColumn'
+
+!		Instance methods for 'GtRemotePhlowNumberColumn'
+
+category: 'converting'
+method: GtRemotePhlowNumberColumn
+asGtDeclarativeColumnDataType
+	^ GtPhlowDeclarativeListingType number
+%
+
+category: 'configuration'
+method: GtRemotePhlowNumberColumn
+format: aBlock
+	formatComputation := aBlock
+%
+
+category: 'accessing'
+method: GtRemotePhlowNumberColumn
+formatComputation
+	^ formatComputation
+%
+
+category: 'computation'
+method: GtRemotePhlowNumberColumn
+updateValue: aCellValue forComputedItem: aComputedItem rowIndex: rowIndex columnIndex: columnIndex
+	| itemText |
+	
+	itemText := self formatComputation 
+		ifNil: [ aComputedItem ]
+		ifNotNil: [ :aFomattingComputation |
+			aFomattingComputation
+				cull: aComputedItem
+				cull: rowIndex 
+				cull: columnIndex ].
+				
+	aCellValue 
+		itemText: (self phlowTextOrStringFrom: itemText).
+%
+
+! Class implementation for 'GtRemotePhlowTextColumn'
+
+!		Instance methods for 'GtRemotePhlowTextColumn'
+
+category: 'converting'
+method: GtRemotePhlowTextColumn
+asGtDeclarativeColumnDataType
+	^ GtPhlowDeclarativeListingType text
+%
+
+category: 'configuration'
+method: GtRemotePhlowTextColumn
+format: aBlock
+	formatComputation := aBlock
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextColumn
+formatComputation
+	^ formatComputation
+%
+
+category: 'computation'
+method: GtRemotePhlowTextColumn
+updateValue: aCellValue forComputedItem: aComputedItem rowIndex: rowIndex columnIndex: columnIndex
+	| itemText |
+	
+	itemText := self formatComputation 
+		ifNil: [ aComputedItem ]
+		ifNotNil: [ :aFomattingComputation |
+			aFomattingComputation
+				cull: aComputedItem
+				cull: rowIndex 
+				cull: columnIndex ].
+	
+	aCellValue 
+		itemText: (self phlowTextOrStringFrom: itemText).
+%
+
+! Class implementation for 'GtRemotePhlowColumnSpecification'
+
+!		Class methods for 'GtRemotePhlowColumnSpecification'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowColumnSpecification
+fromJSONDictionary: aDictionary
+	| column |
+
+	column := self new.
+	column
+		title: (aDictionary at: #title);
+		cellWidth: (aDictionary at: #cellWidth);
+		type: (self instantiateTypeFrom: (aDictionary at: #type));
+		spawnsObjects: (aDictionary at: #spawnsObjects);
+		properties: (aDictionary at: #properties) asOrderedCollection.
+		
+	^column
+%
+
+category: 'instance creation'
+classmethod: GtRemotePhlowColumnSpecification
+instantiateTypeFrom: aValue
+	 ^ GtPhlowDeclarativeListingType forTypeLabel: aValue
+%
+
+!		Instance methods for 'GtRemotePhlowColumnSpecification'
+
+category: 'conversion'
+method: GtRemotePhlowColumnSpecification
+asDictionaryForExport 
+	| dictionary |
+
+	dictionary := Dictionary new 
+		at: #title put: title;
+		at: #cellWidth put: cellWidth;
+		at: #type put: type typeLabel;
+		at: #spawnsObjects put: spawnsObjects;
+		at: #properties put: self properties asArray;
+		yourself.
+
+	^ dictionary
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+cellWidth
+	^ cellWidth
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+cellWidth: anObject
+	cellWidth := anObject
+%
+
+category: 'testing'
+method: GtRemotePhlowColumnSpecification
+hasBackground
+	^ self hasPropertyNamed: #background
+%
+
+category: 'testing'
+method: GtRemotePhlowColumnSpecification
+hasPropertyNamed: aString 
+	^ self properties includes: #background
+%
+
+category: 'testing'
+method: GtRemotePhlowColumnSpecification
+isTextSpawn
+	^ self spawnsObjects and: [
+		self type isText ]
+%
+
+category: 'testing'
+method: GtRemotePhlowColumnSpecification
+markAsHavingBackground
+	self markAsHavingPropertyNamed: #background
+%
+
+category: 'testing'
+method: GtRemotePhlowColumnSpecification
+markAsHavingPropertyNamed: aSymbol 
+	(self hasPropertyNamed:  aSymbol) ifTrue: [ ^ self ].
+	
+	self properties add: aSymbol
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		aStream << self title.
+		self type ifNotNil: [
+			aStream 
+				<< ', ';
+				<< self type typeLabel ]]
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+properties
+	^ properties ifNil: [ 
+		properties := OrderedCollection new ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+properties: anObject
+	properties := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+spawnsObjects
+	^ spawnsObjects
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+spawnsObjects: anObject
+	spawnsObjects := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+title
+	^ title
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+title: anObject
+	title := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+type
+	^ type
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+type: anObject
+	type := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnSpecification
+typeLabel
+	^ self type typeLabel
+%
+
+! Class implementation for 'GtRemotePhlowDataNode'
+
+!		Class methods for 'GtRemotePhlowDataNode'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowDataNode
+fromJSONDictionary: aDictionary
+	"Answer an instance of the receiver from the supplied dictionary."
+
+	^self new 
+		nodeId: (aDictionary at: #nodeId ifAbsent: [ nil ]);
+		nodeValue: (aDictionary 
+			at: #nodeValue 
+			ifPresent: [ :aNodeValueDictionary |
+				self valueType fromJSONDictionary: aNodeValueDictionary ]
+			ifAbsent: [ nil ]);
+		yourself
+%
+
+category: 'accessing'
+classmethod: GtRemotePhlowDataNode
+valueType
+	^ GtRemotePhlowItemValue
+%
+
+!		Instance methods for 'GtRemotePhlowDataNode'
+
+category: 'accessing'
+method: GtRemotePhlowDataNode
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation"
+
+	| data| 
+	
+	data := Dictionary new 
+		at: #nodeId put: self nodeId;
+		at: #nodeValue put: self nodeValue asDictionaryForExport;
+		yourself.
+	
+	^ data
+%
+
+category: 'comparing'
+method: GtRemotePhlowDataNode
+matchesNodeContentWith: aNode
+	self class = aNode class ifFalse: [ ^ false].
+	
+	^ (self nodeId = aNode nodeId) and: [
+		self nodeValue = aNode nodeValue and: [
+			self targetObject = aNode targetObject ] ] 
+%
+
+category: 'accessing'
+method: GtRemotePhlowDataNode
+nodeId
+	^ nodeId
+%
+
+category: 'accessing'
+method: GtRemotePhlowDataNode
+nodeId: anObject
+	nodeId := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowDataNode
+nodeValue
+	^ nodeValue
+%
+
+category: 'accessing'
+method: GtRemotePhlowDataNode
+nodeValue: anObject
+	nodeValue := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowDataNode
+targetObject
+	^ targetObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowDataNode
+targetObject: anObject
+	targetObject := anObject
+%
+
+! Class implementation for 'GtRemotePhlowTreeNode'
+
+!		Instance methods for 'GtRemotePhlowTreeNode'
+
+category: 'converting'
+method: GtRemotePhlowTreeNode
+asDictionaryForExport
+	| exportDictionary  |
+	exportDictionary := super asDictionaryForExport.
+
+	self childNodes ifNotNil: [ :aCollection |
+		exportDictionary 
+			at: #childNodes 
+			put: (aCollection
+				collect: [ :aChildNode | aChildNode asDictionaryForExport ])].
+	
+	^ exportDictionary
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeNode
+childNodes
+	^ childNodes
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeNode
+childNodes: aCollectionOfNodes
+	aCollectionOfNodes do: [ :aChildNode | 
+		aChildNode parentNode ifNotNil: [ 
+			Error signal: 'Parent must be nil.' ].
+		aChildNode parentNode: self ].
+	
+	childNodes := aCollectionOfNodes.
+%
+
+category: 'gt - extensions'
+method: GtRemotePhlowTreeNode
+gtViewChildrenFor: aView 
+	<gtView>
+	childNodes ifNil: [ ^ aView empty ].
+	
+	^ aView columnedTree
+		title: 'Child Nodes';
+		items: [ childNodes ];
+		children: [ :aNode | 
+			aNode childNodes ifNil: [ #() ] ];
+		column: 'Path' text: [ :aNode | 
+			aNode nodePathDescription  ] width: 100;
+		column: 'Id' text: [ :aNode | aNode nodeId ] width: 100;
+		column: 'Value' text: [ :aNode | aNode nodeValue ]
+%
+
+category: 'comparing'
+method: GtRemotePhlowTreeNode
+matchesNodeContentWith: aNode
+	(super matchesNodeContentWith: aNode) ifFalse: [ ^ false ].
+	
+	(self parentNode
+		ifNil: [ aNode parentNode isNil ]
+		ifNotNil: [ :aParentNode |
+			aParentNode matchesNodeContentWith: aNode parentNode ]) ifFalse: [ ^ false ].
+			
+	self childNodes 
+		ifNil: [ ^ aNode childNodes isNil ].
+	self childNodes size = aNode childNodes size ifFalse: [ ^ false ].
+	
+	self childNodes withIndexDo: [ :aChildNode :anIndex |
+		(aChildNode matchesNodeContentWith: (aNode childNodes at: anIndex))
+			ifFalse: [ ^ false ] ].
+			
+	^ true
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeNode
+nodePath
+	^ Array streamContents: [ :aStream | 
+		  self withParentNodesDo: [ :eachNode | aStream nextPut: eachNode nodeId ] ] 
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeNode
+nodePathDescription
+	^ String streamContents: [ :aStream |
+		self printNodePathOn: aStream ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeNode
+parentNode
+	^ parentNode
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeNode
+parentNode: anObject
+	parentNode := anObject
+%
+
+category: 'printing'
+method: GtRemotePhlowTreeNode
+printNodePathOn: aStream
+	self nodePath 
+		do: [:elem | aStream nextPutAll: elem asString]
+		separatedBy: [aStream nextPutAll: '/'] 
+%
+
+category: 'printing'
+method: GtRemotePhlowTreeNode
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [ 
+		self nodePath 
+			do: [:elem | aStream nextPutAll: elem asString]
+			separatedBy: [aStream nextPutAll: '/'] ]
+%
+
+category: 'traversing'
+method: GtRemotePhlowTreeNode
+withParentNodesDo: aBlock
+
+	self parentNode ifNotNil: [ :aParentNode | 
+		aParentNode withParentNodesDo: aBlock ].
+
+	aBlock cull: self
+%
+
+! Class implementation for 'GtRemotePhlowColumnedTreeNode'
+
+!		Class methods for 'GtRemotePhlowColumnedTreeNode'
+
+category: 'accessing'
+classmethod: GtRemotePhlowColumnedTreeNode
+valueType
+	^ GtRemotePhlowRowValue
+%
+
+!		Instance methods for 'GtRemotePhlowColumnedTreeNode'
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeNode
+columnValueAt: anIndex
+	^ self nodeValue columnValueAt: anIndex
+%
+
+category: 'gt - extensions'
+method: GtRemotePhlowColumnedTreeNode
+gtViewColumnValuesFor: aView
+	<gtView>
+	
+	^ aView forward
+		title: 'Column Values';
+		priority: 10;
+		object: [ self nodeValue ];
+		view: #gtViewColumnValuesFor:
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeActionDataSource'
+
+!		Class methods for 'GtRemotePhlowDeclarativeActionDataSource'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowDeclarativeActionDataSource
+forPhlowAction: aPhlowAction
+	^ self new
+		phlowAction: aPhlowAction
+%
+
+!		Instance methods for 'GtRemotePhlowDeclarativeActionDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeActionDataSource
+phlowAction: aPhlowAction 
+	phlowAction := aPhlowAction 
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeBlockActionDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeBlockActionDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeBlockActionDataSource
+executeRemoteActionWithPhlowResult
+	| phlowApiWrapper |
+	
+	phlowApiWrapper := self phlowApiWrapper.
+	self targetBlock value: phlowApiWrapper.
+	
+	^ phlowApiWrapper currentAction asDictionaryForExport
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeBlockActionDataSource
+phlowApiWrapper
+	^ GtRemotePhlowApiWrapper new
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeBlockActionDataSource
+targetBlock
+	^ targetBlock
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeBlockActionDataSource
+targetBlock: aBlockClosure
+	targetBlock := aBlockClosure
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeErrorTestInspectable'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeErrorTestInspectable'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtButtonErrorActionFor: anAction
+	<gtAction>
+	
+	1/0.
+	^ anAction button
+		tooltip: 'Inspect objects';
+		priority: 10;
+		label: 'Inspect';
+		action: [ :aButton |
+			aButton phlow 
+				spawnObject: {1 . 2} ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtColumnedListWithFormatErrorsFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Columned list - format error';
+		priority: 20;
+		items: [ 1 to: 4 ];
+		column: 'Value' text: [ :item | 
+			item < 3 ifTrue: [ 1/ 0]. 
+			item ];
+		column: 'Lowercase' text: [ :item | 
+			item = 2 ifTrue: [ 1/ 0].
+			item asString asLowercase ] width: 100.
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtForwardListWithFormatErrorsFor: aView
+	<gtView>
+
+	^aView forward
+		title: 'Forward List - with format errors';
+		priority: 45;
+		object: [ self ];
+		view: #gtListWithFormatErrors:
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtForwardListWithIFormatErrorsFor: aView
+	<gtView>
+
+	^aView forward
+		title: 'Forward List - with format errors';
+		priority: 45;
+		object: [ self ];
+		view: #gtListWithFormatErrors:
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtForwardListWithItemsErrorsFor: aView
+	<gtView>
+
+	^aView forward
+		title: 'Forward List - with item errors';
+		priority: 45;
+		object: [ self ];
+		view: #gtListWithItemsErrors:
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtListWithFormatErrors: aView
+	<gtView>
+
+	^aView list
+		title: 'List - with format errors';
+		priority: 15;
+		items: [ 1 to: 4 ];
+		itemText: [ :item | item < 3 ifTrue: [ 1/ 0]. item ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtListWithItemsErrors: aView
+	<gtView>
+
+	^aView list
+		title: 'List - with item errors';
+		priority: 15;
+		items: [ 1/0. 1 to: 4 ];
+		itemText: [ :item | item ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtStringWithTextErrorFor: aView
+	<gtView>
+	
+	^aView textEditor
+		title: 'String - with text error';
+		priority: 10;
+		text: [ 1/0 . 'text value' ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtTreeWithChildrenErrorsFor: aView
+	<gtView>
+
+	^aView tree
+		title: 'Tree - with children errors';
+		priority: 30;
+		items: [ 1 to: 5 ];
+		children: [ :aNumber | 
+			1/0 . 
+			(aNumber // 2 = aNumber)
+				ifTrue: [ #() ] 
+				ifFalse: [
+					aNumber // 2 to: (aNumber - 1) ] ];
+		itemText: [ :x | 
+			x asString, ' number']
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtTreeWithFormatErrorsFor: aView
+	<gtView>
+
+	^aView tree
+		title: 'Tree - with format errors';
+		priority: 30;
+		items: [ 1 to: 5 ];
+		children: [ :aNumber | 
+			(aNumber // 2 = aNumber)
+				ifTrue: [ #() ] 
+				ifFalse: [
+					aNumber // 2 to: (aNumber - 1) ] ];
+		itemText: [ :x | 
+			x < 3 ifTrue: [ 1/ 0]. 
+			x asString, ' number']
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeErrorTestInspectable
+gtTreeWithItemsErrorsFor: aView
+	<gtView>
+
+	^aView tree
+		title: 'Tree - with item errors';
+		priority: 30;
+		items: [ 1/0 . 1 to: 5 ];
+		children: [ :aNumber | 
+			(aNumber // 2 = aNumber)
+				ifTrue: [ #() ] 
+				ifFalse: [
+					aNumber // 2 to: (aNumber - 1) ] ];
+		itemText: [ :x | 
+			x asString, ' number']
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeExamples'
+
+!		Class methods for 'GtRemotePhlowDeclarativeExamples'
+
+category: 'testing'
+classmethod: GtRemotePhlowDeclarativeExamples
+isAbstract
+	^ self name = #GtRemotePhlowDeclarativeExamples
+%
+
+!		Instance methods for 'GtRemotePhlowDeclarativeExamples'
+
+category: 'private'
+method: GtRemotePhlowDeclarativeExamples
+basicServer
+	^ server
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeExamples
+basicServer: aServer
+	server := aServer
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeExamples
+getRemoteObject
+	^ self subclassResponsibility
+%
+
+category: 'examples'
+method: GtRemotePhlowDeclarativeExamples
+remoteObject
+	"Answer the remote GtRemotePhlowDeclarativeTestInspectable instance.
+	This will be a proxy with a remote server."
+
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| remoteObject collection |
+	remoteObject := self getRemoteObject.
+
+	self assert: remoteObject string equals: 'hello world'.
+
+	collection := remoteObject collectionOfObjects.	"Check the size and immediate value objects, but assume that proxies are working correctly"
+	self assert: collection size equals: 3.
+	self assert: collection first equals: 42.
+	self assert: collection second equals: 'Hello World'.
+
+	^ remoteObject
+%
+
+category: 'examples'
+method: GtRemotePhlowDeclarativeExamples
+remotePhlowSpecificationsProvider
+	"Answer the object for returning phlow specifications for the object"
+
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider declarativeViews |
+	phlowSpecificationsProvider := self retrieveRemotePhlowSpecificationsProvider.	"The set of views can vary depending on configuration,
+	just check that a common view is present."
+	declarativeViews := phlowSpecificationsProvider getDeclarativeViewMethodNames.
+	self assert: (declarativeViews includes: #gtListFor:).
+
+	^ phlowSpecificationsProvider
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeExamples
+retrieveRemotePhlowSpecificationsProvider
+	"Answer the object that will be used to get phlow specifications"
+
+	^ GtRemotePhlowViewedObject object: self remoteObject.
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeExamples
+runningServer
+	"Answer a running server.
+	No server is required running the examples in a single image.
+	Subclasses should overwrite this to start the server"
+
+	<gtExample>
+	<after: #stopServer>
+	<return: #GtRemotePhlowDeclarativeExamples>
+	
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeExamples
+stopServer 
+
+	server ifNotNil: 
+		[ server stop.
+		server := nil ]
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeActionsExamples'
+
+!		Class methods for 'GtRemotePhlowDeclarativeActionsExamples'
+
+category: 'testing'
+classmethod: GtRemotePhlowDeclarativeActionsExamples
+isAbstract
+	^ self name = #GtRemotePhlowDeclarativeActionsExamples
+%
+
+!		Instance methods for 'GtRemotePhlowDeclarativeActionsExamples'
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeActionsExamples
+assertActionResultForDatasource: actionDatasource
+	| actionResult |
+	actionResult := GtRemotePhlowNavigationAction
+			navigationActionFromDictionary: actionDatasource executeRemoteActionWithPhlowResult.
+	self assert: actionResult targetObject notNil
+%
+
+category: 'examples - actions'
+method: GtRemotePhlowDeclarativeActionsExamples
+buttonActionWithIcon
+	<gtExample>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider actionSpeficificationData actionSpecification actionDatasource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	actionSpeficificationData := phlowSpecificationsProvider
+			getActionSpecificationDataFor: #gtButtonActionWithIconFor:.
+	actionSpecification := GtPhlowActionSpecification
+			phlowActionFromDictionary: actionSpeficificationData.
+
+	self assert: actionSpecification label equals: nil.
+	self assert: actionSpecification priority equals: 11.
+	self
+		assert: actionSpecification iconStencil
+		equals: (GtPhlowGlamorousVectorIconNameStencil forIconName: #playinspect).
+	self assert: actionSpecification tooltipText equals: 'Inspect objects'.
+	self assert: actionSpecification phlowDataSource equals: nil.
+	self
+		assert: actionSpecification methodSelector
+		equals: #gtButtonActionWithIconFor:.
+
+	actionDatasource := phlowSpecificationsProvider
+			getDeclarativeActionDataSourceFor: #gtButtonActionWithIconFor:.
+
+	self assertActionResultForDatasource: actionDatasource.
+
+	^ actionSpecification
+%
+
+category: 'examples - actions'
+method: GtRemotePhlowDeclarativeActionsExamples
+buttonActionWithIconAndLabel
+	<gtExample>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider actionSpeficificationData actionSpecification actionDatasource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	actionSpeficificationData := phlowSpecificationsProvider
+			getActionSpecificationDataFor: #gtButtonActionWithBothIconAndLabelFor:.
+	actionSpecification := GtPhlowActionSpecification
+			phlowActionFromDictionary: actionSpeficificationData.
+
+	self assert: actionSpecification label equals: 'Inspect'.
+	self assert: actionSpecification priority equals: 12.
+	self
+		assert: actionSpecification iconStencil
+		equals: (GtPhlowGlamorousVectorIconNameStencil forIconName: #playinspect).
+	self assert: actionSpecification tooltipText equals: 'Inspect objects'.
+	self assert: actionSpecification phlowDataSource equals: nil.
+	self
+		assert: actionSpecification methodSelector
+		equals: #gtButtonActionWithBothIconAndLabelFor:.
+
+	actionDatasource := phlowSpecificationsProvider
+			getDeclarativeActionDataSourceFor: #gtButtonActionWithBothIconAndLabelFor:.
+
+	self assertActionResultForDatasource: actionDatasource.
+
+	^ actionSpecification
+%
+
+category: 'examples - actions'
+method: GtRemotePhlowDeclarativeActionsExamples
+buttonActionWithLabel
+	<gtExample>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider actionSpeficificationData actionSpecification actionDatasource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	actionSpeficificationData := phlowSpecificationsProvider
+			getActionSpecificationDataFor: #gtButtonActionWithLabelFor:.
+	actionSpecification := GtPhlowActionSpecification
+			phlowActionFromDictionary: actionSpeficificationData.
+
+	self assert: actionSpecification label equals: 'Inspect 1'.
+	self assert: actionSpecification priority equals: 10.
+	self assert: actionSpecification iconStencil equals: nil.
+	self assert: actionSpecification tooltipText equals: 'Inspect objects'.
+	self assert: actionSpecification phlowDataSource equals: nil.
+	self
+		assert: actionSpecification methodSelector
+		equals: #gtButtonActionWithLabelFor:.
+
+	actionDatasource := phlowSpecificationsProvider
+			getDeclarativeActionDataSourceFor: #gtButtonActionWithLabelFor:.
+
+	self assertActionResultForDatasource: actionDatasource.
+
+	^ actionSpecification
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples'
+
+!		Class methods for 'GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples'
+
+category: 'testing'
+classmethod: GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples
+isAbstract
+	^ self name = #GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples
+%
+
+!		Instance methods for 'GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeActionsDirectViewedObjectExamples
+getRemoteObject
+
+	^ GtRemotePhlowDeclarativeTestInspectable new
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeActionsLocalViewedObjectExamples'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeActionsLocalViewedObjectExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeActionsLocalViewedObjectExamples
+remoteViewedObject
+	^ GtRemotePhlowViewedObject object: self remoteObject.
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeActionsRemoteViewedObjectExamples'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeActionsRemoteViewedObjectExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeActionsRemoteViewedObjectExamples
+retrieveRemotePhlowSpecificationsProvider
+	"Answer the GtRemotePhlowViewedObject proxy for the remote object"
+
+	^ GtRemotePhlowViewedObject object: self remoteObject.
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeActionsProxySimulationExamples'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeActionsProxySimulationExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeActionsProxySimulationExamples
+remoteObject
+	<gtExample>
+	<after: #stopServer>
+	<return: #GtRemoteInspectionSimulation>
+	| remoteObject |
+	remoteObject := self getRemoteObject.
+
+	^ remoteObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeActionsProxySimulationExamples
+retrieveRemotePhlowSpecificationsProvider
+
+	self remoteObject 
+		remoteInspectorProxyDo: [ :aProxy | ^ aProxy ].
+	^ nil
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewsExamples'
+
+!		Class methods for 'GtRemotePhlowDeclarativeViewsExamples'
+
+category: 'testing'
+classmethod: GtRemotePhlowDeclarativeViewsExamples
+isAbstract
+	^ self name = #GtRemotePhlowDeclarativeViewsExamples
+%
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewsExamples'
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertBasicStyledTextInViewSpecification: aViewSpecification expectedText: anExpectedText
+	| obtainedStylableText |
+	
+	obtainedStylableText := (GtRemotePhlowStylableText 
+			fromJSONDictionary: aViewSpecification getText).
+			
+
+	self assert: obtainedStylableText string equals: anExpectedText asString.
+	self assert: obtainedStylableText stylerSpecification canAffectText.
+	
+	self 
+		assertTextAttributedRunStyleSpecification: obtainedStylableText stylerSpecification
+		equalsRuns: ((self shouldConvertUsingDisplayTextObject: anExpectedText)
+			ifTrue: [ anExpectedText asRopedText extractRemotePhlowRuns ]
+			ifFalse: [ anExpectedText attributeRuns ]).
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertChildColumnedTreeNodesInViewDatasource: viewDatasource forParentNode: aParentNode  forObjects: anExpectedCollectionOfObjects andColumnsComputation: aCollectionOfBlockClosures
+	^ self 
+		assertChildNodesInViewDatasource: viewDatasource 
+		forParentNode:  aParentNode
+		ofType: GtRemotePhlowColumnedTreeNode
+		equalNodes: (self 
+			createColumnedNodesWithObjectValues: anExpectedCollectionOfObjects
+			andColumnsComputation: aCollectionOfBlockClosures)
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertChildNodesInViewDatasource: viewDatasource forParentNode: aParentNode ofType: aPhlowDataNodeClass equalNodes: anExpectedCollectionOfNodes 
+	| obtainedChildNodes |
+	obtainedChildNodes := (viewDatasource 
+		retrieveChildrenForNodeAtPath:  aParentNode  nodePath)
+			collect: [ :aNodeValueDictionary |
+				aPhlowDataNodeClass 
+					fromJSONDictionary: aNodeValueDictionary ].
+	self 
+		assertListingNodes: obtainedChildNodes 
+		equals: anExpectedCollectionOfNodes.
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertChildTreeNodesInViewDatasource: viewDatasource forParentNode: aParentNode  forObjects: anExpectedCollectionOfObjects
+	^ self 
+		assertChildNodesInViewDatasource: viewDatasource 
+		forParentNode:  aParentNode
+		ofType: GtRemotePhlowTreeNode
+		equalNodes: (self 
+			createTreeNodesWithObjectValues: anExpectedCollectionOfObjects)
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertListingNode: anObtainedObject equals: anExpectedNode 
+	self assert: anObtainedObject nodeId = anExpectedNode nodeId.
+	self assert: (anObtainedObject matchesNodeContentWith: anExpectedNode)
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertListingNodes: obtainedNodes equals: expectedNodes
+	self assert:  obtainedNodes size equals: expectedNodes size.
+	
+	expectedNodes withIndexDo: [ :anExpectedNode :anIndex |
+		self 
+			assertListingNode: (obtainedNodes at: anIndex) 
+			equals: anExpectedNode ]
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertNodesInColumnedViewDatasource: viewDatasource forObjects: aCollectionOfObjects andColumnsComputation: aCollectionOfBlockClosures
+	^ self 
+		assertNodesInViewDatasource: viewDatasource 
+		ofType: GtRemotePhlowColumnedTreeNode
+		equalNodes: (self 
+			createColumnedNodesWithObjectValues: aCollectionOfObjects
+			andColumnsComputation: aCollectionOfBlockClosures).
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertNodesInListViewDatasource: viewDatasource forObjects: anCollectionOfObjects
+	^ self 
+		assertNodesInViewDatasource: viewDatasource 
+		ofType: GtRemotePhlowDataNode
+		equalNodes: (self 
+			createListNodesWithObjectValues: anCollectionOfObjects).
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertNodesInTreeViewDatasource: viewDatasource forObjects: anCollectionOfObjects
+	^ self 
+		assertNodesInViewDatasource: viewDatasource 
+		ofType: GtRemotePhlowTreeNode
+		equalNodes: (self 
+			createTreeNodesWithObjectValues: anCollectionOfObjects).
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertNodesInViewDatasource: viewSpecification ofType: aPhlowDataNodeClass equalNodes: anExpectedCollectionOfNodes 
+	| obtainedNodes |
+	
+	self 
+		assert: viewSpecification retrieveTotalItemsCount 
+		equals: anExpectedCollectionOfNodes size.
+	
+	obtainedNodes := viewSpecification retrieveFormattedItems 
+		collect: [ :aNodeValueDictionary |
+			aPhlowDataNodeClass 
+				fromJSONDictionary: aNodeValueDictionary ].
+	
+	self 
+		assertListingNodes: obtainedNodes 
+		equals: anExpectedCollectionOfNodes.
+	
+	^ obtainedNodes
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertStyledJsonTextInViewSpecification: aViewSpecification
+	| stylableText |
+	
+	stylableText := (GtRemotePhlowStylableText 
+			fromJSONDictionary: aViewSpecification getText).
+	self 
+		assert: stylableText string withUnixLineEndings 
+		equals: self expectedJsonString withUnixLineEndings.
+	self assert: stylableText stylerSpecification canAffectText.
+	self 
+		assert: stylableText stylerSpecification parserClassName equals: #JSONParser.
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertTextAttributedRunStyleSpecification: aStyleSpecification equalsRuns: aRunsCollection
+	self 
+		assert: aStyleSpecification numberOfRuns 
+		equals: aRunsCollection size.
+	
+	self 
+		assert: aStyleSpecification attributeRuns
+		equals: aRunsCollection
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertTextualViewWithBasicStyledTextWithSelector: aViewSelector title: aTitle priority: aPriority expectedText: anExpectedText
+	| phlowSpecificationsProvider viewDictionary viewSpecification dataSource |
+
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary :=  phlowSpecificationsProvider getViewDeclaration: aViewSelector.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+	
+	self assert: viewSpecification title equals: aTitle.
+	self assert: viewSpecification priority equals: aPriority.
+	
+	dataSource := phlowSpecificationsProvider getDeclarativeViewFor: aViewSelector.
+	self 
+		assertBasicStyledTextInViewSpecification: dataSource
+		expectedText: anExpectedText.
+	
+	^ viewSpecification
+%
+
+category: 'assertions'
+method: GtRemotePhlowDeclarativeViewsExamples
+assertUnstyledStringInViewSpecification: aViewSpecification equals: aString
+	| stylableText |
+	
+	stylableText := (GtRemotePhlowStylableText 
+		fromJSONDictionary: aViewSpecification getText).
+	self assert: stylableText string equals: aString.
+	self assert: stylableText stylerSpecification canAffectText not.
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+columnedListView
+	<gtExample>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDatasource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtColumnedListFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'Columned list'.
+	self assert: viewSpecification columnTitles equals: #(Value Lowercase).
+	self assert: viewSpecification columnWidths equals: #(nil 100).
+	self
+		assert: (viewSpecification columnTypes collect: #typeLabel)
+		equals: #(text text).
+
+	self
+		assert: viewSpecification dataTransport
+		equals: GtPhlowViewSpecification dataLazy.
+
+	viewDatasource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtColumnedListFor:.
+	self
+		assertNodesInColumnedViewDatasource: viewDatasource
+		forObjects: GtRemotePhlowDeclarativeTestInspectable new collectionOfObjects
+		andColumnsComputation: {[ :anObject | anObject ].
+				[ :anObject | anObject gtDisplayString asLowercase ]}.
+
+	^ viewSpecification
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+columnedListWithStyledText
+	<gtExample>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewDataSource viewDatasource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtColumnedListWithStyledTextFor:.
+	viewDataSource := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewDataSource title equals: 'Columned list - styled text'.
+	self
+		assert: viewDataSource columnTitles
+		equals: {'Plain'.
+				'Styled'.
+				'Number'}.
+	self assert: viewDataSource columnWidths equals: #(nil nil nil).
+	self
+		assert: (viewDataSource columnTypes collect: #typeLabel)
+		equals: #(text text number).
+	self
+		assert: viewDataSource dataTransport
+		equals: GtPhlowViewSpecification dataLazy.
+
+	viewDatasource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtColumnedListWithStyledTextFor:.
+
+	self
+		assertNodesInColumnedViewDatasource: viewDatasource
+		forObjects: self objectsForListWithStyledTextComparison
+		andColumnsComputation: {[ :anObject | anObject asString ].
+				[ :anObject | anObject ].
+				[  "(GtPhlowText forString: (index*100) asString) bold":anObject :index | (index * 100) asRopedText bold ]}.
+
+	^ viewDataSource
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+columnedListWithTypedColumns
+	<gtExample>
+	<after: #stopServer>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDatasource |
+
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtColumnedListWithTypedColumnsFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	viewSpecification initializeFromInspector: phlowSpecificationsProvider.
+
+	self assert: viewSpecification title equals: 'Columned list with typed columns'.
+	self assert: viewSpecification priority equals: 24.
+
+	self
+		assert: viewSpecification methodSelector
+		equals: #gtColumnedListWithTypedColumnsFor:.
+	self
+		assert: (viewSpecification columnSpecifications
+				collect: [ :aColumnSpecification | aColumnSpecification typeLabel ])
+		equals: #('text' 'number' 'icon').
+	self
+		assert: viewSpecification columnTitles
+		equals: #('Text' 'Number' 'Icon Name').
+	self assert: viewSpecification columnWidths equals: #(nil 100 75).
+
+	self assert: viewSpecification totalItemsCount equals: 500.
+
+	self
+		assert: (viewSpecification retrieveItems: 2 fromIndex: 1)
+		equals: (self expectedColumnedListTypedColumnsTwoItems).
+
+	viewDatasource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtColumnedListWithTypedColumnsFor:.
+	self
+		assertNodesInColumnedViewDatasource: viewDatasource
+		forObjects: (1 to: 500)
+		andColumnsComputation: {[ :aNumber | '+' , (aNumber asFloat printShowingDecimalPlaces: 1) ].
+				[ :aNumber | '+' , (aNumber + 1) asString ].
+				[ :aNumber | self formatExpectedIconName: aNumber asFloat gtSystemIconName ]}.
+
+	^ viewSpecification
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+columnedTreeView
+	<gtExample>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDatasource obtainedNodes |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtColumnedTreeFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'Columned Tree'.
+	self
+		assert: viewSpecification columnTitles
+		equals: {'x'.
+				'x * x'}.
+	self assert: viewSpecification columnWidths equals: #(nil nil).
+	self
+		assert: (viewSpecification columnTypes collect: #typeLabel)
+		equals: #(text text).
+	self
+		assert: viewSpecification dataTransport
+		equals: GtPhlowViewSpecification dataLazy.
+
+	viewDatasource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtColumnedTreeFor:.
+
+	obtainedNodes := self
+			assertNodesInColumnedViewDatasource: viewDatasource
+			forObjects: (1 to: 5)
+			andColumnsComputation: {[ :aNumber | aNumber ].
+					[ :aNumber | aNumber * aNumber ]}.
+
+	self
+		assertChildColumnedTreeNodesInViewDatasource: viewDatasource
+		forParentNode: obtainedNodes third
+		forObjects: (1 to: 2)
+		andColumnsComputation: {[ :aNumber | aNumber ].
+				[ :aNumber | aNumber * aNumber ]}.
+
+	^ viewSpecification
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+computeStyledTextForTreeNumber: anInteger
+	| computedString|
+	computedString := anInteger asString, ' number'.
+	(anInteger \\ 2) = 0 
+		ifTrue: [
+			computedString :=  computedString asRopedText
+				bold;
+				highlight: (GtPhlowColor named: #yellow) asColor ].
+	^ computedString
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+convertIfNeededUsingDisplayTextObject: anObject 
+	"When doing local inspection Phlow text objects are not special.
+	They are just like any other normal objects and we convert them 
+	as any other object"
+	^ (self shouldConvertUsingDisplayTextObject: anObject)
+			ifTrue: [ anObject gtDisplayText ]
+			ifFalse: [ anObject ]
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+createColumnedNodesWithObjectValues: aCollectionOfObjects andColumnsComputation: aCollectionOfBlockClosures
+	^ self createColumnedNodesWithRowValues:  (aCollectionOfObjects 
+		withIndexCollect: [ :anObject :aRowIndex | 
+			GtRemotePhlowRowValue new
+				columnValues: (aCollectionOfBlockClosures 
+					collect: [ :aColumnComputation |
+						| columnedText |
+						columnedText := self convertIfNeededUsingDisplayTextObject: (aColumnComputation 
+							cull: anObject cull: aRowIndex).
+						self createPhlowTextValueFromText: columnedText ]) ])
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+createColumnedNodesWithRowValues: aCollectionOfRowValues
+	^ aCollectionOfRowValues withIndexCollect: [ :aRowValue :anIndex | 
+	 	GtRemotePhlowColumnedTreeNode new
+	 		nodeId: anIndex;
+	 		nodeValue: aRowValue ]
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+createListNodesWithObjectValues: aCollectionOfObjects
+	^ self createListNodesWithTextValues: (aCollectionOfObjects 
+		collect: [ :anObject | 
+			self convertIfNeededUsingDisplayTextObject: anObject ])
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+createListNodesWithTextValues: aCollectionOfValues
+	^ aCollectionOfValues withIndexCollect: [ :aText :anIndex | 
+	 	GtRemotePhlowDataNode new
+	 		nodeId: anIndex;
+	 		nodeValue: (self createPhlowTextValueFromText: aText) ]
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+createPhlowTextValueFromText: aText
+	| convertedText |
+	convertedText := aText.
+	convertedText class name = #BlRunRopedText ifTrue: [
+		convertedText := convertedText asGtPlowText ]. 
+	
+	^ (GtRemotePhlowItemTextualValue new
+	 	itemText: convertedText)
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+createTreeNodesWithObjectValues: aCollectionOfObjects
+	^ self createTreeNodesWithTextValues: (aCollectionOfObjects 
+		collect: [ :anObject | 
+			self convertIfNeededUsingDisplayTextObject: anObject ])
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+createTreeNodesWithTextValues: aCollectionOfValues
+	^ aCollectionOfValues withIndexCollect: [ :aText :anIndex | 
+		| convertedText |
+		convertedText := aText.
+		convertedText class name = #BlRunRopedText ifTrue: [
+			convertedText := convertedText asGtPlowText ]. 
+		 GtRemotePhlowTreeNode new
+	 		nodeId: anIndex;
+	 		nodeValue: (GtRemotePhlowItemTextualValue new
+	 			itemText: convertedText)]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsExamples
+expectedBasicString
+	^ 'Now is the time'
+%
+
+category: 'accessing - expected'
+method: GtRemotePhlowDeclarativeViewsExamples
+expectedColumnedListTypedColumnsTwoItems
+	^ ((Array new: 2) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 3) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'+1.0'); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'+2'); yourself); at: 3 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->#class); yourself); yourself)); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 3) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'+2.0'); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'+3'); yourself); at: 3 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->#class); yourself); yourself)); yourself)); add: (#nodeId->2); yourself); yourself)
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsExamples
+expectedJsonString
+	^ '{
+	"name":"Me", 
+	"age":30, 
+	"data":null
+}'
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsExamples
+expectedNumberOfRunsForBasicStyledText
+	^ 9
+%
+
+category: 'accessing - expected'
+method: GtRemotePhlowDeclarativeViewsExamples
+expectedStyledPhlowTextWithDecorations
+	^ GtRemotePhlowDeclarativeTextTestInspectable new  
+		styledPhlowTextWithDecorations
+%
+
+category: 'accessing - expected'
+method: GtRemotePhlowDeclarativeViewsExamples
+expectedStyledText
+	^ GtRemotePhlowDeclarativeTestInspectable new  
+			styledText
+%
+
+category: 'utils'
+method: GtRemotePhlowDeclarativeViewsExamples
+formatExpectedIconName: anIconName
+	^ anIconName
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+listView
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDatasource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider getViewDeclaration: #gtListFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: #List.
+	self assert: viewSpecification priority equals: 15.
+
+	viewDatasource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtListFor:.
+	self
+		assertNodesInListViewDatasource: viewDatasource
+		forObjects: GtRemotePhlowDeclarativeTestInspectable new collectionOfObjects.
+
+	^ viewSpecification
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+listViewWithStyledText
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDatasource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtListWithStyledTextFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'List - styled text'.
+	self assert: viewSpecification priority equals: 15.1.
+
+	viewDatasource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtListWithStyledTextFor:.
+	self
+		assertNodesInListViewDatasource: viewDatasource
+		forObjects: self objectsForListWithStyledTextComparison.
+
+	^ viewSpecification
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsExamples
+objectsForListWithStyledTextComparison
+	^ GtRemotePhlowDeclarativeTestInspectable new 
+			objectsForListWithStyledText
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+printForString
+	"Answer the string returned in the #gtPrintFor: view.
+	Subclasses may overwrite this as appropriate."
+
+	^ 'a GtRemotePhlowDeclarativeTestInspectable'
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+printView
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDataSource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider getViewDeclaration: #gtPrintFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: #Print.
+	self assert: viewSpecification string equals: nil.	"self printForString"
+
+	viewDataSource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtPrintFor:.
+	self
+		assertUnstyledStringInViewSpecification: viewDataSource
+		equals: self printForString.
+
+	^ viewSpecification
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+shouldConvertUsingDisplayTextObject: anObject 
+	"When doing local inspection Phlow text objects are not special.
+	They are just like any other normal objects and we convert them 
+	as any other object"
+	^ anObject isString not
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textEditorViewWithExplicitStyler
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDataSource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtStyledStringUsingStylerFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'Styled text (styler)'.
+	self assert: viewSpecification priority equals: 11.2.
+	self assert: viewSpecification string equals: nil.
+
+	viewDataSource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtStyledStringUsingStylerFor:.
+	self
+		assertBasicStyledTextInViewSpecification: viewDataSource
+		expectedText: self expectedStyledText.
+
+	^ viewSpecification
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textEditorViewWithParserStylerClass
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDataSource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtStyledStringJsonInEditorFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'Styled JSON'.
+	self assert: viewSpecification priority equals: 11.5.
+	self assert: viewSpecification string equals: nil.
+
+	viewDataSource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtStyledStringJsonInEditorFor:.
+	self assertStyledJsonTextInViewSpecification: viewDataSource.
+
+	^ viewSpecification
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textEditorViewWithSimpleString
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDataSource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtStringInTextEditorViewFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'String (editor)'.
+	self assert: viewSpecification priority equals: 11.
+	self assert: viewSpecification string equals: nil.
+
+	viewDataSource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtStringInTextEditorViewFor:.
+	self
+		assertUnstyledStringInViewSpecification: viewDataSource
+		equals: 'hello world'.
+
+	^ viewSpecification
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textEditorViewWithStyledPhlowText
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| view |
+	view := self
+			assertTextualViewWithBasicStyledTextWithSelector: #gtStyledPhlowTextInEditorFor:
+			title: 'Styled phlow text (editor)'
+			priority: 11.3
+			expectedText: GtRemotePhlowDeclarativeTestInspectable new styledPhlowText.
+
+	self assert: view string equals: nil.
+
+	^ view
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textEditorViewWithStyledText
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| view |
+	view := self
+			assertTextualViewWithBasicStyledTextWithSelector: #gtStyledTextInEditorFor:
+			title: 'Styled text (editor)'
+			priority: 11.1
+			expectedText: self expectedStyledText.
+
+	self assert: view string equals: nil.
+
+	^ view
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textViewWithSimpleString
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification viewDataSource |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtStringInTextViewFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'String (text)'.
+	self assert: viewSpecification priority equals: 10.
+
+	viewDataSource := phlowSpecificationsProvider
+			getDeclarativeViewFor: #gtStringInTextViewFor:.
+	self
+		assertUnstyledStringInViewSpecification: viewDataSource
+		equals: 'hello world'.
+
+	^ viewSpecification
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textViewWithStyledPhlowText
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| view |
+	view := self
+			assertTextualViewWithBasicStyledTextWithSelector: #gtStyledPhlowTextFor:
+			title: 'Styled phlow text'
+			priority: 10.3
+			expectedText: GtRemotePhlowDeclarativeTestInspectable new styledPhlowText.
+
+	^ view
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textViewWithStyledPhlowTextWithDecorations
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| view |
+	view := self
+			assertTextualViewWithBasicStyledTextWithSelector: #gtStyledPhlowTextWithDecorationsFor:
+			title: 'Styled phlow text with decorations'
+			priority: 10.6
+			expectedText: self expectedStyledPhlowTextWithDecorations.
+
+	^ view
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+textViewWithStyledText
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	^ self
+		assertTextualViewWithBasicStyledTextWithSelector: #gtStyledTextFor:
+		title: 'Styled text'
+		priority: 10.1
+		expectedText: self expectedStyledText
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+treeView
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider getViewDeclaration: #gtTreeFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'Tree'.
+	self assert: viewSpecification priority equals: 30.
+
+	self treeViewLazyCheck: phlowSpecificationsProvider.
+
+	^ viewSpecification
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+treeViewLazyCheck: viewProxy
+	| viewDatasource obtainedNodes|
+
+	viewDatasource := viewProxy getDeclarativeViewFor: #gtTreeFor:.
+	self assert: viewDatasource retrieveTotalItemsCount equals: 5.
+	
+	obtainedNodes := self 
+		assertNodesInTreeViewDatasource: viewDatasource 
+		forObjects: ((1 to: 5) 
+			collect: [ :x | x asString, ' number' ]).
+			
+	self 
+		assertChildTreeNodesInViewDatasource: viewDatasource 
+		forParentNode:  obtainedNodes third
+		forObjects:  ((1 to: 2) 
+			collect: [ :x | x asString, ' number' ]).
+%
+
+category: 'examples - views'
+method: GtRemotePhlowDeclarativeViewsExamples
+treeViewWithStyledText
+	<gtExample>
+	<after: #stopServer>
+	<return: #SubclassResponsibility>
+	| phlowSpecificationsProvider viewDictionary viewSpecification |
+	phlowSpecificationsProvider := self remotePhlowSpecificationsProvider.
+	viewDictionary := phlowSpecificationsProvider
+			getViewDeclaration: #gtTreeWithStyledTextFor:.
+	viewSpecification := GtPhlowViewSpecification fromDictionary: viewDictionary.
+
+	self assert: viewSpecification title equals: 'Tree - with styled text'.
+	self assert: viewSpecification priority equals: 30.1.
+
+	self treeViewWithStyledTextLazyCheck: phlowSpecificationsProvider.
+
+	^ viewSpecification
+%
+
+category: 'private'
+method: GtRemotePhlowDeclarativeViewsExamples
+treeViewWithStyledTextLazyCheck: viewProxy
+	| viewDatasource obtainedNodes|
+
+	viewDatasource := viewProxy getDeclarativeViewFor: #gtTreeWithStyledTextFor:.
+	self assert: viewDatasource retrieveTotalItemsCount equals: 5.
+	
+	obtainedNodes := self 
+		assertNodesInTreeViewDatasource: viewDatasource 
+		forObjects: ((1 to: 5) 
+			collect: [ :aNumber | self computeStyledTextForTreeNumber: aNumber ]).
+			
+	self 
+		assertChildTreeNodesInViewDatasource: viewDatasource 
+		forParentNode:  obtainedNodes third
+		forObjects: ((1 to: 2) 
+			collect: [ :aNumber | self computeStyledTextForTreeNumber: aNumber  ]).
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples'
+
+!		Class methods for 'GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples'
+
+category: 'testing'
+classmethod: GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples
+isAbstract
+	^ self name = #GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples
+%
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsDirectViewedObjectExamples
+getRemoteObject
+
+	^ GtRemotePhlowDeclarativeTestInspectable new
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewsLocalViewedObjectExamples'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewsLocalViewedObjectExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsLocalViewedObjectExamples
+remoteViewedObject
+	^ GtRemotePhlowViewedObject object: self remoteObject.
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewsRemoteViewedObjectExamples'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewsRemoteViewedObjectExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsRemoteViewedObjectExamples
+retrieveRemotePhlowSpecificationsProvider
+	"Answer the GtRemotePhlowViewedObject proxy for the remote object"
+
+	^ GtRemotePhlowViewedObject object: self remoteObject.
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewsProxySimulationExamples'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewsProxySimulationExamples'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsProxySimulationExamples
+remoteObject
+	<gtExample>
+	<after: #stopServer>
+	<return: #GtRemoteInspectionSimulation>
+	| remoteObject |
+	remoteObject := self getRemoteObject.
+
+	^ remoteObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewsProxySimulationExamples
+retrieveRemotePhlowSpecificationsProvider
+
+	self remoteObject 
+		remoteInspectorProxyDo: [ :aProxy | ^ aProxy ].
+	^ nil
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeTestForCustomProxyInspectable'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeTestForCustomProxyInspectable'
+
+category: 'inspection'
+method: GtRemotePhlowDeclarativeTestForCustomProxyInspectable
+gtButtonActionWithBothIconAndLabelFor: anAction
+	<gtAction>
+	
+	^ anAction button
+		tooltip: 'Inspect object';
+		priority: 12;
+		label: 'Remote';
+		icon: (GtPhlowGlamorousVectorIconNameStencil new 
+			iconName: #playinspect);
+		action: [ :aButton |
+			aButton phlow 
+				spawnObject: self ]
+%
+
+category: 'inspection'
+method: GtRemotePhlowDeclarativeTestForCustomProxyInspectable
+gtColumnedListFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Columned list';
+		priority: 20;
+		items: [ collectionOfObjects ];
+		column: 'Value' text: [ :anObject | anObject ];
+		column: 'Lowercase' text: [ :anObject | 
+			anObject gtDisplayString asLowercase ] width: 100.
+%
+
+category: 'inspection'
+method: GtRemotePhlowDeclarativeTestForCustomProxyInspectable
+gtListFor: aView
+	<gtView>
+
+	^aView list
+		title: 'List';
+		priority: 15;
+		items: [ collectionOfObjects ];
+		itemText: [ :item | item ]
+%
+
+category: 'initialization'
+method: GtRemotePhlowDeclarativeTestForCustomProxyInspectable
+initialize  
+
+	super initialize.
+
+	collectionOfObjects := { 
+		42. 
+		'Hello World'. 
+		DateAndTime readFrom: '2021-04-06T14:43:50.123456+02:00' readStream }.
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeTestInspectable'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeTestInspectable'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+collectionAt: anIndex put: anObject
+
+	^collectionOfObjects at: anIndex put: anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+collectionOfObjects
+	^ collectionOfObjects
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+collectionOfObjects: anObject
+	collectionOfObjects := anObject
+%
+
+category: 'actions'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtButtonActionWithBothIconAndLabelFor: anAction
+	<gtAction>
+	
+	^ anAction button
+		tooltip: 'Inspect objects';
+		priority: 12;
+		label: 'Inspect';
+		icon: (GtPhlowGlamorousVectorIconNameStencil new 
+			iconName: #playinspect);
+		action: [ :aButton |
+			aButton phlow 
+				spawnObject: collectionOfObjects ]
+%
+
+category: 'actions'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtButtonActionWithIconFor: anAction
+	<gtAction>
+	
+	^ anAction button
+		tooltip: 'Inspect objects';
+		priority: 11;
+		icon: (GtPhlowGlamorousVectorIconNameStencil new 
+			iconName: #playinspect);
+		action: [ :aButton |
+			aButton phlow 
+				spawnObject: collectionOfObjects ]
+%
+
+category: 'actions'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtButtonActionWithLabelFor: anAction
+	<gtAction>
+	
+	^ anAction button
+		tooltip: 'Inspect objects';
+		priority: 10;
+		label: 'Inspect 1';
+		action: [ :aButton |
+			aButton phlow 
+				spawnObject: 1 ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedListFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Columned list';
+		priority: 20;
+		items: [ collectionOfObjects ];
+		column: 'Value' text: [ :anObject | anObject ];
+		column: 'Lowercase' text: [ :anObject | 
+			anObject gtDisplayString asLowercase ] width: 100.
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedListSpawnTextFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Spawn text columned list';
+		priority: 20.2;
+		items: [ collectionOfObjects ];
+		column: 'Value' text: [ :anObject | anObject ];
+		column: 'Value with spawn' 
+			text: [ :anObject | anObject ] 
+			spawn: [ :anObject | anObject ];
+		column: 'Class' 
+			text: [ :anObject | anObject class name ] 
+			spawn: [ :anObject | anObject class ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedListWithHorizontalScrollingFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Columned list with scrolling' ;
+		priority: 23;
+		items: [ 1 to: 500 ];
+		withHorizontalScrolling;
+		column: 'Value' text: [ :anInteger | anInteger ] width: 250;
+		column: 'Value + 1' text: [ :anInteger | anInteger + 1 ] width: 250;
+		column: 'Value + 2' text: [ :anInteger | anInteger + 2 ] width: 250;
+		column: 'Value + 3' text: [ :anInteger | anInteger + 3 ] width: 250;
+		column: 'Value + 4' text: [ :anInteger | anInteger + 4 ] width: 250.
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedListWithStyledTextFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Columned list - styled text';
+		priority: 20.1;
+		items: [ self objectsForListWithStyledText ];
+		column: 'Plain' text: [ :anObject | anObject asString ];
+		column: 'Styled' text: [ :anObject | anObject ];
+		column: 'Number' 
+			number: [ :anObject :index | (index*100) asRopedText bold  ].
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedListWithTypedColumnsFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Columned list with typed columns';
+		priority: 24;
+		items: [ 1 to: 500 ];
+		column: 'Text' textDo: [ :aColumn | 
+			aColumn 
+				item: [ :aNumber | aNumber asFloat ];
+				format: [ :aFloat | 
+					'+',aFloat asString ] ];
+		column: 'Number' numberDo: [ :aColumn | 
+			aColumn
+				item: [ :aNumber | aNumber + 1 ];
+				format: [ :aNumber | '+',aNumber asString ];
+				width: 100 ];
+		column: 'Icon Name' iconNameDo: [ :aColumn | 
+			aColumn 
+				item: [ :aNumber | aNumber asFloat ];
+				iconName: [ :aFloat | 
+					aFloat gtSystemIconName ];
+				width: 75 ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedListWithTypedColumnsInGenericColumnFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Columned list with typed columns - generic';
+		priority: 24.1;
+		items: [ 1 to: 500 ];
+		column: 'Text' do: [ :aColumn | 
+			aColumn 
+				item: [ :aNumber | aNumber asFloat ];
+				text: [ :aFloat | 
+					'+',aFloat asString ] ];
+		column: 'Icon Name' do: [ :aColumn | 
+			aColumn 
+				item: [ :aNumber | aNumber asFloat ];
+				iconName: [ :aFloat | 
+					aFloat gtSystemIconName ];
+				width: 75 ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedTreeFor: aView
+	<gtView>
+
+	^aView columnedTree
+		title: 'Columned Tree';
+		priority: 35;
+		items: [ 1 to: 5 ];
+		children: [ :aNumber | 
+			(aNumber // 2 = aNumber)
+				ifTrue: [ #() ] 
+				ifFalse: [
+					aNumber // 2 to: (aNumber - 1) ] ];
+		column: 'x' text: [ :aNumber | aNumber ];
+		column: 'x * x' text: [ :aNumber | aNumber * aNumber ];
+		send: [ :x | x + 1000 ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtColumnedWithObjectsFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'With Objects';
+		priority: 55;
+		items: [ {
+			'New Instance' -> self class new initialize .
+			'Class Object' -> self class.
+			'Dictionary With Object Keys' -> {
+				Object new -> 'one'.
+				Object new -> 'two'} asDictionary.
+			'Dictionary With Primitive Data' -> {
+				1 -> 10.
+				2 -> 20 }.
+			'Array With Objects' -> (Array 
+				with: Object new 
+				with: Object new).
+			'Array With Numbers' -> (Array with: 1 with: 2) } ];
+		column: 'Key' text: [ :assoc | assoc key ];
+		column: 'Object' text: [ :assoc | assoc value ];
+		send: [ :assoc | assoc value ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtForwardListFor: aView
+	<gtView>
+
+	^aView forward
+		title: 'Forward List';
+		priority: 45;
+		object: [ self ];
+		view: #gtLargeListFor:;
+		send: [ :x | x * 10 ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtForwardListTwiceFor: aView
+	<gtView>
+
+	^aView forward
+		title: 'Forward List Twice';
+		priority: 46;
+		object: [ self ];
+		view: #gtForwardListFor:;
+		send: [ :x | x + 1 ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtForwardListWithSendFor: aView
+	<gtView>
+
+	^aView forward
+		title: 'Forward List Send';
+		priority: 46;
+		object: [ self ];
+		view: #gtLargeListFor:;
+		send: [ :x | x * 10 + 2 ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtItemsWithBackgroundFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'background: usage';
+		priority: 50;
+		items: [ {
+			'Bob' -> -43.
+			'Alice' -> 27.
+			'Mike' -> 0.
+			'Jane' -> -32.
+			'Ben' -> 12
+		} ];
+		column: 'name' text: [ :x | x key ];
+		column: 'value' do: [ :aColumn |
+			aColumn
+				text: [ :x | x value ];
+				background: [ :v |
+					v > 0
+						ifTrue: [ 
+							GtPhlowColor named: #green alpha: 0.3 ]
+						ifFalse: [ v < 0
+							ifTrue: [ 
+								GtPhlowColor named: #red alpha: 0.3 ]
+							ifFalse: [ 
+								GtPhlowColor named: #gray alpha: 0.3] ] ] ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtLargeColumnedListFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Large columned list' ;
+		priority: 21;
+		items: [ 1 to: 1022 ];
+		column: 'Value' text: [ :anObject | anObject ];
+		column: 'Value * 10' text: [ :anObject | (anObject * 10) asString asLowercase ] width: 100.
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtLargeColumnedListWithIndexFor: aView
+	<gtView>
+
+	^aView columnedList
+		title: 'Large columned list with index';
+		priority: 21;
+		items: [ 1 to: 1022 ];
+		column: 'Index' text: [ :anObject  :anIndex | anIndex ];
+		column: 'Value' text: [ :anObject | anObject ].
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtLargeListFor: aView
+	<gtView>
+
+	^aView list
+		title: 'Large list';
+		priority: 20;
+		items: [ 1 to: 1022 ];
+		itemText: [ :item | item  ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtListFor: aView
+	<gtView>
+
+	^aView list
+		title: 'List';
+		priority: 15;
+		items: [ collectionOfObjects ];
+		itemText: [ :item | item ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtListWithSendFor: aView
+	<gtView>
+
+	^aView list
+		title: 'List with send';
+		priority: 15.2;
+		items: [ collectionOfObjects ];
+		itemText: [ :item | item ];
+		send: [ :item | {item. item. item }]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtListWithStyledTextFor: aView
+	<gtView>
+
+	^aView list
+		title: 'List - styled text';
+		priority: 15.1;
+		items: [ self objectsForListWithStyledText ];
+		itemText: [ :item | item ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStringInTextEditorViewFor: aView
+	<gtView>
+	
+	^aView textEditor
+		title: 'String (editor)';
+		priority: 11;
+		text: [ self string ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStringInTextViewFor: aView
+	<gtView>
+	
+	^aView text
+		title: 'String (text)';
+		priority: 10;
+		text: [ self string ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStyledPhlowTextFor: aView
+	<gtView>
+	
+	^ aView text
+		title: 'Styled phlow text';
+		priority: 10.3;
+		text: [ self styledPhlowText ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStyledPhlowTextInEditorFor: aView
+	<gtView>
+	
+	^ aView textEditor
+		title: 'Styled phlow text (editor)';
+		priority: 11.3;
+		text: [ self styledPhlowText ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStyledPhlowTextWithDecorationsFor: aView
+	<gtView>
+	
+	^ aView text
+		title: 'Styled phlow text with decorations';
+		priority: 10.6;
+		text: [ GtRemotePhlowDeclarativeTextTestInspectable new
+			styledPhlowTextWithDecorations ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStyledStringJsonInEditorFor: aView
+	<gtView>
+	
+	^ aView textEditor
+		title: 'Styled JSON';
+		priority: 11.5;
+		text: [ 
+			'{
+	"name":"Me", 
+	"age":30, 
+	"data":null
+}' ];
+		stylerParserClassName: #JSONParser
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStyledStringUsingStylerFor: aView
+	<gtView>
+	
+	^ aView textEditor
+		title: 'Styled text (styler)';
+		priority: 11.2;
+		text: [ 'Now is the time' ];
+		styler: [ GtRemotePhlowDummyTextStyler  new ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStyledTextFor: aView
+	<gtView>
+	
+	^ aView text
+		title: 'Styled text';
+		priority: 10.1;
+		text: [ self styledText ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtStyledTextInEditorFor: aView
+	<gtView>
+	
+	^ aView textEditor
+		title: 'Styled text (editor)';
+		priority: 11.1;
+		text: [ self styledText ]
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtTreeFor: aView
+	<gtView>
+
+	^aView tree
+		title: 'Tree';
+		priority: 30;
+		items: [ 1 to: 5 ];
+		children: [ :aNumber | 
+			(aNumber // 2 = aNumber)
+				ifTrue: [ #() ] 
+				ifFalse: [
+					aNumber // 2 to: (aNumber - 1) ] ];
+		itemText: [ :x | x asString, ' number']
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+gtTreeWithStyledTextFor: aView
+	<gtView>
+
+	^aView tree
+		title: 'Tree - with styled text';
+		priority: 30.1;
+		items: [ 1 to: 5 ];
+		children: [ :aNumber | 
+			(aNumber // 2 = aNumber)
+				ifTrue: [ #() ] 
+				ifFalse: [
+					aNumber // 2 to: (aNumber - 1) ] ];
+		itemText: [ :x | 
+			| computedString|
+			computedString := x asString, ' number'.
+			(x \\ 2) = 0 
+				ifTrue: [
+					computedString := computedString asRopedText
+						bold;
+						highlight: (GtPhlowColor named: #yellow) asColor ].
+			computedString ]
+%
+
+category: 'initialization'
+method: GtRemotePhlowDeclarativeTestInspectable
+initialize 
+
+	super initialize.
+	string := 'hello world'.
+	collectionOfObjects := { 
+		42. 
+		'Hello World'. 
+		DateAndTime readFrom: '2021-04-06T14:43:50.123456+02:00' readStream }.
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+objectsForListWithStyledText
+	^ { 
+			'42' asRopedText bold.
+			self styledHelloWorld.
+			self styledText.
+			self styledPhlowText
+		}
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+objectsForListWithStyledTextForRemoteComparison
+	^ { 
+			'42' asRopedText bold.
+			self styledHelloWorldForRemoteComparison.
+			self styledPhlowTextForRemoteComparison.
+			self styledPhlowTextForRemoteComparison
+		}
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+printStringFor: anObject
+	^ anObject printString
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+string
+
+	^string
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+string: anObject
+	string := anObject
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+styledHelloWorld
+	| text |
+	text := 'Hello World' asRopedText.
+	
+	(text from: 1 to: 5)
+		highlight: (GtPhlowColor named: #yellow) asColor;
+		fontSize: 20.
+		
+	^ text
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+styledHelloWorldForRemoteComparison
+	| text |
+	text := GtPhlowText forString: 'Hello World'.
+	
+	(text from: 1 to: 5)
+		highlight: (GtPhlowColor named: #yellow) "asColor";
+		fontSize: 20.
+		
+	^ text
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+styledPhlowText
+	| text |
+	text := GtPhlowText forString: 'Now is the time'.
+	text glamorousCodeFont.
+	(text from: 12 to: 15) fontSize: 20.
+	(text from: 5 to: 6) highlight: (GtPhlowColor named: #yellow) .
+	(text from: 1 to: 4) bold.
+	(text from: 8 to: 10) foreground: (GtPhlowColor named: #red) .
+	(text from: 12 to: 12) glamorousRegularFont.
+	(text from: 1 to: 6) italic.
+	(text from: 8 to: 15) thin.
+	^ text
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+styledPhlowTextForRemoteComparison
+	| text |
+	text := GtPhlowText forString: 'Now is the time'.
+	text glamorousCodeFont.
+	(text from: 12 to: 15) fontSize: 20.
+	(text from: 5 to: 6) highlight: (GtPhlowColor named: #yellow) "asColor".
+	(text from: 1 to: 4) bold.
+	(text from: 8 to: 10) foreground: (GtPhlowColor named: #red) "asColor".
+	(text from: 12 to: 12) glamorousRegularFont.
+	(text from: 1 to: 6) italic.
+	(text from: 8 to: 15) thin.
+	^ text
+%
+
+category: 'inspecting'
+method: GtRemotePhlowDeclarativeTestInspectable
+styledText
+	| text |
+	text := 'Now is the time' asRopedText.
+	text glamorousCodeFont.
+	(text from: 12 to: 15) fontSize: 20.
+	(text from: 5 to: 6) highlight: (GtPhlowColor named: #yellow) asColor.
+	(text from: 1 to: 4) bold.
+	(text from: 8 to: 10) foreground: (GtPhlowColor named: #red) asColor.
+	(text from: 12 to: 12) glamorousRegularFont.
+	(text from: 1 to: 6) italic.
+	(text from: 8 to: 15) thin.
+	^ text
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestInspectable
+text
+
+	^string asRopedText 
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeTestWithViewIncrement'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeTestWithViewIncrement'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestWithViewIncrement
+gtViewCurrentCounterColumnedListFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Counter (columned list)';
+		priority: 3;
+		items: [ { self nextCounter } ];
+		column: 'Counter' text: [ 'Counter' ];
+		column: 'Value' text: [ :each | each ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestWithViewIncrement
+gtViewCurrentCounterFor: aView
+	<gtView>
+	
+	^ aView text
+		title: 'Counter (text)';
+		priority: 1;
+		text: [ self nextCounter asString ] 
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestWithViewIncrement
+gtViewCurrentCounterListFor: aView
+	<gtView>
+	
+	^ aView list
+		title: 'Counter (list)';
+		priority: 2;
+		items: [ {self nextCounter} ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTestWithViewIncrement
+nextCounter
+	^ counter := counter 
+		ifNil: [ 1 ]
+		ifNotNil: [ counter + 1.]
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeTextTestInspectable'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeTextTestInspectable'
+
+category: 'views'
+method: GtRemotePhlowDeclarativeTextTestInspectable
+gtStyledPhlowTextWithDecorationsFor: aView
+	<gtView>
+	
+	^ aView text
+		title: 'Styled phlow text with decorations';
+		priority: 10.3;
+		text: [ self styledPhlowTextWithDecorations ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTextTestInspectable
+styledPhlowTextWithDecorations
+	<gtExample>
+	<return: #GtPhlowRunBasedText>
+	| text |
+	text := GtPhlowText
+			forString: 'Examples of text decorations:
+
+Different styles:
+	Solid style
+	Dashed style
+	Dotted style
+	Wavy style
+	
+Different types:
+	Line Through
+	Overline
+	Underline
+	
+Different color:
+	Blue color
+	
+Different thickness:
+	Thickness 3
+	
+Combined decorations:
+	Several decorations
+'.
+
+	(text from: 51 to: 61)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				underline ].
+	(text from: 64 to: 75)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				dashed;
+				underline ].
+	(text from: 78 to: 89)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				dotted;
+				underline ].
+	(text from: 92 to: 101)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				wavy;
+				underline ].
+
+	(text from: 123 to: 134)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				lineThrough ].
+	(text from: 137 to: 144)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				overline ].
+	(text from: 147 to: 155)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				underline ].
+
+	(text from: 177 to: 186)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				underline;
+				color: (GtPhlowColor named: #blue) ].
+
+	(text from: 212 to: 222)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				underline;
+				thickness: 3 ].
+
+	(text from: 249 to: 267)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				underline;
+				overline;
+				dashed;
+				thickness: 3;
+				color: (GtPhlowColor named: #blue) ].
+
+	^ text
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTextTestInspectable
+styledPhlowTextWithDecorationsForRemoteComparison
+	<gtExample>
+	<return: #GtPhlowRunBasedText>
+	| text |
+	text := GtPhlowText
+			forString: ('Examples of text decorations:
+
+Different styles:
+	Solid style
+	Dashed style
+	Dotted style
+	Wavy style
+	
+Different types:
+	Line Through
+	Overline
+	Underline
+	
+Different color:
+	Blue color
+	
+Different thickness:
+	Thickness 3
+	
+Combined decorations:
+	Several decorations
+' copyReplaceAll: String cr with: String lf).
+
+	(text from: 51 to: 61)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				underline ].
+	(text from: 64 to: 75)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				dashed;
+				underline ].
+	(text from: 78 to: 89)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				dotted;
+				underline ].
+	(text from: 92 to: 101)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				wavy;
+				underline ].
+
+	(text from: 123 to: 134)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				lineThrough ].
+	(text from: 137 to: 144)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				overline ].
+	(text from: 147 to: 155)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				solid;
+				underline ].
+
+	(text from: 177 to: 186)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				underline;
+				color: (GtPhlowColor named: #blue) ].
+
+	(text from: 212 to: 222)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				underline;
+				thickness: 3 ].
+
+	(text from: 249 to: 267)
+		decorationDo: [ :aDecoration | 
+			aDecoration
+				underline;
+				overline;
+				dashed;
+				thickness: 3;
+				color: (GtPhlowColor named: #blue) ].
+
+	^ text
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTextTestInspectable
+styledPhlowTextWithHighlights
+	<gtExample>
+	<return: #GtPhlowRunBasedText>
+	| text |
+	text := GtPhlowText
+			forString: 'Examples of text styling:
+
+Emphases:
+	Italic text
+	Oblique text
+	Normal text
+
+Colors:
+	Blue foreground
+	Green highlight
+	
+Weight:
+	Thin text
+	Bold text
+	
+Size:
+	8px text
+	28px text
+	
+Fonts:
+	Helvetica font
+	Source Sans Pro font
+	
+Combined styles:
+	Several styles
+'.
+
+	(text from: 39 to: 49) italic.
+	(text from: 52 to: 63) oblique.
+	(text from: 66 to: 76) normal.
+
+	(text from: 88 to: 102) foreground: (GtPhlowColor named: #blue).
+	(text from: 105 to: 119) highlight: (GtPhlowColor named: #green).
+
+	(text from: 132 to: 140) thin.
+	(text from: 143 to: 152) bold.
+
+	(text from: 162 to: 169) fontSize: 8.
+	(text from: 172 to: 180) fontSize: 28.
+
+	(text from: 191 to: 205) fontName: 'Helvetica'.
+	(text from: 208 to: 226) fontName: 'Source Sans Pro'.
+
+	(text from: 249 to: 262)
+		oblique;
+		bold;
+		fontSize: 18;
+		foreground: (GtPhlowColor named: #red);
+		fontName: 'Source Sans Pro'.
+
+	^ text
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeTreeExamples'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeTreeExamples'
+
+category: 'examples'
+method: GtRemotePhlowDeclarativeTreeExamples
+emptyTree
+	<gtExample>
+	<return: #GtRemotePhlowTreeView>
+	| view |
+	view := GtRemotePhlowProtoView new tree.
+	self assert: view class equals: GtRemotePhlowTreeView.
+	^ view
+%
+
+category: 'examples'
+method: GtRemotePhlowDeclarativeTreeExamples
+expectedFormattedItems
+	^ (Array new: 4)
+		at: 1
+			put: (Dictionary new
+					add: #nodeValue
+							-> (Dictionary new
+									add: #valueTypeName -> 'textualValue';
+									add: #itemText -> '1';
+									yourself);
+					add: #nodeId -> 1;
+					yourself);
+		at: 2
+			put: (Dictionary new
+					add: #nodeValue
+							-> (Dictionary new
+									add: #valueTypeName -> 'textualValue';
+									add: #itemText -> '2';
+									yourself);
+					add: #nodeId -> 2;
+					yourself);
+		at: 3
+			put: (Dictionary new
+					add: #nodeValue
+							-> (Dictionary new
+									add: #valueTypeName -> 'textualValue';
+									add: #itemText -> '3';
+									yourself);
+					add: #nodeId -> 3;
+					yourself);
+		at: 4
+			put: (Dictionary new
+					add: #nodeValue
+							-> (Dictionary new
+									add: #valueTypeName -> 'textualValue';
+									add: #itemText -> '4';
+									yourself);
+					add: #nodeId -> 4;
+					yourself);
+		yourself
+%
+
+category: 'examples'
+method: GtRemotePhlowDeclarativeTreeExamples
+sentItemAt
+	"<gtExample>"
+	| treeView declarativeView sentItem sentItems |
+
+	treeView := self treeViewWithItemsAndChildren.
+	declarativeView := treeView asGtDeclarativeView.
+	sentItems := (1 to: 4) collect: [ :i | treeView sentItemAt: { i } ].
+	self assert: sentItems equals: #(1 2 3 4).
+	sentItem := treeView sentItemAt: #(2 1).
+	self assert: sentItem equals: 1.
+	sentItem := treeView sentItemAt: #(3 1).
+	self assert: sentItem equals: 1.
+	sentItem := treeView sentItemAt: #(4 1).
+	self assert: sentItem equals: 1.
+	sentItem := treeView sentItemAt: #(4 2).
+	self assert: sentItem equals: 2.
+	sentItem := treeView sentItemAt: #(4 2 1).
+	self assert: sentItem equals: 1.
+	^ treeView
+%
+
+category: 'examples'
+method: GtRemotePhlowDeclarativeTreeExamples
+treeViewWithItemsAndChildren
+	<gtExample>
+	<return: #GtRemotePhlowTreeView>
+	| aView declarativeView |
+	aView := self emptyTree.
+	aView
+		items: [ 1 to: 4 ];
+		itemText: [ :aNumber | aNumber asString ];
+		children: [ :aNumber | aNumber = 0 ifTrue: [ #() ] ifFalse: [ 1 to: aNumber // 2 ] ].
+	declarativeView := aView asGtDeclarativeView.
+
+	self assert: declarativeView retrieveTotalItemsCount equals: 4.
+	self
+		assert: declarativeView retriveFormattedItems
+		equals: self expectedFormattedItems.
+
+	^ aView
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewDataSource'
+
+!		Class methods for 'GtRemotePhlowDeclarativeViewDataSource'
+
+category: 'as yet unclassified'
+classmethod: GtRemotePhlowDeclarativeViewDataSource
+forPhlowView: aView
+	^ self new
+		phlowView: aView
+%
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewDataSource
+definingMethod
+	^ self phlowView definingMethod
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewDataSource
+phlowView
+	^ phlowView
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewDataSource
+phlowView: anObject
+	phlowView := anObject
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeForwardViewDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeForwardViewDataSource'
+
+category: 'api'
+method: GtRemotePhlowDeclarativeForwardViewDataSource
+getDeclarativeViewFor: aViewSelector
+	"This mimics the API provided by the inspecotr proxy to initialize views.
+	In this case for forwarded views, we allways return the datasource for 
+	the target views, as this is the only view the client will request.
+	
+	We do not check right now if the selector matches, as in some
+	cases the method selector is not set correctly in the specification."
+
+	^ cachedViewSpecification
+%
+
+category: 'api'
+method: GtRemotePhlowDeclarativeForwardViewDataSource
+retrieveForwardTargetDataSource
+	^ cachedViewSpecification phlowDataSource
+%
+
+category: 'api'
+method: GtRemotePhlowDeclarativeForwardViewDataSource
+retrieveViewSpecificationForForwarding
+	| computedPhlowView |
+	computedPhlowView := self phlowView computeForwardedView.
+	self phlowView hasTransformation ifTrue: [ 
+		computedPhlowView 
+			copyTransformationFrom: self phlowView transformation ].
+			
+	cachedViewSpecification := computedPhlowView asGtDeclarativeView.
+	cachedViewSpecification methodSelector: computedPhlowView definingSelector.
+	
+	^ cachedViewSpecification asDictionaryForExport
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeTextualViewDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeTextualViewDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTextualViewDataSource
+computeText
+	| computedText stylerSpecification highlight |
+	computedText := self phlowView textBuilder value asRopedText.
+	stylerSpecification := self
+			createRemotePhlowStylerSpecificationForText: computedText.
+
+	stylerSpecification
+		ifNil: [ stylerSpecification := GtRemotePhlowTextAttributeRunsStylerSpecification new
+					attributeRuns: computedText extractRemotePhlowRuns ].
+
+	self phlowView highlighterSpecification
+		ifNotNil: [ :spec | highlight := spec value ].
+
+	^ GtRemotePhlowStylableText new
+		string: computedText asString;
+		stylerSpecification: stylerSpecification;
+		highlight: highlight
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTextualViewDataSource
+createRemotePhlowStylerSpecificationForText: aText
+	| stylerSpecification |
+	
+	stylerSpecification := self phlowView stylerSpecification.
+	stylerSpecification ifNil: [ ^ nil ].
+	stylerSpecification canAffectText ifFalse: [ ^ nil ].
+	
+	^ stylerSpecification 
+		convertToSerializableSpecificationForText: aText.
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTextualViewDataSource
+getText 
+	^ self computeText asDictionaryForExport
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeTextualViewDataSource
+retrieveStylableText 
+	^ self computeText asDictionaryForExport
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewListingDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewListingDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+buildMainNodeForObject: anObject atIndex: anIndex 
+	^ self buildNodeForObject: anObject atIndex: anIndex 
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+buildNodeForObject: anObject atIndex: anIndex 
+	^ self instantiateNode
+		targetObject: anObject;
+		nodeId: anIndex;
+		nodeValue: (self 
+			computeNodeValueForObject: anObject 
+			atIndex: anIndex)
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+cachedNodes
+	^ cachedNodes ifNil: [
+		cachedNodes := OrderedCollection new ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+computeNodeValueForObject: anObject atIndex: anIndex 
+	^ self valueBuilder 
+		computeNodeValueForObject: anObject 
+		atIndex: anIndex 
+%
+
+category: 'api'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+flushItemsIterator
+	"Flush the items iterator to force the displayed values to be regenerated"
+
+	itemsIterator := nil.
+	cachedNodes := nil.
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+formatItem: anObject atIndex: anIndex
+	self subclassResponsibility
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+forNodesFrom: aStartIndex to: anEndIndex withIndexDo: aBlock
+	| startIndex stopIndex |
+	
+	"The interval of nodes that need to be computed and send back to the client"
+	startIndex := 1 max: aStartIndex.
+	stopIndex  := self itemsIterator totalItemsCount min: anEndIndex.
+	
+	"Increase the size of the cache to ensure that it can hold all nodes, if required."
+	self cachedNodes size + 1 to: stopIndex do: [ :index |
+		self cachedNodes add: nil ].
+	
+	"Iterate over the given interval, 
+	and create the nodes that do not have already a cached value."
+	self itemsIterator 
+		forElementsFrom: startIndex 
+		to: stopIndex 
+		withIndexDo: [ :anObject :anIndex | 
+			(self cachedNodes at: anIndex) ifNil: [
+					| newValueNode |
+					newValueNode := self 
+						buildMainNodeForObject: anObject atIndex: anIndex.
+					self cachedNodes at: anIndex put: newValueNode ].
+			aBlock cull: (self cachedNodes at: anIndex) cull: anIndex ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+gtViewCachedNodesFor: aView 
+	<gtView>
+	cachedNodes ifNil: [ ^ aView empty ].
+	
+	^ aView columnedTree
+		title: 'Cached Nodes';
+		items: [ cachedNodes ];
+		children: [ :aNode | 
+			aNode childNodes ifNil: [ #() ] ];
+		column: 'Id' text: [ :aNode | aNode nodeId ];
+		column: 'Value' text: [ :aNode | aNode nodeValue ]
+%
+
+category: 'gt - extensions'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+instantiateNode
+	^ self subclassResponsibility
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+instantiateValueBuilder
+	^ GtRemotePhlowItemBuilder new
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+itemsIterator
+	^ itemsIterator ifNil: [ 
+		itemsIterator := self phlowView 
+			itemsProviderComputation value asGPhlowItemsIterator ]
+%
+
+category: 'api - data retrival'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+retrieveItems: anItemsCount fromIndex: startIndex
+	| computedNodes endIndex |
+
+	computedNodes := OrderedCollection new: anItemsCount.
+	endIndex := startIndex + anItemsCount - 1.
+	
+	self 
+		forNodesFrom: startIndex 
+		to: endIndex 
+		withIndexDo: [ :aNode |
+			computedNodes add: aNode ].
+	
+	^ computedNodes asArray collect: [ :aNodeValue |
+		aNodeValue asDictionaryForExport ]
+%
+
+category: 'api - data retrival'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+retrieveSentItemAt: aSelectionIndex
+	"Answer the raw value at the supplied index"
+	
+	self  
+		forNodesFrom: aSelectionIndex 
+		to: aSelectionIndex 
+		withIndexDo: [ :aNode :anItemIndex |
+			^ self phlowView transformation 
+				transformedValueFrom: aNode targetObject
+				selection: aSelectionIndex ].
+	^ nil
+%
+
+category: 'api - data retrival'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+retrieveTotalItemsCount
+	^ self itemsIterator totalItemsCount
+%
+
+category: 'api - data retrival'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+retriveSentItemAt: aSelectionIndex
+	"Answer the raw value at the supplied index"
+	
+	self  
+		forNodesFrom: aSelectionIndex 
+		to: aSelectionIndex 
+		withIndexDo: [ :aNode :anItemIndex |
+			^ self phlowView transformation 
+				transformedValueFrom: aNode targetObject
+				selection: aSelectionIndex ].
+	^ nil
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListingDataSource
+valueBuilder
+	^ cachedValueBuilder ifNil: [
+		cachedValueBuilder := self instantiateValueBuilder
+			phlowView:  self phlowView]
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewColumnedListDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewColumnedListDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewColumnedListDataSource
+instantiateNode
+	^ GtRemotePhlowColumnedTreeNode new
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewColumnedListDataSource
+instantiateValueBuilder
+	^ GtRemotePhlowRowBuilder new
+%
+
+category: 'api'
+method: GtRemotePhlowDeclarativeViewColumnedListDataSource
+retriveSpawnedObjectAtRow: aRowIndex column: aColumnIndex	
+	self itemsIterator 
+		forElementsFrom: aRowIndex 
+		to: aRowIndex 
+		withIndexDo: [ :aRowObject :anItemIndex |
+			| aColumn aSpawnedObject |
+			
+			aColumn := self phlowView columns at: aColumnIndex.
+			aSpawnedObject := aColumn isSpawningObject
+				ifTrue: [ aColumn spawnObjectComputation 
+					cull: aRowObject cull: anItemIndex  ]
+				ifFalse: [ aRowObject ].
+			^ aSpawnedObject ].
+	^ nil
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewListDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewListDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewListDataSource
+instantiateNode
+	^ GtRemotePhlowDataNode new
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewTreeDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewTreeDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+buildChildNodesFor: aNode 
+	| childNodes |
+	
+	childNodes := OrderedCollection new.
+	(self phlowView 
+		childrenBuilder cull: aNode targetObject) 
+			withIndexDo: [ :anObject :anIndex | 
+				childNodes add: (self 
+					buildNodeForObject: anObject 
+					atIndex: anIndex) ].
+		
+	^ childNodes asArray
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+buildChildrenForNode: aNode atPath: aNodePath
+	self ensureChildrenForNode: aNode.
+	aNodePath isEmpty ifTrue: [ 
+		^ aNode childNodes ].
+		
+	^ self 
+		buildChildrenForNode: (aNode childNodes at: aNodePath first)
+		atPath: aNodePath allButFirst
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+ensureChildrenForNode: aNode 
+	aNode childNodes ifNotNil: [ ^ self ].
+	
+	aNode childNodes: (self buildChildNodesFor: aNode)
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+instantiateNode
+	^ GtRemotePhlowTreeNode new
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+locateNode: aNode atPath: aNodePath
+	aNodePath isEmpty ifTrue: [ 
+		^ aNode ].
+		
+	^ self 
+		locateNode: (aNode childNodes at: aNodePath first)
+		atPath: aNodePath allButFirst
+%
+
+category: 'api - data retrival'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+retrieveChildrenForNodeAtPath: aNodePath
+	self 
+		forNodesFrom: aNodePath first 
+		to: aNodePath first 
+		withIndexDo: [ :aNode |
+			^ (self 
+				buildChildrenForNode: aNode 
+				atPath: aNodePath allButFirst)
+					collect: [ :aNodeValue |
+						aNodeValue asDictionaryForExport ] ].
+	^ #()
+%
+
+category: 'api - data retrival'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+retrieveSentItemAtPath: aNodePath
+	self 
+		forNodesFrom: aNodePath first 
+		to: aNodePath first 
+		withIndexDo: [ :aNode :aSelectionIndex |
+			| targetNode targetObject |
+			targetNode := self 
+				locateNode: aNode 
+				atPath: aNodePath allButFirst.
+			targetObject := targetNode targetObject.
+			^ self phlowView transformation 
+				transformedValueFrom: targetObject
+				selection: aSelectionIndex ].
+	^ nil
+%
+
+category: 'api - data retrival'
+method: GtRemotePhlowDeclarativeViewTreeDataSource
+retriveSentItemAtPath: aNodePath
+	self 
+		forNodesFrom: aNodePath first 
+		to: aNodePath first 
+		withIndexDo: [ :aNode :aSelectionIndex |
+			| targetNode targetObject |
+			targetNode := self 
+				locateNode: aNode 
+				atPath: aNodePath allButFirst.
+			targetObject := targetNode targetObject.
+			^ self phlowView transformation 
+				transformedValueFrom: targetObject
+				selection: aSelectionIndex ].
+	^ nil
+%
+
+! Class implementation for 'GtRemotePhlowDeclarativeViewColumnedTreeDataSource'
+
+!		Instance methods for 'GtRemotePhlowDeclarativeViewColumnedTreeDataSource'
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewColumnedTreeDataSource
+instantiateNode
+	^ GtRemotePhlowColumnedTreeNode new
+%
+
+category: 'accessing'
+method: GtRemotePhlowDeclarativeViewColumnedTreeDataSource
+instantiateValueBuilder
+	^ GtRemotePhlowRowBuilder new
+%
+
+! Class implementation for 'GtRemotePhlowDummyTextStyler'
+
+!		Instance methods for 'GtRemotePhlowDummyTextStyler'
+
+category: 'accessing'
+method: GtRemotePhlowDummyTextStyler
+affectsText
+	^ true
+%
+
+category: 'accessing'
+method: GtRemotePhlowDummyTextStyler
+style: aText
+
+	aText glamorousCodeFont.
+	(aText from: 12 to: 15) fontSize: 20.
+	(aText from: 5 to: 6) highlight: (GtPhlowColor named: #yellow) asColor.
+	(aText from: 1 to: 4) bold.
+	(aText from: 8 to: 10) foreground: (GtPhlowColor named: #red) asColor.
+	(aText from: 12 to: 12) glamorousRegularFont.
+	(aText from: 1 to: 6) italic.
+	(aText from: 8 to: 15) thin.
+	^ aText 
+%
+
+! Class implementation for 'GtRemotePhlowNodeValue'
+
+!		Instance methods for 'GtRemotePhlowNodeValue'
+
+category: 'printing'
+method: GtRemotePhlowNodeValue
+descriptionOn: aStream 
+	
+%
+
+category: 'printing'
+method: GtRemotePhlowNodeValue
+printOn: aStream 
+	super printOn: aStream .
+	
+	aStream parenthesize: [
+		self descriptionOn: aStream ]
+%
+
+! Class implementation for 'GtRemotePhlowItemValue'
+
+!		Class methods for 'GtRemotePhlowItemValue'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowItemValue
+fromJSONDictionary: aDictionary
+	"Answer an instance of the receiver from the supplied dictionary."
+	| valueClass |
+
+	valueClass := self valueTypeFrom: aDictionary.
+		
+	^ valueClass new
+		initializeFromJSONDictionary: aDictionary
+%
+
+category: 'instance creation'
+classmethod: GtRemotePhlowItemValue
+mySubclasses
+	"LW hook"
+	^self allSubclasses
+%
+
+category: 'instance creation'
+classmethod: GtRemotePhlowItemValue
+valueTypeFrom: aDictionary
+	^aDictionary
+		at: #valueTypeName
+		ifPresent: 
+			[:aTypeName |
+			"We do a manual check for the types that are by default in GT, 
+			as it will be faster; this is called for every value in a table.
+			If the type is not found we iterate subclasses ."
+			| detectedType |
+			detectedType := nil.
+			aTypeName = GtRemotePhlowItemTextualValue valueTypeName
+				ifTrue: [detectedType := GtRemotePhlowItemTextualValue].
+			aTypeName = GtRemotePhlowItemErrorValue valueTypeName
+				ifTrue: [detectedType := GtRemotePhlowItemErrorValue].
+			detectedType ifNotNil: [^detectedType].
+			GtRemotePhlowItemValue mySubclasses
+				do: [:aSubclass | aSubclass valueTypeName = aTypeName ifTrue: [^aSubclass]].
+			GtRemotePhlowItemValue]
+		ifAbsent: [GtRemotePhlowItemValue]
+%
+
+category: 'accessing'
+classmethod: GtRemotePhlowItemValue
+valueTypeName
+	^ 'item'
+%
+
+!		Instance methods for 'GtRemotePhlowItemValue'
+
+category: 'comparing'
+method: GtRemotePhlowItemValue
+= anObject
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	
+	^ self background = anObject background
+%
+
+category: 'converting'
+method: GtRemotePhlowItemValue
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation"
+
+	| data | 
+	
+	data := Dictionary new 
+		at: #valueTypeName put: self class valueTypeName;
+		yourself.
+		
+	"We check the attribute here instead of using the accessor,
+	as subclasses can provide default value in case the background is nil"
+	background ifNotNil: [ :aBackground |
+		data at: #background put: aBackground asDictionaryForExport  ].
+	
+	^ data
+%
+
+category: 'accessing'
+method: GtRemotePhlowItemValue
+background
+	^ background
+%
+
+category: 'accessing'
+method: GtRemotePhlowItemValue
+background: anObject
+	background := anObject
+%
+
+category: 'printing'
+method: GtRemotePhlowItemValue
+descriptionOn: aStream 
+	self printBackgroundOn: aStream.
+%
+
+category: 'comparing'
+method: GtRemotePhlowItemValue
+hash 
+	^ 31 hash bitXor: self background hash
+%
+
+category: 'initialization'
+method: GtRemotePhlowItemValue
+initializeFromJSONDictionary: aDictionary
+	aDictionary 
+		at: #background 
+		ifPresent: [ :aBackgroundValue |
+			self background: (GtPhlowColor fromJSONDictionary: aBackgroundValue) ]
+%
+
+category: 'testing'
+method: GtRemotePhlowItemValue
+isErrorItemValue
+	^ false
+%
+
+category: 'printing'
+method: GtRemotePhlowItemValue
+printBackgroundOn: aStream 
+	self background ifNotNil: [ :aBackground |
+		aStream 
+			<< ', background: ';
+			print: aBackground ]
+%
+
+! Class implementation for 'GtRemotePhlowItemTextualValue'
+
+!		Class methods for 'GtRemotePhlowItemTextualValue'
+
+category: 'accessing'
+classmethod: GtRemotePhlowItemTextualValue
+valueTypeName
+	^ 'textualValue'
+%
+
+!		Instance methods for 'GtRemotePhlowItemTextualValue'
+
+category: 'comparing'
+method: GtRemotePhlowItemTextualValue
+= anObject
+	super = anObject  ifFalse: [ ^ false ].
+	
+	^ self itemText = anObject itemText
+%
+
+category: 'converting'
+method: GtRemotePhlowItemTextualValue
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation"
+
+	| data currentText currentTextData | 
+	
+	data := super asDictionaryForExport.
+	currentText := self itemText.
+	currentTextData := (currentText isNil or: [currentText isString])
+		ifTrue: [ currentText ] 
+		ifFalse: [ currentText asDictionaryForExport ].
+	
+	data at: #itemText put: currentTextData.
+	
+	^ data
+%
+
+category: 'printing'
+method: GtRemotePhlowItemTextualValue
+descriptionOn: aStream 
+	
+	aStream print: self itemText.
+	super descriptionOn: aStream 
+%
+
+category: 'comparing'
+method: GtRemotePhlowItemTextualValue
+hash 
+	^ super hash bitXor: self itemText hash
+%
+
+category: 'initialization'
+method: GtRemotePhlowItemTextualValue
+initializeFromJSONDictionary: aDictionary
+	| textData |
+	super initializeFromJSONDictionary: aDictionary.
+	
+	textData := aDictionary at: #itemText.
+	self itemText: ((textData isNil or: [ textData isString ]) 
+		ifTrue: [ textData ]
+		ifFalse: [ GtPhlowRunBasedText fromJSONDictionary: textData ])
+	
+%
+
+category: 'accessing'
+method: GtRemotePhlowItemTextualValue
+itemText
+	^ itemText
+%
+
+category: 'accessing'
+method: GtRemotePhlowItemTextualValue
+itemText: anObject
+	itemText := anObject
+%
+
+! Class implementation for 'GtRemotePhlowItemErrorValue'
+
+!		Class methods for 'GtRemotePhlowItemErrorValue'
+
+category: 'accessing'
+classmethod: GtRemotePhlowItemErrorValue
+valueTypeName
+	^ 'errorValue'
+%
+
+!		Instance methods for 'GtRemotePhlowItemErrorValue'
+
+category: 'accessing'
+method: GtRemotePhlowItemErrorValue
+background
+	^ super background ifNil: [
+		"#errorBackgroundColor"
+		GtPhlowColor  
+			r: 1.0 
+			g: 0.4701857282502444 
+			b: 0.458455522971652   ]
+%
+
+category: 'testing'
+method: GtRemotePhlowItemErrorValue
+isErrorItemValue
+	^ true
+%
+
+! Class implementation for 'GtRemotePhlowRowValue'
+
+!		Class methods for 'GtRemotePhlowRowValue'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowRowValue
+fromJSONDictionary: aDictionary
+	"Answer an instance of the receiver from the supplied dictionary."
+
+	^self new 
+		columnValues: (aDictionary 
+			at: #columnValues 
+			ifPresent: [ :aCollection |
+				aCollection collect: [ :anItemValueDictionary |
+					GtRemotePhlowItemValue fromJSONDictionary: anItemValueDictionary ] ]
+			ifAbsent: [ nil ]);
+		yourself
+%
+
+!		Instance methods for 'GtRemotePhlowRowValue'
+
+category: 'comparing'
+method: GtRemotePhlowRowValue
+= anObject
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	
+	^ self columnValues = anObject columnValues
+%
+
+category: 'converting'
+method: GtRemotePhlowRowValue
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation"
+
+	| data| 
+	data := Dictionary new 
+		at: #columnValues put: (self columnValues 
+			collect: [ :aColumnValue | aColumnValue asDictionaryForExport ]);
+		yourself.
+	
+	^ data
+%
+
+category: 'accessing'
+method: GtRemotePhlowRowValue
+columnValueAt: anIndex
+	^ self columnValues at: anIndex
+%
+
+category: 'accessing'
+method: GtRemotePhlowRowValue
+columnValues
+	^ columnValues
+%
+
+category: 'accessing'
+method: GtRemotePhlowRowValue
+columnValues: anObject
+	columnValues := anObject
+%
+
+category: 'printing'
+method: GtRemotePhlowRowValue
+descriptionOn: aStream 
+	aStream 
+		print: self columnValues size;
+		<< ' columns'
+%
+
+category: 'gt - extensions'
+method: GtRemotePhlowRowValue
+gtViewColumnValuesFor: aView
+	<gtView>
+	
+	^ aView list
+		title: 'Column Values';
+		priority: 10;
+		items: [ self columnValues]
+%
+
+category: 'comparing'
+method: GtRemotePhlowRowValue
+hash 
+	^ self columnValues hash
+%
+
+! Class implementation for 'GtRemotePhlowNodeValueBuilder'
+
+!		Instance methods for 'GtRemotePhlowNodeValueBuilder'
+
+category: 'accessing'
+method: GtRemotePhlowNodeValueBuilder
+computeNodeValueForObject: anObject atIndex: anIndex 
+	^ self subclassResponsibility
+%
+
+category: 'accessing'
+method: GtRemotePhlowNodeValueBuilder
+phlowView
+	^ phlowView
+%
+
+category: 'accessing'
+method: GtRemotePhlowNodeValueBuilder
+phlowView: anObject
+	phlowView := anObject
+%
+
+category: 'building'
+method: GtRemotePhlowNodeValueBuilder
+withErrorHandlingCompute: aBlock
+	^ aBlock
+		on: Error 
+		do: [ :anError |
+			GtRemotePhlowItemErrorValue new
+				itemText: anError description ] 
+%
+
+! Class implementation for 'GtRemotePhlowItemBuilder'
+
+!		Instance methods for 'GtRemotePhlowItemBuilder'
+
+category: 'building'
+method: GtRemotePhlowItemBuilder
+basicComputeNodeValueForObject: anObject atIndex: anIndex 
+	^ GtRemotePhlowItemTextualValue new 
+		itemText: (self 
+			formatItem: anObject 
+			atIndex: anIndex)
+%
+
+category: 'building'
+method: GtRemotePhlowItemBuilder
+computeNodeValueForObject: anObject atIndex: anIndex 
+	^ self withErrorHandlingCompute: [ 
+		self basicComputeNodeValueForObject: anObject atIndex: anIndex ] 
+%
+
+category: 'accessing'
+method: GtRemotePhlowItemBuilder
+formatItem: anObject atIndex: rowIndex
+	| computedValue |
+	computedValue := self phlowView itemComputation 
+		cull: anObject cull: rowIndex.
+		
+	"This check is an optimisation for not creating text values if not needed."
+	^ computedValue isString 
+		ifTrue: [ computedValue ]
+		ifFalse: [ computedValue gtDisplayText ]
+%
+
+! Class implementation for 'GtRemotePhlowRowBuilder'
+
+!		Instance methods for 'GtRemotePhlowRowBuilder'
+
+category: 'accessing'
+method: GtRemotePhlowRowBuilder
+computeNodeValueForObject: anObject atIndex: aRowIndex 
+	| phlowColumns columnValues |
+
+	phlowColumns := self phlowView columns.
+	columnValues := Array new: phlowColumns size.
+	
+	phlowColumns withIndexDo: [ :aColumn :aColumnIndex | 
+		| computedValue |
+	
+		computedValue := self withErrorHandlingCompute: [ 
+			aColumn 
+				computeItemValuesFor: anObject
+				rowIndex: aRowIndex
+				columnIndex: aColumnIndex ].
+	
+		columnValues 
+			at: aColumnIndex
+			put: computedValue ].
+
+	^ GtRemotePhlowRowValue new
+		columnValues: columnValues
+%
+
+! Class implementation for 'GtRemotePhlowProtoView'
+
+!		Instance methods for 'GtRemotePhlowProtoView'
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+columnedList
+
+	^ self declarativeViewOfType: GtRemotePhlowColumnedListView
+%
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+columnedTree
+
+	^ self declarativeViewOfType: GtRemotePhlowColumnedTreeView
+%
+
+category: 'private'
+method: GtRemotePhlowProtoView
+declarativeViewOfType: aGtDeclarativeViewClass
+	"Answer a new declarative view instance"
+
+	^ aGtDeclarativeViewClass new.
+%
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+empty
+
+	^ self declarativeViewOfType: GtRemotePhlowEmptyView
+%
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+forward
+
+	^ self declarativeViewOfType: GtRemotePhlowForwarderView
+%
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+list
+
+	^ self declarativeViewOfType: GtRemotePhlowListView
+%
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+text
+
+	^ self declarativeViewOfType: GtRemotePhlowTextView
+%
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+textEditor
+
+	^ self declarativeViewOfType: GtRemotePhlowTextEditorView
+%
+
+category: 'decorating'
+method: GtRemotePhlowProtoView
+tree
+
+	^ self declarativeViewOfType: GtRemotePhlowTreeView
+%
+
+! Class implementation for 'GtRemotePhlowView'
+
+!		Class methods for 'GtRemotePhlowView'
+
+category: 'accessing'
+classmethod: GtRemotePhlowView
+handledExceptions
+	"Explicitly catch here Halt and Warning as in case an action raising 
+	those exceptions is embedded in the debugger it will trigger an
+	infinite chain of debuggers.
+	https://github.com/feenkcom/gtoolkit/issues/4383"
+	
+	^ Error, Halt, Warning
+%
+
+!		Instance methods for 'GtRemotePhlowView'
+
+category: 'accessing'
+method: GtRemotePhlowView
+actionUpdateButton
+	"stub"
+%
+
+category: 'converting'
+method: GtRemotePhlowView
+asGtDeclarativeView
+	^ nil
+%
+
+category: 'message performning'
+method: GtRemotePhlowView
+basicOn: anObject perform: aMessageSymbol withArguments: aCollectionOfArguments 
+	^ anObject  
+		perform: aMessageSymbol
+		with: aCollectionOfArguments first
+%
+
+category: 'testing'
+method: GtRemotePhlowView
+canBeGtDeclarativeView
+	^ true
+%
+
+category: 'copying'
+method: GtRemotePhlowView
+copyTransformationFrom: aSendBlock
+	"Do nothing by default. This is a callback used by forward views that define #send: to still work in case the view that we forward to does not support #send:"
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+definingClass
+	^ definingClass
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+definingClass: aClass
+	definingClass := aClass
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+definingMethod
+	^ (definingClass whichClassIncludesSelector: definingSelector) 
+		ifNil: [ nil ]
+		ifNotNil: [ :aClass | aClass compiledMethodAt: definingSelector ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+definingSelector
+
+	^ definingSelector
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+definingSelector: aSelector
+
+	definingSelector := aSelector
+%
+
+category: 'message performing'
+method: GtRemotePhlowView
+on: anObject perform: aMessageSymbol 
+	<return: #GtRemotePhlowView>
+	
+	^ self 
+		on: anObject 
+		perform: aMessageSymbol 
+		withArguments: { self }
+%
+
+category: 'message performning'
+method: GtRemotePhlowView
+on: anObject perform: aMessageSymbol withArguments: aCollectionOfArguments
+	<return: #GtRemotePhlowView>
+	
+	^ [ 
+			self 
+				basicOn: anObject 
+				perform: aMessageSymbol 
+				withArguments: aCollectionOfArguments
+	] on: self class handledExceptions do: [ :anError |
+			self 
+				phlowErrorViewWithException: anError 
+				forBuildContext: nil "(GtPhlowBuildContext new 
+					object: anObject; 
+					arguments: aCollectionOfArguments) "
+				andSelector: aMessageSymbol ]
+%
+
+category: 'message performning'
+method: GtRemotePhlowView
+phlowErrorViewWithException: anException 
+	| aTitle |
+	aTitle := 'Error'.
+	
+	^ GtRemotePhlowViewErrorView new
+		title: aTitle;
+		errorMessage: anException description
+%
+
+category: 'error handling'
+method: GtRemotePhlowView
+phlowErrorViewWithException: anException forBuildContext: aContext andSelector: aMessageSymbol
+	| aPhlow | 
+
+	aPhlow := self phlowErrorViewWithException: anException.
+	
+	"aPhlow buildContext: aContext.
+	aPhlow failedComputation: aFailedComputation."
+
+	^ aPhlow
+%
+
+category: 'printing'
+method: GtRemotePhlowView
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream parenthesize: [
+		aStream << (self title ifNil: ['']) ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+priority
+	^ priority
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+priority: anObject
+	priority := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+title
+	^ title
+%
+
+category: 'accessing'
+method: GtRemotePhlowView
+title: anObject
+	title := anObject
+%
+
+category: 'adding - update definitions'
+method: GtRemotePhlowView
+updateWhen: anAnnouncement if: anIfCondition in: anAnnouncer
+	"Stub"
+%
+
+category: 'adding - update definitions'
+method: GtRemotePhlowView
+updateWhen: anAnnouncement in: anAnnouncer
+	"Stub"
+%
+
+! Class implementation for 'GtRemotePhlowForwarderView'
+
+!		Instance methods for 'GtRemotePhlowForwarderView'
+
+category: 'converting'
+method: GtRemotePhlowForwarderView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView."
+
+	^ GtPhlowForwardViewSpecification new 
+		title: self title;
+		priority: self priority;
+		phlowDataSource: (GtRemotePhlowDeclarativeForwardViewDataSource 
+			forPhlowView: self);
+		dataTransport: GtPhlowViewSpecification dataLazy
+%
+
+category: 'testing'
+method: GtRemotePhlowForwarderView
+canBeGtDeclarativeView
+	^ isDeclarative ifNil: [ true ] 
+%
+
+category: 'converting'
+method: GtRemotePhlowForwarderView
+computeForwardedView
+	| targetObject computedView |
+	
+	[ targetObject := objectComputation value ] 
+		on: Error do: [ :anError |
+			^ self 
+				phlowErrorViewWithException: anError  ].
+				
+	computedView := self on: targetObject perform: viewSelector.
+	
+	computedView class = self class ifTrue: [
+		"If we the forward is to another forwarder view we follow the chain
+		to reach the first view that is now a forward view."
+		^ computedView computeForwardedView ].
+		
+	^ computedView
+%
+
+category: 'accessing'
+method: GtRemotePhlowForwarderView
+defaultTransformation
+	^ GtRemotePhlowSendObjectTransformation forValuable: [ :anObject | anObject ]
+%
+
+category: 'testing'
+method: GtRemotePhlowForwarderView
+hasTransformation
+	<return: #Boolean>
+	^ transformation notNil
+%
+
+category: 'configuring'
+method: GtRemotePhlowForwarderView
+markAsNotDeclarative
+	isDeclarative := false
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowForwarderView
+object: anObjectComputation
+	objectComputation := anObjectComputation.
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowForwarderView
+send: aBlock
+	"Define what object should be displayed on selection and fire select or spawn item requests"
+	self transformation: (GtRemotePhlowSendObjectTransformation forValuable: aBlock)
+%
+
+category: 'accessing'
+method: GtRemotePhlowForwarderView
+transformation 	
+	^ transformation ifNil: [ 
+		transformation := self defaultTransformation ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowForwarderView
+transformation: aGtPhlowSendTransformation
+	transformation := aGtPhlowSendTransformation.
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowForwarderView
+view: aSelector
+	viewSelector := aSelector
+%
+
+! Class implementation for 'GtRemotePhlowListingView'
+
+!		Instance methods for 'GtRemotePhlowListingView'
+
+category: 'copying'
+method: GtRemotePhlowListingView
+copyTransformationFrom: aTransformation
+	aTransformation ifNil: [ ^ self ].
+	self send: aTransformation valuable
+%
+
+category: 'accessing'
+method: GtRemotePhlowListingView
+defaultItemsComputation
+	^ #() asGPhlowItemsIterator
+%
+
+category: 'accessing'
+method: GtRemotePhlowListingView
+defaultTransformation
+	^ GtRemotePhlowSendObjectTransformation forValuable: [ :anObject | anObject ]
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowListingView
+items: aBlockClosure
+	itemsProviderComputation := aBlockClosure
+%
+
+category: 'accessing'
+method: GtRemotePhlowListingView
+itemsProviderComputation
+	^ itemsProviderComputation ifNil: [ 
+		itemsProviderComputation := self defaultItemsComputation ]
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowListingView
+send: aBlock
+	"Define what object should be displayed on selection and fire select or spawn item requests"
+	self transformation: (GtRemotePhlowSendObjectTransformation forValuable: aBlock)
+%
+
+category: 'accessing'
+method: GtRemotePhlowListingView
+transformation 	
+	^ transformation ifNil: [ 
+		transformation := self defaultTransformation ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowListingView
+transformation: aGtPhlowSendTransformation
+	transformation := aGtPhlowSendTransformation.
+%
+
+! Class implementation for 'GtRemotePhlowBasicColumnedView'
+
+!		Instance methods for 'GtRemotePhlowBasicColumnedView'
+
+category: 'accessing'
+method: GtRemotePhlowBasicColumnedView
+column
+	<return: #GtRemotePhlowExplicitColumn>
+	
+	^ self explicitColumn
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString do: aBlock
+	| aColumn |
+	aColumn := self column.
+	aColumn title: aTitleString.
+	aBlock value: aColumn
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString iconName: anIconNameComputation
+	self column: aTitleString iconNameDo: [ :aColumn |
+		aColumn
+			item: [ :each | each ];
+			iconName: anIconNameComputation ]
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString iconName: anIconNameComputation width: aNumber
+	self column: aTitleString iconNameDo: [ :aColumn |
+		aColumn
+			item: [ :each | each ];
+			iconName: anIconNameComputation;
+			width: aNumber ]
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitle iconNameDo: aBlock
+	aBlock value: (self iconNameColumn title: aTitle)
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString item: anItemComputation text: aBlock	
+	self column: aTitleString textDo: [ :aColumn |
+		aColumn
+			item: anItemComputation;
+			format: aBlock ]
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitle number: aBlock
+	self numberColumn
+		title: aTitle;
+		item: aBlock
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitle number: aBlock format: aFormatBlock
+	self numberColumn
+		title: aTitle;
+		item: aBlock;
+		format: aFormatBlock
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitle numberDo: aBlock
+	aBlock value: (self numberColumn title: aTitle)
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString text: aBlock	
+	self column: aTitleString textDo: [ :aColumn |
+		aColumn
+			item: [ :each | each ];
+			format: aBlock ]
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: columnName text: aBlockClosure spawn: aSpawnBlock
+	| aColumn |
+	aColumn := self column.
+	aColumn title: columnName.
+	aColumn text: aBlockClosure spawn: aSpawnBlock.
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: columnName text: aBlockClosure spawn: aSpawnBlock width: aNumberOrNil
+	| aColumn |
+	aColumn := self column.
+	aColumn title: columnName.
+	aColumn text: aBlockClosure spawn: aSpawnBlock.
+	aColumn width: aNumberOrNil.
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString text: aBlock weight: aNumber
+	self column: aTitleString textDo: [ :aColumn |
+		aColumn
+			item: [ :each | each ];
+			format: aBlock;
+			weight: aNumber ]
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString text: aBlock width: aNumber
+	self column: aTitleString textDo: [ :aColumn |
+		aColumn
+			item: [ :each | each ];
+			format: aBlock;
+			width: aNumber ]
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+column: aTitleString textDo: aBlock
+	aBlock value: (self textColumn title: aTitleString)
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+columnOfType: aColumnClass
+	<return: #GtRemotePhlowColumn>
+	| aColumn |
+	
+	aColumn := aColumnClass new index: self columns size + 1.
+	self columns add: aColumn.
+	^ aColumn
+%
+
+category: 'accessing'
+method: GtRemotePhlowBasicColumnedView
+columns
+	^ columns ifNil: [
+		columns := OrderedCollection new ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowBasicColumnedView
+configureColumnsSpecificationOn: aViewSpecification
+	aViewSpecification
+		columnSpecifications: (columns asArray collect: [ :aColumn | 
+			| columnSpecification|
+			columnSpecification := GtRemotePhlowColumnSpecification new
+				title: aColumn title;
+				cellWidth: aColumn cellWidth;
+				type: aColumn asGtDeclarativeColumnDataType;
+				spawnsObjects: aColumn isSpawningObject.
+			
+			aColumn hasBackgroundComputation ifTrue: [ 
+				columnSpecification  markAsHavingBackground ].
+			columnSpecification ] )
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+explicitColumn
+	<return: #GtRemotePhlowExplicitColumn>
+
+	^ self columnOfType: GtRemotePhlowExplicitColumn
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+iconNameColumn
+	<return: #GtRemotePhlowThemeIconNameColumn>
+
+	^ self columnOfType: GtRemotePhlowThemeIconNameColumn
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+numberColumn
+	<return: #GtRemotePhlowNumberColumn>
+
+	^ self columnOfType: GtRemotePhlowNumberColumn
+%
+
+category: 'api - scripting column'
+method: GtRemotePhlowBasicColumnedView
+textColumn
+	<return: #GtRemotePhlowTextColumn>
+
+	^ self columnOfType: GtRemotePhlowTextColumn
+%
+
+! Class implementation for 'GtRemotePhlowColumnedListView'
+
+!		Instance methods for 'GtRemotePhlowColumnedListView'
+
+category: 'accessing'
+method: GtRemotePhlowColumnedListView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView.
+	nil = not supported"
+
+	| viewSpecification |
+	viewSpecification := GtPhlowColumnedListViewSpecification new 
+		phlowDataSource: (GtRemotePhlowDeclarativeViewColumnedListDataSource 
+			forPhlowView: self);
+		title: self title;
+		priority: self priority;
+		horizontalScrollingEnabled:  horizontalScrollingEnabled;
+		dataTransport: GtPhlowViewSpecification dataLazy.
+		
+	self configureColumnsSpecificationOn: viewSpecification.
+	
+	^ viewSpecification
+%
+
+category: 'testing'
+method: GtRemotePhlowColumnedListView
+isHorizontalScrollingEnabled
+	^ horizontalScrollingEnabled ifNil: [ false ]
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowColumnedListView
+withHorizontalScrolling
+	horizontalScrollingEnabled := true
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowColumnedListView
+withoutHorizontalScrolling
+	horizontalScrollingEnabled := false
+%
+
+! Class implementation for 'GtRemotePhlowColumnedTreeView'
+
+!		Instance methods for 'GtRemotePhlowColumnedTreeView'
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView."
+
+	| viewSpecification |
+	
+	viewSpecification := GtPhlowColumnedTreeViewSpecification new 
+		title: self title;
+		priority: self priority;
+		phlowDataSource: (GtRemotePhlowDeclarativeViewColumnedTreeDataSource 
+			forPhlowView: self);
+		dataTransport: GtPhlowViewSpecification dataLazy.
+		
+	self configureColumnsSpecificationOn: viewSpecification.
+	
+	^ viewSpecification
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+children: aBlock
+
+	childrenBuilder := aBlock
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+childrenBuilder
+
+	^ childrenBuilder
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+defaultItemsComputation
+	^ [ #() ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+expandAll
+	"To implement"
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+itemComputation
+	^ self itemText
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+itemsBuilder
+	^ self itemsProviderComputation
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+itemText
+
+	^ itemTextBlock ifNil: [ 
+		itemTextBlock := [ :item | item ] ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowColumnedTreeView
+itemText: aBlock
+
+	itemTextBlock := aBlock
+%
+
+! Class implementation for 'GtRemotePhlowListView'
+
+!		Instance methods for 'GtRemotePhlowListView'
+
+category: 'converting'
+method: GtRemotePhlowListView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView.
+	nil = not supported"
+
+	^ GtPhlowListViewSpecification new 
+		title: self title;
+		priority: self priority;
+		phlowDataSource: (GtRemotePhlowDeclarativeViewListDataSource 
+			forPhlowView: self);
+		dataTransport: GtPhlowViewSpecification dataLazy.
+%
+
+category: 'private - accessing'
+method: GtRemotePhlowListView
+itemComputation
+
+	^ self itemText
+%
+
+category: 'accessing'
+method: GtRemotePhlowListView
+itemText
+	"Answer the BlockClosure that will convert each item to its displayed format.
+	The result of the BlockClosure must be a JSON primitive type, effectively a string or number."
+
+	^ itemTextBlock ifNil: [ 
+		itemTextBlock := [ :item | item ] ] 
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowListView
+itemText: aBlockClosure
+
+	itemTextBlock := aBlockClosure
+%
+
+! Class implementation for 'GtRemotePhlowTreeView'
+
+!		Instance methods for 'GtRemotePhlowTreeView'
+
+category: 'converting'
+method: GtRemotePhlowTreeView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView."
+
+	^ GtPhlowTreeViewSpecification new 
+		title: self title;
+		priority: self priority;
+		phlowDataSource: (GtRemotePhlowDeclarativeViewTreeDataSource 
+			forPhlowView: self);
+		dataTransport: GtPhlowViewSpecification dataLazy
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeView
+children: aBlock
+
+	childrenBuilder := aBlock
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeView
+childrenBuilder
+
+	^ childrenBuilder
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeView
+defaultItemsComputation
+	^ [ #() ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeView
+expandAll
+	"To implement"
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeView
+itemComputation
+	^ self itemText
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeView
+itemsBuilder
+	^ self itemsProviderComputation
+%
+
+category: 'accessing'
+method: GtRemotePhlowTreeView
+itemText
+
+	^ itemTextBlock ifNil: [ 
+		itemTextBlock := [ :item | item ] ]
+%
+
+category: 'api - scripting'
+method: GtRemotePhlowTreeView
+itemText: aBlock
+
+	itemTextBlock := aBlock
+%
+
+! Class implementation for 'GtRemotePhlowTextualView'
+
+!		Instance methods for 'GtRemotePhlowTextualView'
+
+category: 'accessing'
+method: GtRemotePhlowTextualView
+aptitude: anAptitude
+	"stub method"
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextualView
+highlighterSpecification
+	^ nil
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextualView
+text: aBlockClosure
+	"Set the BlockClosure that will generate the string to be displayed.
+	The result of the BlockClosure must be a String (not a BlText)."
+
+	textBuilder := aBlockClosure
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextualView
+textBuilder
+	^ textBuilder
+%
+
+! Class implementation for 'GtRemotePhlowTextEditorView'
+
+!		Instance methods for 'GtRemotePhlowTextEditorView'
+
+category: 'converting'
+method: GtRemotePhlowTextEditorView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView.
+	nil = not supported"
+
+	^ GtPhlowTextEditorViewSpecification new 
+		title: self title;
+		priority: self priority;
+		phlowDataSource: (GtRemotePhlowDeclarativeTextualViewDataSource 
+			forPhlowView: self);
+		dataTransport: GtPhlowViewSpecification dataLazy.
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextEditorView
+styler: aBlockClosure
+	"Set the computation that will create the styler."
+
+	stylerSpecification := GtRemoteTextStylerComputableSpecification new 
+		stylerComputation: aBlockClosure
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextEditorView
+stylerClassName: aStylerClassName
+	stylerSpecification := GtRemotePhlowTextClassStylerSpecification new 
+		stylerClassName: aStylerClassName
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextEditorView
+stylerParserClassName: aParserClassName
+	stylerSpecification := GtRemotePhlowTextParserStylerSpecification new 
+		parserClassName: aParserClassName
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextEditorView
+stylerSpecification
+	^ stylerSpecification
+%
+
+! Class implementation for 'GtRemotePhlowTextView'
+
+!		Instance methods for 'GtRemotePhlowTextView'
+
+category: 'accessing'
+method: GtRemotePhlowTextView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView.
+	nil = not supported"
+
+	^ GtPhlowTextViewSpecification new 
+		title: self title;
+		priority: self priority;
+		phlowDataSource: (GtRemotePhlowDeclarativeTextualViewDataSource 
+			forPhlowView: self);
+		dataTransport: GtPhlowViewSpecification dataLazy.
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextView
+stylerSpecification
+	"Should be extended to support a styler that could be applied on the text"
+	^ nil
+%
+
+! Class implementation for 'GtRemotePhlowViewErrorView'
+
+!		Instance methods for 'GtRemotePhlowViewErrorView'
+
+category: 'converting'
+method: GtRemotePhlowViewErrorView
+asGtDeclarativeView
+	"Answer the receiver as a GtDeclarativeView."
+
+	^GtPhlowViewErrorViewSpecification new 
+		title: self title;
+		priority: self priority;
+		errorMessage: self errorMessage;
+		dataTransport: GtPhlowViewSpecification dataIncluded.
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewErrorView
+errorMessage
+	^ errorMessage
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewErrorView
+errorMessage: aStringMessage
+	errorMessage := aStringMessage
+%
+
+! Class implementation for 'GtRemotePhlowSendObjectTransformation'
+
+!		Class methods for 'GtRemotePhlowSendObjectTransformation'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowSendObjectTransformation
+forValuable: aValuable
+	^ self new
+		valuable: aValuable
+%
+
+!		Instance methods for 'GtRemotePhlowSendObjectTransformation'
+
+category: 'api - converting'
+method: GtRemotePhlowSendObjectTransformation
+asPhlowSendTransformation
+	^ self
+%
+
+category: 'asserting'
+method: GtRemotePhlowSendObjectTransformation
+assertValuable: aBlock
+	self
+		assert: [ aBlock isNotNil ].
+	self
+		assert: [ aBlock argumentCount <= 2 ].
+%
+
+category: 'api - transformation'
+method: GtRemotePhlowSendObjectTransformation
+transformedValueFrom: aSelectedObject selection: aSelectionIndices
+	^ self valuable cull: aSelectedObject cull: aSelectionIndices
+%
+
+category: 'accessing'
+method: GtRemotePhlowSendObjectTransformation
+valuable
+	^ valuable
+%
+
+category: 'accessing'
+method: GtRemotePhlowSendObjectTransformation
+valuable: anObject
+	valuable := anObject
+%
+
+! Class implementation for 'GtRemotePhlowSpawnObjectWrapper'
+
+!		Instance methods for 'GtRemotePhlowSpawnObjectWrapper'
+
+category: 'accessing'
+method: GtRemotePhlowSpawnObjectWrapper
+targetObject
+	^ targetObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowSpawnObjectWrapper
+targetObject: anObject
+	targetObject := anObject
+%
+
+! Class implementation for 'GtRemotePhlowActionSpecificationConversionExamples'
+
+!		Instance methods for 'GtRemotePhlowActionSpecificationConversionExamples'
+
+category: 'examples'
+method: GtRemotePhlowActionSpecificationConversionExamples
+convertButtonActionWithIcon
+	"Demonstrate converting a button action to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowButtonActionSpecification>
+	| phlowAction declarativeSpecification |
+	phlowAction := self createProtoActions button
+			tooltip: 'Inspect objects';
+			priority: 12;
+			icon: (GtPhlowGlamorousVectorIconNameStencil new iconName: #playinspect).
+
+	declarativeSpecification := phlowAction asGtDeclarativeAction.
+
+	self assert: declarativeSpecification tooltipText equals: 'Inspect objects'.
+	self assert: declarativeSpecification label equals: nil.
+	self
+		assert: declarativeSpecification iconStencil
+		equals: (GtPhlowGlamorousVectorIconNameStencil forIconName: #playinspect).
+	self assert: declarativeSpecification priority equals: 12.
+
+	self
+		assert: declarativeSpecification asDictionaryForExport
+		equals: self expectedButtonActionWithIconSpecification.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowActionSpecificationConversionExamples
+convertButtonActionWithIconAndLabel
+	"Demonstrate converting a button action to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowButtonActionSpecification>
+	| phlowAction declarativeSpecification |
+	phlowAction := self createProtoActions button
+			tooltip: 'Inspect objects';
+			priority: 12;
+			label: 'Inspect';
+			icon: (GtPhlowGlamorousVectorIconNameStencil new iconName: #playinspect).
+
+	declarativeSpecification := phlowAction asGtDeclarativeAction.
+
+	self assert: declarativeSpecification tooltipText equals: 'Inspect objects'.
+	self assert: declarativeSpecification label equals: 'Inspect'.
+	self
+		assert: declarativeSpecification iconStencil
+		equals: (GtPhlowGlamorousVectorIconNameStencil forIconName: #playinspect).
+	self assert: declarativeSpecification priority equals: 12.
+
+	self
+		assert: declarativeSpecification asDictionaryForExport
+		equals: self expectedButtonActionWithIconAndLabelSpecification.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowActionSpecificationConversionExamples
+convertButtonActionWithLabelAndNoTooltip
+	"Demonstrate converting a button action to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowButtonActionSpecification>
+	| phlowAction declarativeSpecification |
+	phlowAction := self createProtoActions button
+			label: 'Inspect';
+			priority: 12.
+
+	declarativeSpecification := phlowAction asGtDeclarativeAction.
+
+	self assert: declarativeSpecification tooltipText equals: nil.
+	self assert: declarativeSpecification label equals: 'Inspect'.
+	self assert: declarativeSpecification iconStencil equals: nil.
+	self assert: declarativeSpecification priority equals: 12.
+
+	self
+		assert: declarativeSpecification asDictionaryForExport
+		equals: self expectedButtonActionWithLabelAndNoTooltipSpecification.
+
+	^ declarativeSpecification
+%
+
+category: 'accessing'
+method: GtRemotePhlowActionSpecificationConversionExamples
+createProtoActions
+	^ GtRemotePhlowAction new
+%
+
+category: 'data'
+method: GtRemotePhlowActionSpecificationConversionExamples
+expectedButtonActionWithIconAndLabelSpecification
+	^ Dictionary new
+		add: '__typeName' -> #GtPhlowButtonActionSpecification;
+		add: '__typeLabel' -> 'phlowButtonActionSpecification';
+		add: 'iconStencil'
+				-> (Dictionary new
+						add: '__typeName' -> #GtPhlowGlamorousVectorIconNameStencil;
+						add: '__typeLabel' -> 'phlowGlamorousVectorIconNameStencil';
+						add: 'iconName' -> #playinspect;
+						yourself);
+		add: 'priority' -> 12;
+		add: 'tooltipText' -> 'Inspect objects';
+		add: 'methodSelector' -> nil;
+		add: 'label' -> 'Inspect';
+		yourself
+%
+
+category: 'data'
+method: GtRemotePhlowActionSpecificationConversionExamples
+expectedButtonActionWithIconSpecification
+	^ Dictionary new
+		add: '__typeName' -> #GtPhlowButtonActionSpecification;
+		add: '__typeLabel' -> 'phlowButtonActionSpecification';
+		add: 'iconStencil'
+				-> (Dictionary new
+						add: 'iconName' -> #playinspect;
+						add: '__typeName' -> #GtPhlowGlamorousVectorIconNameStencil;
+						add: '__typeLabel' -> 'phlowGlamorousVectorIconNameStencil';
+						yourself);
+		add: 'priority' -> 12;
+		add: 'tooltipText' -> 'Inspect objects';
+		add: 'methodSelector' -> nil;
+		yourself
+%
+
+category: 'data'
+method: GtRemotePhlowActionSpecificationConversionExamples
+expectedButtonActionWithLabelAndNoTooltipSpecification
+	^ Dictionary new
+		add: '__typeName' -> #GtPhlowButtonActionSpecification;
+		add: '__typeLabel' -> 'phlowButtonActionSpecification';
+		add: 'priority' -> 12;
+		add: 'methodSelector' -> nil;
+		add: 'label' -> 'Inspect';
+		yourself
+%
+
+! Class implementation for 'GtRemotePhlowViewSpecificationConversionExamples'
+
+!		Instance methods for 'GtRemotePhlowViewSpecificationConversionExamples'
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertColumnedList
+	"Demonstrate converting a columned list phlow view to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowColumnedListViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := self createProtoViews columnedList
+			title: #Test;
+			priority: 10;
+			items: [ #(1 2 3) ];
+			column: 'One' text: [ :item | item ];
+			column: 'Two'
+				text: [ :item | item asString ]
+				width: 100.
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: #Test.
+	self assert: declarativeSpecification priority equals: 10.
+	self assert: declarativeSpecification columnTitles equals: #('One' 'Two').
+	self assert: declarativeSpecification columnWidths equals: #(nil 100).
+
+	self
+		assert: declarativeSpecification retriveFormattedItems
+		equals: self expectedColumnedListWithNumbersItems.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertColumnedListWithTextColumns
+	"Check the conversion to declarative specification with data"
+
+	<gtExample>
+	<return: #GtPhlowColumnedListViewSpecification>
+	| declarativeSpecification |
+	declarativeSpecification := (GtRemotePhlowDeclarativeTestInspectable new
+			gtColumnedListFor: self createProtoViews) asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: 'Columned list'.
+	self assert: declarativeSpecification priority equals: 20.
+	self
+		assert: declarativeSpecification columnTitles
+		equals: #('Value' 'Lowercase').
+	self assert: declarativeSpecification columnWidths equals: #(nil 100).
+
+	self
+		assert: declarativeSpecification retriveFormattedItems
+		equals: self expectedColumnedListForExampleObjectItems.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertColumnedListWithTypedColumns
+	"Check the conversion to declarative specification with data"
+
+	<gtExample>
+	<return: #GtPhlowColumnedListViewSpecification>
+	| declarativeSpecification |
+	declarativeSpecification := (GtRemotePhlowDeclarativeTestInspectable new
+			gtColumnedListWithTypedColumnsFor: self createProtoViews) asGtDeclarativeView.
+
+	self
+		assert: declarativeSpecification title
+		equals: 'Columned list with typed columns'.
+	self assert: declarativeSpecification priority equals: 24.
+	self
+		assert: (declarativeSpecification columnSpecifications
+				collect: [ :aColumnSpecification | aColumnSpecification typeLabel ])
+		equals: #('text' 'number' 'icon').
+	self
+		assert: declarativeSpecification columnTitles
+		equals: #('Text' 'Number' 'Icon Name').
+	self assert: declarativeSpecification columnWidths equals: #(nil 100 75).
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertColumnedTree
+	"Demonstrate converting a columned tree phlow view to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowColumnedTreeViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := self createProtoViews columnedTree
+			title: #Test;
+			priority: 10;
+			items: [ 1 to: 4 ];
+			children: [ :aNumber | aNumber = 0 ifTrue: [ #() ] ifFalse: [ 1 to: aNumber // 2 ] ];
+			column: 'One' text: [ :item | item ];
+			column: 'Two'
+				text: [ :item | (item + 1) asString ]
+				width: 100.
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: #Test.
+	self assert: declarativeSpecification priority equals: 10.
+	self assert: declarativeSpecification columnTitles equals: #('One' 'Two').
+	self assert: declarativeSpecification columnWidths equals: #(nil 100).
+
+	self
+		assert: declarativeSpecification retriveFormattedItems
+		equals: self expectedColumnedTreeWithNumberItems.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertListWithNumbers
+	"Demonstrate converting a columned list phlow view to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowListViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := self createProtoViews list
+			title: #Test;
+			priority: 10;
+			items: [ #(1 2 3) ];
+			itemText: [ :item | 'Number: ' , item asString ].
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: #Test.
+	self assert: declarativeSpecification priority equals: 10.
+	self
+		assert: declarativeSpecification retriveFormattedItems
+		equals: self expectedListWithNumberItems.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertListWithObjects
+	"Check the conversion to declarative specification with data"
+
+	<gtExample>
+	<return: #GtPhlowListViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := GtRemotePhlowDeclarativeTestInspectable new
+			gtListFor: self createProtoViews.
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: 'List'.
+	self assert: declarativeSpecification priority equals: 15.
+	self
+		assert: declarativeSpecification retriveFormattedItems
+		equals: self expectedListForExampleObjectItems.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertListWithStyledText
+	<gtExample>
+	<return: #GtPhlowListViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := GtRemotePhlowDeclarativeTestInspectable new
+			gtListWithStyledTextFor: self createProtoViews.
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: 'List - styled text'.
+	self assert: declarativeSpecification priority equals: 15.1.
+	self
+		assert: declarativeSpecification retriveFormattedItems
+		equals: self expectedListForStyledText.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertText
+	"Demonstrate converting a columned list phlow view to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowTextViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := self createProtoViews text
+			title: #Test;
+			priority: 11;
+			text: [ 'hello world' ].
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: #Test.
+	self assert: declarativeSpecification priority equals: 11.
+
+	self
+		assert: declarativeSpecification retrieveStylableText
+		equals: self expectedTextEditorBasicStringStylableTextData.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertTextEditor
+	"Demonstrate converting a columned list phlow view to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowTextEditorViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := self createProtoViews textEditor
+			title: 'String (editor)';
+			priority: 11;
+			text: [ 'hello world' ].
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: 'String (editor)'.
+	self assert: declarativeSpecification priority equals: 11.
+	self assert: declarativeSpecification string equals: nil.
+
+	self
+		assert: declarativeSpecification retrieveStylableText
+		equals: self expectedTextEditorBasicStringStylableTextData.
+
+	^ declarativeSpecification
+%
+
+category: 'examples'
+method: GtRemotePhlowViewSpecificationConversionExamples
+convertTree
+	"Demonstrate converting a tree phlow view to a declarative specification"
+
+	<gtExample>
+	<return: #GtPhlowTreeViewSpecification>
+	| phlowView declarativeSpecification |
+	phlowView := self createProtoViews tree
+			title: #Test;
+			priority: 10;
+			items: [ 1 to: 4 ];
+			children: [ :aNumber | aNumber = 0 ifTrue: [ #() ] ifFalse: [ 1 to: aNumber // 2 ] ].
+	declarativeSpecification := phlowView asGtDeclarativeView.
+
+	self assert: declarativeSpecification title equals: #Test.
+	self assert: declarativeSpecification priority equals: 10.
+	self
+		assert: declarativeSpecification retriveFormattedItems
+		equals: self expectedTreeWithNumberItems.
+
+	^ declarativeSpecification
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewSpecificationConversionExamples
+createProtoViews
+	^ GtRemotePhlowProtoView new
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedColumnedListForExampleObjectItems
+	^ ((Array new: 3) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'42'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'42'); yourself); yourself)); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'Hello World'); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'hello world'); yourself); yourself)); yourself)); add: (#nodeId->2); yourself); at: 3 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'2021-04-06T14:43:50.123456+02:00'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'2021-04-06t14:43:50.123456+02:00'); yourself); yourself)); yourself)); add: (#nodeId->3); yourself); yourself)
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedColumnedListWithNumbersItems
+	^ ((Array new: 3) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'1'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'1'); yourself); yourself)); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'2'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'2'); yourself); yourself)); yourself)); add: (#nodeId->2); yourself); at: 3 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'3'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'3'); yourself); yourself)); yourself)); add: (#nodeId->3); yourself); yourself)
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedColumnedTreeWithNumberItems
+	^ ((Array new: 4) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'1'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'2'); yourself); yourself)); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'2'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'3'); yourself); yourself)); yourself)); add: (#nodeId->2); yourself); at: 3 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'3'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'4'); yourself); yourself)); yourself)); add: (#nodeId->3); yourself); at: 4 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#columnValues->((Array new: 2) at: 1 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'4'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself); at: 2 put: ((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'5'); yourself); yourself)); yourself)); add: (#nodeId->4); yourself); yourself)
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedListForExampleObjectItems
+	^ ((Array new: 3) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'42'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'Hello World'); yourself)); add: (#nodeId->2); yourself); at: 3 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'2021-04-06T14:43:50.123456+02:00'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->3); yourself); yourself)
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedListForStyledText
+	^ ((Array new: 4) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'42'); add: ('attributeRuns'->((Dictionary new) add: ('items'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->2); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontWeightAttribute'); add: ('weight'->#bold); yourself); yourself)); yourself); yourself)); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'Hello World'); add: ('attributeRuns'->((Dictionary new) add: ('items'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->5); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 2) at: 1 put: ((Dictionary new) add: ('color'->((Dictionary new) add: (#a->1.0); add: (#r->1.0); add: (#g->1.0); add: (#b->0.0); yourself)); add: ('__typeLabel'->'phlowTextHighlightAttribute'); yourself); at: 2 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontSizeAttribute'); add: ('size'->20); yourself); yourself)); yourself); yourself)); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->2); yourself); at: 3 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'Now is the time'); add: ('attributeRuns'->((Dictionary new) add: ('items'->((Array new: 9) at: 1 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->11); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('name'->'Source Code Pro'); add: ('__typeLabel'->'phlowFontNameAttribute'); yourself); yourself)); yourself); at: 2 put: ((Dictionary new) add: ('startIndex'->13); add: ('endIndex'->15); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('name'->'Source Code Pro'); add: ('__typeLabel'->'phlowFontNameAttribute'); yourself); yourself)); yourself); at: 3 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->4); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontWeightAttribute'); add: ('weight'->#bold); yourself); yourself)); yourself); at: 4 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->6); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontEmphasisAttribute'); add: ('emphasis'->'italic'); yourself); yourself)); yourself); at: 5 put: ((Dictionary new) add: ('startIndex'->5); add: ('endIndex'->6); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('color'->((Dictionary new) add: (#a->1.0); add: (#r->1.0); add: (#g->1.0); add: (#b->0.0); yourself)); add: ('__typeLabel'->'phlowTextHighlightAttribute'); yourself); yourself)); yourself); at: 6 put: ((Dictionary new) add: ('startIndex'->8); add: ('endIndex'->10); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('color'->((Dictionary new) add: (#a->1.0); add: (#r->1.0); add: (#g->0.0); add: (#b->0.0); yourself)); add: ('__typeLabel'->'phlowTextForegroundAttribute'); yourself); yourself)); yourself); at: 7 put: ((Dictionary new) add: ('startIndex'->8); add: ('endIndex'->15); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontWeightAttribute'); add: ('weight'->#thin); yourself); yourself)); yourself); at: 8 put: ((Dictionary new) add: ('startIndex'->12); add: ('endIndex'->12); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('name'->'Source Sans Pro'); add: ('__typeLabel'->'phlowFontNameAttribute'); yourself); yourself)); yourself); at: 9 put: ((Dictionary new) add: ('startIndex'->12); add: ('endIndex'->15); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontSizeAttribute'); add: ('size'->20); yourself); yourself)); yourself); yourself)); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->3); yourself); at: 4 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'Now is the time'); add: ('attributeRuns'->((Dictionary new) add: ('items'->((Array new: 9) at: 1 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->11); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('name'->'Source Code Pro'); add: ('__typeLabel'->'phlowFontNameAttribute'); yourself); yourself)); yourself); at: 2 put: ((Dictionary new) add: ('startIndex'->13); add: ('endIndex'->15); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('name'->'Source Code Pro'); add: ('__typeLabel'->'phlowFontNameAttribute'); yourself); yourself)); yourself); at: 3 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->4); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontWeightAttribute'); add: ('weight'->#bold); yourself); yourself)); yourself); at: 4 put: ((Dictionary new) add: ('startIndex'->1); add: ('endIndex'->6); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontEmphasisAttribute'); add: ('emphasis'->'italic'); yourself); yourself)); yourself); at: 5 put: ((Dictionary new) add: ('startIndex'->5); add: ('endIndex'->6); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('color'->((Dictionary new) add: (#a->1.0); add: (#r->1.0); add: (#g->1.0); add: (#b->0.0); yourself)); add: ('__typeLabel'->'phlowTextHighlightAttribute'); yourself); yourself)); yourself); at: 6 put: ((Dictionary new) add: ('startIndex'->8); add: ('endIndex'->10); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('color'->((Dictionary new) add: (#a->1.0); add: (#r->1.0); add: (#g->0.0); add: (#b->0.0); yourself)); add: ('__typeLabel'->'phlowTextForegroundAttribute'); yourself); yourself)); yourself); at: 7 put: ((Dictionary new) add: ('startIndex'->8); add: ('endIndex'->15); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontWeightAttribute'); add: ('weight'->#thin); yourself); yourself)); yourself); at: 8 put: ((Dictionary new) add: ('startIndex'->12); add: ('endIndex'->12); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('name'->'Source Sans Pro'); add: ('__typeLabel'->'phlowFontNameAttribute'); yourself); yourself)); yourself); at: 9 put: ((Dictionary new) add: ('startIndex'->12); add: ('endIndex'->15); add: ('__typeLabel'->'phlowRun'); add: ('attributes'->((Array new: 1) at: 1 put: ((Dictionary new) add: ('__typeLabel'->'phlowFontSizeAttribute'); add: ('size'->20); yourself); yourself)); yourself); yourself)); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->4); yourself); yourself)
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedListWithNumberItems
+	^ ((Array new: 3) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'Number: 1'); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'Number: 2'); yourself)); add: (#nodeId->2); yourself); at: 3 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->'Number: 3'); yourself)); add: (#nodeId->3); yourself); yourself)
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedTextEditorBasicStringStylableTextData
+	^ ((Dictionary new) add: ('string'->'hello world'); add: ('__typeLabel'->'remotePhlowText'); add: ('stylerSpecification'->((Dictionary new) add: ('__typeLabel'->'remotePhlowTextAttributeRunsStylerSpecification'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)
+%
+
+category: 'accessing - data'
+method: GtRemotePhlowViewSpecificationConversionExamples
+expectedTreeWithNumberItems
+	^ ((Array new: 4) at: 1 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'1'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->1); yourself); at: 2 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'2'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->2); yourself); at: 3 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'3'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->3); yourself); at: 4 put: ((Dictionary new) add: (#nodeValue->((Dictionary new) add: (#valueTypeName->'textualValue'); add: (#itemText->((Dictionary new) add: ('__typeLabel'->'gtPhlowRunBasedText'); add: ('sourceString'->'4'); add: ('attributeRuns'->((Dictionary new) add: ('items'->#()); add: ('__typeLabel'->'phlowRunsGroup'); yourself)); yourself)); yourself)); add: (#nodeId->4); yourself); yourself)
+%
+
+! Class implementation for 'GtRemotePhlowStylableText'
+
+!		Class methods for 'GtRemotePhlowStylableText'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowStylableText
+fromJSONDictionary: aDictionary
+	^ self new
+		initializeFromJSONDictionary: aDictionary
+%
+
+category: 'accessing'
+classmethod: GtRemotePhlowStylableText
+typeLabel
+	^ 'remotePhlowText'
+%
+
+!		Instance methods for 'GtRemotePhlowStylableText'
+
+category: 'converting'
+method: GtRemotePhlowStylableText
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	| dataForExport |
+	dataForExport := Dictionary new.
+	dataForExport
+		at: '__typeLabel' put: self class typeLabel;
+		at: 'string' put: self string.
+	self stylerSpecification
+		ifNotNil: [ :aStylerSpecification | 
+			dataForExport
+				at: 'stylerSpecification'
+				put: aStylerSpecification asDictionaryForExport ].
+	highlight
+		ifNotNil: [ dataForExport at: 'highlight' put: highlight asDictionaryForExport ].
+
+	^ dataForExport
+%
+
+category: 'accessing'
+method: GtRemotePhlowStylableText
+createStyledText
+	^ self stylerSpecification 
+		ifNil: [ string asRopedText ]
+		ifNotNil: [ :aStylerSpecification |
+			aStylerSpecification createBlStyler 
+				style: string asRopedText]
+%
+
+category: 'accessing'
+method: GtRemotePhlowStylableText
+highlight
+	^ highlight
+%
+
+category: 'accessing'
+method: GtRemotePhlowStylableText
+highlight: aGtPhlowTextHighlight
+	highlight := aGtPhlowTextHighlight
+%
+
+category: 'initialization'
+method: GtRemotePhlowStylableText
+initializeFromJSONDictionary: aDictionary
+	self string: (aDictionary at: 'string').
+
+	(aDictionary includesKey: 'stylerSpecification')
+		ifTrue: [ self
+				stylerSpecification: (GtRemotePhlowTextStylerSpecification
+						fromJSONDictionary: (aDictionary at: 'stylerSpecification')) ].
+	aDictionary
+		at: 'highlight'
+		ifPresent: [ :dict | self highlight: (GtPhlowTextHighlight fromJSONDictionary: dict) ]
+%
+
+category: 'accessing'
+method: GtRemotePhlowStylableText
+string
+	^ string
+%
+
+category: 'accessing'
+method: GtRemotePhlowStylableText
+string: anObject
+	string := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowStylableText
+stylerSpecification
+	^ stylerSpecification
+%
+
+category: 'accessing'
+method: GtRemotePhlowStylableText
+stylerSpecification: anObject
+	stylerSpecification := anObject
+%
+
+! Class implementation for 'GtRemotePhlowTextStylerSpecification'
+
+!		Class methods for 'GtRemotePhlowTextStylerSpecification'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowTextStylerSpecification
+fromJSONDictionary: aTextStylerSpecificationData 
+	| typeLabel stylerSpecificationClass |
+ 	typeLabel := aTextStylerSpecificationData at: '__typeLabel'.
+ 	
+ 	stylerSpecificationClass := self stylerSpecificationClassForType: typeLabel.
+		
+	^ stylerSpecificationClass 
+		ifNil: [ nil ]
+		ifNotNil: [
+			stylerSpecificationClass new 
+				initializeFromJSONDictionary: aTextStylerSpecificationData ]
+%
+
+category: 'instance creation'
+classmethod: GtRemotePhlowTextStylerSpecification
+stylerSpecificationClassForType: aTypeLabel 
+	aTypeLabel = GtRemotePhlowTextAttributeRunsStylerSpecification typeLabel ifTrue: [
+ 		^ GtRemotePhlowTextAttributeRunsStylerSpecification  ].
+			
+	aTypeLabel = GtRemotePhlowTextClassStylerSpecification typeLabel ifTrue: [
+ 		^ GtRemotePhlowTextClassStylerSpecification  ].
+			
+	aTypeLabel = GtRemotePhlowTextParserStylerSpecification typeLabel ifTrue: [
+ 		^  GtRemotePhlowTextParserStylerSpecification ].
+ 		
+ 	^ nil
+%
+
+category: 'accessing'
+classmethod: GtRemotePhlowTextStylerSpecification
+typeLabel
+	^ '<missing>'
+%
+
+!		Instance methods for 'GtRemotePhlowTextStylerSpecification'
+
+category: 'converting'
+method: GtRemotePhlowTextStylerSpecification
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ Dictionary new 
+		at: '__typeLabel' put: self class typeLabel;
+		yourself
+%
+
+category: 'testing'
+method: GtRemotePhlowTextStylerSpecification
+canAffectText
+	^ true
+%
+
+category: 'converting'
+method: GtRemotePhlowTextStylerSpecification
+convertToSerializableSpecificationForText: aText
+	^ self
+%
+
+category: 'initialization'
+method: GtRemotePhlowTextStylerSpecification
+initializeFromJSONDictionary: aTextStylerSpecificationData 
+	
+%
+
+! Class implementation for 'GtRemotePhlowTextAttributeRunsStylerSpecification'
+
+!		Class methods for 'GtRemotePhlowTextAttributeRunsStylerSpecification'
+
+category: 'accessing'
+classmethod: GtRemotePhlowTextAttributeRunsStylerSpecification
+typeLabel
+	^ 'remotePhlowTextAttributeRunsStylerSpecification'
+%
+
+!		Instance methods for 'GtRemotePhlowTextAttributeRunsStylerSpecification'
+
+category: 'converting'
+method: GtRemotePhlowTextAttributeRunsStylerSpecification
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ super asDictionaryForExport
+		at: 'attributeRuns' put: attributeRuns  asDictionaryForExport;
+		yourself
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextAttributeRunsStylerSpecification
+attributeRuns
+	^ attributeRuns
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextAttributeRunsStylerSpecification
+attributeRuns: aCollection
+	attributeRuns := aCollection
+%
+
+category: 'testing'
+method: GtRemotePhlowTextAttributeRunsStylerSpecification
+canAffectText
+	^ attributeRuns notNil and: [ attributeRuns notEmpty ]
+%
+
+category: 'gt - extensions'
+method: GtRemotePhlowTextAttributeRunsStylerSpecification
+gtViewRunWithAttributesFor: aView 
+	<gtView>
+	
+	^ aView forward 
+		title: 'Runs';
+		object: [ attributeRuns ];
+		view: #gtViewIntervalsFor:
+%
+
+category: 'initialization'
+method: GtRemotePhlowTextAttributeRunsStylerSpecification
+initializeFromJSONDictionary: aTextStylerSpecificationData 
+	super initializeFromJSONDictionary: aTextStylerSpecificationData .
+	
+	attributeRuns := GtPhlowRuns fromJSONDictionary:   (aTextStylerSpecificationData at: 'attributeRuns')
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextAttributeRunsStylerSpecification
+numberOfRuns
+	^ attributeRuns 
+		ifNil: [ 0 ] 
+		ifNotNil: [ attributeRuns size ]
+%
+
+! Class implementation for 'GtRemotePhlowTextClassStylerSpecification'
+
+!		Class methods for 'GtRemotePhlowTextClassStylerSpecification'
+
+category: 'accessing'
+classmethod: GtRemotePhlowTextClassStylerSpecification
+typeLabel
+	^ 'remotePhlowTextClassStylerSpecification'
+%
+
+!		Instance methods for 'GtRemotePhlowTextClassStylerSpecification'
+
+category: 'converting'
+method: GtRemotePhlowTextClassStylerSpecification
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ super asDictionaryForExport
+		at: 'stylerClassName' put: stylerClassName;
+		yourself
+%
+
+category: 'initialization'
+method: GtRemotePhlowTextClassStylerSpecification
+initializeFromJSONDictionary: aTextStylerSpecificationData 
+	super initializeFromJSONDictionary: aTextStylerSpecificationData .
+	
+	stylerClassName := (aTextStylerSpecificationData at: 'stylerClassName') asSymbol
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextClassStylerSpecification
+stylerClassName
+	^ stylerClassName
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextClassStylerSpecification
+stylerClassName: aClassName
+	stylerClassName := aClassName
+%
+
+! Class implementation for 'GtRemotePhlowTextParserStylerSpecification'
+
+!		Class methods for 'GtRemotePhlowTextParserStylerSpecification'
+
+category: 'accessing'
+classmethod: GtRemotePhlowTextParserStylerSpecification
+typeLabel
+	^ 'remotePhlowTextParserStylerSpecification'
+%
+
+!		Instance methods for 'GtRemotePhlowTextParserStylerSpecification'
+
+category: 'converting'
+method: GtRemotePhlowTextParserStylerSpecification
+asDictionaryForExport
+	"Answer the receiver as a dictionary ready for JSON serialisation.
+	Subclasses will override and add to the dictionary"
+
+	^ super asDictionaryForExport
+		at: 'parserClassName' put: parserClassName;
+		yourself
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextParserStylerSpecification
+initializeFromJSONDictionary: aTextStylerSpecificationData 
+	super initializeFromJSONDictionary: aTextStylerSpecificationData .
+	
+	parserClassName := (aTextStylerSpecificationData at: 'parserClassName') asSymbol
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextParserStylerSpecification
+parserClassName
+	^ parserClassName
+%
+
+category: 'accessing'
+method: GtRemotePhlowTextParserStylerSpecification
+parserClassName: aClassName
+	parserClassName := aClassName
+%
+
+! Class implementation for 'GtRemotePhlowTextNullStylerSpecification'
+
+!		Class methods for 'GtRemotePhlowTextNullStylerSpecification'
+
+category: 'accessing'
+classmethod: GtRemotePhlowTextNullStylerSpecification
+typeLabel
+	^ 'remotePhlowTextNullStylerSpecification'
+%
+
+!		Instance methods for 'GtRemotePhlowTextNullStylerSpecification'
+
+category: 'testing'
+method: GtRemotePhlowTextNullStylerSpecification
+canAffectText
+	^ false
+%
+
+! Class implementation for 'GtRemoteTextStylerComputableSpecification'
+
+!		Instance methods for 'GtRemoteTextStylerComputableSpecification'
+
+category: 'converting'
+method: GtRemoteTextStylerComputableSpecification
+convertToSerializableSpecificationForText: aText
+	| computedStyler styledText |
+	
+	computedStyler := self stylerComputation value.
+	styledText := computedStyler style: aText.
+	^ GtRemotePhlowTextAttributeRunsStylerSpecification new
+		attributeRuns: styledText extractRemotePhlowRuns
+%
+
+category: 'accessing'
+method: GtRemoteTextStylerComputableSpecification
+stylerComputation
+	^ stylerComputation
+%
+
+category: 'accessing'
+method: GtRemoteTextStylerComputableSpecification
+stylerComputation: aComputation
+	stylerComputation := aComputation
+%
+
+! Class implementation for 'GtRemotePhlowViewedObject'
+
+!		Class methods for 'GtRemotePhlowViewedObject'
+
+category: 'instance creation'
+classmethod: GtRemotePhlowViewedObject
+object: anObject
+
+	^ self new initializeWith: anObject
+%
+
+!		Instance methods for 'GtRemotePhlowViewedObject'
+
+category: 'accessing'
+method: GtRemotePhlowViewedObject
+actionSpecificationsBySelector
+	actionSpecificationsBySelector ifNil: [ 
+		self initializeActionSpecifications ].
+	^ actionSpecificationsBySelector
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+computeActionSpecificationForPhlowAction: aPhlowAction
+	^ [ aPhlowAction asGtDeclarativeAction ] 
+		on: Error do: [ :anError |
+			| errorView |
+			errorView := aPhlowAction phlowErrorViewWithException: anError.
+			errorView title: aPhlowAction title.
+			errorView priority: aPhlowAction priority.
+			
+			errorView asGtDeclarativeAction ]
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+computeDeclarativeActionSpecifications
+	| specifications phlowActions |
+	
+	specifications := OrderedCollection new. 
+
+	phlowActions := self phlowDeclarativeActions.
+	phlowActions
+		do: [ :aPhlowAction | 
+			| actionSpecification |
+			actionSpecification := self 
+				computeActionSpecificationForPhlowAction: aPhlowAction.
+			actionSpecification
+				ifNotNil: [ 
+					actionSpecification methodSelector: aPhlowAction definingSelector.
+					specifications add: actionSpecification ] ].
+					
+	^ specifications
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+computeDeclarativeViewSpecifications
+	| specifications phlowViews |
+
+	specifications := OrderedCollection new. 
+	
+	phlowViews := self phlowDeclarativeViews.
+	phlowViews do: [ :aPhlowView | 
+		| viewSpecification |
+		viewSpecification := self computeViewSpecificationForPhlowView: aPhlowView.
+		viewSpecification
+			ifNotNil: [ 
+				viewSpecification methodSelector: aPhlowView definingSelector.
+				specifications add: viewSpecification ] ].
+					 
+	^ specifications
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+computeViewSpecificationForPhlowView: aPhlowView
+	^ [ aPhlowView asGtDeclarativeView ] 
+		on: Error do: [ :anError |
+			| errorView |
+			errorView := aPhlowView phlowErrorViewWithException: anError.
+			errorView title: aPhlowView title.
+			errorView priority: aPhlowView priority.
+			
+			errorView asGtDeclarativeView ]
+%
+
+category: 'api - views'
+method: GtRemotePhlowViewedObject
+getActionSpecificationDataFor: anActionSelector
+	| declarativeAction |
+	declarativeAction := self getActionSpecificationFor: anActionSelector.
+	^ self specificationDataForAction: declarativeAction
+%
+
+category: 'api - actions'
+method: GtRemotePhlowViewedObject
+getActionSpecificationFor: anActionSelector
+	^ self actionSpecificationsBySelector 
+		at: anActionSelector
+%
+
+category: 'api - actions'
+method: GtRemotePhlowViewedObject
+getActionSpecifications
+	^ self getActionSpecificationsData
+%
+
+category: 'api - actions'
+method: GtRemotePhlowViewedObject
+getActionSpecificationsData
+	| actionsSpecifications |
+	actionsSpecifications := self actionSpecificationsBySelector 
+		collect: [ :anActionSpecification |
+			self specificationDataForAction: anActionSpecification ].
+	^ Dictionary new
+		at: 'actions' put: actionsSpecifications asArray;
+		yourself
+%
+
+category: 'api - actions'
+method: GtRemotePhlowViewedObject
+getActionSpecificationsPhlowDataSource
+	| actionsSpecifications |
+	actionsSpecifications := (self actionSpecificationsBySelector 
+		collect: [ :anActionSpecification |
+			(self specificationDataForAction: anActionSpecification)
+				ifNotNil: [ :aDictionary |
+					aDictionary 
+						at: 'phlowDataSource' 
+							put: anActionSpecification phlowDataSource;
+						yourself ] ]).
+	^ Dictionary new
+		at: 'actions' put: actionsSpecifications asArray;
+		yourself
+%
+
+category: 'api - actions'
+method: GtRemotePhlowViewedObject
+getActionSpecificationsWithPhlowDataSource
+	| actionsSpecifications |
+	actionsSpecifications := (self actionSpecificationsBySelector 
+		collect: [ :anActionSpecification |
+			(self specificationDataForAction: anActionSpecification)
+				ifNotNil: [ :aDictionary |
+					aDictionary 
+						at: 'phlowDataSource' 
+							put: anActionSpecification phlowDataSource;
+						yourself ] ]).
+	^ Dictionary new
+		at: 'actions' put: actionsSpecifications asArray;
+		yourself
+%
+
+category: 'api  - inspector'
+method: GtRemotePhlowViewedObject
+getClassSpecification
+	^ GtRemotePhlowViewedObjectClassSpecification forClass: object class
+%
+
+category: 'api  - inspector'
+method: GtRemotePhlowViewedObject
+getClassSpecificationData 
+	^ self getClassSpecification asDictionaryForExport
+%
+
+category: 'api - actions'
+method: GtRemotePhlowViewedObject
+getDeclarativeActionDataSourceFor: anActionSelector
+	^ (self getActionSpecificationFor: anActionSelector) phlowDataSource
+%
+
+category: 'api - views deprecated'
+method: GtRemotePhlowViewedObject
+getDeclarativeViewFor: viewSelector
+	^ self getViewSpecificationFor: viewSelector
+%
+
+category: 'api - views'
+method: GtRemotePhlowViewedObject
+getDeclarativeViewMethodNames
+	"Answer the set of declarative view selectors provided by the object"
+
+	^ self viewSpecificationsBySelector keys
+%
+
+category: 'api  - inspector'
+method: GtRemotePhlowViewedObject
+getInspectorSpecificationData
+	^ Dictionary new 
+		at: 'gtDisplayString' put: (
+			self getRemoteObjectGtDisplayString);
+		at: 'views' put:   (self getViewSpecificationsData
+			at: 'views');
+		at: 'actions' put: (self getActionSpecificationsData
+			at: 'actions');
+		at:'class' put: self getClassSpecificationData;
+		yourself
+%
+
+category: 'api  - inspector'
+method: GtRemotePhlowViewedObject
+getInspectorSpecificationWithPhlowDataSource
+	^ Dictionary new 
+		at: 'gtDisplayString' put: (
+			self getRemoteObjectGtDisplayString);
+		at: 'views' put:   (self getViewSpecificationWithPhlowDataSource
+			at: 'views');
+		at: 'actions' put: (self getActionSpecificationsWithPhlowDataSource
+			at: 'actions');
+		at:'class' put: self getClassSpecificationData;
+		yourself
+%
+
+category: 'api - printing'
+method: GtRemotePhlowViewedObject
+getRemoteObjectGtDisplayString
+	^ object gtDisplayString
+%
+
+category: 'api - views deprecated'
+method: GtRemotePhlowViewedObject
+getViewDeclaration: aViewSelector
+	^ self getViewSpecificationDataFor: aViewSelector
+%
+
+category: 'api - views deprecated'
+method: GtRemotePhlowViewedObject
+getViewsDeclarations
+	^ self getViewSpecificationsData
+%
+
+category: 'api - views deprecated'
+method: GtRemotePhlowViewedObject
+getViewsDeclarationsWithPhlowDataSource
+	^ self getViewSpecificationWithPhlowDataSource
+%
+
+category: 'api - views'
+method: GtRemotePhlowViewedObject
+getViewSpecificationDataFor: aViewSelector
+	| declarativeView |
+	declarativeView := self getViewSpecificationFor: aViewSelector.
+	^ self specificationDataForView: declarativeView
+%
+
+category: 'api - views'
+method: GtRemotePhlowViewedObject
+getViewSpecificationFor: viewSelector
+	^ self viewSpecificationsBySelector at: viewSelector
+%
+
+category: 'api - views'
+method: GtRemotePhlowViewedObject
+getViewSpecificationsData
+	| viewDeclarations |
+	viewDeclarations := (self viewSpecificationsBySelector 
+		collect: [ :aViewSpecification |
+			self specificationDataForView: aViewSpecification ]).
+	^ Dictionary new
+		at: 'views' put: viewDeclarations asArray;
+		yourself
+%
+
+category: 'api  - inspector'
+method: GtRemotePhlowViewedObject
+getViewSpecificationWithPhlowDataSource
+	| viewDeclarations |
+	viewDeclarations := (self viewSpecificationsBySelector 
+		collect: [ :aViewSpecification |
+			(self specificationDataForView: aViewSpecification)
+				ifNotNil: [ :aDictionary |
+					aDictionary 
+						at: 'phlowDataSource' put: aViewSpecification;
+						yourself ] ]).
+	^ Dictionary new
+		at: 'views' put: viewDeclarations asArray;
+		yourself
+%
+
+category: 'gt - extensions'
+method: GtRemotePhlowViewedObject
+gtViewCurrentViewsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Current views';
+		priority: 10;
+		items: [ (viewSpecificationsBySelector
+			ifNil: [ #() ] ifNotNil: [ :aDictionary | aDictionary values ]) 
+				sort: [ :a :b |  a priority < b priority ]];
+		column: 'Title' text: [ :aViewAccessor | aViewAccessor title ];
+		column: 'Selector' text: [ :aViewAccessor | aViewAccessor methodSelector ];
+		column: 'View' text: [ :aViewAccessor | aViewAccessor viewName ];
+		column: 'Priority' text: [ :aViewAccessor | aViewAccessor priority ] width: 75;
+		column: 'Transport' text: [ :aViewAccessor | aViewAccessor dataTransport ] width: 75;
+		send: [ :aDeclarativeView | aDeclarativeView ]
+%
+
+category: 'gt - extensions'
+method: GtRemotePhlowViewedObject
+gtViewsCurrentActionsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Current actions';
+		priority: 20;
+		items: [ (actionSpecificationsBySelector
+			ifNil: [ #() ] ifNotNil: [ :aDictionary | aDictionary values ]) 
+				sort: [ :a :b |  a priority < b priority ]];
+		column: 'Tooltip' text: [ :aViewAccessor | aViewAccessor tooltipText ];
+		column: 'Label' text: [ :aViewAccessor | aViewAccessor label ];
+		"column: 'Icon' 
+			icon: [ :aViewAccessor | 
+				aViewAccessor iconStencil ifNil: [BlElement new
+					size: 0@0] ] 
+			width: 75;"
+		column: 'Selector' text: [ :aViewAccessor | aViewAccessor methodSelector ];
+		column: 'Priority' text: [ :aViewAccessor | aViewAccessor priority ] width: 70;
+		send: [ :aDeclarativeView | aDeclarativeView ]
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+initializeActionSpecifications
+	actionSpecificationsBySelector := Dictionary new.
+
+	self computeDeclarativeActionSpecifications
+		do: [ :anActionSpecification |
+			actionSpecificationsBySelector
+				at: anActionSpecification methodSelector
+				put: anActionSpecification ] 
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+initializeViewSpecifications
+	viewSpecificationsBySelector := Dictionary new.
+
+	self computeDeclarativeViewSpecifications
+		do: [ :aViewSpecification| 
+			viewSpecificationsBySelector
+				at: aViewSpecification methodSelector
+				put: aViewSpecification ] 
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+initializeWith: anObject
+	object := anObject
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewedObject
+object
+
+	^ object
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+phlowDeclarativeActions
+	"Retrieve the declarative phlow actions of the current object."
+	
+	 ^ object gtDeclarativePhlowActions.
+%
+
+category: 'initialization'
+method: GtRemotePhlowViewedObject
+phlowDeclarativeViews
+	"Retrieve the objects declarative views.
+	If the default Raw view can't be declarative, provide one that is."
+	| views |
+
+	views := object gtDeclarativePhlowViews.
+	views 
+		detect: [ :each | each title = 'Raw' ]
+		ifNone: [ views := views, (Array with: (object 
+			gtRemoteGtRawFor: #GtPhlowView asClass empty)) ].
+	
+	^ views
+%
+
+category: 'utils'
+method: GtRemotePhlowViewedObject
+specificationDataForAction: anActionSpecification
+
+	^ anActionSpecification asDictionaryForExport
+%
+
+category: 'utils'
+method: GtRemotePhlowViewedObject
+specificationDataForView: aViewSpecification
+
+	^ aViewSpecification asDictionaryForExport
+%
+
+category: 'accessing'
+method: GtRemotePhlowViewedObject
+viewSpecificationsBySelector
+	viewSpecificationsBySelector ifNil: [ 
+		self initializeViewSpecifications ].
+	^ viewSpecificationsBySelector
+%
+
+! Class implementation for 'GtRmGeoGpsGroup'
+
+!		Instance methods for 'GtRmGeoGpsGroup'
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+add: anObject
+	self clearCache.
+	self items add: anObject
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+addAll: aCollection
+	self clearCache.
+	self items addAll: aCollection
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+cacheAt: aKey ifAbsentPut: aBlock
+	cache ifNil: [ 
+		cache := Dictionary new].
+	^ cache 
+		at: aKey
+		ifAbsentPut: [ aBlock value ]
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+clearCache
+	cache := nil
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+collect: aBlock
+	^ self items  collect: aBlock
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+detect: aBlock ifNone: exceptionBlock
+	^ self items 
+		detect: aBlock ifNone: exceptionBlock
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+do: aBlock 
+	self items do: aBlock
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+items
+	^ items ifNil: [
+		items := OrderedCollection new ]
+%
+
+category: 'printing'
+method: GtRmGeoGpsGroup
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream 
+		<< '[';
+		print: self size;
+		<< ' items';
+		<< ']'
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+select: aBlock
+	^ self class new 
+		addAll: (self items  select: aBlock)
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+size
+	^ self items size
+%
+
+category: 'accessing'
+method: GtRmGeoGpsGroup
+sumNumbers: aBlock
+	^ self items
+		inject: 0 
+		into: [ :sum :each |  sum + (aBlock value: each) ]
+%
+
+! Class implementation for 'GtRmGeoGpsRecordsGroup'
+
+!		Instance methods for 'GtRmGeoGpsRecordsGroup'
+
+category: 'accessing'
+method: GtRmGeoGpsRecordsGroup
+computeDistance
+	| distance |
+	self size = 1 ifTrue: [ ^ 0 ].
+	distance := 0.
+	1 to: self size - 1 do: [ :anIndex |
+		distance := distance + (self
+			distanceFrom: (self items at: anIndex)
+			to: (self items at: anIndex + 1)) ].
+	^ distance
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecordsGroup
+computeDistanceWithBug
+	| distance |
+	self size = 1 ifTrue: [ ^ 0 ].
+	distance := 0.
+	1 to: self size + 1 do: [ :anIndex |
+		distance := distance + (self
+			distanceFrom: (self items at: anIndex)
+			to: (self items at: anIndex + 1)) ].
+	^ distance
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecordsGroup
+distance
+	^ self 
+		cacheAt: 'distance' 
+		ifAbsentPut: [
+			self computeDistance ]
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecordsGroup
+distanceBetween: firstPosition and: secondPosition
+        "T3GeoTools distanceBetween: 5.33732@50.926 and: 5.49705@50.82733"
+
+        | c |
+        c := (firstPosition y degreesToRadians sin 
+        	* secondPosition y degreesToRadians sin)
+                + (firstPosition y degreesToRadians cos 
+                	* secondPosition y degreesToRadians cos
+                        * (secondPosition x degreesToRadians 
+                        	- firstPosition x degreesToRadians) cos).
+        c := c >= 0 ifTrue: [ 1 min: c ] ifFalse: [ -1 max: c ].
+        ^ c arcCos * 6371000
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecordsGroup
+distanceFrom: firstRecord to: secondRecord
+	| c |
+    c := (firstRecord longitude degreesToRadians sin 
+    	* secondRecord longitude degreesToRadians sin)
+			+ (firstRecord longitude degreesToRadians cos 
+				* secondRecord longitude degreesToRadians cos
+            		* (secondRecord latitude degreesToRadians 
+            			- firstRecord latitude degreesToRadians) cos).
+    c := c >= 0 ifTrue: [ 1 min: c ] ifFalse: [ -1 max: c ].
+    ^ c arcCos * 6371000
+%
+
+category: 'gt - extensions'
+method: GtRmGeoGpsRecordsGroup
+gtItemsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Records';
+		items: [ self items ];
+		column: 'Timestamp' text: [ :aRecord | aRecord timestamp ];
+		column: 'Latitude' text: [ :aRecord | aRecord latitude ];
+		column: 'Longitude' text: [ :aRecord | aRecord longitude ]
+%
+
+! Class implementation for 'GtRmGeoGpsTrajectoriesGroup'
+
+!		Instance methods for 'GtRmGeoGpsTrajectoriesGroup'
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectoriesGroup
+allRecords
+	^ self 
+		cacheAt: 'allRecords' 
+		ifAbsentPut: [  
+			self items
+				inject: GtRmGeoGpsRecordsGroup new 
+				into: [ :records :aTrajectory |
+					records addAll: aTrajectory records items.
+					records ] ]
+%
+
+category: 'gt - extensions'
+method: GtRmGeoGpsTrajectoriesGroup
+gtItemsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Trajectories';
+		items: [ self items ];
+		column: 'Filename' text: [ :aTrajectory | 
+			aTrajectory targetFolderName ];
+		column: 'Records' text: [ :aTrajectory | 
+			aTrajectory numberOfRecords ];
+		column: 'Distance (km)' text: [ :aTrajectory | 
+			self 
+				gtDo: [
+					(aTrajectory distance /1000) printShowingDecimalPlaces: 2] 
+				gemstoneDo: [
+					(aTrajectory distance /1000) asStringUsingFormat: #(0 2 false)  ] ]
+%
+
+! Class implementation for 'GtRmGeoGpsUsersGroup'
+
+!		Instance methods for 'GtRmGeoGpsUsersGroup'
+
+category: 'accessing'
+method: GtRmGeoGpsUsersGroup
+allRecords
+	^ self 
+		cacheAt: 'allRecords'
+		ifAbsentPut: [ 
+			self allTrajectories allRecords ]
+%
+
+category: 'accessing'
+method: GtRmGeoGpsUsersGroup
+allTrajectories
+	^ self 
+		cacheAt: 'allTrajectories'
+		ifAbsentPut: [  
+			self items
+				inject: GtRmGeoGpsTrajectoriesGroup new 
+				into: [ :trajectories :aUser |
+					trajectories addAll: aUser trajectories.
+					trajectories ] ]
+%
+
+category: 'gt - extensions'
+method: GtRmGeoGpsUsersGroup
+gtItemsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Users';
+		priority: 5;
+		items: [ self items ];
+		column: 'Id' text: [ :aUser | aUser id ];
+		column: 'Number of trajectories' 
+			text: [ :aUser | aUser numberOfTrajectories ];
+		column: 'Number of records' 
+			text: [ :aUser | aUser numberOfRecords  ]
+%
+
+category: 'gt - extensions'
+method: GtRmGeoGpsUsersGroup
+gtViewAllTrajectoriesFor: aView
+	<gtView>
+	
+	^ aView forward
+		title: 'All trajectories';
+		priority: 45;
+		object: [ self allTrajectories ];
+		view: #gtItemsFor:
+%
+
+category: 'accessing'
+method: GtRmGeoGpsUsersGroup
+removeUser: aString
+	"Remove the supplied user.
+	GS only has #detect:ifNone: (not #detect:ifFound:)"
+
+	(items
+		detect: [ :user | user id = aString ]
+		ifNone: [ nil ]) ifNotNil:
+			[ :user | items remove: user ]
+%
+
+category: 'accessing'
+method: GtRmGeoGpsUsersGroup
+shortDistancesWithBug
+	^ self allTrajectories select: [ :aTrajectory |
+		aTrajectory distanceWithBug < 5 ]
+%
+
+! Class implementation for 'GtRmGeoGpsRecord'
+
+!		Class methods for 'GtRmGeoGpsRecord'
+
+category: 'instance creation'
+classmethod: GtRmGeoGpsRecord
+fromJsonDictionary: aDictionary
+	^ self new 
+		initializeFomJsonDictionary: aDictionary
+%
+
+!		Instance methods for 'GtRmGeoGpsRecord'
+
+category: 'converting'
+method: GtRmGeoGpsRecord
+asJsonDictionary
+	^ {
+		#timestamp -> self timestamp.
+		#latitude -> self latitude.
+		#longitude -> self longitude } asDictionary
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+asPoint
+
+	^ self longitude @ self latitude
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+googleMapsUrl
+	^ 'https://www.google.com/maps/search/?api=1&query='
+		,self latitude printString
+		,'%2C'
+		, self longitude printString 
+%
+
+category: 'initialization'
+method: GtRmGeoGpsRecord
+initializeFomJsonDictionary: aDictionary
+	self latitude: (aDictionary at: #latitude).
+	self longitude: (aDictionary at: #longitude).
+	self timestamp: (aDictionary at: #timestamp)
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+latitude
+	^ latitude
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+latitude: aFloat
+	latitude := aFloat
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+longitude
+	^ longitude
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+longitude: aFloat
+	longitude := aFloat
+%
+
+category: 'printing'
+method: GtRmGeoGpsRecord
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream 
+		<< '(';
+		print: self timestamp;
+		<< '; ';
+		print: self latitude;
+		<< ', ';
+		print: self longitude;
+		<< ')'
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+timestamp
+	^ timestamp
+%
+
+category: 'accessing'
+method: GtRmGeoGpsRecord
+timestamp: aDateAndTime
+	timestamp := aDateAndTime
+%
+
+! Class implementation for 'GtRmGeoGpsTrajectory'
+
+!		Class methods for 'GtRmGeoGpsTrajectory'
+
+category: 'instance creation'
+classmethod: GtRmGeoGpsTrajectory
+fromJsonDictionary: aDictionary
+	^ self new 
+		initializeFomJsonDictionary: aDictionary
+%
+
+!		Instance methods for 'GtRmGeoGpsTrajectory'
+
+category: 'adding'
+method: GtRmGeoGpsTrajectory
+addRecord: aRecord
+	self records add: aRecord
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+asJsonDictionary
+	^ {
+		'targetFolderName' -> self targetFolderName.
+		'records' -> self recordsAsJsonData  } asDictionary
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+distance
+	^ self records distance
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+distanceWithBug
+	^ self records computeDistanceWithBug
+%
+
+category: 'gt - extensions'
+method: GtRmGeoGpsTrajectory
+gtViewGpsRecordsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Records';
+		priority: 10;
+		items: [ self records items ];
+		column: 'Timestamp' text: [ :aRecord | aRecord timestamp ];
+		column: 'Latitude' text: [ :aRecord | aRecord latitude ];
+		column: 'Longitude' text: [ :aRecord | aRecord longitude ]
+%
+
+category: 'initialization'
+method: GtRmGeoGpsTrajectory
+initializeFomJsonDictionary: aDictionary
+	self targetFolderName: (aDictionary at: 'targetFolderName').
+	
+	(aDictionary at: 'records') do: [ :aRecordData |
+		self addRecord:  (GtRmGeoGpsRecord 
+			fromJsonDictionary: aRecordData) ].
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+numberOfRecords
+	^ self records size
+%
+
+category: 'printing'
+method: GtRmGeoGpsTrajectory
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream 
+		<< '(';
+		print: self targetFolderName;
+		<< '; ';
+		print: self records size;
+		<< ' records';
+		<< ')'
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+records
+	^ records ifNil: [
+		records := GtRmGeoGpsRecordsGroup new ]
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+recordsAsJsonData
+	^ (self records collect: [ :aRecord |
+			aRecord asJsonDictionary ]) asArray
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+targetFolderName
+	^ targetFolderName
+%
+
+category: 'accessing'
+method: GtRmGeoGpsTrajectory
+targetFolderName: aFolderName
+	targetFolderName := aFolderName
+%
+
+! Class implementation for 'GtRmGeolife'
+
+!		Class methods for 'GtRmGeolife'
+
+category: 'accessing'
+classmethod: GtRmGeolife
+defaultInstance
+	^ DEFAULT ifNil: [
+		DEFAULT := self new ]
+%
+
+category: 'accessing'
+classmethod: GtRmGeolife
+resetDefaultInstance
+	DEFAULT := nil
+%
+
+!		Instance methods for 'GtRmGeolife'
+
+category: 'adding'
+method: GtRmGeolife
+addUser: aUser
+	self users add: aUser
+%
+
+category: 'adding'
+method: GtRmGeolife
+addUsers: aCollection
+	self users addAll: aCollection
+%
+
+category: 'accessing'
+method: GtRmGeolife
+allRecords
+	
+	^ self users allRecords
+%
+
+category: 'accessing'
+method: GtRmGeolife
+allTrajectories
+	
+	^ self users allTrajectories
+%
+
+category: 'initialization'
+method: GtRmGeolife
+defaultUsersGroup
+	^ GtRmGeoGpsUsersGroup new
+%
+
+category: 'adding'
+method: GtRmGeolife
+ensureUserWithId: anId
+	^ self users 
+		detect: [ :aUser | aUser id = anId ]
+		ifNone: [ 
+			| newUser |
+			newUser := GtRmGeoUser new 
+				id: anId.
+			self addUser: newUser.
+			newUser ]
+%
+
+category: 'gt - extensions'
+method: GtRmGeolife
+gtViewAllTrajectoriesFor: aView
+	<gtView>
+	
+	^ aView forward
+		title: 'Trajectories';
+		priority: 45;
+		object: [ self allTrajectories ];
+		view: #gtItemsFor:
+%
+
+category: 'gt - extensions'
+method: GtRmGeolife
+gtViewSummaryDataFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Overview';
+		priority: 1;
+		items: [ self summaryData ];
+		column: 'Name' text: [ :array | array first ];
+		column: 'Value' text: [ :array | array second value ];
+		send: [ :array | array third value ]
+%
+
+category: 'gt - extensions'
+method: GtRmGeolife
+gtViewUsersFor: aView
+	<gtView>
+	
+	^ aView forward
+		title: 'Users';
+		priority: 10;
+		object: [ self users ];
+		view: #gtItemsFor:
+%
+
+category: 'accessing'
+method: GtRmGeolife
+numberOfUsers
+	^ self users size
+%
+
+category: 'printing'
+method: GtRmGeolife
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream 
+		<< '(';
+		print: self numberOfUsers;
+		<< ' users';
+		<< ')'
+%
+
+category: 'accessing'
+method: GtRmGeolife
+removeUser: aString
+
+	self users removeUser: aString
+%
+
+category: 'accessing'
+method: GtRmGeolife
+summaryData
+	^ {
+		{'Users'. [ self users size]. [self users]}.
+		{'Trajectories'. [ self allTrajectories size]. [self allTrajectories]}.
+		{'Records'. [ self allRecords size]. [self allRecords]}
+	}
+%
+
+category: 'accessing'
+method: GtRmGeolife
+users
+	^ users ifNil: [
+		users := self defaultUsersGroup ]
+%
+
+! Class implementation for 'GtRmGeolifeBaseImporter'
+
+!		Instance methods for 'GtRmGeolifeBaseImporter'
+
+category: 'importing'
+method: GtRmGeolifeBaseImporter
+createRecordFromLine: aLine
+	| parts record |
+	record := GtRmGeoGpsRecord new.
+	parts := aLine splitOn: ','.
+	
+	record 
+		timestamp: (DateAndTime  
+			date: (Date fromString: parts sixth)
+			time: (Time fromString: parts seventh));
+		longitude: (parts second asNumber);
+		latitude:(parts first asNumber).
+		
+	^ record
+%
+
+category: 'importing'
+method: GtRmGeolifeBaseImporter
+createTrajectoryFromDirectory: aTrajectoryFolder 
+	| trajectory lines |
+	
+	trajectory := GtRmGeoGpsTrajectory new.
+	trajectory targetFolderName: aTrajectoryFolder basename.
+	lines := aTrajectoryFolder contents lines.
+	7 to: lines size do: [ :anIndex |
+		| record | 
+		record := self createRecordFromLine: (lines at: anIndex).
+		trajectory addRecord: record ].
+		
+	^ trajectory
+%
+
+category: 'accessing'
+method: GtRmGeolifeBaseImporter
+directoriesToImport
+	| directories |
+	
+	directories := (currentDirectory / 'Data') directories.
+	^ usersCount 
+		ifNil: [ directories ] 
+		ifNotNil: [ directories first: usersCount ]
+%
+
+category: 'accessing'
+method: GtRmGeolifeBaseImporter
+usersCount: aNumber
+	usersCount := aNumber
+%
+
+! Class implementation for 'GtRmGeolifeLocalImporter'
+
+!		Instance methods for 'GtRmGeolifeLocalImporter'
+
+category: 'importing'
+method: GtRmGeolifeLocalImporter
+createUserFromDirectory: aUserFolder
+	| user |
+	
+	user := GtRmGeoUser new.
+	user id: aUserFolder basename.
+	((aUserFolder / 'Trajectory') childrenMatching: '*.plt') 
+		do: [ :aTrajectoryFolder |
+			| trajectory |
+			trajectory := self createTrajectoryFromDirectory: aTrajectoryFolder.
+			user addTrajectory:trajectory ].
+	
+	^ user
+%
+
+category: 'importing'
+method: GtRmGeolifeLocalImporter
+importFromDirectory: aDirectory
+	| geoLife |
+	
+	currentDirectory := aDirectory.
+	geoLife := GtRmGeolife new.
+	
+	self directoriesToImport do: [ :aUserFolder |
+		self 
+			importUserFromDirectory: aUserFolder
+			into: geoLife ].
+		
+	^ geoLife
+%
+
+category: 'importing'
+method: GtRmGeolifeLocalImporter
+importUserFromDirectory: aUserFolder into: aGeolife
+	| user |
+	user := self createUserFromDirectory: aUserFolder.
+	aGeolife addUser: user
+%
+
+! Class implementation for 'GtRmGeoUser'
+
+!		Class methods for 'GtRmGeoUser'
+
+category: 'accessing'
+classmethod: GtRmGeoUser
+fromJsonDictionary: aDictionary
+	^ self new 
+		initializeFomJsonDictionary: aDictionary
+%
+
+!		Instance methods for 'GtRmGeoUser'
+
+category: 'adding'
+method: GtRmGeoUser
+addTrajectory: aTrajectory 
+	self trajectories add: aTrajectory
+%
+
+category: 'adding'
+method: GtRmGeoUser
+addTrajectoryFromJsonData: aJsonData
+	self addTrajectory: (GtRmGeoGpsTrajectory 
+		fromJsonDictionary:  aJsonData)
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+allRecords
+	
+	^ self trajectories allRecords
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+asJsonDictionary
+	^ {
+		'id' -> self id.
+		'trajectories' -> self trajectoriesAsJsonData  } asDictionary
+%
+
+category: 'gt - extensions'
+method: GtRmGeoUser
+gtViewRecordsFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Records';
+		priority: 10;
+		items: [ self allRecords items ];
+		column: 'Timestamp' text: [ :aRecord | aRecord timestamp ];
+		column: 'Lat' text: [ :aRecord | aRecord latitude ];
+		column: 'Lon' text: [ :aRecord | aRecord longitude ]
+		
+	"^ aView forward
+		title: 'Records';
+		priority: 10;
+		object: [ self allRecords ];
+		view: #gtItemsFor: "
+%
+
+category: 'gt - extensions'
+method: GtRmGeoUser
+gtViewSummaryDataFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Overview';
+		priority: 1;
+		items: [ self summaryData ];
+		column: 'Name' text: [ :array | array first ];
+		column: 'Value' text: [ :array | array second value ];
+		send: [ :array | array third value ]
+%
+
+category: 'gt - extensions'
+method: GtRmGeoUser
+gtViewTrajectoriesFor: aView
+	<gtView>
+	
+	^ aView forward
+		title: 'Trajectories';
+		priority: 5;
+		object: [ self trajectories ];
+		view: #gtItemsFor:
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+id
+	^ id
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+id: anObject
+	id := anObject
+%
+
+category: 'initialization'
+method: GtRmGeoUser
+initializeFomJsonDictionary: aDictionary
+	self id: (aDictionary at: 'id').
+	
+	(aDictionary at: 'trajectories') do: [ :aTrajectoryData |
+		self addTrajectory:  (GtRmGeoGpsTrajectory 
+			fromJsonDictionary: aTrajectoryData) ].
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+numberOfRecords
+	^ self trajectories sumNumbers: [ :aTrajectory |
+		aTrajectory numberOfRecords ]
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+numberOfTrajectories
+	^ self trajectories size
+%
+
+category: 'printing'
+method: GtRmGeoUser
+printOn: aStream
+	super printOn: aStream.
+	
+	aStream 
+		<< '(';
+		print: self id;
+		<< '; ';
+		print: self trajectories size;
+		<< ' trajectories';
+		<< ')'
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+summaryData
+	^ {
+		{'Trajectories'. [ self trajectories size]. [self trajectories]}.
+		{'Records'. [ self allRecords size]. [self allRecords]}
+	}
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+trajectories
+	^ trajectories ifNil: [
+		trajectories := GtRmGeoGpsTrajectoriesGroup new ]
+%
+
+category: 'accessing'
+method: GtRmGeoUser
+trajectoriesAsJsonData
+	^ (self trajectories collect: [ :aTrajectory |
+			aTrajectory asJsonDictionary ]) asArray
+%
+
+! Class implementation for 'GtRmMovie'
+
+!		Class methods for 'GtRmMovie'
+
+category: 'instance creation'
+classmethod: GtRmMovie
+fromRawData: aRawData withProperties: aCollectionOfPropertyNames
+	^ self new 
+		rawData: aRawData;
+		propertyNames:aCollectionOfPropertyNames
+%
+
+!		Instance methods for 'GtRmMovie'
+
+category: 'gt - extensions'
+method: GtRmMovie
+gtViewDetailsFor: aView 
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Details';
+		priority: 20;
+		items: [ 1 to: propertyNames size ];
+		column: 'Key' text: [ :anIndex | propertyNames at: anIndex ];
+		column: 'Value' text: [ :anIndex | rawData at: anIndex ];
+		send: [ :anIndex | rawData at: anIndex ]
+%
+
+category: 'accessing'
+method: GtRmMovie
+propertyNames
+	^ propertyNames
+%
+
+category: 'accessing'
+method: GtRmMovie
+propertyNames: aCollectionOfPropertyNames
+	propertyNames := aCollectionOfPropertyNames
+%
+
+category: 'accessing'
+method: GtRmMovie
+rawData
+	^ rawData
+%
+
+category: 'accessing'
+method: GtRmMovie
+rawData: anObject
+	rawData := anObject
+%
+
+! Class implementation for 'GtRmMovieCollection'
+
+!		Class methods for 'GtRmMovieCollection'
+
+category: 'accessing'
+classmethod: GtRmMovieCollection
+defaultInstance
+	^ DEFAULT ifNil: [
+		DEFAULT := self new ]
+%
+
+category: 'instance creation'
+classmethod: GtRmMovieCollection
+fromFullData: anArray 
+	^ self new 
+		initializeFromFullData: anArray 
+%
+
+category: 'instance creation'
+classmethod: GtRmMovieCollection
+fromRawData: aRawData withProperties: aCollectionOfPropertyNames
+	^ self new 
+		initializeFromData: aRawData
+		propertyNames:aCollectionOfPropertyNames
+%
+
+category: 'accessing'
+classmethod: GtRmMovieCollection
+resetDefaultInstance
+	DEFAULT := nil
+%
+
+!		Instance methods for 'GtRmMovieCollection'
+
+category: 'accessing'
+method: GtRmMovieCollection
+directors
+	^ self groupedByPropertyNamed: 'Directors'
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+groupDataBy: aBlock
+	| groups |
+	groups := Dictionary new.
+	rawData do: [ :each |
+		| key |
+		key := aBlock value: each.
+		key ifNotNil: [
+		(groups 
+			at: key
+			ifAbsentPut: [ OrderedCollection new ]) add: each ] ].
+	^ groups
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+groupedByPropertyNamed: aPropertyName 
+	^ ((self groupDataBy: [ :aRow | 
+		self 
+			propertyNamed: aPropertyName
+			inData: aRow ]) asGPhlowAssociationsIterator retrieveAllItems
+		collect: [ :assoc | 
+			assoc key -> (self movieCollectionFrom: assoc value)])
+		sort: [ :a :b | 
+			a key asString < b key asString ]
+%
+
+category: 'gt - extensions'
+method: GtRmMovieCollection
+gtViewDirectorsFor: aView
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Directors';
+		priority: 20;
+		items: [ self directors ];
+		column: 'Director' text: [ :each | 
+			each key  ];
+		column: 'Count' text: [ :each | 
+			each value size ];
+		send: [ :each | each value ]
+%
+
+category: 'gt - extensions'
+method: GtRmMovieCollection
+gtViewMoviesFor: aView
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Movies';
+		priority: 40;
+		items: [ 1 to: self rawData size ];
+		column: 'Title' text: [ :anIndex | 
+			self 
+				propertyNamed: 'Title' 
+				atDataIndex: anIndex ];
+		column: 'Release Date' text: [ :anIndex | 
+			self 
+				propertyNamed: 'Release Date' 
+				atDataIndex: anIndex ];
+		column: 'Directors' text: [ :anIndex |
+			self 
+				propertyNamed: 'Release Date' 
+				atDataIndex: anIndex  ];
+		column: 'Genres' text: [ :anIndex | 
+			self 
+				propertyNamed: 'Genres' 
+				atDataIndex: anIndex ];
+		send: [ :anIndex |
+			self movieAtIndex: anIndex ]
+%
+
+category: 'gt - extensions'
+method: GtRmMovieCollection
+gtViewMoviesWithDetailsFor: aView
+	<gtView>
+	| currentView |
+	
+	currentView := aView columnedList 
+		title: 'Movies with details';
+		priority: 45;
+		items: [ 1 to: self rawData size ].
+		
+	propertyNames do: [ :aPropertyName |
+		currentView 
+			column: aPropertyName 
+			text: [ :anIndex |
+				self 
+					propertyNamed: aPropertyName
+					atDataIndex: anIndex ] ].
+	currentView send: [ :anIndex |
+		self movieAtIndex: anIndex ].
+	
+	^ currentView
+%
+
+category: 'gt - extensions'
+method: GtRmMovieCollection
+gtViewYearsFor: aView
+	<gtView>
+	
+	^ aView columnedList 
+		title: 'Years';
+		priority: 30;
+		items: [ self years ];
+		column: 'Year' text: [ :each | 
+			each key  ];
+		column: 'Count' text: [ :each | 
+			each value size ];
+		send: [ :each | each value ]
+%
+
+category: 'initialization'
+method: GtRmMovieCollection
+initializeFromData: aRawData propertyNames: aCollectionOfPropertyNames 
+	self
+		rawData: aRawData;
+		propertyNames:aCollectionOfPropertyNames
+%
+
+category: 'initialization'
+method: GtRmMovieCollection
+initializeFromFullData: fullData 
+	| data transformedData |
+	data := fullData copyFrom: 2 to: fullData size + 1.
+	transformedData := data collect: [ :each | self transformData: each ].
+	self 
+		initializeFromData:  transformedData
+		propertyNames: (self transformData: fullData first )
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+movieAtIndex: anIndex 
+	^ GtRmMovie 
+		fromRawData: (rawData at: anIndex)
+		withProperties: propertyNames
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+movieCollectionFrom: aCollectionOfMoviesData
+	^ GtRmMovieCollection
+		 fromRawData: aCollectionOfMoviesData 
+		 withProperties: propertyNames 
+%
+
+category: 'accessing - properties'
+method: GtRmMovieCollection
+propertyNamed: aPropertyName atDataIndex: anIndex 
+	^ self 
+		propertyNamed: aPropertyName 
+		inData: (rawData at: anIndex).
+%
+
+category: 'accessing - properties'
+method: GtRmMovieCollection
+propertyNamed: aPropertyName inData: aDataRow
+	^ aDataRow at: (propertyNames indexOf: aPropertyName)
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+propertyNames
+	^ propertyNames
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+propertyNames: aCollectionOfPropertyNames
+	propertyNames := aCollectionOfPropertyNames
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+rawData
+	^ rawData
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+rawData: anObject
+	rawData := anObject
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+size
+	^ rawData size
+%
+
+category: 'initialization'
+method: GtRmMovieCollection
+transformData: aCollection
+	^ aCollection collect: [ :each |
+		String streamContents: [ :aStream |
+			each ifNotNil: [ aStream << each ] ] ]
+%
+
+category: 'accessing'
+method: GtRmMovieCollection
+years
+	^ self groupedByPropertyNamed: 'Year'
+%
+
+! Class implementation for 'GtRsrInspectorProxySerializationStrategy'
+
+!		Class methods for 'GtRsrInspectorProxySerializationStrategy'
+
+category: 'accessing'
+classmethod: GtRsrInspectorProxySerializationStrategy
+strategyLabel
+	^ 'InspectorProxy'
+%
+
+!		Instance methods for 'GtRsrInspectorProxySerializationStrategy'
+
+category: 'accessing'
+method: GtRsrInspectorProxySerializationStrategy
+serialize: anObject
+	"Called from GemStone. We defined is also for GT as it does not references GemStone specific classes"
+	| inspectorWrapper |
+	inspectorWrapper := GtRemotePhlowViewedObject object: anObject.
+	^ self serializedDataForInspectorWrapper: inspectorWrapper
+%
+
+category: 'accessing'
+method: GtRsrInspectorProxySerializationStrategy
+serializedDataForInspectorWrapper: anInspectorWrapper
+	"Called from GemStone. We defined is also for GT as it does not references GemStone specific classes"
+	| dictionaryData proxyData |
+	
+	dictionaryData := Dictionary new.
+	
+	dictionaryData 
+		at: 'proxyObject'
+		put: anInspectorWrapper.
+		
+	proxyData := anInspectorWrapper getInspectorSpecificationWithPhlowDataSource.
+	dictionaryData 
+		at: 'proxyData'
+		put: proxyData.
+	
+	^ dictionaryData asGtRsrProxyObjectForConnection: nil
+%
+
+! Class implementation for 'GtRsrInspectorProxyDataSerializationStrategy'
+
+!		Class methods for 'GtRsrInspectorProxyDataSerializationStrategy'
+
+category: 'accessing'
+classmethod: GtRsrInspectorProxyDataSerializationStrategy
+strategyLabel
+	^ 'InspectorProxyData'
+%
+
+!		Instance methods for 'GtRsrInspectorProxyDataSerializationStrategy'
+
+category: 'accessing'
+method: GtRsrInspectorProxyDataSerializationStrategy
+deserialize: viewProxyData
+	^ viewProxyData
+%
+
+! Class extensions for 'AbstractDictionary'
+
+!		Instance methods for 'AbstractDictionary'
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-GemStone'
+method: AbstractDictionary
+asGPhlowAssociationsIterator
+	^ GtRemotePhlowDictionaryAssociationsIterator forCollection: self
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-GemStone'
+method: AbstractDictionary
+asGPhlowKeysIterator
+	^ GtRemotePhlowDictionaryKeysIterator forCollection: self
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-GemStone'
+method: AbstractDictionary
+gtItemsFor: aView
+	^ aView columnedList
+		title: 'Items';
+		priority: 1;
+		items: [ self asGPhlowAssociationsIterator ];
+		column: 'Key' text: [ :assoc | assoc key ];
+		column: 'Value' text: [ :assoc | assoc value ];
+		send: [ :assoc | assoc value ]
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-GemStone'
+method: AbstractDictionary
+gtRemoteKeysFor: aView
+	<gtView>
+	^ aView list
+		title: 'Keys';
+		priority: 5;
+		items: [ self asGPhlowKeysIterator ]
+%
+
+! Class extensions for 'AbstractFileReference'
+
+!		Instance methods for 'AbstractFileReference'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtChildren
+	self isDirectory ifFalse: [ ^ Array new ].
+
+	^ (self directories sort: [:a :b | a basename < b basename ]) , 
+		(self files sort: [:a :b | a basename < b basename ]).
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtChildrenWithParent
+	| aChildrenCollection |
+	self isDirectory ifFalse: [ ^ Array new ].
+	
+	aChildrenCollection := self gtChildren.
+	aChildrenCollection := self isRoot
+		ifTrue: [ aChildrenCollection ]
+		ifFalse: [ aChildrenCollection asOrderedCollection
+			addFirst: self parent;
+			yourself ].
+	^ aChildrenCollection
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtContentsFor: aView
+	<gtView>
+	
+	self isFile ifFalse: [ ^ aView empty ].
+
+	^ aView textEditor
+		title: 'Contents';
+		priority: 50;
+		text: [ self contents ]
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtDetails
+	| details |
+
+	details := {
+		{ #self . self }.
+		{ #printString. self printString }.
+		{ #gtDisplayString. self gtDisplayString }.
+		{ #pathString . self pathString }.
+		{ #base . self base }.
+		{ #basename . self basename }.
+		{ #extension . self extension }.
+		{ #parent . self parent }.
+		{ #path . self path }.
+		{ #fullPath . self fullPath }.
+		{ #absolutePath . self absolutePath }. 
+		{ #fileSystem . self fileSystem }.
+		{ #exists . self exists }.
+		{ #isFile . self isFile }.
+		{ #isDirectory . self isDirectory }.
+		{ #isAbsolute . self isAbsolute }.
+		{ #isRelative . self isRelative }.
+	}.
+	self exists ifTrue: [
+		details := details , {
+			{ #isReadable . [self isReadable] on: Error do: ['unsuported'] }.
+			{ #isWritable . [self isWritable] on: Error do: ['unsuported'] }.
+			{ #size . self size size . self size }.
+			{ #uid . self uid }.
+			{ #gid . self gid }.
+			{ #inode . self inode }.
+			{ #creationTime . [self creationTime ] 
+				on: Error do: ['unsuported']}.
+			{ #modificationTime . self modificationTime }.
+			{ #changeTime . self changeTime }.
+			{ #accessTime . self accessTime }.
+			{ #permissions . self permissions }.
+	} ].
+	^ details
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtDetailsFor: composite
+	<gtView>
+
+	^ composite columnedList
+		title: 'Details';
+		priority: 60;
+		items: [ self gtDetails ];
+		column: 'key' text: [ :each | each first ] width: 250;
+		column: 'value' text: [ :each | each second ];
+		send: [ :each | each last ]
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtItemsFor: aView
+	<gtView>
+	self isDirectory
+		ifFalse: [ ^ aView empty ].
+
+	^ aView columnedList
+		title: 'Items';
+		priority: 1;
+		items: [ self gtChildrenWithParent ];
+		column: 'Icon' 
+			iconName: [ :each | 
+				each isDirectory
+					ifTrue: [ #emptyPackage ]
+					ifFalse: [ #workspace ] ]
+			width: 35;
+		column: 'Name'  text: [ :each | 
+			(self isChildOf: each)
+				ifTrue: [ '..' ]
+				ifFalse: [ each basename asString ] ];
+		column: 'Size' 
+			text: [ :each | 
+				[ each isDirectory 
+					ifTrue: [ '--' ]
+					ifFalse: [ each humanReadableSize asString ] ]
+				on: Error
+				do: [ :anException | anException return: '' ] ]
+			width: 100;
+		column: 'Creation' 
+			text: [ :each | 
+				[ String
+					streamContents: [ :s | 
+						each creationTime printYMDOn: s.
+						s nextPut: Character space.
+						each creationTime printHMSOn: s ] ]
+				on: Error
+				do: [ :anException | anException return: '' ] ]
+			width: 150
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtPathFor: aView
+	<gtView>
+	
+	^ aView columnedList
+		title: 'Path';
+		priority: 55;
+		items: [ 
+			self asFileReference asAbsolute path withParents ];
+		column: 'Icon'
+			iconName: [ :aPath | 
+				aPath asFileReference exists
+					ifTrue: [ #smallOk  ]
+					ifFalse: [  #changeRemove ] ]
+			width: 35;
+		column: 'Name'
+			text: [ :aPath | 
+				aPath asFileReference basename
+					, (aPath asFileReference isDirectory ifTrue: [ '/' ] ifFalse: [ '' ]) ];
+		send: [ :aPath |
+			aPath asFileReference ]
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+gtTreeFor: aView
+	<gtView>
+	self isDirectory
+		ifFalse: [ ^ aView empty ].
+	^ aView columnedTree
+		title: 'Tree' ;
+		priority: 10;
+		items: [ self gtChildren ];
+		children: [ :each | each gtChildren ];
+		column: 'Icon' 
+			iconName: [ :each | 
+				each isDirectory
+					ifTrue: [ #emptyPackage ]
+					ifFalse: [ #workspace ] ]
+			width: 35;
+		column: 'Name'  text: [ :each | 
+			(self isChildOf: each)
+				ifTrue: [ '..' ]
+				ifFalse: [ each basename asString ] ];
+		column: 'Size' 
+			text: [ :each | 
+				[ each isDirectory 
+					ifTrue: [ '--' ]
+					ifFalse: [ each humanReadableSize asString ] ]
+				on: Error
+				do: [ :anException | anException return: '' ] ]
+			width: 100;
+		column: 'Creation' 
+			text: [ :each | 
+				[ String
+					streamContents: [ :s | 
+						each creationTime printYMDOn: s.
+						s nextPut: Character space.
+						each creationTime printHMSOn: s ] ]
+				on: Error
+				do: [ :anException | anException return: '' ] ]
+			width: 150
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: AbstractFileReference
+humanReadableSize
+
+	^ self size humanReadableSISizeString
+%
+
+! Class extensions for 'Behavior'
+
+!		Instance methods for 'Behavior'
+
+category: '*GToolkit-RemotePhlow-Gemstone'
+method: Behavior
+gtMethodsListRemoteFor: aView
+	<gtView>
+
+	^ aView list
+		title: 'Methods List';
+		priority: 10;
+		items: [ (self methodDictForEnv: 0) values asSortedCollection: [ :a :b | a selector < b selector ] ];
+		itemText: [ :method | method selector ]
+%
+
+category: '*GToolkit-RemotePhlow-Gemstone'
+method: Behavior
+gtSubclasses
+	"A hack to figure out all subclasses since Metaclass3>>_subclasses always answers nil"
+	| allClasses result |
+
+	allClasses := Array new.
+	System myUserProfile symbolList
+		do: [ :dict | allClasses addAll: (dict select: [ :each | each isBehavior ]) ].
+	result := allClasses select: [ :each | each isBehavior and: [ each superclass = self ] ].
+	^ result
+%
+
+category: '*GToolkit-RemotePhlow-Gemstone'
+method: Behavior
+gtSubclassesFor: aView
+	<gtView>
+
+	^ aView tree
+		title: 'Subclasses';
+		priority: 11;
+		items: [ self gtSubclasses ];
+		itemText: [ :cls | cls name ];
+		children: [ :cls | cls gtSubclasses ]
+%
+
+category: '*GToolkit-RemotePhlow-Gemstone'
+method: Behavior
+gtSuperclassesFor: aView
+	<gtView>
+
+	^ aView list
+		title: 'Superclasses';
+		priority: 12;
+		items: [ self allSuperClasses reversed ];
+		itemText: [ :cls | cls name ]
+%
+
+! Class extensions for 'Collection'
+
+!		Class methods for 'Collection'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: Collection
+gtGsInspectorIconName
+	^ #collectionIcon
+%
+
+!		Instance methods for 'Collection'
+
+category: '*GToolkit-RemotePhlow-PhlowViews'
+method: Collection
+asGPhlowItemsIterator
+	^ GtRemotePhlowGenericCollectionIterator forCollection: self
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-Remote'
+method: Collection
+gtItemsFor: aView
+	<gtView>
+	^ aView list
+		title: 'Items';
+		priority: 50;
+		items: [ self ];
+		itemText: [ :eachItem | eachItem gtDisplayString ]
+%
+
+! Class extensions for 'Dictionary'
+
+!		Instance methods for 'Dictionary'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Dictionary
+gtDisplayOn: aStream
+
+	GtGemStoneRemotePhlowDictionaryPrinter
+		displayStringFor: self 
+		on: aStream
+%
+
+! Class extensions for 'GtPhlowColor'
+
+!		Instance methods for 'GtPhlowColor'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: GtPhlowColor
+asColor
+	^ self
+%
+
+! Class extensions for 'GtPhlowViewSpecification'
+
+!		Class methods for 'GtPhlowViewSpecification'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: GtPhlowViewSpecification
+globalsDictionary
+
+	self halt.  "How to look up classes?"
+	^ GsCurrentSession currentSession symbolList
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: GtPhlowViewSpecification
+new
+
+	^ super new initialize
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: GtPhlowViewSpecification
+readJsonString: aString
+
+	self halt.
+	^ JsonParser parse: aString
+%
+
+!		Instance methods for 'GtPhlowViewSpecification'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: GtPhlowViewSpecification
+writeJsonString: aJsonObject
+
+	^ aJsonObject asJson
+%
+
+! Class extensions for 'GtRemotePhlowDeclarativeTestForCustomProxyInspectable'
+
+!		Class methods for 'GtRemotePhlowDeclarativeTestForCustomProxyInspectable'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: GtRemotePhlowDeclarativeTestForCustomProxyInspectable
+new
+
+	^ super new initialize
+%
+
+! Class extensions for 'GtRemotePhlowDeclarativeTestInspectable'
+
+!		Class methods for 'GtRemotePhlowDeclarativeTestInspectable'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: GtRemotePhlowDeclarativeTestInspectable
+new
+
+	^ super new initialize
+%
+
+! Class extensions for 'GtRemotePhlowViewedObject'
+
+!		Class methods for 'GtRemotePhlowViewedObject'
+
+category: '*GToolkit-RemotePhlow-Gemstone'
+classmethod: GtRemotePhlowViewedObject
+new
+
+	^ super new initialize
+%
+
+!		Instance methods for 'GtRemotePhlowViewedObject'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: GtRemotePhlowViewedObject
+addRawSelfNodeTo: variableNodes
+
+	^ self "TBS"
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: GtRemotePhlowViewedObject
+rawViewData
+	"Answer the data for the raw view"
+	| variableBindings |
+
+	variableBindings := object gtRemoteVariableValuePairsWithSelfIf: true.
+
+	^ Array streamContents: [ :stream |
+		variableBindings do: [ :binding |
+			| icon name value |
+			name := binding key.
+			value := binding value.
+
+			icon := ([ value class gtGsInspectorIconName ]
+					on: Error 
+					do: [ :error | #smallWarningIcon ]).
+			
+			stream nextPut: { icon. name. value } ] ].
+%
+
+! Class extensions for 'Integer'
+
+!		Instance methods for 'Integer'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Integer
+humanReadableSISizeOn: aStream
+	"Print a SI representation of myself on the argument. See humanReadableSIByteSize for better comment."
+
+	| exponent base |
+	base := 1000.
+	self < base
+		ifTrue: [ ^ aStream print: self; space; nextPut: $B ].
+	exponent := ((self log:10) / (base log:10)) asInteger.
+	aStream nextPutAll: (self / (base raisedTo: exponent)) asFloat asString.
+	aStream
+		space;
+		nextPut: ('kMGTPE' at: exponent);
+		nextPut: $B
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Integer
+humanReadableSISizeString
+	"Return the receiver as a string with SI binary (International System of Units) file size, e.g. '50 KB'. It means that it takes 1000 and not 1024 as unit as humanReadableByteSizeString does."
+
+	"(1000 * 1000 * 1000) humanReadableSISizeString >>> '1.00 GB'"
+	"(1000 * 1000 * 1000) humanReadableByteSizeString >>> '953 MB'"
+	"(1024 * 1024 * 1024) humanReadableSISizeString >>> '1.07 GB'"
+
+
+	^ String streamContents: [ :s|
+		self humanReadableSISizeOn: s ]
+%
+
+! Class extensions for 'Magnitude'
+
+!		Class methods for 'Magnitude'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: Magnitude
+gtGsInspectorIconName
+	^ #magnitudeIcon
+%
+
+! Class extensions for 'Object'
+
+!		Instance methods for 'Object'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+asRopedText
+	^ GtPhlowText forString: self asString
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-Remote'
+method: Object
+gtActionBrowseFor: anAction
+	<gtAction>
+	
+	^ anAction button
+		tooltip: 'Browse class for current object';
+		priority: 70;
+		icon: (GtPhlowGlamorousVectorIconNameStencil new 
+			iconName: #emphasizedBrowse);
+		action: [ :aButton |
+			aButton phlow 
+				spawnObject: self class ]
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-Remote'
+method: Object
+gtActionInspectFor: anAction
+	<gtAction>
+	
+	^ anAction button
+		tooltip:'Inspect current object';
+		priority: 75;
+		icon: (GtPhlowGlamorousVectorIconNameStencil new 
+			iconName: #inspect);
+		action: [ :aButton |
+			aButton phlow 
+				spawnObject: self ]
+%
+
+category: '*GToolkit-RemotePhlow-Remote'
+method: Object
+gtActionsInCurrentContext
+	"Answer a collection of the object's declarative actions"
+
+	^ self gtDeclarativeActionPragmas collect: [ :aPragma |
+		| methodSelector phlowAction |
+		methodSelector := aPragma method selector.
+			
+		phlowAction := GtRemotePhlowAction new  noAction
+			on: self
+			perform: methodSelector.
+		
+		phlowAction definingSelector: methodSelector.
+		phlowAction definingClass: self class.
+		phlowAction ]
+%
+
+category: '*GToolkit-RemotePhlow-Remote'
+method: Object
+gtDeclarativeActionPragmas
+	"Answer a collection of the object's declarative view selectors"
+
+	^ Pragma 
+		allNamed: #gtAction
+		from: self class
+		to: Object
+%
+
+category: '*GToolkit-RemotePhlow-InspectorCore'
+method: Object
+gtDeclarativePhlowActions
+	"Answer a collection of the object's declarative phlow actions"
+	
+	^ self gtActionsInCurrentContext
+		select: [ :aPhlowAction | aPhlowAction canBeGtDeclarativeAction ]
+%
+
+category: '*GToolkit-RemotePhlow-InspectorCore'
+method: Object
+gtDeclarativePhlowViews
+	"Answer a collection of the object's declarative phlow view"
+	
+	^ self gtViewsInCurrentContext
+		select: [ :aPhlowView | aPhlowView canBeGtDeclarativeView ]
+%
+
+category: '*GToolkit-RemotePhlow-Remote'
+method: Object
+gtDeclarativeViewPragmas
+	"Answer a collection of the object's declarative view selectors"
+
+	^ Pragma 
+		allNamed: #gtView
+		from: self class
+		to: Object
+%
+
+category: '*GToolkit-RemotePhlow-Remote'
+method: Object
+gtDeclarativeViewPragms
+	"Answer a collection of the object's declarative view selectors"
+
+	^ self gtDeclarativeViewPragmas
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+gtDeclarativeViewSelectors
+	"Answer a collection of the object's declarative view selectors"
+
+	^ ((Pragma 
+		allNamed: #gtView
+		from: self class
+		to: Object) collect: [ :each | each method selector ]) asSet asArray
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+gtDisplayOn: writeStream
+	self printOn: writeStream
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+gtDisplayString
+  | ws contents |
+  ws := PrintStream printingOn: String new "maxSize: 100".
+
+  [ self gtDisplayOn: ws ] 
+	on: Error 
+	do: [ :error | ^ '<error printing>' ].
+  contents := ws _collection.
+
+  ^ contents size > 200
+    ifTrue: [ (contents copyFrom: 1 to: 200) , '...' ]
+    ifFalse: [ contents ]
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+gtDisplayText
+	^ [ self gtDisplayString asRopedText ]
+		on: Error 
+		do: [ :e | e printString asRopedText 
+			foreground: (GtPhlowColor named: #red) ]
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+gtGsInspectorIconName
+	^ #classIcon
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-Remote'
+method: Object
+gtPrintFor: aView
+	<gtView>
+	^ aView textEditor
+		title: 'Print';
+		priority: 110;
+		text: [ self printString ]
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-Remote'
+method: Object
+gtRawFor: aView
+	<gtView>
+	^ aView columnedList
+		title: 'Raw';
+		priority: 100;
+		items: [ self gtRemoteVariableValuePairsWithSelfIf: true ];
+		column: 'Icon' 
+			iconName: [ :anAssociation | anAssociation value class gtSystemIconName ]
+			width: 36;
+		column: 'Variable' text: [ :anAssociation | anAssociation key ];
+		column: 'Value' text: [ :anAssociation | anAssociation value gtDisplayString ];
+		send: [ :anAssociation | anAssociation value ]
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+gtRemoteVariableValuePairsWithSelfIf: aBoolean
+	| instVarNames bindings instanceVariables indexedVarsSize |
+	instVarNames := self class allInstVarNames.
+	indexedVarsSize := self basicSize - instVarNames size.
+	bindings := OrderedCollection new: instVarNames size + 1.
+	instanceVariables := OrderedCollection new: instVarNames size + 1.
+	
+	aBoolean ifTrue: [ bindings add: 'self' -> self ].
+	
+	instVarNames doWithIndex: [ :each :index | 
+		instanceVariables add: (each -> (self instVarAt: index))].
+	bindings addAll: (instanceVariables sort: [ :a :b | a key < b key ]).
+	
+	1 to: (indexedVarsSize min: 21) do: [ :index | 
+		bindings add: (index asString -> (self _at: index)) ].
+	
+	((indexedVarsSize - 20) max: 22) to: indexedVarsSize do: [ :index | 
+		bindings add: (index asString -> (self _at: index)) ].
+	
+	^ bindings
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Object
+gtSystemIconName
+	^ self gtGsInspectorIconName
+%
+
+category: '*GToolkit-RemotePhlow-Remote'
+method: Object
+gtViewsInCurrentContext
+	"Answer a collection of the object's declarative views"
+
+	^ self gtDeclarativeViewPragmas collect: [ :aPragma |
+		| methodSelector phlowView |
+		methodSelector := aPragma method selector.
+			
+		phlowView := GtRemotePhlowProtoView new empty 
+			on: self
+			perform: methodSelector.
+		
+		phlowView definingSelector: methodSelector.
+		phlowView definingClass: self class.
+		phlowView ]
+%
+
+! Class extensions for 'OrderedCollection'
+
+!		Instance methods for 'OrderedCollection'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: OrderedCollection
+gtDisplayOn: aStream
+
+	GtGemStoneRemotePhlowCollectionPrinter
+		displayStringFor: self 
+		on: aStream
+%
+
+! Class extensions for 'PrintStream'
+
+!		Instance methods for 'PrintStream'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: PrintStream
+parenthesize: aBlock
+	self nextPut: $(.
+	aBlock ensure: [ self nextPut: $) ]
+%
+
+! Class extensions for 'Semaphore'
+
+!		Instance methods for 'Semaphore'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: Semaphore
+gtDisplayOn: aStream
+	"Reuse the printOn: implementation"
+	self printOn: aStream
+%
+
+! Class extensions for 'SequenceableCollection'
+
+!		Instance methods for 'SequenceableCollection'
+
+category: '*GToolkit-RemotePhlow-PhlowViews'
+method: SequenceableCollection
+asGPhlowItemsIterator
+	^ GtRemotePhlowSequenceableCollectionIterator forCollection: self
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-Remote'
+method: SequenceableCollection
+gtItemsFor: aView
+	^ aView columnedList
+		title: 'Items';
+		priority: 50;
+		items: [ self ];
+		column: 'Index' 
+			text: [ :eachItem :eachIndex | eachIndex  ]
+			width: 45;
+		column: 'Item' 
+			text: [ :eachItem | eachItem gtDisplayString ].
+%
+
+! Class extensions for 'String'
+
+!		Class methods for 'String'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+classmethod: String
+gtGsInspectorIconName
+	^ #stringIcon
+%
+
+!		Instance methods for 'String'
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: String
+asRopedText
+	^ GtPhlowText forString: self
+%
+
+category: '*GToolkit-RemotePhlow-GemStone'
+method: String
+gtDisplayOn: writeStream
+	writeStream nextPutAll: self
+%
+
+category: '*GToolkit-RemotePhlow-InspectorExtensions-Remote'
+method: String
+gtStringFor: aView
+	<gtView>
+
+	^ aView text
+		title: 'String';
+		priority: 9;
+		text: [ self ]
+%
+
+! Class extensions for 'WriteStream'
+
+!		Instance methods for 'WriteStream'
+
+category: '*GToolkit-RemotePhlow-Remote'
+method: WriteStream
+parenthesize: aBlock
+	self nextPut: $(.
+	aBlock ensure: [ self nextPut: $) ]
+%
+

--- a/docs/gtSupport/gtoolkit-wireencoding.gs
+++ b/docs/gtSupport/gtoolkit-wireencoding.gs
@@ -1,0 +1,4879 @@
+! Class Declarations
+! Generated file, do not Edit
+
+doit
+(Error
+	subclass: 'GtWireUnsupportedObject'
+	instVarNames: #(object)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireUnsupportedObject
+removeallclassmethods GtWireUnsupportedObject
+
+doit
+(Object
+	subclass: 'GtWireEncoderDecoder'
+	instVarNames: #(stream map reverseMap classCache)
+	classVars: #(GtDefaultMap GtDefaultReverseMap)
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireEncoderDecoder
+removeallclassmethods GtWireEncoderDecoder
+
+doit
+(GtWireEncoderDecoder
+	subclass: 'GtWireDecoder'
+	instVarNames: #(proxyObjectMap)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireDecoder
+removeallclassmethods GtWireDecoder
+
+doit
+(GtWireDecoder
+	subclass: 'GtWireInspectionDecoder'
+	instVarNames: #(stack root byteArray)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireInspectionDecoder
+removeallclassmethods GtWireInspectionDecoder
+
+doit
+(GtWireEncoderDecoder
+	subclass: 'GtWireEncoder'
+	instVarNames: #(defaultEncoder maxObjects objectCount remainingDepth maxDepthEncoder)
+	classVars: #(DefaultEncoder)
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireEncoder
+removeallclassmethods GtWireEncoder
+
+doit
+(GtWireEncoder
+	subclass: 'GtRemoteObjectWireEncoder'
+	instVarNames: #(maxProxyDepth currentProxyDepth)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtRemoteObjectWireEncoder is used when all objects up to the specified depth are to be returned as remote objects, i.e. they are returned by value with a proxy object registered with GtRsrProxyServiceClient.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtRemoteObjectWireEncoder
+removeallclassmethods GtRemoteObjectWireEncoder
+
+doit
+(Object
+	subclass: 'GtWireEncodingDummyProxy'
+	instVarNames: #(description)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireEncodingDummyProxy
+removeallclassmethods GtWireEncodingDummyProxy
+
+doit
+(Object
+	subclass: 'GtWireEncodingExampleInstVarObject'
+	instVarNames: #(var1 var2 var3 var4)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireEncodingExampleInstVarObject
+removeallclassmethods GtWireEncodingExampleInstVarObject
+
+doit
+(Object
+	subclass: 'GtWireEncodingExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireEncodingExamples
+removeallclassmethods GtWireEncodingExamples
+
+doit
+(Object
+	subclass: 'GtWireEncodingInspectionObject'
+	instVarNames: #(startIndex object decoder parent children components endIndex)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireEncodingInspectionObject
+removeallclassmethods GtWireEncodingInspectionObject
+
+doit
+(Object
+	subclass: 'GtWireGbsReplicationSpecConverter'
+	instVarNames: #(maxDepth)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireGbsReplicationSpecConverter takes a dictionary of Gbs replicationSpecs and modifies the supplied {{gtClass:GtWireEncoder}} to match the dictionary.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGbsReplicationSpecConverter
+removeallclassmethods GtWireGbsReplicationSpecConverter
+
+doit
+(Object
+	subclass: 'GtWireGbsReplicationSpecConverterExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGbsReplicationSpecConverterExamples
+removeallclassmethods GtWireGbsReplicationSpecConverterExamples
+
+doit
+(Object
+	subclass: 'GtWireGbsReplicationSpecEncodingExamples'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGbsReplicationSpecEncodingExamples
+removeallclassmethods GtWireGbsReplicationSpecEncodingExamples
+
+doit
+(Object
+	subclass: 'GtWireNestedEncodingExamples'
+	instVarNames: #(signals)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding-Examples';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireNestedEncodingExamples
+removeallclassmethods GtWireNestedEncodingExamples
+
+doit
+(Object
+	subclass: 'GtWireObjectEncoder'
+	instVarNames: #()
+	classVars: #(DefaultMap)
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireObjectEncoder
+removeallclassmethods GtWireObjectEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireAssociationEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireAssociationEncoder
+removeallclassmethods GtWireAssociationEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireBlockClosureEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireBlockClosureEncoder
+removeallclassmethods GtWireBlockClosureEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireBooleanEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireBooleanEncoder
+removeallclassmethods GtWireBooleanEncoder
+
+doit
+(GtWireBooleanEncoder
+	subclass: 'GtWireFalseEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireFalseEncoder
+removeallclassmethods GtWireFalseEncoder
+
+doit
+(GtWireBooleanEncoder
+	subclass: 'GtWireTrueEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireTrueEncoder
+removeallclassmethods GtWireTrueEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireByteArrayEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireByteArrayEncoder
+removeallclassmethods GtWireByteArrayEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireCharacterArrayEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireCharacterArrayEncoder
+removeallclassmethods GtWireCharacterArrayEncoder
+
+doit
+(GtWireCharacterArrayEncoder
+	subclass: 'GtWireStringEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireStringEncoder
+removeallclassmethods GtWireStringEncoder
+
+doit
+(GtWireCharacterArrayEncoder
+	subclass: 'GtWireSymbolEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireSymbolEncoder
+removeallclassmethods GtWireSymbolEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireCharacterEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireCharacterEncoder
+removeallclassmethods GtWireCharacterEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireClassEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireClassEncoder passes class references by name, assuming that the local and remote class definitions are equivalent.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireClassEncoder
+removeallclassmethods GtWireClassEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireCollectionEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireCollectionEncoder
+removeallclassmethods GtWireCollectionEncoder
+
+doit
+(GtWireCollectionEncoder
+	subclass: 'GtWireArrayEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireArrayEncoder
+removeallclassmethods GtWireArrayEncoder
+
+doit
+(GtWireCollectionEncoder
+	subclass: 'GtWireDictionaryEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireDictionaryEncoder
+removeallclassmethods GtWireDictionaryEncoder
+
+doit
+(GtWireCollectionEncoder
+	subclass: 'GtWireOrderedCollectionEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireOrderedCollectionEncoder
+removeallclassmethods GtWireOrderedCollectionEncoder
+
+doit
+(GtWireCollectionEncoder
+	subclass: 'GtWireSetEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireSetEncoder
+removeallclassmethods GtWireSetEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireDateAndTimeEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireDateAndTimeEncoder
+removeallclassmethods GtWireDateAndTimeEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireDummyProxyEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireDummyProxyEncoder is used for testing as the real proxy encoders require the associated environment to be instantiated.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireDummyProxyEncoder
+removeallclassmethods GtWireDummyProxyEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireFloatEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireFloatEncoder
+removeallclassmethods GtWireFloatEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireGemStoneOopEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGemStoneOopEncoder
+removeallclassmethods GtWireGemStoneOopEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireGemStoneRemoteObjectEncoder'
+	instVarNames: #(encoder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireGemStoneRemoteObjectEncoder is used in a replication spec to specify that instances of the registered class should be returned as remote objects, i.e. they are returned by value and a proxy is registered with GtRsrProxyServiceClient.
+
+Note that GtWireGemStoneRemoteObjectEncoder has no typeIdentifier as it doesn''t directly encode objects, they are encoded by GtWireGemStoneWithRsrEncoder and the appropriate value encoder.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGemStoneRemoteObjectEncoder
+removeallclassmethods GtWireGemStoneRemoteObjectEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireGemStoneRsrEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireGemStoneRsrEncoder is used to pass GemStone Rsr proxy objects via wire encoding.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGemStoneRsrEncoder
+removeallclassmethods GtWireGemStoneRsrEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireGemStoneWithRsrEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireGemStoneWithRsrEncoder is used to pass a remote object back from GemStone to GT.
+
+A remote object is one which is passed back by value, but is also registered with GtRsrProxyServiceClient so that it''s proxy object automatically accessible.
+
+GtWireGemStoneWithRsrEncoder is not used directly in a replication spec, but either by the GtRemoteObjectWireEncoder or GtWireGemStoneRemoteObjectEncoder.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGemStoneWithRsrEncoder
+removeallclassmethods GtWireGemStoneWithRsrEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireGsBareProxyEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireGsBareProxyEncoder
+removeallclassmethods GtWireGsBareProxyEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireInstVarEncoder'
+	instVarNames: #(instVarMap)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireInstVarEncoder uses the specified mapping to encode the supplied objects.  No mapping is required for decoding.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireInstVarEncoder
+removeallclassmethods GtWireInstVarEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireIntegerEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireIntegerEncoder
+removeallclassmethods GtWireIntegerEncoder
+
+doit
+(GtWireIntegerEncoder
+	subclass: 'GtWireNegativeIntegerEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireNegativeIntegerEncoder
+removeallclassmethods GtWireNegativeIntegerEncoder
+
+doit
+(GtWireIntegerEncoder
+	subclass: 'GtWirePositiveIntegerEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWirePositiveIntegerEncoder
+removeallclassmethods GtWirePositiveIntegerEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireMaxDepthEncoder'
+	instVarNames: #(depth encoder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireMaxDepthEncoder
+removeallclassmethods GtWireMaxDepthEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireMinDepthEncoder'
+	instVarNames: #(depth encoder)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireMinDepthEncoder
+removeallclassmethods GtWireMinDepthEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireNilEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireNilEncoder
+removeallclassmethods GtWireNilEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireObjectByNameEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireObjectByNameEncoder
+removeallclassmethods GtWireObjectByNameEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireReplicationEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		comment: 'GtWireReplicationEncoder uses the current mapping for the supplied object, unless it would return a type of proxy, in which case {{gtClass:GtWireObjectByNameEncoder}} is used.';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireReplicationEncoder
+removeallclassmethods GtWireReplicationEncoder
+
+doit
+(GtWireObjectEncoder
+	subclass: 'GtWireStonEncoder'
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireStonEncoder
+removeallclassmethods GtWireStonEncoder
+
+doit
+(Stream
+	subclass: 'GtWireStream'
+	instVarNames: #(wrappedStream)
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: Globals
+	options: #( #logCreation )
+)
+		category: 'GToolkit-WireEncoding';
+		immediateInvariant.
+true.
+%
+
+removeallmethods GtWireStream
+removeallclassmethods GtWireStream
+
+! Class implementation for 'GtWireUnsupportedObject'
+
+!		Class methods for 'GtWireUnsupportedObject'
+
+category: 'signaling'
+classmethod: GtWireUnsupportedObject
+signal: anObject
+
+	self new
+		object: anObject;
+		messageText: 'Unable to serialize', anObject class name;
+		signal
+%
+
+!		Instance methods for 'GtWireUnsupportedObject'
+
+category: 'accessing'
+method: GtWireUnsupportedObject
+object
+	^ object
+%
+
+category: 'accessing'
+method: GtWireUnsupportedObject
+object: anObject
+	object := anObject
+%
+
+! Class implementation for 'GtWireEncoderDecoder'
+
+!		Class methods for 'GtWireEncoderDecoder'
+
+category: 'maintenance'
+classmethod: GtWireEncoderDecoder
+generateDefaultGsMapMethod
+	"Generate and save the defaultMap method for GS.
+	Traversing a class hierarchy is very expensive, especially on GemStone.
+	Generate a method to create the map by traversing the required class hierarchies."
+	| mapping source |
+	
+	mapping := self defaultMapping.
+	source := self generateDefaultGsMapMethodFrom: mapping.
+	"How to compile on GemStone when under Rowan control?"
+	"self class
+		compileMethod: source
+		dictionaries: GsCurrentSession currentSession symbolList
+		category: '*GToolkit-WireEncoding-GemStone'
+		environmentId: 0."
+	^ source
+%
+
+category: 'maintenance'
+classmethod: GtWireEncoderDecoder
+generateDefaultGsMapMethodFrom: aDictionary
+	"Answer the source code for the #defaultMap method from the supplied map dictionary.
+	.gs files don't allow undeclared classes to be referenced... 
+	hack around it by deferring class lookup."
+	| source |
+
+	source := String streamContents: [ :stream |
+		stream
+			<< 'getDefaultMap'; lf;
+			tab; << '"Generated by #generateDefaultMapMethodFrom:.'; lf;
+			tab; << 'Original source is #defaultMapping, changes should be made there and the code regenerated."'; lf;
+			lf;
+			tab; << '^ IdentityDictionary new'; lf.
+		(aDictionary keys asSortedCollection: [ :a :b | a name < b name ]) do: [ :key |
+				stream
+					tab; tab; << 'at: ((self lookupClass: #';
+					<< key name;
+					<< (') ifNil: [ self error: ''Unable to find: ', key name asString, ''' ]) put: ');
+					<< (aDictionary at: key) class name;
+					<< ' new' ]
+			separatedBy: [ stream << ';'; lf ].
+		stream
+			<< ';'; lf;
+			tab; tab; << 'yourself.'; lf ].
+	^ source
+%
+
+category: 'maintenance'
+classmethod: GtWireEncoderDecoder
+generateDefaultGsReverseMapMethod
+	"Generate and save the defaultMap method for GS.
+	Traversing a class hierarchy is very expensive, especially on GemStone.
+	Generate a method to create the map by traversing the required class hierarchies."
+	| reverse source |
+	
+	reverse := self reverseMapFrom: self defaultMapping.
+	source := self generateDefaultReverseMapMethodFrom: reverse.
+	"How to compile on GemStone when under Rowan control?"
+	"self class
+		compileMethod: source
+		dictionaries: GsCurrentSession currentSession symbolList
+		category: '*GToolkit-WireEncoding-GemStone'
+		environmentId: 0."
+	^ source
+%
+
+category: 'maintenance'
+classmethod: GtWireEncoderDecoder
+generateDefaultGtMapMethod
+	"Generate and save the defaultMap method for Gt.
+	Traversing a class hierarchy is very expensive, especially on GemStone.
+	Generate a method to create the map by traversing the required class hierarchies."
+	| mapping source reverse |
+
+	mapping := self defaultMapping.
+	source := self generateDefaultMapMethodFrom: mapping.
+	self class
+		compile: source
+		classified: '*GToolkit-WireEncoding-GT'.
+
+	reverse := self reverseMapFrom: mapping.
+	source := self generateDefaultReverseMapMethodFrom: reverse.
+	self class
+		compile: source
+		classified: '*GToolkit-WireEncoding-GT'.
+	self  initialize.
+%
+
+category: 'maintenance'
+classmethod: GtWireEncoderDecoder
+generateDefaultMapMethodFrom: aDictionary
+	"Answer the source code for the #defaultMap method from the supplied map dictionary"
+	| source |
+
+	source := String streamContents: [ :stream |
+		stream
+			<< 'getDefaultMap'; lf;
+			tab; << '"Generated by #generateDefaultMapMethodFrom:.'; lf;
+			tab; << 'Original source is #defaultMapping, changes should be made there and the code regenerated."'; lf;
+			lf;
+			tab; << '^ IdentityDictionary new'; lf.
+		(aDictionary keys asSortedCollection: [ :a :b | a name < b name ]) do: [ :key |
+				stream
+					tab; tab; << 'at: ';
+					<< key name;
+					<< ' put: ';
+					<< (aDictionary at: key) class name;
+					<< ' new' ]
+			separatedBy: [ stream << ';'; lf ].
+		stream
+			<< ';'; lf;
+			tab; tab; << 'yourself.'; lf ].
+	^ source
+%
+
+category: 'utilities'
+classmethod: GtWireEncoderDecoder
+generateDefaultReverseMapMethodFrom: aDictionary
+	"Answer the source code for the #defaultMap method from the supplied map dictionary"
+	| source maxKey |
+
+	maxKey := aDictionary keys asArray max.
+	source := String streamContents: [ :stream |
+		stream
+			<< 'getDefaultReverseMap'; lf;
+			tab; << '"Generated by #generateDefaultReverseMapMethodFrom:.'; lf;
+			tab; << 'Original source is #defaultMapping, changes should be made there and the code regenerated."'; lf;
+			lf;
+			tab; << '^ (Array new: ';
+			<< maxKey asString;
+			<< ')'; lf.
+		aDictionary keys asSortedCollection do: [ :key |
+				stream
+					tab; tab; << 'at: ';
+					<< key asString;
+					<< ' put: ';
+					<< (aDictionary at: key) class name;
+					<< ' new' ]
+			separatedBy: [ stream << ';'; lf ].
+		stream
+			<< ';'; lf;
+			tab; tab; << 'yourself.'; lf ].
+	^ source
+%
+
+category: 'initialization'
+classmethod: GtWireEncoderDecoder
+initialize
+	"NOTE: GtDefaultMap and GtDefaultReverseMap should only be used on GT.
+	On GemStone they should always be nil."
+
+	GtDefaultMap := GtDefaultReverseMap := nil
+%
+
+category: 'private'
+classmethod: GtWireEncoderDecoder
+lookupClass: className
+	"Answer the class with the supplied name or nil if not found.
+	For GemStone, see STONReader>>lookupClass: for inspiration."
+
+	^ self
+		gtDo: [ self class environment classOrTraitNamed: className ]
+		gemstoneDo: [ System myUserProfile objectNamed: className asSymbol ]
+%
+
+category: 'private'
+classmethod: GtWireEncoderDecoder
+map: aClass withSubclassesTo: anEncoder in: mapping
+	"Add the mapping for aClass and all its subclasses"
+	
+	"GemStone doesn't have #withAllSubclasses"
+	mapping at: aClass put: anEncoder.
+	aClass allSubclasses do: [ :cls |
+		mapping at: cls put: anEncoder ].
+%
+
+category: 'accessing'
+classmethod: GtWireEncoderDecoder
+reverseMapFrom: aDictionary
+	"Construct the reverse map.
+	Build a default reverse map and then  overwrite with the supplied configured encoders."
+	| reverseMap |
+
+	reverseMap := IdentityDictionary new.
+	GtWireObjectEncoder allSubclasses do: [ :cls |
+		cls typeIdentifierOrNil ifNotNil:
+			[ :id | reverseMap at: id put: cls new ] ].
+	aDictionary associationsDo: [ :assoc |
+		assoc value class typeIdentifierOrNil ifNotNil: [ :id |
+			reverseMap at: id put: assoc value ] ].
+	^ reverseMap
+%
+
+!		Instance methods for 'GtWireEncoderDecoder'
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+addMapping: aClass to: anEncoder
+	"Add/Overwrite the supplied encoder.
+	Be careful not to accidentally overwrite the default map unintentionally."
+	| typeIdentifier |
+	
+	self map at: aClass put: anEncoder.
+	typeIdentifier := anEncoder class typeIdentifierOrNil.
+	typeIdentifier ifNotNil:
+		[ self reverseMap at: typeIdentifier put: anEncoder ]
+%
+
+category: 'as yet unclassified'
+method: GtWireEncoderDecoder
+classCache
+
+	^ classCache ifNil: [ classCache := Dictionary new ]
+%
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+contents
+
+	^ stream contents
+%
+
+category: 'testing'
+method: GtWireEncoderDecoder
+hasValidConfiguration
+
+	^ (self map values allSatisfy: [ :each | each hasValidConfiguration ]) and:
+		[ self reverseMap allSatisfy: [ :each | each hasValidConfiguration ] ]
+%
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+map
+
+	^ map ifNil: 
+		[ reverseMap := self class defaultReverseMap copy.
+		map := self class defaultMap copy ]
+%
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+map: aDictionary
+
+	map := aDictionary.
+	reverseMap := nil.
+%
+
+category: 'copying'
+method: GtWireEncoderDecoder
+postCopy
+
+	super postCopy.
+	stream := stream copy.
+%
+
+category: 'private - helpers'
+method: GtWireEncoderDecoder
+replaceMappingsMatching: matchBlock with: replacementBlock
+	"Replace all the mappings matching matchBlock with the encoder returned by replacementBlock.
+	Used by examples to avoid needing live servers."
+
+	self map associationsDo: [ :assoc |
+		(matchBlock value: assoc value) ifTrue:
+			[ assoc value: replacementBlock value ]
+		ifFalse:
+			[ assoc value replaceMappingsMatching: matchBlock with: replacementBlock ] ]
+%
+
+category: 'initialization'
+method: GtWireEncoderDecoder
+reset
+
+	stream reset
+%
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+reverseMap
+
+	^ reverseMap ifNil: 
+		[ "Requesting the map will potentially also load the reverseMap.
+		Check if it still needs to be calculated."
+		self map.
+		reverseMap ifNil:
+			[ reverseMap := self class defaultReverseMap ] ]
+%
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+reverseMap: anObject
+	reverseMap := anObject
+%
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+stream
+
+	^ stream ifNil: [ stream := GtWireStream on:
+		(ByteArray new: 64 * 1024) ]
+%
+
+category: 'accessing'
+method: GtWireEncoderDecoder
+stream: aGtWireReadWriteStream
+
+	stream := aGtWireReadWriteStream
+%
+
+! Class implementation for 'GtWireDecoder'
+
+!		Class methods for 'GtWireDecoder'
+
+category: 'instance creation'
+classmethod: GtWireDecoder
+on: aReadStream
+
+	^ self basicNew initialize stream:
+		(GtWireStream on: aReadStream)
+%
+
+!		Instance methods for 'GtWireDecoder'
+
+category: 'accessing'
+method: GtWireDecoder
+next
+	| type |
+
+	type := self nextTypeIdentifier.
+	^ (self reverseMap at: type) decodeWith: self.
+%
+
+category: 'decoding'
+method: GtWireDecoder
+nextByteArray
+
+	^ stream next: self nextSize
+%
+
+category: 'decoding'
+method: GtWireDecoder
+nextFloat64
+
+	^ stream float64
+%
+
+category: 'decoding'
+method: GtWireDecoder
+nextInt64
+
+	^ stream int64
+%
+
+category: 'decoding'
+method: GtWireDecoder
+nextPackedInteger
+
+	^ stream packedInteger
+%
+
+category: 'decoding'
+method: GtWireDecoder
+nextSize
+
+	^ stream packedInteger
+%
+
+category: 'decoding'
+method: GtWireDecoder
+nextString
+	"Answer the next string.
+	GemStone requires conversion from a Unicode object to a String (asString)"
+
+	^ (stream next: self nextSize) utf8Decoded asString
+%
+
+category: 'decoding'
+method: GtWireDecoder
+nextTypeIdentifier
+
+	^ stream packedInteger
+%
+
+! Class implementation for 'GtWireInspectionDecoder'
+
+!		Class methods for 'GtWireInspectionDecoder'
+
+category: 'instance creation'
+classmethod: GtWireInspectionDecoder
+byteArray: aByteArray
+
+	^ (self on: aByteArray readStream)
+		byteArray: aByteArray;
+		next;
+		root
+%
+
+!		Instance methods for 'GtWireInspectionDecoder'
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+byteArray
+	^ byteArray
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+byteArray: anObject
+	byteArray := anObject
+%
+
+category: 'initialization'
+method: GtWireInspectionDecoder
+initialize
+
+	super initialize.
+	"Use an OrderedCollection for the stack since GemStone doesn't have a Stack"
+	stack := OrderedCollection new.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+next
+	| inspectionObject object parent |
+
+	inspectionObject := GtWireEncodingInspectionObject new.
+	root ifNil: [ root := inspectionObject ].
+	parent := stack
+			ifEmpty: [ nil ]
+			ifNotEmpty: [ stack last ].
+	inspectionObject 
+		parent: parent;
+		startIndex: stream position + 1;
+		decoder: self.
+	stack addLast: inspectionObject.
+	object := super next.
+	inspectionObject 
+		object: object;
+		endIndex: stream position.
+	parent ifNotNil: [ parent addComponent: #object ->inspectionObject ].
+	stack removeLast.
+	^ object
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+nextByteArray
+	| ba |
+	ba := super nextByteArray.
+	stack last addComponent: #byteArray -> ba.
+	^ ba.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+nextFloat64
+	| float64 |
+
+	float64 := super nextFloat64.
+	stack last addComponent: #float64 -> float64.
+	^ float64.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+nextInt64
+	| int64 |
+
+	int64 := super nextInt64.
+	stack last addComponent: #int64 -> int64.
+	^ int64.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+nextPackedInteger
+	| packedInteger |
+
+	packedInteger := super nextPackedInteger.
+	stack last addComponent: #packedInteger -> packedInteger.
+	^ packedInteger.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+nextSize
+	| size |
+
+	size := super nextSize.
+	stack last addComponent: #size -> size.
+	^ size.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+nextString
+	| string |
+
+	string := super nextString.
+	stack last addComponent: #string -> string.
+	^ string.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+nextTypeIdentifier
+	| typeIdentifier |
+
+	typeIdentifier := super nextTypeIdentifier.
+	stack last addComponent: #typeIdentifier -> typeIdentifier.
+	^ typeIdentifier.
+%
+
+category: 'accessing'
+method: GtWireInspectionDecoder
+root
+	^ root
+%
+
+! Class implementation for 'GtWireEncoder'
+
+!		Class methods for 'GtWireEncoder'
+
+category: 'accessing'
+classmethod: GtWireEncoder
+byNameEncoder
+
+	^ [ :anObject | GtWireObjectByNameEncoder new ]
+%
+
+category: 'cleanup'
+classmethod: GtWireEncoder
+cleanUp
+
+	DefaultEncoder := nil
+%
+
+category: 'accessing'
+classmethod: GtWireEncoder
+defaultEncoder
+	"Answer the default encoder.
+	Normally fall back to encoding objects by name."
+
+	^ DefaultEncoder ifNil: [ self byNameEncoder ]
+%
+
+category: 'accessing'
+classmethod: GtWireEncoder
+defaultEncoder: aBlockClosure
+
+	DefaultEncoder := aBlockClosure
+%
+
+category: 'testing'
+classmethod: GtWireEncoder
+hasDefaultEncoder
+
+	^ DefaultEncoder isNotNil
+%
+
+category: 'instance creation'
+classmethod: GtWireEncoder
+on: aWriteStream
+
+	^ self basicNew initialize stream:
+		(GtWireStream on: aWriteStream)
+%
+
+category: 'instance creation'
+classmethod: GtWireEncoder
+onByteArray
+
+	^ self on: (WriteStream on: (ByteArray new: 100))
+%
+
+!		Instance methods for 'GtWireEncoder'
+
+category: 'accessing'
+method: GtWireEncoder
+decoderOn: aReadStream
+	| decoder |
+	
+	decoder := GtWireDecoder on: aReadStream.
+	decoder 
+		map: self map;
+		reverseMap: self reverseMap.
+	^ decoder
+%
+
+category: 'accessing'
+method: GtWireEncoder
+defaultEncoder
+
+	^ defaultEncoder ifNil: [ defaultEncoder := self class defaultEncoder ]
+%
+
+category: 'accessing'
+method: GtWireEncoder
+defaultEncoder: anObject
+	defaultEncoder := anObject
+%
+
+category: 'initialization'
+method: GtWireEncoder
+initialize
+
+	super initialize.
+	maxObjects := 5000000.
+	objectCount := 0.
+	remainingDepth := maxObjects.
+	maxDepthEncoder := GtWireNilEncoder new.
+%
+
+category: 'accessing'
+method: GtWireEncoder
+isMaxDepthLiteral: anObject
+	"Answer a boolean indicating whether the supplied object is considered a literal, and so can be returned even if the max depth has been reached.
+	Based on observed behaviour by GemStone Gbs."
+
+	^ { Number. String. Boolean. } anySatisfy: [ :cls |
+		anObject isKindOf: cls ].
+%
+
+category: 'accessing'
+method: GtWireEncoder
+maxDepthEncoder
+	^ maxDepthEncoder
+%
+
+category: 'accessing'
+method: GtWireEncoder
+maxDepthEncoder: anObject
+	maxDepthEncoder := anObject
+%
+
+category: 'accessing'
+method: GtWireEncoder
+maxObjects
+	"Answer the maximum number of objects encoded.
+	This is intended as a guard against infinite recursion and is only approximate,
+	as enforcing max or min depth is currently counted as an object."
+	<return: #Integer>
+
+	^ maxObjects
+%
+
+category: 'accessing'
+method: GtWireEncoder
+maxObjects: anInteger
+	"Set the maximum number of objects encoded.
+	This is intended as a guard against infinite recursion and is only approximate,
+	as enforcing max or min depth is currently counted as an object."
+
+	maxObjects := anInteger
+%
+
+category: 'accessing'
+method: GtWireEncoder
+nextPut: anObject
+
+	self nextPut: anObject objectEncoder: nil
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+nextPut: anObject objectEncoder: objectEncoder
+	| saveDepth |
+	objectCount > maxObjects
+		ifTrue: [ self error: 'Exceeded maximum object count' ].
+	remainingDepth := remainingDepth - 1.
+	[ saveDepth := remainingDepth.
+	"remainingDepth includes the first (root) object, so compare to -1."
+	remainingDepth < 0 ifTrue: 
+		[ (self isMaxDepthLiteral: anObject)
+			ifTrue: [ self privateNextPutMapEncoded: anObject objectEncoder: objectEncoder ]
+			ifFalse: [ maxDepthEncoder encode: anObject with: self ] ]
+		ifFalse:
+			[ self privateNextPutMapEncoded: anObject objectEncoder: objectEncoder ] ]
+				ensure: [ remainingDepth := remainingDepth + 1 ].
+%
+
+category: 'accessing'
+method: GtWireEncoder
+objectEncoderFor: anObject
+	"Answer the encoder for anObject.
+	Classes (and meta-classes) are a special case as asking a class for its class doesn't result in a unique class."
+
+	anObject isClass ifTrue:
+		[ ^ GtWireClassEncoder new ].
+	^ self map  at: anObject class ifAbsent: [ self defaultEncoder value: anObject ]
+%
+
+category: 'accessing'
+method: GtWireEncoder
+privateNextPutMapEncoded: anObject
+
+	(self objectEncoderFor: anObject)
+		encode: anObject
+		with: self
+%
+
+category: 'accessing'
+method: GtWireEncoder
+privateNextPutMapEncoded: anObject objectEncoder: objectEncoder
+
+	(objectEncoder ifNil: [ self objectEncoderFor: anObject ])
+			encode: anObject
+			with: self.
+	objectCount := objectCount + 1.
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+putByteArray: aByteArray
+
+	self putSize: aByteArray size.
+	stream nextPutAll: aByteArray.
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+putFloat64: aFloat
+
+	"GtWireEncodingFloat64Signal new
+		float: aFloat;
+		emit."
+	stream float64: aFloat.
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+putInt64: anInteger
+
+	"GtWireEncodingInt64Signal new
+		integer: anInteger;
+		emit."
+	stream int64: anInteger.
+%
+
+category: 'accessing'
+method: GtWireEncoder
+putNil
+
+	self putTypeIdentifier: GtWireNilEncoder typeIdentifier.
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+putPackedInteger: aPositiveInteger
+
+	"GtWireEncodingPositiveIntegerSignal new
+		integer: aPositiveInteger;
+		emit."
+	stream packedInteger: aPositiveInteger.
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+putSize: anInteger
+
+	"GtWireEncodingSizeSignal new
+		size: anInteger;
+		emit."
+	stream packedInteger: anInteger.
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+putString: aString
+	| encoded |
+
+	encoded := aString utf8Encoded.
+	self putSize: encoded size.
+	stream nextPutAll: encoded.
+%
+
+category: 'private - encoding'
+method: GtWireEncoder
+putTypeIdentifier: anInteger
+
+	"GtWireEncodingTypeIdentifierSignal new
+		typeIdentifier: anInteger;
+		emit."
+	stream packedInteger: anInteger.
+%
+
+category: 'accessing'
+method: GtWireEncoder
+remainingDepth
+	^ remainingDepth
+%
+
+category: 'accessing'
+method: GtWireEncoder
+remainingDepth: anInteger
+	"Set the remaining depth.
+	The count includes the first (root) or current object."
+
+	remainingDepth := anInteger
+%
+
+category: 'initialization'
+method: GtWireEncoder
+reset
+
+	super reset.
+	objectCount := 0.
+%
+
+! Class implementation for 'GtRemoteObjectWireEncoder'
+
+!		Instance methods for 'GtRemoteObjectWireEncoder'
+
+category: 'accessing'
+method: GtRemoteObjectWireEncoder
+currentProxyDepth
+	^ currentProxyDepth
+%
+
+category: 'accessing'
+method: GtRemoteObjectWireEncoder
+currentProxyDepth: anObject
+	^ currentProxyDepth := anObject
+%
+
+category: 'initialization'
+method: GtRemoteObjectWireEncoder
+initialize
+	super initialize.
+	currentProxyDepth := -1
+%
+
+category: 'accessing'
+method: GtRemoteObjectWireEncoder
+maxProxyDepth
+	"Answer the maximum depth to which proxy objects will be returned along with the object by value.
+	nil = unlimited"
+
+	^ maxProxyDepth
+%
+
+category: 'accessing'
+method: GtRemoteObjectWireEncoder
+maxProxyDepth: anIntegerOrNil
+
+	maxProxyDepth := anIntegerOrNil
+%
+
+category: 'private - encoding'
+method: GtRemoteObjectWireEncoder
+nextPut: anObject objectEncoder: objectEncoder
+	currentProxyDepth := currentProxyDepth + 1.
+	^ [ super nextPut: anObject objectEncoder: objectEncoder ] 
+		ensure: [ currentProxyDepth := currentProxyDepth - 1 ]
+%
+
+category: 'encoding'
+method: GtRemoteObjectWireEncoder
+privateNextPutMapEncoded: anObject objectEncoder: objectEncoder
+	| encoder |
+	
+	encoder := objectEncoder ifNil:
+		[ self map at: anObject class ifAbsent: [ self defaultEncoder value: anObject ] ].
+	(anObject isNil or: 
+	[ encoder isProxyObjectEncoder or:
+	[ self shouldEncodeWithProxyAtCurrentDepth not ] ]) ifTrue:
+		[ encoder encode: anObject with: self. ]
+	ifFalse:
+		[ GtWireGemStoneWithRsrEncoder new encode: anObject with: self objectEncoder: encoder ].
+	objectCount := objectCount + 1.
+%
+
+category: 'testing'
+method: GtRemoteObjectWireEncoder
+shouldEncodeWithProxyAtCurrentDepth
+	maxProxyDepth ifNil: [ ^ true ].
+	^ currentProxyDepth <= maxProxyDepth
+%
+
+! Class implementation for 'GtWireEncodingDummyProxy'
+
+!		Instance methods for 'GtWireEncodingDummyProxy'
+
+category: 'accessing'
+method: GtWireEncodingDummyProxy
+description
+	^ description
+%
+
+category: 'accessing'
+method: GtWireEncodingDummyProxy
+description: anObject
+	description := anObject
+%
+
+! Class implementation for 'GtWireEncodingExampleInstVarObject'
+
+!		Class methods for 'GtWireEncodingExampleInstVarObject'
+
+category: 'accessing'
+classmethod: GtWireEncodingExampleInstVarObject
+leJsonV4Name
+
+	^  #gtWireEncodingExampleInstVarObject
+%
+
+!		Instance methods for 'GtWireEncodingExampleInstVarObject'
+
+category: 'as yet unclassified'
+method: GtWireEncodingExampleInstVarObject
+= anObject
+
+	self == anObject ifTrue: [ ^ true ].
+	anObject class = self class ifFalse: [ ^ false ].
+	^ anObject var1 = var1 and:
+		[ anObject var2 = var2 and:
+		[ anObject var3 = var3 and:
+		[ anObject var4 = var4 ] ] ]
+%
+
+category: 'as yet unclassified'
+method: GtWireEncodingExampleInstVarObject
+hash
+
+	^ var1 hash bitXor:
+		(var2 hash bitXor:
+		(var3 hash bitXor:
+		var4 hash))
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var1
+	^ var1
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var1: anObject
+	var1 := anObject
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var2
+	^ var2
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var2: anObject
+	var2 := anObject
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var3
+	^ var3
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var3: anObject
+	var3 := anObject
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var4
+	^ var4
+%
+
+category: 'accessing'
+method: GtWireEncodingExampleInstVarObject
+var4: anObject
+	var4 := anObject
+%
+
+! Class implementation for 'GtWireEncodingExamples'
+
+!		Instance methods for 'GtWireEncodingExamples'
+
+category: 'examples'
+method: GtWireEncodingExamples
+array
+	<gtExample>
+	<return: #ByteArray>
+	| array encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	array := {1.
+			'hello'.
+			#hello}.
+	encoder nextPut: array.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 18.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Array.
+	self assert: next = array.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+association
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| association encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	association := 1 -> 'one'.
+	encoder nextPut: association.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 8.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Association.
+	self assert: next = association
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+blockClosure
+	<gtExample>
+	<return: #ByteArray>
+	| blockClosure encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	blockClosure := [ :a :b | a + b ].
+	encoder nextPut: blockClosure.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 20.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: (#(FullBlockClosure ExecBlock) includes: next class name).
+	self assert: (next value: 4 value: 3) equals: 7.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+boolean
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| encoder byteArray decoder |
+	encoder := GtWireEncoder onByteArray.
+	encoder nextPut: true.
+	encoder nextPut: false.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 2.
+	decoder := GtWireDecoder on: byteArray readStream.
+	self assert: decoder next.
+	self assert: decoder next not
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+byteArray
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| source encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	source := #[3 1 4 1 5].
+	encoder nextPut: source.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: source size + 2.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: ByteArray.
+	self assert: next equals: source
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+byteString
+	<gtExample>
+	<return: #ByteArray>
+	| string encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	string := 'Hello, World'.
+	encoder nextPut: string.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: string size + 2.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: (#(ByteString String) includes: next class name).
+	self assert: next equals: string.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+byteStringWithNull
+	<gtExample>
+	<return: #ByteArray>
+	| string encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	string := 'abc' , (String with: Character null) , 'def'.
+	encoder nextPut: string.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: string size + 2.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: (#(ByteString String) includes: next class name).
+	self assert: next equals: string.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+byteSymbol
+	<gtExample>
+	<return: #ByteArray>
+	| string encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	string := #'Hello, World'.
+	encoder nextPut: string.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: string size + 2.
+	next := (GtWireDecoder on: byteArray readStream) next.	"Allow for differences in GT & GS class hierarchy"
+	self assert: (#(ByteSymbol Symbol) includes: next class name).
+	self assert: next equals: string.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+character
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	encoder nextPut: $§.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 3.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Character.
+	self assert: next == $§
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+classByName
+	<gtExample>
+	| exampleClass encoder byteArray next |
+	
+	encoder := GtWireEncoder onByteArray.
+	exampleClass := Array.
+	encoder nextPut: exampleClass.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: exampleClass name size + 3.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next identicalTo: exampleClass.
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+dateAndTime
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| dateAndTime encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	dateAndTime := DateAndTime now.
+	encoder nextPut: dateAndTime.
+	byteArray := encoder contents.
+	self assert: (byteArray size between: 10 and: 25).
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: (next isKindOf: DateAndTime).
+	self assert: next = dateAndTime
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+deepArray
+	<gtExample>
+	<return: #ByteArray>
+	| array currentArray encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 5
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	encoder nextPut: array.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 24.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Array.
+	self assert: next = array.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+dictionary
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| dictionary encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	dictionary := {1 -> 'one'.
+			2 -> 'two'} asDictionary.
+	encoder nextPut: dictionary.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 16.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Dictionary.
+	self assert: next = dictionary
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+encoderDecoderHasInvalidConfigurationWithInvalidMapping
+	<gtExample>
+	| encoder |
+	encoder := GtWireEncoder onByteArray.
+	encoder addMapping: Object to: GtWireGemStoneRemoteObjectEncoder new.
+	self assert: encoder hasValidConfiguration not.
+	^ encoder
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+encoderDecoderHasValidConfigurationWithDefaultMap
+	<gtExample>
+	| encoder |
+	encoder := GtWireEncoder onByteArray.
+	self assert: encoder hasValidConfiguration.
+	^ encoder
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+encoderHasValidConfigurationByDefault
+	<gtExample>
+	| encoder |
+	encoder := GtWireObjectEncoder new.
+	self assert: encoder hasValidConfiguration.
+	^ encoder
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+float
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	{Float fmin.
+		Float fmax.
+		1.25}
+		doWithIndex: [ :f :i | 
+			encoder reset.
+			encoder nextPut: f.
+			byteArray := encoder contents.
+			self assert: byteArray size equals: 9.
+			next := (GtWireDecoder on: byteArray readStream) next.
+			self assert: next equals: f ]
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+gemStoneRemoteObjectEncoderHasInvalidConfigurationWithoutEncoder
+	<gtExample>
+	| encoder |
+	encoder := GtWireGemStoneRemoteObjectEncoder new.
+	self assert: encoder hasValidConfiguration not.
+	^ encoder
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+generalObject
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| object encoder byteArray next root |
+	encoder := GtWireEncoder onByteArray.
+	object := self
+			gtDo: [ (self class environment classOrTraitNamed: #AdditionalMethodState) new: 3 ]
+			gemstoneDo: [ ^ self ].
+	object
+		selector: #one;
+		method: 'fake'.
+	1 to: 3 do: [ :i | object basicAt: i put: 2 ** i ].
+	encoder nextPut: object.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 60.
+	root := GtWireInspectionDecoder byteArray: byteArray.
+	next := root object.
+	self assert: (#(AdditionalMethodState) includes: next class name).
+	self assert: next basicSize equals: 3.
+	1 to: 3 do: [ :i | self assert: (next basicAt: i) equals: 2 ** i ].
+	self assert: next selector equals: #one.
+	self assert: next method equals: 'fake'
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+maxDepth
+	<gtExample>
+	<return: #ByteArray>
+	| array currentArray encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 5
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	encoder
+		remainingDepth: 2;
+		nextPut: array.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 9.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Array.
+	self assert: next first equals: 1.
+	next := next second.
+	self assert: next equals: #(2 nil).
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+metaClassByName
+	<gtExample>
+	| exampleClass encoder byteArray next |
+	
+	encoder := GtWireEncoder onByteArray.
+	exampleClass := Array class.
+	encoder nextPut: exampleClass.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: exampleClass instanceSide name size + 3.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next identicalTo: exampleClass.
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+nil
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| encoder byteArray |
+	encoder := GtWireEncoder onByteArray.
+	encoder nextPut: nil.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 1.
+	self assert: (GtWireDecoder on: byteArray readStream) next isNil
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+orderedCollection
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| orderedCollection encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	orderedCollection := {1.
+			'hello'.
+			#hello} asOrderedCollection.
+	encoder nextPut: orderedCollection.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 18.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: OrderedCollection.
+	self assert: next = orderedCollection
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+packedInteger
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| encoder byteArray integer |
+	encoder := GtWireEncoder onByteArray.
+	encoder nextPut: 0.
+	byteArray := encoder contents.
+	self assert: byteArray equals: #[13 0].
+	self assert: (GtWireDecoder on: byteArray readStream) next equals: 0.
+	integer := 1.	"GemStone is slow at this test, if it works in GT for the full range, testing a small range in
+	GemStone is probably enough"
+	[ integer < ((self gtDo: [ SmallInteger maxVal ] gemstoneDo: [ 10 ]) * 10) ]
+		whileTrue: [ encoder reset.
+			encoder nextPut: integer.
+			byteArray := encoder contents.
+			self assert: (GtWireDecoder on: byteArray readStream) next equals: integer.
+			encoder reset.
+			encoder nextPut: integer negated.
+			byteArray := encoder contents.
+			encoder reset.
+			self
+				assert: (GtWireDecoder on: byteArray readStream) next
+				equals: integer negated.
+			integer := (1.001 * integer) ceiling ]
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+set
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| set encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	set := {1.
+			'hello'.
+			true} asSet.
+	encoder nextPut: set.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 12.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Set.
+	self assert: next = set
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+wideString
+	<gtExample>
+	<return: #ByteArray>
+	| string encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	string := 'čtyři'.
+	encoder nextPut: string.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: string asString utf8Encoded size + 2.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self
+		assert: (#(WideString DoubleByteString Unicode16) includes: next class name).
+	self assert: next equals: string.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+wideStringWithNull
+	<gtExample>
+	<return: #ByteArray>
+	| string encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	string := 'čty' , (String with: Character null) , 'ři'.
+	encoder nextPut: string.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: string asString utf8Encoded size + 2.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self
+		assert: (#(WideString DoubleByteString Unicode16) includes: next class name).
+	self assert: next equals: string.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireEncodingExamples
+wideSymbol
+	<gtExample>
+	<return: #GtWireEncodingExamples>
+	| wideSymbol encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	wideSymbol := #'kancelař'.
+	encoder nextPut: wideSymbol.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: wideSymbol asString utf8Encoded size + 2.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: (#(WideSymbol DoubleByteSymbol) includes: next class name).
+	self assert: next equals: wideSymbol
+%
+
+! Class implementation for 'GtWireEncodingInspectionObject'
+
+!		Instance methods for 'GtWireEncodingInspectionObject'
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+addComponent: anObject
+
+	components add: anObject
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+byteArray
+
+	^ decoder byteArray
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+decoder
+	^ decoder
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+decoder: anObject
+	decoder := anObject
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+endIndex
+	^ endIndex
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+endIndex: anObject
+	endIndex := anObject
+%
+
+category: 'ui'
+method: GtWireEncodingInspectionObject
+gtChildrenFor: aView
+	<gtView>
+
+	^ aView columnedList
+		  title: 'Components';
+		  priority: 15;
+		  items: [ components ];
+		  column: 'Field' text: [ :item | item key ];
+		  column: 'Value' text: [ :item | item value ];
+		  send: [ :item | item value ];
+		  actionUpdateButton
+%
+
+category: 'ui'
+method: GtWireEncodingInspectionObject
+gtHexDumpFor: aView
+	<gtView>
+
+	^ aView forward
+		title: 'Buffer';
+		priority: 20;
+		object: [ self objectByteArray ];
+		view: #gtHexDumpFor:
+%
+
+category: 'ui'
+method: GtWireEncodingInspectionObject
+gtSummaryFor: aView
+	<gtView>
+
+	^ aView columnedList
+		  title: 'Summary';
+		  priority: 10;
+		  items: [ self summaryAttributes ];
+		  column: #Attribute text: [ :item | item first ];
+		  column: #Value text: [ :item | item second ];
+		  send: [ :item | item last ];
+		  actionUpdateButton
+%
+
+category: 'initialization'
+method: GtWireEncodingInspectionObject
+initialize
+
+	super initialize.
+	components := OrderedCollection new.
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+object
+	^ object
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+object: anObject
+	object := anObject
+%
+
+category: 'as yet unclassified'
+method: GtWireEncodingInspectionObject
+objectByteArray
+
+	^ self byteArray copyFrom: startIndex to: endIndex
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+parent
+	^ parent
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+parent: anObject
+	parent := anObject
+%
+
+category: 'as yet unclassified'
+method: GtWireEncodingInspectionObject
+printOn: aStream
+
+	aStream
+		<< self type name;
+		<< '(';
+		print: object;
+		<< ')'.
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+startIndex
+	^ startIndex
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+startIndex: anObject
+	startIndex := anObject
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+summaryAttributes
+
+	^ {
+		{ 'Start Index'. startIndex. }.
+		{ 'Type Indicator'. self typeIndicator. }.
+		{ 'Type'. self type. }.
+		{ 'Object'. object. }.
+	}
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+type
+
+	^ decoder reverseMap at: self typeIndicator
+%
+
+category: 'accessing'
+method: GtWireEncodingInspectionObject
+typeIndicator
+	| stream |
+
+	stream := ReadStream on: self byteArray.
+	stream position: startIndex - 1.
+	^ (GtWireDecoder on: stream) stream packedInteger.
+%
+
+! Class implementation for 'GtWireGbsReplicationSpecConverter'
+
+!		Instance methods for 'GtWireGbsReplicationSpecConverter'
+
+category: 'actions'
+method: GtWireGbsReplicationSpecConverter
+flattenSpec: anArray
+	"Remove entries that are later overridden.
+	This answers the array in reverse order, which doesn't affect the final outcome."
+	| seen |
+
+	seen := Set new.
+	^ Array streamContents: [ :stream |
+		anArray size to: 1 by: -1 do: [ :i | | iVarEntry |
+			iVarEntry := anArray at: i.
+			(seen includes: iVarEntry first) ifFalse:
+				[ stream nextPut: iVarEntry.
+				seen add: iVarEntry first. ] ] ].
+%
+
+category: 'private'
+method: GtWireGbsReplicationSpecConverter
+forwarderEncodingFor: aGtWireEncoder class: aClass objectEncoder: aGtWireInstVarEncoder instVarMap: instVarMap replicationSpec: replicationSpecArray
+
+	instVarMap
+		at: replicationSpecArray first
+		put: GtWireGemStoneRsrEncoder new.
+%
+
+category: 'private'
+method: GtWireGbsReplicationSpecConverter
+indexablePartEncodingFor: aGtWireEncoder class: aClass objectEncoder: aGtWireInstVarEncoder instVarMap: instVarMap replicationSpec: replicationSpecArray
+	"Indexable objects aren't supported at the moment"
+
+	self notYetImplemented
+%
+
+category: 'accessing'
+method: GtWireGbsReplicationSpecConverter
+maxDepth
+	"Answer the maximum depth to replicate to.
+	The default (4) is taken from the GBS User's Guide faultLevelRpc."
+
+	^ maxDepth ifNil: [ 4 ]
+%
+
+category: 'accessing'
+method: GtWireGbsReplicationSpecConverter
+maxDepth: anObject
+	maxDepth := anObject
+%
+
+category: 'private'
+method: GtWireGbsReplicationSpecConverter
+maxEncodingFor: aGtWireEncoder class: aClass objectEncoder: aGtWireInstVarEncoder instVarMap: instVarMap replicationSpec: replicationSpecArray
+
+	instVarMap
+		at: replicationSpecArray first
+		put: (GtWireMaxDepthEncoder new depth: replicationSpecArray third).
+%
+
+category: 'private'
+method: GtWireGbsReplicationSpecConverter
+minEncodingFor: aGtWireEncoder class: aClass objectEncoder: aGtWireInstVarEncoder instVarMap: instVarMap replicationSpec: replicationSpecArray
+
+	instVarMap
+		at: replicationSpecArray first
+		put: (GtWireMinDepthEncoder new depth: replicationSpecArray third).
+%
+
+category: 'private'
+method: GtWireGbsReplicationSpecConverter
+replicateEncodingFor: aGtWireEncoder class: aClass objectEncoder: aGtWireInstVarEncoder instVarMap: instVarMap replicationSpec: replicationSpecArray
+
+	instVarMap
+		at: replicationSpecArray first
+		put: GtWireReplicationEncoder new.
+%
+
+category: 'actions'
+method: GtWireGbsReplicationSpecConverter
+replicationSpecKeywordToWireObjectEncoderMap
+	"Answer the map from replicationSpec keyword to Wire encoder.
+	#replicate and #indexable_part are special cases."
+
+	^ {
+		#stub -> #stubEncodingFor:class:objectEncoder:instVarMap:replicationSpec:.
+		#forwarder -> #forwarderEncodingFor:class:objectEncoder:instVarMap:replicationSpec:.
+		#min -> #minEncodingFor:class:objectEncoder:instVarMap:replicationSpec:.
+		#max -> #maxEncodingFor:class:objectEncoder:instVarMap:replicationSpec:.
+		#replicate -> #replicateEncodingFor:class:objectEncoder:instVarMap:replicationSpec:.
+		#indexable_part -> #indexablePartEncodingFor:class:objectEncoder:instVarMap:replicationSpec:.
+	} asDictionary.
+%
+
+category: 'private'
+method: GtWireGbsReplicationSpecConverter
+stubEncodingFor: aGtWireEncoder class: aClass objectEncoder: aGtWireInstVarEncoder instVarMap: instVarMap replicationSpec: replicationSpecArray
+	"Stubs aren't supported at the moment, return a proxy (forwarder)"
+
+	self forwarderEncodingFor: aGtWireEncoder class: aClass objectEncoder: aGtWireInstVarEncoder instVarMap: instVarMap replicationSpec: replicationSpecArray
+%
+
+category: 'actions'
+method: GtWireGbsReplicationSpecConverter
+update: aGtWireEncoder class: aClass spec: aSpecArray
+	| flattenedSpec objectEncoder rsWireMap instVarMap defaultSpec |
+
+	defaultSpec := aClass allInstVarNames collect: [ :name | { name. #replicate. } ].
+	flattenedSpec := self flattenSpec: defaultSpec, aSpecArray.
+	rsWireMap := self replicationSpecKeywordToWireObjectEncoderMap.
+	objectEncoder := GtWireInstVarEncoder new.
+	instVarMap := Dictionary new.
+	flattenedSpec do: [ :anArray |
+		self perform: (rsWireMap at: anArray second)
+			withArguments: { aGtWireEncoder. aClass. objectEncoder. instVarMap. anArray. }
+		].
+	objectEncoder instVarMap: instVarMap.
+	aGtWireEncoder map at: aClass put: objectEncoder.
+%
+
+category: 'actions'
+method: GtWireGbsReplicationSpecConverter
+update: aGtWireEncoder from: aGbsReplicationSpecDictionary
+
+	aGbsReplicationSpecDictionary associationsDo: [ :assoc |
+		self update: aGtWireEncoder class: assoc key spec: assoc value ].
+	aGtWireEncoder remainingDepth: self maxDepth.
+%
+
+! Class implementation for 'GtWireGbsReplicationSpecConverterExamples'
+
+!		Instance methods for 'GtWireGbsReplicationSpecConverterExamples'
+
+category: 'examples'
+method: GtWireGbsReplicationSpecConverterExamples
+flattenSpec
+	"Check that the spec is correctly flattened."
+
+	<gtExample>
+	<return: #GtWireGbsReplicationSpecConverterExamples>
+	| spec actual expected |
+	spec := #(#(a 1) #(b 1) #(a 2)).
+	actual := GtWireGbsReplicationSpecConverter new flattenSpec: spec.
+	expected := #(#(a 2) #(b 1)).
+	self assert: actual equals: expected
+%
+
+! Class implementation for 'GtWireGbsReplicationSpecEncodingExamples'
+
+!		Instance methods for 'GtWireGbsReplicationSpecEncodingExamples'
+
+category: 'examples'
+method: GtWireGbsReplicationSpecEncodingExamples
+gbsAllInstVarsExample
+	"Check that all instance variables are encoded with `replicate` by default"
+
+	<gtExample>
+	<return: #ByteArray>
+	| replicationSpec object encoder byteArray decoder next now |
+	replicationSpec := {GtWireEncodingExampleInstVarObject -> #()} asDictionary.
+	now := DateAndTime now.
+	object := GtWireEncodingExampleInstVarObject new
+			var1: 1;
+			var2: '2';
+			var3: now;
+			var4: #(1 2 3).
+	encoder := GtWireEncoder onByteArray.
+	GtWireGbsReplicationSpecConverter new update: encoder from: replicationSpec.	"GemStone isn't available here, so replace all GtGemStoneRsrEncoders with dummies"
+	encoder
+		replaceMappingsMatching: [ :each | each isKindOf: GtWireGemStoneRsrEncoder ]
+		with: [ GtWireDummyProxyEncoder new ].
+	encoder nextPut: object.
+	byteArray := encoder contents.
+	decoder := GtWireDecoder on: byteArray readStream.
+	next := decoder next.
+
+	self assert: next class equals: GtWireEncodingExampleInstVarObject.
+	self assert: next var1 equals: 1.
+	self assert: next var2 equals: '2'.
+	self assert: next var3 equals: now.
+	self assert: next var4 equals: #(1 2 3).
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireGbsReplicationSpecEncodingExamples
+gbsDefaultMaxDepthToWireExample
+	"Demonstrate the default max depth in a replication spec"
+	<gtExample>
+	<return: #GtWireGbsReplicationSpecEncodingExamples>
+	| object encoder byteArray decoder next array currentArray |
+
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 10
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	object := GtWireEncodingExampleInstVarObject new var1: array.
+	encoder := GtWireEncoder onByteArray.
+	GtWireGbsReplicationSpecConverter new 
+		maxDepth: 4;
+		update: encoder from: Dictionary new.
+	"GemStone isn't available here, so replace all GtGemStoneRsrEncoders with dummies"
+	encoder
+		replaceMappingsMatching: [ :each | each isKindOf: GtWireGemStoneRsrEncoder ]
+		with: [ GtWireDummyProxyEncoder new ].
+	encoder nextPut: object.
+	byteArray := encoder contents.
+	decoder := GtWireDecoder on: byteArray readStream.
+	next := decoder next.
+
+	self assert: next class equals: GtWireEncodingExampleInstVarObject.
+	self assert: next var1 class equals: Array.
+	self assert: next var1 first equals: 1.
+	next := next var1 second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next equals: #(3 nil)
+%
+
+category: 'examples'
+method: GtWireGbsReplicationSpecEncodingExamples
+gbsMaxDepthIncreaseToWireExample
+	"Demonstrate `max` and `min` keywords in a replication spec.
+	Since the replicationSpec max is greater than the default, it has no 
+	effect in practice."
+	<gtExample>
+	<return: #GtWireGbsReplicationSpecEncodingExamples>
+	| replicationSpec object encoder byteArray decoder next array currentArray |
+
+	replicationSpec := {GtWireEncodingExampleInstVarObject -> #(#(var1 max 8))}
+			asDictionary.
+	array := Array new: 2.
+	currentArray := array.
+	1 to: 10 do: [ :i | 
+		currentArray
+			at: 1 put: i;
+			at: 2 put: (Array new: 2).
+		currentArray := currentArray second ].
+	object := GtWireEncodingExampleInstVarObject new var1: array.
+	encoder := GtWireEncoder onByteArray.
+	GtWireGbsReplicationSpecConverter new 
+		maxDepth: 4;
+		update: encoder from: replicationSpec.
+	"GemStone isn't available here, so replace all GtGemStoneRsrEncoders with dummies"
+	encoder
+		replaceMappingsMatching: [ :each | each isKindOf: GtWireGemStoneRsrEncoder ]
+		with: [ GtWireDummyProxyEncoder new ].
+	encoder nextPut: object.
+	byteArray := encoder contents.
+	decoder := GtWireDecoder on: byteArray readStream.
+	next := decoder next.
+
+	self assert: next class equals: GtWireEncodingExampleInstVarObject.
+	self assert: next var1 class equals: Array.
+	self assert: next var1 first equals: 1.
+	next := next var1 second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next equals: #(3 nil)
+%
+
+category: 'examples'
+method: GtWireGbsReplicationSpecEncodingExamples
+gbsMaxDepthToWireExample
+	"Demonstrate `max` and `min` keywords in a replication spec"
+
+	<gtExample>
+	<return: #GtWireGbsReplicationSpecEncodingExamples>
+	| replicationSpec object encoder byteArray decoder next array currentArray |
+	replicationSpec := {GtWireEncodingExampleInstVarObject -> #(#(var1 max 2))}
+			asDictionary.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 10
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	object := GtWireEncodingExampleInstVarObject new var1: array.
+	encoder := GtWireEncoder onByteArray.
+	GtWireGbsReplicationSpecConverter new 
+		maxDepth: 100;
+		update: encoder from: replicationSpec.
+	"GemStone isn't available here, so replace all GtGemStoneRsrEncoders with dummies"
+	encoder
+		replaceMappingsMatching: [ :each | each isKindOf: GtWireGemStoneRsrEncoder ]
+		with: [ GtWireDummyProxyEncoder new ].
+	encoder nextPut: object.
+	byteArray := encoder contents.
+	decoder := GtWireDecoder on: byteArray readStream.
+	next := decoder next.
+
+	self assert: next class equals: GtWireEncodingExampleInstVarObject.
+	self assert: next var1 class equals: Array.
+	self assert: next var1 first equals: 1.
+	next := next var1 second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next equals: #(3 nil)
+%
+
+category: 'examples'
+method: GtWireGbsReplicationSpecEncodingExamples
+gbsToWireExample1
+	"Demonstrate `replicate`, `forwarder` and `stub` keywords in a replication spec"
+
+	<gtExample>
+	<return: #GtWireGbsReplicationSpecEncodingExamples>
+	| replicationSpec object encoder byteArray decoder next |
+	replicationSpec := {GtWireEncodingExampleInstVarObject
+				-> #(#(var1 replicate) #(var2 forwarder) #(var3 stub))} asDictionary.	"var4 is default, replicate"
+	object := GtWireEncodingExampleInstVarObject new
+			var1: (GtWireEncodingExampleInstVarObject new var1: 'replicated');
+			var2: (GtWireEncodingExampleInstVarObject new var1: 'forwarded (proxy)');
+			var3: (GtWireEncodingExampleInstVarObject new var1: 'stub (proxy)');
+			var4: (GtWireEncodingExampleInstVarObject new var1: 'default replication').
+	encoder := GtWireEncoder onByteArray.
+	GtWireGbsReplicationSpecConverter new update: encoder from: replicationSpec.	"GemStone isn't available here, so replace all GtGemStoneRsrEncoders with dummies"
+	encoder
+		replaceMappingsMatching: [ :each | each isKindOf: GtWireGemStoneRsrEncoder ]
+		with: [ GtWireDummyProxyEncoder new ].
+	encoder nextPut: object.
+	byteArray := encoder contents.
+	decoder := GtWireDecoder on: byteArray readStream.
+	next := decoder next.
+
+	self assert: next var1 class equals: GtWireEncodingExampleInstVarObject.
+	self assert: next var1 var1 equals: 'replicated'.
+	self assert: next var1 var2 isNil.
+	self assert: next var1 var3 isNil.
+	self assert: next var1 var4 isNil.
+	self assert: next var2 class equals: GtWireEncodingDummyProxy.
+	self
+		assert: next var2 description
+		equals: '(GtWireEncodingExampleInstVarObject basicNew instVarAt: 1 put: ''forwarded (proxy)''; instVarAt: 2 put: nil; instVarAt: 3 put: nil; instVarAt: 4 put: nil; yourself)'.
+	self assert: next var3 class equals: GtWireEncodingDummyProxy.
+	self
+		assert: next var3 description
+		equals: '(GtWireEncodingExampleInstVarObject basicNew instVarAt: 1 put: ''stub (proxy)''; instVarAt: 2 put: nil; instVarAt: 3 put: nil; instVarAt: 4 put: nil; yourself)'.
+	self assert: next var4 var1 equals: 'default replication'
+%
+
+! Class implementation for 'GtWireNestedEncodingExamples'
+
+!		Instance methods for 'GtWireNestedEncodingExamples'
+
+category: 'private'
+method: GtWireNestedEncodingExamples
+cleanUp
+
+	signals ifNotNil: [ signals stop ].
+%
+
+category: 'examples'
+method: GtWireNestedEncodingExamples
+defaultMaxDepth
+	<gtExample>
+	<return: #ByteArray>
+	| array currentArray encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	encoder
+		maxDepthEncoder: GtWireDummyProxyEncoder new;
+		remainingDepth: 4.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 10
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	encoder nextPut: array.
+	byteArray := encoder contents.	"self assert: byteArray size equals: 57."
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Array.
+	self assert: next first equals: 1.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second second.
+	self assert: next size equals: 2.
+	self assert: next first equals: 4.
+	self assert: next second class = GtWireEncodingDummyProxy.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireNestedEncodingExamples
+defaultReverseMapIsArray
+	<gtExample>
+	<return: #Array>
+	| reverseMap |
+
+	reverseMap := GtWireEncoderDecoder defaultReverseMap.
+	self assert: reverseMap isArray.
+	self assert: reverseMap size equals: 28.
+	self assert: (reverseMap at: 1) class equals: GtWireNilEncoder.
+	^ reverseMap
+%
+
+category: 'examples'
+method: GtWireNestedEncodingExamples
+maxDepth2
+	<gtExample>
+	<return: #ByteArray>
+	| array currentArray encoder byteArray next object |
+	encoder := GtWireEncoder onByteArray
+			maxDepthEncoder: GtWireDummyProxyEncoder new.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 10
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	object := GtWireEncodingExampleInstVarObject new var1: array.
+	encoder
+		addMapping: Array
+		to: (GtWireMaxDepthEncoder depth: 2 encoder: GtWireArrayEncoder new).
+	encoder nextPut: object.
+	byteArray := encoder contents.	"self assert: byteArray size equals: 24."
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: GtWireEncodingExampleInstVarObject.
+	next := next var1.
+	self assert: next class equals: Array.
+	self assert: next first equals: 1.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 3.
+	self assert: next second class equals: GtWireEncodingDummyProxy.
+	self
+		assert: next second description
+		equals: '#(4 #(5 #(6 #(7 #(8 #(9 #(10 #(nil nil))))))))'.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireNestedEncodingExamples
+maxDepth2RootObject
+	<gtExample>
+	<return: #ByteArray>
+	| array currentArray encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 10
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	encoder
+		addMapping: Array
+		to: (GtWireMaxDepthEncoder depth: 2 encoder: GtWireArrayEncoder new).
+	encoder nextPut: array.
+	byteArray := encoder contents.	"self assert: byteArray size equals: 24."
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Array.
+	self assert: next first equals: 1.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next equals: #(3 nil).
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireNestedEncodingExamples
+minDepth2
+	<gtExample>
+	<return: #ByteArray>
+	| array currentArray encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 5
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			currentArray := currentArray second ].
+	encoder
+		addMapping: Array
+		to: (GtWireMinDepthEncoder depth: 2 encoder: GtWireArrayEncoder new).
+	encoder
+		remainingDepth: 2;
+		nextPut: array.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 24.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Array.
+	self assert: next = array.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireNestedEncodingExamples
+proxyScaledDecimal
+	"Configure the encoding to always return scaled decimals as proxies
+	(as opposed to the general GtWireObjectByNameEncoder serialisation)."
+
+	<gtExample>
+	<return: #ByteArray>
+	| array currentArray encoder byteArray next |
+	encoder := GtWireEncoder onByteArray.
+	encoder map at: ScaledDecimal put: GtWireDummyProxyEncoder new.
+	array := Array new: 2.
+	currentArray := array.
+	1
+		to: 5
+		do: [ :i | 
+			currentArray
+				at: 1 put: i;
+				at: 2 put: (Array new: 2).
+			i = 3 ifTrue: [ currentArray at: 1 put: 1.25 asScaledDecimal ].
+			currentArray := currentArray second ].
+	encoder nextPut: array.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 43.
+	next := (GtWireDecoder on: byteArray readStream) next.
+	self assert: next class equals: Array.
+	self assert: next first equals: 1.
+	next := next second.
+	self assert: next class equals: Array.
+	self assert: next first equals: 2.
+	next := next second.
+	self assert: next size equals: 2.
+	self assert: next first class equals: GtWireEncodingDummyProxy.
+	self assert: next first description equals: '1.25000000000000s14'.
+	self assert: next second class equals: Array.
+	^ byteArray
+%
+
+category: 'examples'
+method: GtWireNestedEncodingExamples
+stonEncoding
+	<gtExample>
+	<return: #GtWireNestedEncodingExamples>
+	| object encoder decoder byteArray next |
+	"signals := CircularMemoryLogger new startFor: GtWireEncodingSignal."
+	encoder := GtWireEncoder onByteArray.
+	encoder
+		addMapping: GtWireEncodingExampleInstVarObject
+		to: GtWireStonEncoder new.
+	object := GtWireEncodingExampleInstVarObject new.
+	object
+		var1: 1;
+		var2: 'two'.
+	encoder nextPut: object.
+	byteArray := encoder contents.
+	self assert: byteArray size equals: 57.
+	decoder := GtWireDecoder on: byteArray readStream.
+	decoder
+		map: encoder map;
+		reverseMap: encoder reverseMap.
+	next := decoder next.
+	self assert: next class equals: GtWireEncodingExampleInstVarObject.
+	self assert: next = object
+%
+
+! Class implementation for 'GtWireObjectEncoder'
+
+!		Class methods for 'GtWireObjectEncoder'
+
+category: 'accessing'
+classmethod: GtWireObjectEncoder
+typeIdentifier
+
+	^ self subclassResponsibility
+%
+
+category: 'accessing'
+classmethod: GtWireObjectEncoder
+typeIdentifierOrNil
+
+	^ [ self typeIdentifier ]
+		on: Error
+		do: [ :ex | 
+			self gtDo: [ ex class name = #SubclassResponsibility ifFalse: [ ex pass ] ]
+				gemstoneDo: [].
+			nil ]
+%
+
+category: 'test'
+classmethod: GtWireObjectEncoder
+validateTypeIdentifiers
+	 "Validate that there aren't duplicate type identifiers and answer the maximum value"
+	| visited |
+	
+	visited := Set new.
+	self allSubclassesDo: [ :cls | | typeIdentifier |
+		typeIdentifier := cls typeIdentifierOrNil.
+		typeIdentifier ifNotNil:
+			[ (visited includes: typeIdentifier) ifTrue:
+				[ self error: 'Duplicate typeIdentifier found' ].
+			visited add: typeIdentifier ] ].
+	^ visited max
+%
+
+!		Instance methods for 'GtWireObjectEncoder'
+
+category: 'encoding - decoding'
+method: GtWireObjectEncoder
+decodeWith: aGtWireEncoderContext
+	
+	^ self subclassResponsibility
+%
+
+category: 'encoding - decoding'
+method: GtWireObjectEncoder
+encode: anObject with: aGtWireEncoderContext
+
+	aGtWireEncoderContext putTypeIdentifier: self class typeIdentifier
+%
+
+category: 'testing'
+method: GtWireObjectEncoder
+hasValidConfiguration
+
+	^ true
+%
+
+category: 'testing'
+method: GtWireObjectEncoder
+isProxyObjectEncoder
+	"Answer a boolean indicating whether the receiver is a type of proxy encoder.
+	Proxy encoding is platform dependent."
+
+	^ false.
+%
+
+category: 'as yet unclassified'
+method: GtWireObjectEncoder
+name
+
+	^ self class name
+%
+
+category: 'private - helpers'
+method: GtWireObjectEncoder
+replaceMappingsMatching: matchBlock with: replacementBlock
+	"Replace all the mappings matching matchBlock with the encoder returned by replacementBlock.
+	Used by examples to avoid needing live servers.
+	Overwritten by encoders as required."
+%
+
+category: 'accessing'
+method: GtWireObjectEncoder
+typeIdentifier
+
+	^ self class typeIdentifier
+%
+
+! Class implementation for 'GtWireAssociationEncoder'
+
+!		Class methods for 'GtWireAssociationEncoder'
+
+category: 'accessing'
+classmethod: GtWireAssociationEncoder
+typeIdentifier
+
+	^ 15
+%
+
+!		Instance methods for 'GtWireAssociationEncoder'
+
+category: 'encoding - decoding'
+method: GtWireAssociationEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ Association
+		key: aGtWireEncoderContext next
+		value: aGtWireEncoderContext next
+%
+
+category: 'encoding - decoding'
+method: GtWireAssociationEncoder
+encode: anInteger with: aGtWireEncoderContext
+
+	aGtWireEncoderContext putTypeIdentifier: self typeIdentifier.
+	aGtWireEncoderContext
+		nextPut: anInteger key;
+		nextPut: anInteger value
+%
+
+! Class implementation for 'GtWireBlockClosureEncoder'
+
+!		Class methods for 'GtWireBlockClosureEncoder'
+
+category: 'accessing'
+classmethod: GtWireBlockClosureEncoder
+typeIdentifier
+
+	^ 21
+%
+
+!		Instance methods for 'GtWireBlockClosureEncoder'
+
+category: 'encoding - decoding'
+method: GtWireBlockClosureEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ self
+		gtDo: [ BlockClosure compiler 
+			evaluate: aGtWireEncoderContext next ]
+		gemstoneDo: [ | bindings receiver |
+			bindings := GsCurrentSession currentSession symbolList.
+			receiver := self.
+			aGtWireEncoderContext next evaluate.
+				"_compileInContext: receiver symbolList: bindings" ].
+%
+
+category: 'encoding - decoding'
+method: GtWireBlockClosureEncoder
+encode: aBlockClosure with: aGtWireEncoderContext
+
+	aBlockClosure isClean ifFalse:
+		[ self error: 'BlockClosures must be clean' ].
+	aGtWireEncoderContext 
+		putTypeIdentifier: self class typeIdentifier;
+		nextPut: (self
+			gtDo: [ aBlockClosure printString ]
+			gemstoneDo: [ aBlockClosure method _sourceStringForBlock  ]).
+%
+
+! Class implementation for 'GtWireBooleanEncoder'
+
+!		Instance methods for 'GtWireBooleanEncoder'
+
+category: 'encoding - decoding'
+method: GtWireBooleanEncoder
+encode: anObject with: aGtWireEncoderContext
+
+	aGtWireEncoderContext putTypeIdentifier: (anObject
+		ifTrue: [ GtWireTrueEncoder ]
+		ifFalse: [ GtWireFalseEncoder ])
+			typeIdentifier
+%
+
+! Class implementation for 'GtWireFalseEncoder'
+
+!		Class methods for 'GtWireFalseEncoder'
+
+category: 'accessing'
+classmethod: GtWireFalseEncoder
+typeIdentifier
+
+	^ 3
+%
+
+!		Instance methods for 'GtWireFalseEncoder'
+
+category: 'encoding - decoding'
+method: GtWireFalseEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ false
+%
+
+! Class implementation for 'GtWireTrueEncoder'
+
+!		Class methods for 'GtWireTrueEncoder'
+
+category: 'accessing'
+classmethod: GtWireTrueEncoder
+typeIdentifier
+
+	^ 2
+%
+
+!		Instance methods for 'GtWireTrueEncoder'
+
+category: 'encoding - decoding'
+method: GtWireTrueEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ true
+%
+
+! Class implementation for 'GtWireByteArrayEncoder'
+
+!		Class methods for 'GtWireByteArrayEncoder'
+
+category: 'accessing'
+classmethod: GtWireByteArrayEncoder
+typeIdentifier
+
+	^ 4
+%
+
+!		Instance methods for 'GtWireByteArrayEncoder'
+
+category: 'encoding - decoding'
+method: GtWireByteArrayEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ aGtWireEncoderContext nextByteArray
+%
+
+category: 'encoding - decoding'
+method: GtWireByteArrayEncoder
+encode: aByteArray with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self typeIdentifier;
+		putByteArray: aByteArray
+%
+
+! Class implementation for 'GtWireCharacterArrayEncoder'
+
+!		Instance methods for 'GtWireCharacterArrayEncoder'
+
+category: 'encoding - decoding'
+method: GtWireCharacterArrayEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ aGtWireEncoderContext nextString
+%
+
+category: 'encoding - decoding'
+method: GtWireCharacterArrayEncoder
+encode: aString with: aGtWireEncoderContext
+
+	aGtWireEncoderContext 
+		putTypeIdentifier: self typeIdentifier;
+		putString: aString
+%
+
+! Class implementation for 'GtWireStringEncoder'
+
+!		Class methods for 'GtWireStringEncoder'
+
+category: 'accessing'
+classmethod: GtWireStringEncoder
+typeIdentifier
+
+	^ 5
+%
+
+! Class implementation for 'GtWireSymbolEncoder'
+
+!		Class methods for 'GtWireSymbolEncoder'
+
+category: 'accessing'
+classmethod: GtWireSymbolEncoder
+typeIdentifier
+
+	^ 6
+%
+
+!		Instance methods for 'GtWireSymbolEncoder'
+
+category: 'encoding - decoding'
+method: GtWireSymbolEncoder
+decodeWith: aGtWireEncoderContext
+	
+	^ (super decodeWith: aGtWireEncoderContext) asSymbol
+%
+
+! Class implementation for 'GtWireCharacterEncoder'
+
+!		Class methods for 'GtWireCharacterEncoder'
+
+category: 'accessing'
+classmethod: GtWireCharacterEncoder
+typeIdentifier
+
+	^ 7
+%
+
+!		Instance methods for 'GtWireCharacterEncoder'
+
+category: 'encoding - decoding'
+method: GtWireCharacterEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ Character value: aGtWireEncoderContext nextPackedInteger
+%
+
+category: 'encoding - decoding'
+method: GtWireCharacterEncoder
+encode: aCharacter with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self typeIdentifier;
+		putPackedInteger: aCharacter codePoint.
+%
+
+! Class implementation for 'GtWireClassEncoder'
+
+!		Class methods for 'GtWireClassEncoder'
+
+category: 'accessing'
+classmethod: GtWireClassEncoder
+typeIdentifier
+
+	^ 28
+%
+
+!		Instance methods for 'GtWireClassEncoder'
+
+category: 'encoding - decoding'
+method: GtWireClassEncoder
+decodeWith: aGtWireEncoderContext
+	| className isMeta instanceClass |
+
+	className := aGtWireEncoderContext nextString.
+	isMeta := aGtWireEncoderContext next.
+	instanceClass := self
+		gtDo: [ self class environment classOrTraitNamed: className ]
+		gemstoneDo: [ (System myUserProfile resolveSymbol: className asSymbol) value ].
+	^ isMeta
+		ifTrue: [ instanceClass class ]
+		ifFalse: [ instanceClass ].
+%
+
+category: 'encoding - decoding'
+method: GtWireClassEncoder
+encode: aClass with: aGtWireEncoderContext
+
+	aGtWireEncoderContext 
+		putTypeIdentifier: self typeIdentifier;
+		putString: (self
+			gtDo: [ aClass instanceSide name ]
+			gemstoneDo: [ aClass thisClass name ]);
+		nextPut: aClass isMeta.
+%
+
+! Class implementation for 'GtWireCollectionEncoder'
+
+!		Instance methods for 'GtWireCollectionEncoder'
+
+category: 'encoding - decoding'
+method: GtWireCollectionEncoder
+decodeWith: aGtWireEncoderContext
+	"Decode the array on the supplied context"
+	| count |
+
+	count := aGtWireEncoderContext nextSize.
+	^ Array new: count streamContents: [ :arrayStream |
+		count timesRepeat:
+			[ arrayStream nextPut: aGtWireEncoderContext next ] ]
+%
+
+category: 'encoding - decoding'
+method: GtWireCollectionEncoder
+encode: aCollection with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self typeIdentifier;
+		putSize: aCollection size.
+	aCollection do: [ :each |
+		aGtWireEncoderContext nextPut: each ].
+%
+
+! Class implementation for 'GtWireArrayEncoder'
+
+!		Class methods for 'GtWireArrayEncoder'
+
+category: 'accessing'
+classmethod: GtWireArrayEncoder
+typeIdentifier
+
+	^ 8
+%
+
+! Class implementation for 'GtWireDictionaryEncoder'
+
+!		Class methods for 'GtWireDictionaryEncoder'
+
+category: 'accessing'
+classmethod: GtWireDictionaryEncoder
+typeIdentifier
+
+	^ 9
+%
+
+!		Instance methods for 'GtWireDictionaryEncoder'
+
+category: 'encoding - decoding'
+method: GtWireDictionaryEncoder
+decodeWith: aGtWireEncoderContext
+	"Decode the dictionary on the supplied context"
+	| count dictionary |
+
+	count := aGtWireEncoderContext nextSize.
+	dictionary := Dictionary new: count * 2.
+	count timesRepeat:
+		[ dictionary
+			at: aGtWireEncoderContext next
+			put: aGtWireEncoderContext next ].
+	^ dictionary
+%
+
+category: 'encoding - decoding'
+method: GtWireDictionaryEncoder
+encode: aDictionary with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self typeIdentifier;
+		putSize: aDictionary size.
+	aDictionary associationsDo: [ :each |
+		aGtWireEncoderContext 
+			nextPut: each key;
+			nextPut: each value ].
+%
+
+! Class implementation for 'GtWireOrderedCollectionEncoder'
+
+!		Class methods for 'GtWireOrderedCollectionEncoder'
+
+category: 'accessing'
+classmethod: GtWireOrderedCollectionEncoder
+typeIdentifier
+
+	^ 10
+%
+
+!		Instance methods for 'GtWireOrderedCollectionEncoder'
+
+category: 'encoding - decoding'
+method: GtWireOrderedCollectionEncoder
+decodeWith: aGtWireEncoderContext
+	"Decode the OrderedCollection on the supplied context"
+	| count |
+
+	count := aGtWireEncoderContext nextSize.
+	^ OrderedCollection new: count streamContents: [ :arrayStream |
+		count timesRepeat:
+			[ arrayStream nextPut: aGtWireEncoderContext next ] ]
+%
+
+! Class implementation for 'GtWireSetEncoder'
+
+!		Class methods for 'GtWireSetEncoder'
+
+category: 'accessing'
+classmethod: GtWireSetEncoder
+typeIdentifier
+
+	^ 11
+%
+
+!		Instance methods for 'GtWireSetEncoder'
+
+category: 'encoding - decoding'
+method: GtWireSetEncoder
+decodeWith: aGtWireEncoderContext
+	"Decode the OrderedCollection on the supplied context"
+	| count set |
+
+	count := aGtWireEncoderContext nextSize.
+	set := Set new: count * 2.
+	count timesRepeat:
+		[ set add: aGtWireEncoderContext next ].
+	^ set
+%
+
+! Class implementation for 'GtWireDateAndTimeEncoder'
+
+!		Class methods for 'GtWireDateAndTimeEncoder'
+
+category: 'accessing'
+classmethod: GtWireDateAndTimeEncoder
+typeIdentifier
+
+	^ 12
+%
+
+!		Instance methods for 'GtWireDateAndTimeEncoder'
+
+category: 'encoding - decoding'
+method: GtWireDateAndTimeEncoder
+decodeWith: aGtWireEncoderContext
+	"Decode the array on the supplied context"
+	| unixSeconds nanoSeconds offset |
+
+	unixSeconds :=  aGtWireEncoderContext nextPackedInteger.
+	nanoSeconds := aGtWireEncoderContext nextPackedInteger.
+	offset := aGtWireEncoderContext next.
+	^ self
+		gtDo: [ (DateAndTime fromUnixTime: unixSeconds)
+			setNanoSeconds: nanoSeconds;
+			translateTo: offset ]
+		gemstoneDo: [ DateAndTime posixSeconds: (unixSeconds + (nanoSeconds / (10 raisedTo: 9))) offset: (Duration seconds: offset) ].
+%
+
+category: 'encoding - decoding'
+method: GtWireDateAndTimeEncoder
+encode: aDateAndTime with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self class typeIdentifier;
+		putPackedInteger: aDateAndTime asUnixTime truncated;
+		putPackedInteger: aDateAndTime nanoSecond;
+		nextPut: aDateAndTime offset asSeconds.
+%
+
+! Class implementation for 'GtWireDummyProxyEncoder'
+
+!		Class methods for 'GtWireDummyProxyEncoder'
+
+category: 'access'
+classmethod: GtWireDummyProxyEncoder
+typeIdentifier
+
+	^ 25
+%
+
+!		Instance methods for 'GtWireDummyProxyEncoder'
+
+category: 'encoding - decoding'
+method: GtWireDummyProxyEncoder
+decodeWith: aGtWireEncoderContext
+	"Decode the object on the supplied context"
+
+	^ GtWireEncodingDummyProxy new description: aGtWireEncoderContext nextString.
+%
+
+category: 'encoding - decoding'
+method: GtWireDummyProxyEncoder
+encode: anObject with: aGtWireEncoderContext
+
+	anObject ifNil:
+		[ ^ GtWireNilEncoder new encode: anObject with: aGtWireEncoderContext ].
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self class typeIdentifier;
+		putString: anObject storeString.
+%
+
+category: 'as yet unclassified'
+method: GtWireDummyProxyEncoder
+isProxyObjectEncoder
+	"Answer a boolean indicating whether the receiver is a type of proxy encoder.
+	Proxy encoding is platform dependent."
+
+	^ true.
+%
+
+! Class implementation for 'GtWireFloatEncoder'
+
+!		Class methods for 'GtWireFloatEncoder'
+
+category: 'accessing'
+classmethod: GtWireFloatEncoder
+typeIdentifier
+
+	^ 17
+%
+
+!		Instance methods for 'GtWireFloatEncoder'
+
+category: 'encoding - decoding'
+method: GtWireFloatEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ aGtWireEncoderContext nextFloat64.
+%
+
+category: 'encoding - decoding'
+method: GtWireFloatEncoder
+encode: aFloat with: aGtWireEncoderContext
+
+	aGtWireEncoderContext 
+		putPackedInteger: self typeIdentifier;
+		putFloat64: aFloat
+%
+
+! Class implementation for 'GtWireGemStoneOopEncoder'
+
+!		Class methods for 'GtWireGemStoneOopEncoder'
+
+category: 'accessing'
+classmethod: GtWireGemStoneOopEncoder
+typeIdentifier
+
+	^ 23
+%
+
+!		Instance methods for 'GtWireGemStoneOopEncoder'
+
+category: 'encoding - decoding'
+method: GtWireGemStoneOopEncoder
+decodeWith: aGtWireEncoderContext
+	"It is up to the user to ensure the Object isn't GCd during transfer and decoding
+	(which would allow the oop to be reused and the wrong object returned), or that the
+	session is aborted."
+
+	^ self
+		gtDo: [ #GtGemStoneCurrentSession asClass value evaluateAndWaitReturnProxy:
+			'Object objectForOop: ', aGtWireEncoderContext nextPackedInteger asString ]
+		gemstoneDo: [ Object objectForOop: aGtWireEncoderContext nextPackedInteger ]
+%
+
+category: 'encoding - decoding'
+method: GtWireGemStoneOopEncoder
+encode: anObject with: aGtWireEncoderContext
+	"It is up to the user to ensure that anObject isn't GCd during transfer and decoding
+	(which would allow the oop to be reused and the wrong object returned), or that the
+	session is aborted."
+
+	aGtWireEncoderContext 
+		putTypeIdentifier: self class typeIdentifier;
+		putPackedInteger: anObject asOop
+%
+
+category: 'testing'
+method: GtWireGemStoneOopEncoder
+isProxyObjectEncoder
+	"Answer a boolean indicating whether the receiver is a type of proxy encoder.
+	Proxy encoding is platform dependent."
+
+	^ true.
+%
+
+! Class implementation for 'GtWireGemStoneRemoteObjectEncoder'
+
+!		Instance methods for 'GtWireGemStoneRemoteObjectEncoder'
+
+category: 'encoding - decoding'
+method: GtWireGemStoneRemoteObjectEncoder
+decodeWith: aGtWireEncoderContext
+
+	self error: self class name asString, ' should never need decoding'
+%
+
+category: 'encoding - decoding'
+method: GtWireGemStoneRemoteObjectEncoder
+encode: anObject with: aGtWireEncoderContext
+	"Encode the supplied object as a remote object, i.e. it is returned by value and a proxy is registered with GtRsrProxyServiceClient"
+
+	GtWireGemStoneWithRsrEncoder new
+		encode: anObject 
+		with: aGtWireEncoderContext
+		objectEncoder: encoder.
+%
+
+category: 'accessing'
+method: GtWireGemStoneRemoteObjectEncoder
+encoder
+	^ encoder
+%
+
+category: 'accessing'
+method: GtWireGemStoneRemoteObjectEncoder
+encoder: anObject
+	encoder := anObject
+%
+
+category: 'testing'
+method: GtWireGemStoneRemoteObjectEncoder
+hasValidConfiguration
+	"An encoder must be supplied as using the default encoder will result in an infinite loop"
+	
+	^ encoder isKindOf: GtWireObjectEncoder
+%
+
+! Class implementation for 'GtWireGemStoneRsrEncoder'
+
+!		Class methods for 'GtWireGemStoneRsrEncoder'
+
+category: 'accessing'
+classmethod: GtWireGemStoneRsrEncoder
+typeIdentifier
+
+	^ 24
+%
+
+!		Instance methods for 'GtWireGemStoneRsrEncoder'
+
+category: 'testing'
+method: GtWireGemStoneRsrEncoder
+isProxyObjectEncoder
+	"Answer a boolean indicating whether the receiver is a type of proxy encoder.
+	Proxy encoding is platform dependent."
+
+	^ true.
+%
+
+! Class implementation for 'GtWireGemStoneWithRsrEncoder'
+
+!		Class methods for 'GtWireGemStoneWithRsrEncoder'
+
+category: 'accessing'
+classmethod: GtWireGemStoneWithRsrEncoder
+typeIdentifier
+
+	^ 27
+%
+
+!		Instance methods for 'GtWireGemStoneWithRsrEncoder'
+
+category: 'testing'
+method: GtWireGemStoneWithRsrEncoder
+isProxyObjectEncoder
+	"Answer a boolean indicating whether the receiver is a type of proxy encoder.
+	Proxy encoding is platform dependent."
+
+	^ true.
+%
+
+! Class implementation for 'GtWireGsBareProxyEncoder'
+
+!		Instance methods for 'GtWireGsBareProxyEncoder'
+
+category: 'encoding - decoding'
+method: GtWireGsBareProxyEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ GtWireGemStoneRsrEncoder new
+		decodeWith: aGtWireEncoderContext
+%
+
+category: 'encoding - decoding'
+method: GtWireGsBareProxyEncoder
+encode: aBareProxy with: aGtWireEncoderContext
+
+	^ GtWireGemStoneRsrEncoder new
+		encode: aBareProxy asGtProxyObject
+		with: aGtWireEncoderContext
+%
+
+category: 'testing'
+method: GtWireGsBareProxyEncoder
+isProxyObjectEncoder
+	"Answer a boolean indicating whether the receiver is a type of proxy encoder.
+	Proxy encoding is platform dependent."
+
+	^ true.
+%
+
+! Class implementation for 'GtWireInstVarEncoder'
+
+!		Class methods for 'GtWireInstVarEncoder'
+
+category: 'accessing'
+classmethod: GtWireInstVarEncoder
+typeIdentifier
+
+	^ 20
+%
+
+!		Instance methods for 'GtWireInstVarEncoder'
+
+category: 'as yet unclassified'
+method: GtWireInstVarEncoder
+decodeWith: aGtWireEncoderContext
+	| count instance className |
+
+	count := aGtWireEncoderContext nextSize.
+	className := aGtWireEncoderContext next.
+	instance := (self class environment classOrTraitNamed: className) basicNew.
+	count timesRepeat:
+		[ | instVarName |
+		instVarName := aGtWireEncoderContext next.
+		instance
+			instVarNamed: instVarName
+			put: aGtWireEncoderContext next ].
+	^ instance
+%
+
+category: 'as yet unclassified'
+method: GtWireInstVarEncoder
+encode: anObject with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self class typeIdentifier;
+		putSize: instVarMap size.
+	aGtWireEncoderContext nextPut: anObject class name.
+	instVarMap keysAndValuesDo: [ :key :value |
+		aGtWireEncoderContext 
+			nextPut: key;
+			nextPut: (anObject instVarNamed: key) objectEncoder: value ].
+%
+
+category: 'accessing'
+method: GtWireInstVarEncoder
+instVarMap
+	^ instVarMap
+%
+
+category: 'accessing'
+method: GtWireInstVarEncoder
+instVarMap: anObject
+	instVarMap := anObject
+%
+
+category: 'private - helpers'
+method: GtWireInstVarEncoder
+replaceMappingsMatching: matchBlock with: replacementBlock
+	"Replace all the mappings matching matchBlock with the encoder returned by replacementBlock.
+	Used by examples to avoid needing live servers."
+
+	instVarMap associationsDo: [ :assoc |
+		(matchBlock value: assoc value) ifTrue:
+			[ assoc value: replacementBlock value ]
+		ifFalse:
+			[ assoc value replaceMappingsMatching: matchBlock with: replacementBlock ] ]
+%
+
+! Class implementation for 'GtWireIntegerEncoder'
+
+!		Class methods for 'GtWireIntegerEncoder'
+
+category: 'accessing'
+classmethod: GtWireIntegerEncoder
+typeIdentifier
+
+	^ 16
+%
+
+!		Instance methods for 'GtWireIntegerEncoder'
+
+category: 'encoding - decoding'
+method: GtWireIntegerEncoder
+encode: anInteger with: aGtWireEncoderContext
+
+	anInteger >= 0
+		ifTrue: [ GtWirePositiveIntegerEncoder new encode: anInteger with: aGtWireEncoderContext ]
+		ifFalse: [ GtWireNegativeIntegerEncoder new encode: anInteger with: aGtWireEncoderContext ]
+%
+
+! Class implementation for 'GtWireNegativeIntegerEncoder'
+
+!		Class methods for 'GtWireNegativeIntegerEncoder'
+
+category: 'accessing'
+classmethod: GtWireNegativeIntegerEncoder
+typeIdentifier
+
+	^ 14
+%
+
+!		Instance methods for 'GtWireNegativeIntegerEncoder'
+
+category: 'encoding - decoding'
+method: GtWireNegativeIntegerEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ aGtWireEncoderContext nextPackedInteger negated
+%
+
+category: 'encoding - decoding'
+method: GtWireNegativeIntegerEncoder
+encode: anInteger with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self typeIdentifier;
+		putPackedInteger: anInteger negated
+%
+
+! Class implementation for 'GtWirePositiveIntegerEncoder'
+
+!		Class methods for 'GtWirePositiveIntegerEncoder'
+
+category: 'accessing'
+classmethod: GtWirePositiveIntegerEncoder
+typeIdentifier
+
+	^ 13
+%
+
+!		Instance methods for 'GtWirePositiveIntegerEncoder'
+
+category: 'encoding - decoding'
+method: GtWirePositiveIntegerEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ aGtWireEncoderContext nextPackedInteger
+%
+
+category: 'encoding - decoding'
+method: GtWirePositiveIntegerEncoder
+encode: anInteger with: aGtWireEncoderContext
+
+	aGtWireEncoderContext
+		putTypeIdentifier: self typeIdentifier;
+		putPackedInteger: anInteger
+%
+
+! Class implementation for 'GtWireMaxDepthEncoder'
+
+!		Class methods for 'GtWireMaxDepthEncoder'
+
+category: 'instance creation'
+classmethod: GtWireMaxDepthEncoder
+depth: anInteger encoder: aGtWireEncoder
+
+	^ self new
+		depth: anInteger;
+		encoder: aGtWireEncoder
+%
+
+!		Instance methods for 'GtWireMaxDepthEncoder'
+
+category: 'encoding - decoding'
+method: GtWireMaxDepthEncoder
+decodeWith: aGtWireEncoderContext
+
+	self error: 'Should not be decoded'
+%
+
+category: 'accessing'
+method: GtWireMaxDepthEncoder
+depth
+	^ depth
+%
+
+category: 'accessing'
+method: GtWireMaxDepthEncoder
+depth: anObject
+	depth := anObject
+%
+
+category: 'encoding - decoding'
+method: GtWireMaxDepthEncoder
+encode: anObject with: aGtWireEncoderContext
+	"Ensure the remaining depth is no more than the receiver's depth - 1.
+	Subtract one from the depth since we are inside anObject's nextPut:objectEncoder: and the remaining depth has already been decremented for anObject."
+	| oldDepth |
+
+	oldDepth := aGtWireEncoderContext remainingDepth.
+	aGtWireEncoderContext remainingDepth: (oldDepth min: depth).
+	aGtWireEncoderContext privateNextPutMapEncoded: anObject objectEncoder: encoder.
+	aGtWireEncoderContext remainingDepth: oldDepth.
+%
+
+category: 'accessing'
+method: GtWireMaxDepthEncoder
+encoder
+	^ encoder
+%
+
+category: 'accessing'
+method: GtWireMaxDepthEncoder
+encoder: anObject
+	encoder := anObject
+%
+
+category: 'private - helpers'
+method: GtWireMaxDepthEncoder
+replaceMappingsMatching: matchBlock with: replacementBlock
+	"Replace all the mappings matching matchBlock with the encoder returned by replacementBlock.
+	Used by examples to avoid needing live servers."
+
+	encoder ifNotNil:
+		[ encoder replaceMappingsMatching: matchBlock with: replacementBlock ]
+%
+
+! Class implementation for 'GtWireMinDepthEncoder'
+
+!		Class methods for 'GtWireMinDepthEncoder'
+
+category: 'instance creation'
+classmethod: GtWireMinDepthEncoder
+depth: anInteger encoder: aGtWireEncoder
+
+	^ self new
+		depth: anInteger;
+		encoder: aGtWireEncoder
+%
+
+!		Instance methods for 'GtWireMinDepthEncoder'
+
+category: 'encoding - decoding'
+method: GtWireMinDepthEncoder
+decodeWith: aGtWireEncoderContext
+
+	self error: 'Should not be decoded'
+%
+
+category: 'accessing'
+method: GtWireMinDepthEncoder
+depth
+	^ depth
+%
+
+category: 'accessing'
+method: GtWireMinDepthEncoder
+depth: anObject
+	depth := anObject
+%
+
+category: 'encoding - decoding'
+method: GtWireMinDepthEncoder
+encode: anObject with: aGtWireEncoderContext
+	"Ensure the remaining depth is at least the receiver's depth - 1.
+	Subtract one from the depth since we are inside anObject's nextPut:objectEncoder: and the remaining depth has already been decremented for anObject."
+	| oldDepth |
+
+	oldDepth := aGtWireEncoderContext remainingDepth.
+	aGtWireEncoderContext remainingDepth: (oldDepth max: depth).
+	aGtWireEncoderContext privateNextPutMapEncoded: anObject objectEncoder: encoder.
+	aGtWireEncoderContext remainingDepth: oldDepth.
+%
+
+category: 'accessing'
+method: GtWireMinDepthEncoder
+encoder
+	^ encoder
+%
+
+category: 'accessing'
+method: GtWireMinDepthEncoder
+encoder: anObject
+	encoder := anObject
+%
+
+category: 'private - helpers'
+method: GtWireMinDepthEncoder
+replaceMappingsMatching: matchBlock with: replacementBlock
+	"Replace all the mappings matching matchBlock with the encoder returned by replacementBlock.
+	Used by examples to avoid needing live servers."
+
+	encoder replaceMappingsMatching: matchBlock with: replacementBlock
+%
+
+! Class implementation for 'GtWireNilEncoder'
+
+!		Class methods for 'GtWireNilEncoder'
+
+category: 'accessing'
+classmethod: GtWireNilEncoder
+typeIdentifier
+
+	^ 1
+%
+
+!		Instance methods for 'GtWireNilEncoder'
+
+category: 'encoding - decoding'
+method: GtWireNilEncoder
+decodeWith: aGtWireEncoderContext
+	
+	^ nil
+%
+
+! Class implementation for 'GtWireObjectByNameEncoder'
+
+!		Class methods for 'GtWireObjectByNameEncoder'
+
+category: 'instance creation'
+classmethod: GtWireObjectByNameEncoder
+typeIdentifier
+
+	^ 22
+%
+
+!		Instance methods for 'GtWireObjectByNameEncoder'
+
+category: 'encoding - decoding'
+method: GtWireObjectByNameEncoder
+decodeWith: aGtWireEncoderContext
+	| count instance className cls |
+
+	className := aGtWireEncoderContext nextString.
+	"Retrieve the number of variable slots"
+	count := aGtWireEncoderContext nextSize.
+	cls := self lookupClass: className context: aGtWireEncoderContext.
+	cls ifNil: [ self error: 'Unknown class: ', className asString ].
+	instance := cls isVariable
+		ifTrue: [ cls basicNew: count ]
+		ifFalse: [ cls basicNew ].
+	1 to: count do: [ :i |
+		instance basicAt: i put: aGtWireEncoderContext next ].
+	count := aGtWireEncoderContext nextSize.
+	count timesRepeat:
+		[ | instVarName |
+		instVarName := self
+			gtDo: [ aGtWireEncoderContext next asString ]
+			gemstoneDo: [ aGtWireEncoderContext next asSymbol ].
+		instance
+			instVarNamed: instVarName
+			put: aGtWireEncoderContext next ].
+	^ instance
+%
+
+category: 'encoding - decoding'
+method: GtWireObjectByNameEncoder
+encode: anObject with: aGtWireEncoderContext
+	| instVarNames namesAndValues |
+
+	(anObject isKindOf: RsrService) ifTrue:
+		[ self error: 'Attempt to encode proxy by name' ].
+	instVarNames := anObject class allInstVarNames.
+	namesAndValues := OrderedCollection new.
+	instVarNames do: [ :name |
+		(anObject instVarNamed: name) ifNotNil: [ :value |
+			namesAndValues add: name -> value ] ].
+	aGtWireEncoderContext
+		putTypeIdentifier: self class typeIdentifier;
+		putString: anObject class name asString.
+	anObject class isVariable ifTrue:
+		[ | basicSize |
+		basicSize := anObject basicSize.
+		self gtDo: [] gemstoneDo:
+			[ basicSize := basicSize - instVarNames size ].
+		aGtWireEncoderContext putSize: basicSize.
+		1 to: basicSize do: [ :i |
+			aGtWireEncoderContext nextPut: (anObject basicAt: i) ] ]
+	ifFalse:
+		[ aGtWireEncoderContext putSize: 0 ].
+	aGtWireEncoderContext putSize: namesAndValues size.
+	namesAndValues do: [ :assoc |
+		aGtWireEncoderContext nextPut: assoc key asString.
+		aGtWireEncoderContext nextPut: assoc value ].
+%
+
+category: 'private'
+method: GtWireObjectByNameEncoder
+lookupClass: className context: aGtWireEncoderContext
+	"Answer the class with the supplied name or nil if not found.
+	For GemStone, see STONReader>>lookupClass: for inspiration."
+
+	^ self
+		gtDo: [ aGtWireEncoderContext classCache
+			at: className
+			ifAbsentPut: [ self class environment classOrTraitNamed: className ] ]
+		gemstoneDo: [ System myUserProfile objectNamed: className asSymbol ].
+%
+
+! Class implementation for 'GtWireReplicationEncoder'
+
+!		Instance methods for 'GtWireReplicationEncoder'
+
+category: 'encoding - decoding'
+method: GtWireReplicationEncoder
+decodeWith: aGtWireEncoderContext
+	
+	^ self error: 'This can''t be serialised directly'
+%
+
+category: 'as yet unclassified'
+method: GtWireReplicationEncoder
+encode: anObject with: aGtWireEncoderContext
+	"Encode the supplied object using its default encoding, unless it would return a type of proxy, in which case {{gtClass:GtWireObjectByNameEncoder}} is used."
+	| encoder |
+
+	encoder := aGtWireEncoderContext map at: anObject class.
+	encoder isProxyObjectEncoder ifTrue:
+		[ encoder := GtWireObjectByNameEncoder new ].
+	encoder encode: anObject with: aGtWireEncoderContext.
+%
+
+! Class implementation for 'GtWireStonEncoder'
+
+!		Class methods for 'GtWireStonEncoder'
+
+category: 'accessing'
+classmethod: GtWireStonEncoder
+typeIdentifier
+
+	^ 19
+%
+
+!		Instance methods for 'GtWireStonEncoder'
+
+category: 'encoding - decoding'
+method: GtWireStonEncoder
+decodeWith: aGtWireEncoderContext
+
+	^ STON fromString: aGtWireEncoderContext nextByteArray utf8Decoded.
+%
+
+category: 'encoding - decoding'
+method: GtWireStonEncoder
+encode: anObject with: aGtWireEncoderContext
+	| stonEncoded |
+
+	stonEncoded := (STON toString: anObject) utf8Encoded.
+	aGtWireEncoderContext
+		putTypeIdentifier: self class typeIdentifier;
+		putByteArray: stonEncoded.
+%
+
+! Class implementation for 'GtWireStream'
+
+!		Class methods for 'GtWireStream'
+
+category: 'instance creation'
+classmethod: GtWireStream
+on: aStream
+
+	^ self basicNew on: aStream
+%
+
+!		Instance methods for 'GtWireStream'
+
+category: 'accessing'
+method: GtWireStream
+contents
+
+	^ wrappedStream contents
+%
+
+category: 'encoding - decoding'
+method: GtWireStream
+float64
+	| byteArray |
+
+	byteArray := self next: 8.
+	^ byteArray doubleAt: 1.
+%
+
+category: 'encoding - decoding'
+method: GtWireStream
+float64: aFloat
+	| byteArray |
+
+	byteArray := ByteArray new: 8.
+	byteArray doubleAt: 1 put: aFloat.
+	self nextPutAll: byteArray.
+%
+
+category: 'as yet unclassified'
+method: GtWireStream
+int64
+	"Answer the next signed, 32-bit integer from this (binary) stream."
+	"Details: As a fast check for negative number, check the high bit of the first digit"
+	| n firstDigit |
+	n := firstDigit := self next.
+	n := (n bitShift: 8) + self next.
+	n := (n bitShift: 8) + self next.
+	n := (n bitShift: 8) + self next.
+	n := (n bitShift: 8) + self next.
+	n := (n bitShift: 8) + self next.
+	n := (n bitShift: 8) + self next.
+	n := (n bitShift: 8) + self next.
+	firstDigit >= 128 ifTrue: [n := -16r10000000000000000 + n].  "decode negative 64-bit integer"
+	^ n
+%
+
+category: 'as yet unclassified'
+method: GtWireStream
+int64: anInteger
+	| n |
+	(anInteger < -16r8000000000000000) | (anInteger >= 16r8000000000000000)
+		ifTrue: [self error: 'outside 64-bit integer range'].
+
+	anInteger < 0
+		ifTrue: [n := 16r10000000000000000 + anInteger]
+		ifFalse: [n := anInteger].
+	self nextPut: (n digitAt: 8).
+	self nextPut: (n digitAt: 7).
+	self nextPut: (n digitAt: 6).
+	self nextPut: (n digitAt: 5).
+	self nextPut: (n digitAt: 4).
+	self nextPut: (n digitAt: 3).
+	self nextPut: (n digitAt: 2).
+	self nextPut: (n digitAt: 1).
+%
+
+category: 'accessing'
+method: GtWireStream
+next
+
+	^ wrappedStream next
+%
+
+category: 'accessing'
+method: GtWireStream
+next: anInteger
+	"Answer the next anInteger number of objects accessible by the receiver."
+
+	^ wrappedStream next: anInteger
+%
+
+category: 'accessing'
+method: GtWireStream
+nextPut: aByte
+
+	wrappedStream nextPut: aByte
+%
+
+category: 'as yet unclassified'
+method: GtWireStream
+on: aStream
+
+	wrappedStream := aStream
+%
+
+category: 'encoding - decoding'
+method: GtWireStream
+packedInteger
+	| result |
+
+	result := 0.
+	[ | byte |
+	byte := self next.
+	result := (result bitShift: 7) + (byte bitAnd: 16r7F).
+	byte >= 16r80 ] whileTrue.
+	^ result
+%
+
+category: 'encoding - decoding'
+method: GtWireStream
+packedInteger: anInteger
+	| bitCount byteCount |
+
+	anInteger isInteger ifFalse:
+		[ self error: anInteger asString, ' isn''t integer' ].
+	anInteger < 0 ifTrue:
+		[ self error: anInteger asString, ' is less than 0' ].
+	anInteger = 0 ifTrue:
+		[ self nextPut: 0.
+		^ self ].
+
+	bitCount := (anInteger log: 2) floor + 1.
+	byteCount := (bitCount / 7) ceiling.
+	byteCount to: 1 by: -1 do: [ :byteOffset |
+		| byte |
+		byte := (anInteger bitShift: (byteOffset - 1 * -7)) bitAnd: 16r7F.
+		byteOffset > 1 ifTrue: [ byte := byte bitOr: 16r80 ].
+		self nextPut: byte ].
+%
+
+category: 'accessing'
+method: GtWireStream
+position
+
+	^ wrappedStream position
+%
+
+category: 'as yet unclassified'
+method: GtWireStream
+postCopy
+	"Creating a copy of a WriteStream doesn't copy the underlying collection.
+	For now, create a new WriteStream."
+	
+	 super postCopy.
+	 wrappedStream := WriteStream on: (ByteArray new: 100).
+%
+
+category: 'as yet unclassified'
+method: GtWireStream
+reset
+
+	wrappedStream reset
+%
+
+! Class extensions for 'DateAndTimeANSI'
+
+!		Instance methods for 'DateAndTimeANSI'
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: DateAndTimeANSI
+asUnixTime
+
+	^ self asPosixSeconds
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: DateAndTimeANSI
+nanoSecond
+
+	^ (self second fractionPart * (10 raisedTo: 9)) rounded
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: DateAndTimeANSI
+setNanoSeconds: nanoSeconds
+	"Set the fractional seconds of the receiver"
+
+	^ DateAndTime posixSeconds: self asPosixSeconds truncated + (nanoSeconds / (10 raisedTo: 9))
+		offset: self offset
+%
+
+! Class extensions for 'GtWireDecoder'
+
+!		Instance methods for 'GtWireDecoder'
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireDecoder
+nextNullTerminatedUtf8
+	| ch wStream |
+
+	wStream := WriteStream on: (ByteArray new: 1024).
+	[ (ch := stream next) = 0 ] whileFalse:
+		[ wStream nextPut: ch ].
+	^ wStream contents utf8Decoded asString
+%
+
+! Class extensions for 'GtWireEncoder'
+
+!		Instance methods for 'GtWireEncoder'
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireEncoder
+putNullTerminatedUtf8: aString
+
+	stream nextPutAll: aString utf8Encoded.
+	stream nextPut: 0.
+%
+
+! Class extensions for 'GtWireEncoderDecoder'
+
+!		Class methods for 'GtWireEncoderDecoder'
+
+category: '*GToolkit-WireEncoding-GemStone'
+classmethod: GtWireEncoderDecoder
+defaultMap
+
+	^ SessionTemps current
+		at: #gtGsWireEncodingDefaultMap
+		ifAbsentPut: [ self getDefaultMap ]
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+classmethod: GtWireEncoderDecoder
+defaultMapping
+	"The default mapping only encodes directly supported classes"
+	| mapping |
+
+	mapping := IdentityDictionary new.
+	self map: ExecBlock withSubclassesTo: GtWireBlockClosureEncoder new in: mapping.
+	self map: RsrService withSubclassesTo: GtWireGemStoneRsrEncoder new in: mapping.
+	mapping
+		at: Association put: GtWireAssociationEncoder new;
+		at: Boolean put: GtWireBooleanEncoder new;
+		at: ByteArray put: GtWireByteArrayEncoder new;
+		at: String  put: GtWireStringEncoder new;
+		at: DoubleByteString put: GtWireStringEncoder new;
+		at: Unicode7 put: GtWireStringEncoder new;
+		at: Unicode16 put: GtWireStringEncoder new;
+		at: Unicode32 put: GtWireStringEncoder new;
+		at: Symbol put: GtWireSymbolEncoder new;
+		at: DoubleByteSymbol put: GtWireSymbolEncoder new;
+		at: Character put: GtWireCharacterEncoder new;
+		at: Array put: GtWireArrayEncoder new;
+		at: Dictionary put: GtWireDictionaryEncoder new;
+		at: OrderedCollection put: GtWireOrderedCollectionEncoder new;
+		at: Set put: GtWireSetEncoder new;
+		at: SmallInteger put: GtWireIntegerEncoder new;
+		at: LargeInteger put: GtWireIntegerEncoder new;
+		at: Float put: GtWireFloatEncoder new;
+		at: SmallDouble put: GtWireFloatEncoder new;
+		at: UndefinedObject put: GtWireNilEncoder new;
+		at: DateAndTime put: GtWireDateAndTimeEncoder new;
+		at: SmallDateAndTime put: GtWireDateAndTimeEncoder new.
+	^ mapping
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+classmethod: GtWireEncoderDecoder
+defaultReverseMap
+
+	^ SessionTemps current
+		at: #gtGsWireEncodingDefaultReverseMap
+		ifAbsentPut: [ self getDefaultReverseMap ]
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+classmethod: GtWireEncoderDecoder
+getDefaultMap
+	"Generated by #generateDefaultMapMethodFrom:.
+	Original source is #defaultMapping, changes should be made there and the code regenerated."
+
+	^ IdentityDictionary new
+		at: ((self lookupClass: #Array) ifNil: [ self error: 'Unable to find: Array' ]) put: GtWireArrayEncoder new;
+		at: ((self lookupClass: #Association) ifNil: [ self error: 'Unable to find: Association' ]) put: GtWireAssociationEncoder new;
+		at: ((self lookupClass: #Boolean) ifNil: [ self error: 'Unable to find: Boolean' ]) put: GtWireBooleanEncoder new;
+		at: ((self lookupClass: #ByteArray) ifNil: [ self error: 'Unable to find: ByteArray' ]) put: GtWireByteArrayEncoder new;
+		at: ((self lookupClass: #Character) ifNil: [ self error: 'Unable to find: Character' ]) put: GtWireCharacterEncoder new;
+		at: ((self lookupClass: #DateAndTime) ifNil: [ self error: 'Unable to find: DateAndTime' ]) put: GtWireDateAndTimeEncoder new;
+		at: ((self lookupClass: #Dictionary) ifNil: [ self error: 'Unable to find: Dictionary' ]) put: GtWireDictionaryEncoder new;
+		at: ((self lookupClass: #DoubleByteString) ifNil: [ self error: 'Unable to find: DoubleByteString' ]) put: GtWireStringEncoder new;
+		at: ((self lookupClass: #DoubleByteSymbol) ifNil: [ self error: 'Unable to find: DoubleByteSymbol' ]) put: GtWireSymbolEncoder new;
+		at: ((self lookupClass: #ExecBlock) ifNil: [ self error: 'Unable to find: ExecBlock' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #ExecBlock0) ifNil: [ self error: 'Unable to find: ExecBlock0' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #ExecBlock1) ifNil: [ self error: 'Unable to find: ExecBlock1' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #ExecBlock2) ifNil: [ self error: 'Unable to find: ExecBlock2' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #ExecBlock3) ifNil: [ self error: 'Unable to find: ExecBlock3' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #ExecBlock4) ifNil: [ self error: 'Unable to find: ExecBlock4' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #ExecBlock5) ifNil: [ self error: 'Unable to find: ExecBlock5' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #ExecBlockN) ifNil: [ self error: 'Unable to find: ExecBlockN' ]) put: GtWireBlockClosureEncoder new;
+		at: ((self lookupClass: #Float) ifNil: [ self error: 'Unable to find: Float' ]) put: GtWireFloatEncoder new;
+		at: ((self lookupClass: #GtRsrEvaluatorFeaturesService) ifNil: [ self error: 'Unable to find: GtRsrEvaluatorFeaturesService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrEvaluatorFeaturesServiceServer) ifNil: [ self error: 'Unable to find: GtRsrEvaluatorFeaturesServiceServer' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrEvaluatorService) ifNil: [ self error: 'Unable to find: GtRsrEvaluatorService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrEvaluatorServiceServer) ifNil: [ self error: 'Unable to find: GtRsrEvaluatorServiceServer' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrProxyService) ifNil: [ self error: 'Unable to find: GtRsrProxyService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrProxyServiceServer) ifNil: [ self error: 'Unable to find: GtRsrProxyServiceServer' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrTestService) ifNil: [ self error: 'Unable to find: GtRsrTestService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrTestServiceClient) ifNil: [ self error: 'Unable to find: GtRsrTestServiceClient' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrTestServiceServer) ifNil: [ self error: 'Unable to find: GtRsrTestServiceServer' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrWireTransferService) ifNil: [ self error: 'Unable to find: GtRsrWireTransferService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #GtRsrWireTransferServiceServer) ifNil: [ self error: 'Unable to find: GtRsrWireTransferServiceServer' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #LargeInteger) ifNil: [ self error: 'Unable to find: LargeInteger' ]) put: GtWireIntegerEncoder new;
+		at: ((self lookupClass: #OrderedCollection) ifNil: [ self error: 'Unable to find: OrderedCollection' ]) put: GtWireOrderedCollectionEncoder new;
+		at: ((self lookupClass: #RsrPolicyRejectedService) ifNil: [ self error: 'Unable to find: RsrPolicyRejectedService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #RsrPolicyRejectedServiceClient) ifNil: [ self error: 'Unable to find: RsrPolicyRejectedServiceClient' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #RsrPolicyRejectedServiceServer) ifNil: [ self error: 'Unable to find: RsrPolicyRejectedServiceServer' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #RsrReasonService) ifNil: [ self error: 'Unable to find: RsrReasonService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #RsrRemoteException) ifNil: [ self error: 'Unable to find: RsrRemoteException' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #RsrRemoteExceptionClient) ifNil: [ self error: 'Unable to find: RsrRemoteExceptionClient' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #RsrRemoteExceptionServer) ifNil: [ self error: 'Unable to find: RsrRemoteExceptionServer' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #RsrService) ifNil: [ self error: 'Unable to find: RsrService' ]) put: GtWireGemStoneRsrEncoder new;
+		at: ((self lookupClass: #Set) ifNil: [ self error: 'Unable to find: Set' ]) put: GtWireSetEncoder new;
+		at: ((self lookupClass: #SmallDateAndTime) ifNil: [ self error: 'Unable to find: SmallDateAndTime' ]) put: GtWireDateAndTimeEncoder new;
+		at: ((self lookupClass: #SmallDouble) ifNil: [ self error: 'Unable to find: SmallDouble' ]) put: GtWireFloatEncoder new;
+		at: ((self lookupClass: #SmallInteger) ifNil: [ self error: 'Unable to find: SmallInteger' ]) put: GtWireIntegerEncoder new;
+		at: ((self lookupClass: #String) ifNil: [ self error: 'Unable to find: String' ]) put: GtWireStringEncoder new;
+		at: ((self lookupClass: #Symbol) ifNil: [ self error: 'Unable to find: Symbol' ]) put: GtWireSymbolEncoder new;
+		at: ((self lookupClass: #UndefinedObject) ifNil: [ self error: 'Unable to find: UndefinedObject' ]) put: GtWireNilEncoder new;
+		at: ((self lookupClass: #Unicode16) ifNil: [ self error: 'Unable to find: Unicode16' ]) put: GtWireStringEncoder new;
+		at: ((self lookupClass: #Unicode32) ifNil: [ self error: 'Unable to find: Unicode32' ]) put: GtWireStringEncoder new;
+		at: ((self lookupClass: #Unicode7) ifNil: [ self error: 'Unable to find: Unicode7' ]) put: GtWireStringEncoder new;
+		yourself.
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+classmethod: GtWireEncoderDecoder
+getDefaultReverseMap
+	"Generated by #generateDefaultReverseMapMethodFrom:.
+	Original source is #defaultMapping, changes should be made there and the code regenerated."
+
+	^ (Array new: 28)
+		at: 1 put: GtWireNilEncoder new;
+		at: 2 put: GtWireTrueEncoder new;
+		at: 3 put: GtWireFalseEncoder new;
+		at: 4 put: GtWireByteArrayEncoder new;
+		at: 5 put: GtWireStringEncoder new;
+		at: 6 put: GtWireSymbolEncoder new;
+		at: 7 put: GtWireCharacterEncoder new;
+		at: 8 put: GtWireArrayEncoder new;
+		at: 9 put: GtWireDictionaryEncoder new;
+		at: 10 put: GtWireOrderedCollectionEncoder new;
+		at: 11 put: GtWireSetEncoder new;
+		at: 12 put: GtWireDateAndTimeEncoder new;
+		at: 13 put: GtWirePositiveIntegerEncoder new;
+		at: 14 put: GtWireNegativeIntegerEncoder new;
+		at: 15 put: GtWireAssociationEncoder new;
+		at: 16 put: GtWireIntegerEncoder new;
+		at: 17 put: GtWireFloatEncoder new;
+		at: 19 put: GtWireStonEncoder new;
+		at: 20 put: GtWireInstVarEncoder new;
+		at: 21 put: GtWireBlockClosureEncoder new;
+		at: 22 put: GtWireObjectByNameEncoder new;
+		at: 23 put: GtWireGemStoneOopEncoder new;
+		at: 24 put: GtWireGemStoneRsrEncoder new;
+		at: 25 put: GtWireDummyProxyEncoder new;
+		at: 27 put: GtWireGemStoneWithRsrEncoder new;
+		at: 28 put: GtWireClassEncoder new;
+		yourself.
+%
+
+! Class extensions for 'GtWireEncodingExamples'
+
+!		Instance methods for 'GtWireEncodingExamples'
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireEncodingExamples
+assert: aBoolean
+
+	self
+		assert: aBoolean
+		description: 'Assertion failed'.
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireEncodingExamples
+assert: aBoolean description: aString
+
+	aBoolean == true ifFalse:
+		[ TestResult failure signal: aString value ]
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireEncodingExamples
+assert: actual equals: expected
+
+	self
+		assert: actual = expected
+		description: actual printString, ' is not equal to ', expected printString.
+%
+
+! Class extensions for 'GtWireGemStoneRsrEncoder'
+
+!		Instance methods for 'GtWireGemStoneRsrEncoder'
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireGemStoneRsrEncoder
+connection
+
+	^ (SessionTemps current at: #GtRsrServer) connection
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireGemStoneRsrEncoder
+currentWireService
+
+	^ SessionTemps current at: #GtRsrCurrentWireService
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireGemStoneRsrEncoder
+decodeWith: aGtWireEncoderContext
+	"It is up to the user to ensure the Object isn't GCd during transfer and decoding
+	(which would allow the oop to be reused and the wrong object returned), or that the
+	session is aborted."
+
+	^ (self connection serviceAt: aGtWireEncoderContext next) asGtGsArgument
+%
+
+! Class extensions for 'GtWireGemStoneWithRsrEncoder'
+
+!		Instance methods for 'GtWireGemStoneWithRsrEncoder'
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireGemStoneWithRsrEncoder
+connection
+
+	^ (SessionTemps current at: #GtRsrServer) connection
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireGemStoneWithRsrEncoder
+currentWireService
+
+	^ SessionTemps current at: #GtRsrCurrentWireService
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireGemStoneWithRsrEncoder
+decodeWith: aGtWireEncoderContext
+
+	self notYetImplemented
+%
+
+! Class extensions for 'GtWireNestedEncodingExamples'
+
+!		Instance methods for 'GtWireNestedEncodingExamples'
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireNestedEncodingExamples
+assert: aBoolean
+
+	self
+		assert: aBoolean
+		description: 'Assertion failed'.
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireNestedEncodingExamples
+assert: aBoolean description: aString
+
+	aBoolean == true ifFalse:
+		[ TestResult failure signal: aString value ]
+%
+
+category: '*GToolkit-WireEncoding-GemStone'
+method: GtWireNestedEncodingExamples
+assert: actual equals: expected
+
+	self
+		assert: actual = expected
+		description: actual printString, ' is not equal to ', expected printString.
+%
+
+! Class Initialization
+
+run
+GtWireEncoderDecoder initialize.
+true
+%

--- a/docs/gtSupport/load_gemstone_gt_support.sh
+++ b/docs/gtSupport/load_gemstone_gt_support.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+#
+# Loads GT remote support into a running plain-vanilla GemStone stone by
+# filing in the pre-built .gs files from each project's src-gs/ directory.
+# These files are bundled in the same directory as this script and do not
+# require Rowan or $ROWAN_PROJECTS_HOME.
+#
+# Files are loaded in dependency order. Source paths are from git checkouts:
+#   1. Announcements.gs            gt4gemstone/src-gs/Announcements.gs
+#   2. RemoteServiceReplication.gs RemoteServiceReplication/src-gs/bootstrapRSR.gs
+#   3. STON.gs                     gt4gemstone/src-gs/STON.gs
+#   4. patch-gemstone.gs           gt4gemstone/src-gs/patch-gemstone.gs
+#   5. gtoolkit-wireencoding.gs    gtoolkit-wireencoding/src-gs/gtoolkit-wireencoding.gs
+#   6. gt4gemstone.gs              gt4gemstone/src-gs/gt4gemstone.gs
+#   7. gtoolkit-remote.gs          gtoolkit-remote/src-gs/gtoolkit-remote.gs
+#
+# REQUIREMENTS:
+#   $GEMSTONE     Path to the GemStone product directory
+#   .topazini     Must exist in the current working directory (or use -I).
+#                 It should contain the stone name, username, and password:
+#                   set gemstone <stone-name>
+#                   set username SystemUser
+#                   set password swordfish
+#   The stone must be running and accessible via netldi.
+#   The seven .gs files listed above must already be present in the same
+#   directory as this script.
+#
+# USAGE:
+#   cd /path/to/stone/data/dir     # the directory containing .topazini
+#   ./load_gemstone_gt_support.sh
+#
+#   Or specify the topazini path explicitly:
+#   ./load_gemstone_gt_support.sh -I /path/to/.topazini
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOPAZINI=".topazini"
+
+usage() {
+    echo "Usage: $0 [-I topazini-path]"
+    exit 1
+}
+
+while getopts "I:h" opt; do
+    case $opt in
+        I) TOPAZINI="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+# Check prerequisites
+if [ -z "$GEMSTONE" ]; then
+    echo "Error: GEMSTONE is not set."
+    exit 1
+fi
+
+if [ ! -f "$TOPAZINI" ]; then
+    echo "Error: .topazini not found at: $TOPAZINI"
+    echo "Run from the stone's data directory, or use -I to specify the path."
+    exit 1
+fi
+
+missing=()
+for f in Announcements.gs RemoteServiceReplication.gs STON.gs patch-gemstone.gs \
+         gtoolkit-wireencoding.gs gt4gemstone.gs gtoolkit-remote.gs; do
+    [ ! -f "$SCRIPT_DIR/$f" ] && missing+=("$f")
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "Error: missing .gs files in $SCRIPT_DIR:"
+    for f in "${missing[@]}"; do
+        echo "  $f"
+    done
+    echo "Copy the missing files from the project src-gs/ directories."
+    exit 1
+fi
+
+echo "Loading GT support into stone..."
+
+"$GEMSTONE/bin/topaz" -l -I "$TOPAZINI" << EOF
+login
+input $SCRIPT_DIR/Announcements.gs
+input $SCRIPT_DIR/RemoteServiceReplication.gs
+input $SCRIPT_DIR/STON.gs
+input $SCRIPT_DIR/patch-gemstone.gs
+input $SCRIPT_DIR/gtoolkit-wireencoding.gs
+input $SCRIPT_DIR/gt4gemstone.gs
+input $SCRIPT_DIR/gtoolkit-remote.gs
+commit
+logout
+exit
+EOF
+
+echo "Done."

--- a/docs/gtSupport/patch-gemstone.gs
+++ b/docs/gtSupport/patch-gemstone.gs
@@ -1,0 +1,26 @@
+! GT patches for GemStone
+! These are modifications to the core GemStone code that can't be included
+! as extension methods in git.
+
+category: 'writing'
+method: STONWriter
+encodeCharacter: char
+  | code encoding |
+  ((code := char codePoint) < 127
+    and: [ (encoding := STONCharacters at: code + 1) notNil ])
+    ifTrue: [ (encoding = #'pass' or: [ jsonMode and: [ char = $' ] ])
+        ifTrue: [ writeStream nextPut: char ]
+        ifFalse: [ writeStream nextPutAll: encoding ] ]
+    ifFalse: [ | paddedStream padding digits |
+      paddedStream := WriteStream on: String new.
+      code printOn: paddedStream base: 16 showRadix: false.
+      digits := paddedStream contents.
+      padding := 4 - digits size.
+      writeStream nextPutAll: '\u'.
+      encoding := padding > 0
+        ifTrue: [ ((String new: padding)
+            atAllPut: $0;
+            yourself) , digits ]
+        ifFalse: [ digits ].
+      writeStream nextPutAll: encoding ]
+%

--- a/docs/gtSupport/update_gemstone_gt_support.sh
+++ b/docs/gtSupport/update_gemstone_gt_support.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+#
+# Updates the .gs files in this directory from the project checkouts
+# in $ROWAN_PROJECTS_HOME. Run this script to pick up the latest GT support
+# files when the projects have been updated.
+#
+# The following four projects must be cloned into $ROWAN_PROJECTS_HOME:
+#   gt4gemstone            github.com/feenkcom/gt4gemstone
+#   gtoolkit-remote        github.com/feenkcom/gtoolkit-remote
+#   gtoolkit-wireencoding  github.com/feenkcom/gtoolkit-wireencoding
+#   RemoteServiceReplication  github.com/GemTalk/RemoteServiceReplication
+#
+# REQUIREMENTS:
+#   $ROWAN_PROJECTS_HOME  Directory containing the four project checkouts above
+#
+# USAGE:
+#   ./update_gemstone_gt_support.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "$ROWAN_PROJECTS_HOME" ]; then
+    echo "Error: ROWAN_PROJECTS_HOME is not set."
+    exit 1
+fi
+
+# Verify all four project directories are present
+missing_projects=()
+for project in gt4gemstone gtoolkit-wireencoding gtoolkit-remote RemoteServiceReplication; do
+    [ ! -d "$ROWAN_PROJECTS_HOME/$project" ] && missing_projects+=("$project")
+done
+
+if [ ${#missing_projects[@]} -gt 0 ]; then
+    echo "Cannot update: the following project directories were not found in $ROWAN_PROJECTS_HOME:"
+    for p in "${missing_projects[@]}"; do
+        echo "  $p"
+    done
+    echo ""
+    echo "Clone the missing projects into \$ROWAN_PROJECTS_HOME before running this script:"
+    echo "  gt4gemstone            github.com/feenkcom/gt4gemstone"
+    echo "  gtoolkit-remote        github.com/feenkcom/gtoolkit-remote"
+    echo "  gtoolkit-wireencoding  github.com/feenkcom/gtoolkit-wireencoding"
+    echo "  RemoteServiceReplication  github.com/GemTalk/RemoteServiceReplication"
+    exit 1
+fi
+
+# Before running this script, pull the latest from each of the four repos:
+#   git -C "$ROWAN_PROJECTS_HOME/gt4gemstone" pull
+#   git -C "$ROWAN_PROJECTS_HOME/gtoolkit-wireencoding" pull
+#   git -C "$ROWAN_PROJECTS_HOME/gtoolkit-remote" pull
+#   git -C "$ROWAN_PROJECTS_HOME/RemoteServiceReplication" pull
+
+
+
+# Warn and confirm before overwriting
+existing=()
+for f in Announcements.gs RemoteServiceReplication.gs STON.gs patch-gemstone.gs \
+         gtoolkit-wireencoding.gs gt4gemstone.gs gtoolkit-remote.gs; do
+    [ -f "$SCRIPT_DIR/$f" ] && existing+=("$f")
+done
+
+if [ ${#existing[@]} -gt 0 ]; then
+    echo "Warning: the following files will be overwritten in $SCRIPT_DIR:"
+    for f in "${existing[@]}"; do
+        echo "  $f"
+    done
+    echo ""
+    read -rp "Continue? [y/N] " answer
+    case "$answer" in
+        [yY]*) ;;
+        *) echo "Aborted."; exit 0 ;;
+    esac
+fi
+
+# Copy the src-gs files
+cp "$ROWAN_PROJECTS_HOME/gt4gemstone/src-gs/Announcements.gs"        "$SCRIPT_DIR/"
+cp "$ROWAN_PROJECTS_HOME/RemoteServiceReplication/src-gs/bootstrapRSR.gs"  "$SCRIPT_DIR/RemoteServiceReplication.gs"
+cp "$ROWAN_PROJECTS_HOME/gt4gemstone/src-gs/STON.gs"                  "$SCRIPT_DIR/"
+cp "$ROWAN_PROJECTS_HOME/gt4gemstone/src-gs/patch-gemstone.gs"        "$SCRIPT_DIR/"
+cp "$ROWAN_PROJECTS_HOME/gtoolkit-wireencoding/src-gs/gtoolkit-wireencoding.gs" "$SCRIPT_DIR/"
+cp "$ROWAN_PROJECTS_HOME/gt4gemstone/src-gs/gt4gemstone.gs"           "$SCRIPT_DIR/"
+cp "$ROWAN_PROJECTS_HOME/gtoolkit-remote/src-gs/gtoolkit-remote.gs"   "$SCRIPT_DIR/"
+
+echo ""
+echo "Update complete. Files written to $SCRIPT_DIR"
+echo "Use load_gemstone_gt_support.sh to load these into a stone."


### PR DESCRIPTION
## Summary

- Adds a new `docs/gtSupport/` directory with scripts and GemStone source files needed to load GT remote inspection support into a plain-vanilla GemStone server.
- Includes `load_gemstone_gt_support.sh` to load the seven `.gs` files into a running stone, and `update_gemstone_gt_support.sh` to refresh them from feenk project checkouts.
- Adds a `README.md` explaining quick-start steps and how to keep the files current.

## Files

| File | Purpose |
|------|---------|
| `load_gemstone_gt_support.sh` | Loads GT support into a running stone |
| `update_gemstone_gt_support.sh` | Refreshes `.gs` files from feenk checkouts |
| `README.md` | Setup and usage instructions |
| `Announcements.gs`, `STON.gs`, `gt4gemstone.gs`, etc. | GT remote inspection source files |

## Test plan

- [ ] Run `load_gemstone_gt_support.sh` against a plain-vanilla stone and confirm GT inspector views work in Jasper
- [ ] Run `update_gemstone_gt_support.sh` after pulling feenk repos and confirm `.gs` files are refreshed
