### PR TITLE
Auto-open new compiled methods

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "@types/vscode": "^1.85.0",
     "css.escape": "^1.5.1",
     "jsdom": "^27.4.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "vscode-uri": "^3.1.0"
   }
 }

--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -1,4 +1,7 @@
 import { vi } from 'vitest';
+import { URI as Uri } from 'vscode-uri';
+
+export { Uri };
 
 // ── Configuration mock ─────────────────────────────────────
 
@@ -270,56 +273,6 @@ export const commands = {
   registerCommand: vi.fn((_command: string, _callback: unknown) => ({ dispose: () => {} })),
   executeCommand: vi.fn(),
 };
-
-// ── Uri mock ───────────────────────────────────────────────
-
-export class Uri {
-  scheme: string;
-  authority: string;
-  path: string;
-  fsPath: string;
-  query: string;
-  fragment: string;
-
-  private constructor(scheme: string, authority: string, path: string, query = '', fragment = '') {
-    this.scheme = scheme;
-    this.authority = authority;
-    this.path = path;
-    this.fsPath = path;
-    this.query = query;
-    this.fragment = fragment;
-  }
-
-  with(_change: { scheme?: string; authority?: string; path?: string; query?: string; fragment?: string }): Uri {
-    return new Uri(
-      _change.scheme ?? this.scheme,
-      _change.authority ?? this.authority,
-      _change.path ?? this.path,
-      _change.query ?? this.query,
-      _change.fragment ?? this.fragment,
-    );
-  }
-
-  toJSON(): unknown {
-    return { scheme: this.scheme, authority: this.authority, path: this.path, query: this.query, fragment: this.fragment };
-  }
-
-  toString(): string {
-    return `${this.scheme}://${this.authority}${this.path}`;
-  }
-
-  static file(path: string) {
-    return new Uri('file', '', path);
-  }
-
-  static parse(value: string): Uri {
-    const match = value.match(/^([^:]+):\/\/([^/]*)([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/);
-    if (match) {
-      return new Uri(match[1], match[2], match[3], match[4] || '', match[5] || '');
-    }
-    return new Uri('file', '', value);
-  }
-}
 
 // ── FileSystemError mock ──────────────────────────────────
 

--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -274,6 +274,12 @@ export const commands = {
   executeCommand: vi.fn(),
 };
 
+// ── Tab input mock ────────────────────────────────────────
+
+export class TabInputText {
+  constructor(public readonly uri: Uri) {}
+}
+
 // ── FileSystemError mock ──────────────────────────────────
 
 export class FileSystemError extends Error {

--- a/client/src/__tests__/extension.test.ts
+++ b/client/src/__tests__/extension.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+
+vi.mock('vscode-languageclient/node', () => ({
+  LanguageClient: class {
+    start() {}
+    stop() {
+      return Promise.resolve();
+    }
+    sendRequest() {
+      return Promise.resolve(null);
+    }
+  },
+  TransportKind: { ipc: 0 },
+}));
+
+vi.mock('../browserQueries', () => ({
+  BrowserQueryError: class BrowserQueryError extends Error {
+    gciErrorNumber: number;
+    constructor(message: string, gciErrorNumber = 0) {
+      super(message);
+      this.gciErrorNumber = gciErrorNumber;
+    }
+  },
+  compileMethod: vi.fn(() => 'Compiled: Array >> foo'),
+}));
+
+import * as vscode from 'vscode';
+import * as extension from '../extension';
+import { GemStoneFileSystemProvider } from '../gemstoneFileSystemProvider';
+import type { SessionManager } from '../sessionManager';
+import * as queries from '../browserQueries';
+
+describe('openTextEditorOn', () => {
+  const uri = vscode.Uri.parse('gemstone://1/SymbolDictionary/Array/instance/accessing/at:');
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(vscode.workspace.openTextDocument).mockReset();
+    vi.mocked(vscode.window.showTextDocument).mockReset();
+    vi.mocked(vscode.window.showErrorMessage).mockReset();
+    vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
+  });
+
+  it('opens and shows the document with preview disabled, without logging an error', async () => {
+    const document = { uri, getText: vi.fn(() => '') } as unknown as vscode.TextDocument;
+    vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
+    vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as vscode.TextEditor);
+
+    await extension.openTextEditorOn(uri);
+
+    expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(uri);
+    expect(vscode.window.showTextDocument).toHaveBeenCalledWith(document, { preview: false });
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when openTextDocument fails and does not call showTextDocument', async () => {
+    const error = new Error('open failed');
+    vi.mocked(vscode.workspace.openTextDocument).mockRejectedValue(error);
+
+    await extension.openTextEditorOn(uri);
+
+    expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(uri);
+    expect(vscode.window.showTextDocument).not.toHaveBeenCalled();
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      `Failed to open text editor on ${uri.toString()}`,
+      'Show Details',
+    );
+  });
+
+  it('logs an error when showTextDocument fails after openTextDocument succeeds', async () => {
+    const document = { uri, getText: vi.fn(() => '') } as unknown as vscode.TextDocument;
+    const error = new Error('show failed');
+    vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
+    vi.mocked(vscode.window.showTextDocument).mockRejectedValue(error);
+
+    await extension.openTextEditorOn(uri);
+
+    expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(uri);
+    expect(vscode.window.showTextDocument).toHaveBeenCalledWith(document, { preview: false });
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      `Failed to open text editor on ${uri.toString()}`,
+      'Show Details',
+    );
+  });
+});
+
+describe('closeTextEditorOn', () => {
+  const targetUri = vscode.Uri.parse('gemstone://1/SymbolDictionary/Array/instance/accessing/at:');
+  const otherUri = vscode.Uri.parse('gemstone://1/SymbolDictionary/Array/instance/accessing/at:put:');
+
+  const makeTextTab = (uri: vscode.Uri): vscode.Tab => ({
+    input: new vscode.TabInputText(uri),
+  } as unknown as vscode.Tab);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (vscode.window.tabGroups as any).all = [];
+    vi.mocked(vscode.window.tabGroups.close).mockReset();
+    vi.mocked(vscode.window.showErrorMessage).mockReset();
+    vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
+  });
+
+  it('does nothing when no tabs are opened for the given uri', async () => {
+    (vscode.window.tabGroups as any).all = [{ tabs: [] }];
+
+    await extension.closeTextEditorOn(targetUri);
+
+    expect(vscode.window.tabGroups.close).not.toHaveBeenCalled();
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('closes one matching opened tab (happy path)', async () => {
+    const tab = makeTextTab(targetUri);
+    (vscode.window.tabGroups as any).all = [{ tabs: [tab] }];
+    vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
+
+    await extension.closeTextEditorOn(targetUri);
+
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledTimes(1);
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(tab);
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs error when closing one matching opened tab fails', async () => {
+    const tab = makeTextTab(targetUri);
+    const error = new Error('close failed');
+    (vscode.window.tabGroups as any).all = [{ tabs: [tab] }];
+    vi.mocked(vscode.window.tabGroups.close).mockRejectedValue(error);
+
+    await extension.closeTextEditorOn(targetUri);
+
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledTimes(1);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      `Failed to close text editor on ${targetUri.toString()}`,
+      'Show Details',
+    );
+  });
+
+  it('closes both tabs when more than one matching tab is opened (happy path)', async () => {
+    const tab1 = makeTextTab(targetUri);
+    const tab2 = makeTextTab(targetUri);
+    (vscode.window.tabGroups as any).all = [{ tabs: [tab1, tab2] }];
+    vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
+
+    await extension.closeTextEditorOn(targetUri);
+
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledTimes(2);
+    expect(vscode.window.tabGroups.close).toHaveBeenNthCalledWith(1, tab1);
+    expect(vscode.window.tabGroups.close).toHaveBeenNthCalledWith(2, tab2);
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('handles per-tab failure: first fails and second still closes', async () => {
+    const tab1 = makeTextTab(targetUri);
+    const tab2 = makeTextTab(targetUri);
+    const error = new Error('first close failed');
+    (vscode.window.tabGroups as any).all = [{ tabs: [tab1, tab2] }];
+    vi.mocked(vscode.window.tabGroups.close)
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined as never);
+
+    await extension.closeTextEditorOn(targetUri);
+
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledTimes(2);
+    expect(vscode.window.tabGroups.close).toHaveBeenNthCalledWith(1, tab1);
+    expect(vscode.window.tabGroups.close).toHaveBeenNthCalledWith(2, tab2);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      `Failed to close text editor on ${targetUri.toString()}`,
+      'Show Details',
+    );
+  });
+
+  it('does not close tabs for different uris', async () => {
+    const matching = makeTextTab(targetUri);
+    const different = makeTextTab(otherUri);
+    const notText = { input: { uri: targetUri } } as unknown as vscode.Tab;
+    (vscode.window.tabGroups as any).all = [{ tabs: [matching, different, notText] }];
+    vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
+
+    await extension.closeTextEditorOn(targetUri);
+
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledTimes(1);
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(matching);
+  });
+});
+
+describe('handleMethodCompiled', () => {
+  const uri = vscode.Uri.parse('gemstone://1/SymbolDictionary/Array/instance/accessing/at:');
+  const previousUri = vscode.Uri.parse('gemstone://1/SymbolDictionary/Array/instance/accessing/at:put:');
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
+  });
+
+  it('opens the new uri and then closes the previous uri', async () => {
+    const document = { uri, getText: vi.fn(() => '') } as unknown as vscode.TextDocument;
+    vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
+    vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as vscode.TextEditor);
+    const previousTab = { input: new vscode.TabInputText(previousUri) } as unknown as vscode.Tab;
+    (vscode.window.tabGroups as any).all = [{ tabs: [previousTab] }];
+    vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
+
+    await extension.handleMethodCompiled({ uri, previousUri });
+
+    expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(uri);
+    expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(previousTab);
+    expect(vi.mocked(vscode.workspace.openTextDocument).mock.invocationCallOrder[0])
+      .toBeLessThan(vi.mocked(vscode.window.tabGroups.close).mock.invocationCallOrder[0]);
+  });
+});
+
+describe('onMethodCompiled event subscription (functional)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handleMethodCompiled is invoked when new-method is compiled', async () => {
+    vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >> foo');
+
+    const makeSession = (id = 1) => ({
+      id,
+      gci: {},
+      handle: {},
+      login: { label: 'Test', gs_user: 'DataCurator' },
+      stoneVersion: '3.7.2',
+    });
+
+    const sessionManager = {
+      getSessions: vi.fn(() => [makeSession(1)]),
+      getSession: vi.fn((id: number) => (id === 1 ? makeSession(1) : undefined)),
+    } as unknown as SessionManager;
+
+    const provider = new GemStoneFileSystemProvider(sessionManager);
+    const handler = vi.spyOn(extension, 'handleMethodCompiled');
+
+    provider.onMethodCompiled(handler);
+
+    const newMethodUri = vscode.Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+    const source = 'foo\n  ^42';
+
+    provider.writeFile(newMethodUri, new TextEncoder().encode(source), { create: true, overwrite: true });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.mock.calls[0][0];
+    expect(event.previousUri.toString()).toBe(newMethodUri.toString());
+    expect(event.uri.toString()).toBe('gemstone://1/Globals/Array/instance/accessing/foo');
+  });
+});
+

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -424,49 +424,53 @@ describe('buildNewMethodUri', () => {
     expect(uri.authority).toBe('42');
   });
 
-  it('produces an instance-side path when the class side is not meta', () => {
-    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
-    const parts = uri.path.split('/');
-    expect(parts[3]).toBe('instance');
+  it('places the dictionary name at path segment 1', () => {
+    const uri = buildNewMethodUri(1, 'UserGlobals', 'Array', false, 'accessing', 0);
+    expect(uri.path.split('/')[1]).toBe('UserGlobals');
   });
 
-  it('produces a class-side path when the class side is meta', () => {
+  it('places the class name at path segment 2', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
+    expect(uri.path.split('/')[2]).toBe('Array');
+  });
+
+  it('places "instance" at path segment 3 when isMeta is false', () => {
+    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
+    expect(uri.path.split('/')[3]).toBe('instance');
+  });
+
+  it('places "class" at path segment 3 when isMeta is true', () => {
     const uri = buildNewMethodUri(1, 'Globals', 'Array', true, 'accessing', 0);
-    const parts = uri.path.split('/');
-    expect(parts[3]).toBe('class');
+    expect(uri.path.split('/')[3]).toBe('class');
   });
 
-  it('URL-encodes the dictionary name', () => {
-    const uri = buildNewMethodUri(1, 'User Globals', 'Array', false, 'accessing', 0);
-    const parts = uri.path.split('/');
-    expect(parts[1]).toBe('User%20Globals');
-  });
-
-  it('URL-encodes the class name', () => {
-    const uri = buildNewMethodUri(1, 'Globals', 'My Class', false, 'accessing', 0);
-    const parts = uri.path.split('/');
-    expect(parts[2]).toBe('My%20Class');
-  });
-
-  it('URL-encodes the category name', () => {
-    const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'as yet unclassified', 0);
-    const parts = uri.path.split('/');
-    expect(parts[4]).toBe('as%20yet%20unclassified');
-  });
-
-  it('places new-method as the final path segment', () => {
+  it('places the method category at path segment 4', () => {
     const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
-    const parts = uri.path.split('/');
-    expect(parts[5]).toBe('new-method');
+    expect(uri.path.split('/')[4]).toBe('accessing');
   });
 
-  it('omits the env query parameter when the environment is the default', () => {
+  it('omits the env query parameter when environmentId is 0', () => {
     const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 0);
     expect(uri.query).toBe('');
   });
 
-  it('appends the env query parameter when a non-default environment is specified', () => {
+  it('appends the env query parameter when environmentId is non-zero', () => {
     const uri = buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing', 2);
     expect(uri.query).toBe('env=2');
+  });
+
+  it('throws when dictName contains a slash', () => {
+    expect(() => buildNewMethodUri(1, 'User/Globals', 'Array', false, 'accessing', 0))
+      .toThrow("Dictionary name must not contain '/': User/Globals");
+  });
+
+  it('throws when className contains a slash', () => {
+    expect(() => buildNewMethodUri(1, 'Globals', 'My/Class', false, 'accessing', 0))
+      .toThrow("Class name must not contain '/': My/Class");
+  });
+
+  it('throws when category contains a slash', () => {
+    expect(() => buildNewMethodUri(1, 'Globals', 'Array', false, 'accessing/stuff', 0))
+      .toThrow("Method category name must not contain '/': accessing/stuff");
   });
 });

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -21,7 +21,7 @@ vi.mock('../browserQueries', () => ({
 }));
 
 import { Uri, FileSystemError, FilePermission, window, languages } from '../__mocks__/vscode';
-import { GemStoneFileSystemProvider, buildNewMethodUri } from '../gemstoneFileSystemProvider';
+import { GemStoneFileSystemProvider, buildMethodUri, buildNewMethodUri } from '../gemstoneFileSystemProvider';
 import { SessionManager } from '../sessionManager';
 import * as queries from '../browserQueries';
 import { BrowserQueryError } from '../browserQueries';
@@ -249,14 +249,89 @@ describe('GemStoneFileSystemProvider', () => {
       });
     });
 
-    it('compiles new-method on save', () => {
-      const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
-      const source = 'foo\n  ^42';
-      provider.writeFile(uri, encode(source), { create: true, overwrite: true });
-      expect(queries.compileMethod).toHaveBeenCalledWith(
-        expect.anything(), 'Array', false, 'accessing', source, 0,
-      );
-    });
+     it('compiles new-method on save', () => {
+       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+       const source = 'foo\n  ^42';
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >> foo');
+       provider.writeFile(uri, encode(source), { create: true, overwrite: true });
+       expect(queries.compileMethod).toHaveBeenCalledWith(
+         expect.anything(), 'Array', false, 'accessing', source, 0,
+       );
+     });
+
+     it('emits onMethodCompiled event when new-method compiles successfully', async () => {
+       const newMethodUri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+       const source = 'foo\n  ^42';
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >> foo');
+       const listener = vi.fn();
+       provider.onMethodCompiled(listener);
+
+       provider.writeFile(newMethodUri, encode(source), { create: true, overwrite: true });
+       await new Promise(resolve => setImmediate(resolve));
+
+       expect(listener).toHaveBeenCalledTimes(1);
+       const event = listener.mock.calls[0][0];
+       expect(event.previousUri.toString()).toBe(newMethodUri.toString());
+       expect(event.uri.toString()).toBe('gemstone://1/Globals/Array/instance/accessing/foo');
+     });
+
+     it('trims trailing whitespace from the selector when building the compiled method uri', async () => {
+       const newMethodUri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >> foo ');
+       const listener = vi.fn();
+       provider.onMethodCompiled(listener);
+
+       provider.writeFile(newMethodUri, encode('foo\n  ^42'), { create: true, overwrite: true });
+       await new Promise(resolve => setImmediate(resolve));
+
+       const event = listener.mock.calls[0][0];
+       expect(event.uri.toString()).toBe('gemstone://1/Globals/Array/instance/accessing/foo');
+     });
+
+     it('trims leading whitespace from the selector when building the compiled method uri', async () => {
+       const newMethodUri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >>  foo');
+       const listener = vi.fn();
+       provider.onMethodCompiled(listener);
+
+       provider.writeFile(newMethodUri, encode('foo\n  ^42'), { create: true, overwrite: true });
+       await new Promise(resolve => setImmediate(resolve));
+
+       const event = listener.mock.calls[0][0];
+       expect(event.uri.toString()).toBe('gemstone://1/Globals/Array/instance/accessing/foo');
+     });
+
+     it('does not fire onMethodCompiled after dispose', async () => {
+       const newMethodUri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >> foo');
+       const listener = vi.fn();
+       provider.onMethodCompiled(listener);
+
+       provider.dispose();
+       provider.writeFile(newMethodUri, encode('foo\n  ^42'), { create: true, overwrite: true });
+       await new Promise(resolve => setImmediate(resolve));
+
+       expect(listener).not.toHaveBeenCalled();
+     });
+
+     it('sets diagnostic (no throw) when new-method compile result cannot extract selector', () => {
+       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+       const source = 'foo\n  ^42';
+       const listener = vi.fn();
+       provider.onMethodCompiled(listener);
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Class not found: Array');
+
+       expect(() => provider.writeFile(uri, encode(source), { create: true, overwrite: true }))
+         .not.toThrow();
+       expect(listener).not.toHaveBeenCalled();
+       const collection = vi.mocked(languages.createDiagnosticCollection).mock.results[0].value;
+       expect(collection.set).toHaveBeenCalledWith(
+         uri,
+         expect.arrayContaining([
+           expect.objectContaining({ message: 'Class not found: Array' }),
+         ]),
+       );
+     });
 
     it('shows success message after compiling a method', () => {
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A');
@@ -410,6 +485,79 @@ describe('GemStoneFileSystemProvider', () => {
         expect.anything(), 'Array', false, 'size', 0,
       );
     });
+  });
+
+});
+
+describe('buildMethodUri', () => {
+  it('uses the gemstone scheme', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 42, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.scheme).toBe('gemstone');
+  });
+
+  it('uses the session id as the authority', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 42, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.authority).toBe('42');
+  });
+
+  it('places the dictionary name at path segment 1', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'UserGlobals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.path.split('/')[1]).toBe('UserGlobals');
+  });
+
+  it('places the class name at path segment 2', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'String', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.path.split('/')[2]).toBe('String');
+  });
+
+  it('places "instance" at path segment 3 when isMeta is false', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.path.split('/')[3]).toBe('instance');
+  });
+
+  it('places "class" at path segment 3 when isMeta is true', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: true, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.path.split('/')[3]).toBe('class');
+  });
+
+  it('places the method category at path segment 4', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.path.split('/')[4]).toBe('accessing');
+  });
+
+  it('places the selector at path segment 5', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at:put:', environmentId: 0 });
+    expect(uri.path.split('/')[5]).toBe('at:put:');
+  });
+
+  it('omits the env query parameter when environmentId is 0', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 });
+    expect(uri.query).toBe('');
+  });
+
+  it('appends the env query parameter when environmentId is non-zero', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 2 });
+    expect(uri.query).toBe('env=2');
+  });
+
+  it('throws when dictName contains a slash', () => {
+    expect(() => buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'User/Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 }))
+      .toThrow("Dictionary name must not contain '/': User/Globals");
+  });
+
+  it('throws when className contains a slash', () => {
+    expect(() => buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'My/Class', isMeta: false, category: 'accessing', selector: 'at', environmentId: 0 }))
+      .toThrow("Class name must not contain '/': My/Class");
+  });
+
+  it('throws when category contains a slash', () => {
+    expect(() => buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing/stuff', selector: 'at', environmentId: 0 }))
+      .toThrow("Method category name must not contain '/': accessing/stuff");
+  });
+
+  it('throws when selector contains a slash', () => {
+    expect(() => buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'foo/bar', environmentId: 0 }))
+      .toThrow("Selector must not contain '/': foo/bar");
   });
 });
 

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -496,8 +496,8 @@ describe('SystemBrowser', () => {
       await vi.waitFor(() => { expect(workspace.openTextDocument).toHaveBeenCalled(); });
 
       const uri = (workspace.openTextDocument as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(uri.path).toContain('as%20yet%20unclassified');
-      expect(uri.path).not.toContain('ALL%20METHODS');
+      expect(uri.path).toContain('as yet unclassified');
+      expect(uri.path).not.toContain('ALL METHODS');
     });
 
     it('uses "as yet unclassified" when no method category is selected', async () => {
@@ -508,7 +508,7 @@ describe('SystemBrowser', () => {
       await vi.waitFor(() => { expect(workspace.openTextDocument).toHaveBeenCalled(); });
 
       const uri = (workspace.openTextDocument as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(uri.path).toContain('as%20yet%20unclassified');
+      expect(uri.path).toContain('as yet unclassified');
     });
 
     it('opens a gemstone:// editor even when method is not found in the .gs file', async () => {
@@ -1141,8 +1141,8 @@ describe('SystemBrowser', () => {
       await vi.waitFor(() => { expect(workspace.openTextDocument).toHaveBeenCalled(); });
 
       const uri = vi.mocked(workspace.openTextDocument).mock.calls[0][0] as { path: string };
-      expect(uri.path).toContain('as%20yet%20unclassified');
-      expect(uri.path).not.toContain('ALL%20METHODS');
+      expect(uri.path).toContain('as yet unclassified');
+      expect(uri.path).not.toContain('ALL METHODS');
     });
   });
 

--- a/client/src/__tests__/vitest.uriSetup.ts
+++ b/client/src/__tests__/vitest.uriSetup.ts
@@ -1,0 +1,11 @@
+import { expect } from 'vitest';
+import { URI } from 'vscode-uri';
+
+expect.addEqualityTesters([
+  function uriEquality(a: unknown, b: unknown): boolean | undefined {
+    if (a instanceof URI && b instanceof URI) {
+      return a.toString() === b.toString();
+    }
+    return undefined;
+  },
+]);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,7 +17,7 @@ import { CodeExecutor } from './codeExecutor';
 import { SystemBrowser } from './systemBrowser';
 import { GlobalsBrowser } from './globalsBrowser';
 import { GtInspector } from './gtInspector';
-import { GemStoneFileSystemProvider } from './gemstoneFileSystemProvider';
+import { GemStoneFileSystemProvider, MethodCompiledEvent } from './gemstoneFileSystemProvider';
 import { openWorkspace } from './workspace';
 import { GemStoneDebugSession } from './gemstoneDebugSession';
 import { InspectorTreeProvider, InspectorNode } from './inspectorTreeProvider';
@@ -75,10 +75,10 @@ let fileInManager: FileInManager;
 let jasperChannel:OutputChannel;
 
 function logLine(level: "ERROR", scope: string, message: string, data: unknown) {
-  jasperChannel.appendLine(`${new Date().toISOString()} [${level}] [${scope}] ${message} | ${data && JSON.stringify(data)}`);
+  jasperChannel?.appendLine(`${new Date().toISOString()} [${level}] [${scope}] ${message} | ${data && JSON.stringify(data)}`);
 }
 
-export async function logJasperError(message: string, scope: string, error: unknown) {
+async function logJasperError(message: string, scope: string, error: unknown) {
   logLine("ERROR", scope, message, { error: error instanceof Error ? error.message : String(error) });
 
   await vscode.window
@@ -88,6 +88,11 @@ export async function logJasperError(message: string, scope: string, error: unkn
           jasperChannel.show(true);
         }
       });
+}
+
+export async function handleMethodCompiled(event: MethodCompiledEvent) {
+  await openTextEditorOn(event.uri);
+  await closeTextEditorOn(event.previousUri);
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -205,6 +210,7 @@ export function activate(context: vscode.ExtensionContext) {
   // ── GemStone FileSystem Provider ─────────────────────────
   const gemstoneFs = new GemStoneFileSystemProvider(sessionManager, exportManager);
   context.subscriptions.push(
+    gemstoneFs,
     vscode.workspace.registerFileSystemProvider('gemstone', gemstoneFs, {
       isCaseSensitive: true,
     })
@@ -294,6 +300,10 @@ export function activate(context: vscode.ExtensionContext) {
         }
       }
     }),
+  );
+
+  context.subscriptions.push(
+    gemstoneFs.onMethodCompiled(handleMethodCompiled)
   );
 
   context.subscriptions.push(
@@ -1922,4 +1932,33 @@ export function deactivate(): Thenable<void> | undefined {
   }
   if (!client) return undefined;
   return client.stop();
+}
+
+export async function openTextEditorOn(uri: vscode.Uri) {
+  try {
+    const document = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(document, {preview: false});
+  } catch (error) {
+    await logJasperError(`Failed to open text editor on ${uri.toString()}`, "Editor", error);
+  }
+}
+
+export async function closeTextEditorOn(uri: vscode.Uri) {
+  const uriString = uri.toString();
+  await Promise.all(textEditorsOn(uriString).map(async tab => {
+    try {
+      await vscode.window.tabGroups.close(tab)
+    } catch (error) {
+      await logJasperError(`Failed to close text editor on ${uriString}`, "Editor", error);
+    }
+  }))
+}
+
+function textEditorsOn(uriString: string) {
+  return vscode.window.tabGroups.all
+      .flatMap(tabGroup => tabGroup.tabs.filter(tab => isTextEditorFor(tab, uriString)));
+}
+
+function isTextEditorFor(tab: vscode.Tab, uriString: string) {
+  return tab.input instanceof vscode.TabInputText && tab.input.uri.toString() === uriString;
 }

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -110,16 +110,23 @@ export function buildNewMethodUri(
   category: string,
   environmentId: number,
 ): vscode.Uri {
+  assertIsValidUriPath('Dictionary name', dictName);
+  assertIsValidUriPath('Class name', className);
+  assertIsValidUriPath('Method category name', category);
+  
   const side = isMeta ? 'class' : 'instance';
-  const envQuery = environmentId > 0 ? `?env=${environmentId}` : '';
-  return vscode.Uri.parse(
-    `gemstone://${sessionId}` +
-    `/${encodeURIComponent(dictName)}` +
-    `/${encodeURIComponent(className)}` +
-    `/${side}` +
-    `/${encodeURIComponent(category)}` +
-    `/new-method${envQuery}`,
-  );
+  return vscode.Uri.from({
+    scheme: 'gemstone',
+    authority: String(sessionId),
+    path: `/${dictName}/${className}/${side}/${category}/new-method`,
+    query: environmentId > 0 ? `env=${environmentId}` : '',
+  });
+}
+
+function assertIsValidUriPath(parameterName: string, value: string) {
+  if (value.includes('/')) {
+    throw new Error(`${parameterName} must not contain '/': ${value}`);
+  }
 }
 
 // ── FileSystemProvider ────────────────────────────────────────

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
-import { SessionManager } from './sessionManager';
+import {ActiveSession, SessionManager} from './sessionManager';
 import * as queries from './browserQueries';
 import { BrowserQueryError } from './browserQueries';
 import { ExportManager } from './exportManager';
 import { logInfo } from './gciLog';
+import {receiver} from "./queries/util";
 
 // ── URI Structure ────────────────────────────────────────────
 // Method:     gemstone://{sessionId}/{dictName}/{className}/{side}/{category}/{selector}
@@ -98,8 +99,8 @@ function parseUri(uri: vscode.Uri): ParsedUri {
       selector: parts[5],
       environmentId,
     };
-  }
-  throw vscode.FileSystemError.FileNotFound(uri);
+   }
+   throw vscode.FileSystemError.FileNotFound(uri);
 }
 
 export function buildNewMethodUri(
@@ -110,16 +111,21 @@ export function buildNewMethodUri(
   category: string,
   environmentId: number,
 ): vscode.Uri {
-  assertIsValidUriPath('Dictionary name', dictName);
-  assertIsValidUriPath('Class name', className);
-  assertIsValidUriPath('Method category name', category);
+  return buildMethodUri({ kind: 'method', sessionId, dictName, className, isMeta, category, selector: 'new-method', environmentId });
+}
+
+export function buildMethodUri(parsedUri: ParsedMethodUri): vscode.Uri {
+  assertIsValidUriPath('Dictionary name', parsedUri.dictName);
+  assertIsValidUriPath('Class name', parsedUri.className);
+  assertIsValidUriPath('Method category name', parsedUri.category);
+  assertIsValidUriPath('Selector', parsedUri.selector);
   
-  const side = isMeta ? 'class' : 'instance';
+  const side = parsedUri.isMeta ? 'class' : 'instance';
   return vscode.Uri.from({
     scheme: 'gemstone',
-    authority: String(sessionId),
-    path: `/${dictName}/${className}/${side}/${category}/new-method`,
-    query: environmentId > 0 ? `env=${environmentId}` : '',
+    authority: String(parsedUri.sessionId),
+    path: `/${parsedUri.dictName}/${parsedUri.className}/${side}/${parsedUri.category}/${parsedUri.selector}`,
+    query: parsedUri.environmentId > 0 ? `env=${parsedUri.environmentId}` : '',
   });
 }
 
@@ -129,11 +135,19 @@ function assertIsValidUriPath(parameterName: string, value: string) {
   }
 }
 
+export interface MethodCompiledEvent{
+  uri: vscode.Uri;
+  previousUri: vscode.Uri
+}
+
 // ── FileSystemProvider ────────────────────────────────────────
 
 export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
   private _onDidChangeFile = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
   readonly onDidChangeFile = this._onDidChangeFile.event;
+
+  private _onMethodCompiled = new vscode.EventEmitter<MethodCompiledEvent>();
+  readonly onMethodCompiled = this._onMethodCompiled.event;
 
   private diagnostics = vscode.languages.createDiagnosticCollection('gemstone-method');
 
@@ -254,12 +268,13 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
           vscode.window.showInformationMessage('Class created');
           break;
         case 'new-method':
-          queries.compileMethod(
-            session, parsed.className, parsed.isMeta, parsed.category, source, parsed.environmentId,
-          );
-          vscode.window.showInformationMessage(
-            `Compiled new method in ${parsed.className}${parsed.isMeta ? ' class' : ''}`
-          );
+          const newMethodUri = this.compileMethod(parsed, source, session);
+          
+          // Defer the event to the next event-loop iteration so VS Code has time to
+          // process the completed save and mark the document clean. Firing synchronously
+          // here — before writeFile returns — means the tab is still dirty when
+          // closeTextEditorOn runs, which triggers a "save before closing?" dialog.
+          setImmediate(() => this._onMethodCompiled.fire({uri: newMethodUri, previousUri: uri}));
           break;
       }
 
@@ -297,6 +312,32 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
       logInfo(`[FS] writeFile → unexpected error: ${e instanceof Error ? e.message : String(e)}`);
       throw e;
     }
+  }
+
+  private compileMethod(parsedMethodUri: ParsedNewMethodUri, sourceCode: string, session: ActiveSession) : vscode.Uri {
+    const result = queries.compileMethod(
+        session, parsedMethodUri.className, parsedMethodUri.isMeta, parsedMethodUri.category, sourceCode, parsedMethodUri.environmentId,
+    );
+    const selector = result.split('>> ')[1]?.trim();
+
+    if (!selector) {
+      throw new BrowserQueryError(result);
+    }
+    
+    vscode.window.showInformationMessage(
+        `Compiled method ${receiver(parsedMethodUri.className, parsedMethodUri.isMeta)}>>#${selector}`
+    );
+    
+    return buildMethodUri({
+      ...parsedMethodUri,
+      kind: 'method',
+      selector: selector
+    });
+  }
+
+  dispose(): void {
+    this._onDidChangeFile.dispose();
+    this._onMethodCompiled.dispose();
   }
 
   createDirectory(): void {

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     include: ['src/**/__tests__/**/*.test.ts'],
     exclude: ['src/__tests__/gci/**'],
-    setupFiles: ['src/__tests__/vitest.windowSetup.cjs']
+    setupFiles: ['src/__tests__/vitest.windowSetup.cjs', 'src/__tests__/vitest.uriSetup.ts']
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "@types/vscode": "^1.85.0",
         "css.escape": "^1.5.1",
         "jsdom": "^27.4.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "vscode-uri": "^3.1.0"
       }
     },
     "mcp-server": {
@@ -7841,6 +7842,13 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {


### PR DESCRIPTION
Previously, after compiling a new method from the new-method editor,
the tab remained open with no clear path to the resulting method.

https://github.com/user-attachments/assets/e77f84f3-bcc8-46f0-996a-809f22c59618


Now Jasper automatically opens the newly compiled method in a permanent
tab and closes the new-method placeholder. The success message also
shows the actual selector (e.g. "Compiled method Array>>#foo").


https://github.com/user-attachments/assets/14ce0c03-1ab8-488a-b24a-68c610c07741

