### PR TITLE
GT Inspector: fix styled-text layout after table views; add IMCSystem gtView examples

### DIFF
--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -214,6 +214,13 @@ export const window = {
   }),
 };
 
+export const env = {
+  clipboard: {
+    writeText: vi.fn(async (_text: string) => {}),
+    readText: vi.fn(async () => ''),
+  },
+};
+
 // ── Workspace mock ─────────────────────────────────────────
 
 export const TextDocumentSaveReason = {

--- a/client/src/__tests__/gtPerfTracker.test.ts
+++ b/client/src/__tests__/gtPerfTracker.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  gtPerfTracker,
+  wrapWithGtPerfProxy,
+  buildGtPerfStatusBarText,
+  buildGtPerfClipboardText,
+  buildGtPerfQuickPickItems,
+  RESET_LABEL,
+  COPY_LABEL,
+} from '../gtPerfTracker';
+import type { GciLibrary } from '../gciLibrary';
+
+// Reset singleton state before each test.
+beforeEach(() => {
+  gtPerfTracker.setEnabled(false);
+  gtPerfTracker.reset();
+  gtPerfTracker.onCountChanged = undefined;
+});
+
+// ── gtPerfTracker singleton ────────────────────────────────
+
+describe('gtPerfTracker.increment', () => {
+  it('does not count when disabled', () => {
+    gtPerfTracker.setEnabled(false);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    expect(gtPerfTracker.count).toBe(0);
+    expect(gtPerfTracker.methodCounts.size).toBe(0);
+  });
+
+  it('increments count when enabled', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    expect(gtPerfTracker.count).toBe(1);
+  });
+
+  it('tracks per-method counts', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.increment('GciTsPerformFetchBytes');
+    expect(gtPerfTracker.methodCounts.get('GciTsExecuteFetchBytes')).toBe(2);
+    expect(gtPerfTracker.methodCounts.get('GciTsPerformFetchBytes')).toBe(1);
+    expect(gtPerfTracker.count).toBe(3);
+  });
+
+  it('fires onCountChanged when enabled', () => {
+    gtPerfTracker.setEnabled(true);
+    const cb = vi.fn();
+    gtPerfTracker.onCountChanged = cb;
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire onCountChanged when disabled', () => {
+    gtPerfTracker.setEnabled(false);
+    const cb = vi.fn();
+    gtPerfTracker.onCountChanged = cb;
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe('gtPerfTracker.reset', () => {
+  it('clears count and methodCounts', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.reset();
+    expect(gtPerfTracker.count).toBe(0);
+    expect(gtPerfTracker.methodCounts.size).toBe(0);
+  });
+
+  it('fires onCountChanged', () => {
+    const cb = vi.fn();
+    gtPerfTracker.onCountChanged = cb;
+    gtPerfTracker.reset();
+    expect(cb).toHaveBeenCalledOnce();
+  });
+});
+
+describe('gtPerfTracker.setEnabled', () => {
+  it('enables tracking', () => {
+    gtPerfTracker.setEnabled(true);
+    expect(gtPerfTracker.enabled).toBe(true);
+  });
+
+  it('disabling clears count and methodCounts', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.setEnabled(false);
+    expect(gtPerfTracker.count).toBe(0);
+    expect(gtPerfTracker.methodCounts.size).toBe(0);
+  });
+
+  it('fires onCountChanged on enable and disable', () => {
+    const cb = vi.fn();
+    gtPerfTracker.onCountChanged = cb;
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.setEnabled(false);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── wrapWithGtPerfProxy ────────────────────────────────────
+
+function makeFakeGci(): GciLibrary {
+  return {
+    GciTsExecuteFetchBytes: vi.fn(() => ({ bytesReturned: 4, data: 'ok', err: { number: 0 } })),
+    GciTsOopIsSpecial: vi.fn(() => false),
+    GciTsCallInProgress: vi.fn(() => false),
+  } as unknown as GciLibrary;
+}
+
+describe('wrapWithGtPerfProxy', () => {
+  it('counts a round-trip method when enabled', () => {
+    gtPerfTracker.setEnabled(true);
+    const proxy = wrapWithGtPerfProxy(makeFakeGci());
+    proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    expect(gtPerfTracker.count).toBe(1);
+    expect(gtPerfTracker.methodCounts.get('GciTsExecuteFetchBytes')).toBe(1);
+  });
+
+  it('does not count a round-trip method when disabled', () => {
+    const proxy = wrapWithGtPerfProxy(makeFakeGci());
+    proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    expect(gtPerfTracker.count).toBe(0);
+  });
+
+  it('does not count a non-round-trip method even when enabled', () => {
+    gtPerfTracker.setEnabled(true);
+    const proxy = wrapWithGtPerfProxy(makeFakeGci());
+    proxy.GciTsOopIsSpecial(0n);
+    expect(gtPerfTracker.count).toBe(0);
+  });
+
+  // Regression: GciTsCallInProgress is a local session-state check called on every
+  // executeFetchString guard. It must never be counted or the tracker explodes.
+  it('does not count GciTsCallInProgress', () => {
+    gtPerfTracker.setEnabled(true);
+    const proxy = wrapWithGtPerfProxy(makeFakeGci());
+    proxy.GciTsCallInProgress({} as never);
+    expect(gtPerfTracker.count).toBe(0);
+  });
+
+  it('passes the return value through unchanged', () => {
+    gtPerfTracker.setEnabled(true);
+    const proxy = wrapWithGtPerfProxy(makeFakeGci());
+    const result = proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    expect(result.data).toBe('ok');
+  });
+
+  it('calls the original function', () => {
+    gtPerfTracker.setEnabled(true);
+    const fake = makeFakeGci();
+    const proxy = wrapWithGtPerfProxy(fake);
+    proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    expect(fake.GciTsExecuteFetchBytes).toHaveBeenCalledOnce();
+  });
+});
+
+// ── buildGtPerfStatusBarText ───────────────────────────────
+
+describe('buildGtPerfStatusBarText', () => {
+  it('formats zero count', () => {
+    expect(buildGtPerfStatusBarText(0)).toBe('$(record) GT Perf: 0');
+  });
+
+  it('formats a non-zero count', () => {
+    expect(buildGtPerfStatusBarText(14)).toBe('$(record) GT Perf: 14');
+  });
+});
+
+// ── buildGtPerfClipboardText ───────────────────────────────
+
+describe('buildGtPerfClipboardText', () => {
+  it('shows zero total with no methods when empty', () => {
+    const text = buildGtPerfClipboardText(gtPerfTracker);
+    expect(text).toBe('GT Perf: 0 total GCI calls');
+  });
+
+  it('includes the total count header', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    const text = buildGtPerfClipboardText(gtPerfTracker);
+    expect(text).toContain('GT Perf: 2 total GCI calls');
+  });
+
+  it('lists methods with their counts', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.increment('GciTsPerformFetchBytes');
+    const text = buildGtPerfClipboardText(gtPerfTracker);
+    expect(text).toContain('  GciTsExecuteFetchBytes: 1');
+    expect(text).toContain('  GciTsPerformFetchBytes: 1');
+  });
+
+  it('sorts methods by count descending', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsResolveSymbol');          // count: 1, inserted first
+    gtPerfTracker.increment('GciTsPerformFetchBytes');       // count: 2, inserted second
+    gtPerfTracker.increment('GciTsPerformFetchBytes');
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');       // count: 3, inserted third
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    const lines = buildGtPerfClipboardText(gtPerfTracker).split('\n');
+    expect(lines[1]).toContain('GciTsExecuteFetchBytes: 3');
+    expect(lines[2]).toContain('GciTsPerformFetchBytes: 2');
+    expect(lines[3]).toContain('GciTsResolveSymbol: 1');
+  });
+});
+
+// ── buildGtPerfQuickPickItems ──────────────────────────────
+
+describe('buildGtPerfQuickPickItems', () => {
+  it('always has Reset Counter as first item', () => {
+    const items = buildGtPerfQuickPickItems(gtPerfTracker);
+    expect(items[0].label).toBe(RESET_LABEL);
+  });
+
+  it('always has Copy to Clipboard as second item', () => {
+    const items = buildGtPerfQuickPickItems(gtPerfTracker);
+    expect(items[1].label).toBe(COPY_LABEL);
+  });
+
+  it('has a separator as third item', () => {
+    const items = buildGtPerfQuickPickItems(gtPerfTracker);
+    expect(items[2].isSeparator).toBe(true);
+  });
+
+  it('shows only the three fixed items when there are no method counts', () => {
+    const items = buildGtPerfQuickPickItems(gtPerfTracker);
+    expect(items).toHaveLength(3);
+  });
+
+  it('Reset Counter description shows current count', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    const items = buildGtPerfQuickPickItems(gtPerfTracker);
+    expect(items[0].description).toContain('2');
+  });
+
+  it('lists methods after the separator sorted by count descending', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsResolveSymbol');          // count: 1, inserted first
+    gtPerfTracker.increment('GciTsPerformFetchBytes');       // count: 2, inserted second
+    gtPerfTracker.increment('GciTsPerformFetchBytes');
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');       // count: 3, inserted third
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    const items = buildGtPerfQuickPickItems(gtPerfTracker);
+    // items[0]=Reset, [1]=Copy, [2]=separator, [3..5]=methods high→low
+    expect(items[3].label).toBe('GciTsExecuteFetchBytes');
+    expect(items[3].description).toBe('3');
+    expect(items[4].label).toBe('GciTsPerformFetchBytes');
+    expect(items[4].description).toBe('2');
+    expect(items[5].label).toBe('GciTsResolveSymbol');
+    expect(items[5].description).toBe('1');
+  });
+
+  it('method descriptions are strings not numbers', () => {
+    gtPerfTracker.setEnabled(true);
+    gtPerfTracker.increment('GciTsExecuteFetchBytes');
+    const items = buildGtPerfQuickPickItems(gtPerfTracker);
+    expect(typeof items[3].description).toBe('string');
+  });
+});

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -13,6 +13,14 @@ import { LoginTreeProvider, GemStoneLoginItem, GemStoneSessionItem } from './log
 import { GemStoneLogin, loginLabel, sameLoginTarget } from './loginTypes';
 import { LoginEditorPanel } from './loginEditorPanel';
 import { SessionManager } from './sessionManager';
+import {
+  gtPerfTracker,
+  buildGtPerfStatusBarText,
+  buildGtPerfClipboardText,
+  buildGtPerfQuickPickItems,
+  RESET_LABEL,
+  COPY_LABEL,
+} from './gtPerfTracker';
 import { CodeExecutor } from './codeExecutor';
 import { SystemBrowser } from './systemBrowser';
 import { GlobalsBrowser } from './globalsBrowser';
@@ -369,6 +377,82 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   );
   updateStatusBar();
+
+  // ── GT Perf Tracking ───────────────────────────────────
+  const gtPerfChannel = vscode.window.createOutputChannel('GemStone GT Perf');
+  context.subscriptions.push(gtPerfChannel);
+
+  const gtPerfCountItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 98);
+  gtPerfCountItem.tooltip = 'GT Perf: click to see breakdown';
+  gtPerfCountItem.command = 'gemstone.showGtPerfDetails';
+  context.subscriptions.push(gtPerfCountItem);
+
+  const gtPerfResetItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 97);
+  gtPerfResetItem.text = '$(debug-restart)';
+  gtPerfResetItem.tooltip = 'Reset GT Perf Counter';
+  gtPerfResetItem.command = 'gemstone.resetGtPerfCounter';
+  context.subscriptions.push(gtPerfResetItem);
+
+  function updateGtPerfStatusBar() {
+    if (gtPerfTracker.enabled) {
+      gtPerfCountItem.text = buildGtPerfStatusBarText(gtPerfTracker.count);
+      gtPerfCountItem.show();
+      gtPerfResetItem.show();
+    } else {
+      gtPerfCountItem.hide();
+      gtPerfResetItem.hide();
+    }
+  }
+
+  gtPerfTracker.onCountChanged = updateGtPerfStatusBar;
+
+  const applyGtPerfSetting = () => {
+    const enabled = vscode.workspace.getConfiguration('gemstone').get<boolean>('gtPerfTracking', false);
+    gtPerfTracker.setEnabled(enabled);
+    vscode.commands.executeCommand('setContext', 'gemstone.gtPerfTracking', enabled);
+    updateGtPerfStatusBar();
+  };
+  applyGtPerfSetting();
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration('gemstone.gtPerfTracking')) {
+        applyGtPerfSetting();
+      }
+    }),
+    vscode.commands.registerCommand('gemstone.enableGtPerfTracking', async () => {
+      await vscode.workspace.getConfiguration('gemstone').update('gtPerfTracking', true, vscode.ConfigurationTarget.Workspace);
+    }),
+    vscode.commands.registerCommand('gemstone.disableGtPerfTracking', async () => {
+      await vscode.workspace.getConfiguration('gemstone').update('gtPerfTracking', false, vscode.ConfigurationTarget.Workspace);
+    }),
+    vscode.commands.registerCommand('gemstone.resetGtPerfCounter', () => {
+      const sorted = [...gtPerfTracker.methodCounts.entries()].sort((a, b) => b[1] - a[1]);
+      gtPerfChannel.appendLine(`[reset] ${gtPerfTracker.count} total GCI calls`);
+      for (const [method, count] of sorted) {
+        gtPerfChannel.appendLine(`  ${method}: ${count}`);
+      }
+      gtPerfTracker.reset();
+    }),
+    vscode.commands.registerCommand('gemstone.showGtPerfDetails', async () => {
+      const clipboardText = buildGtPerfClipboardText(gtPerfTracker);
+      const items: vscode.QuickPickItem[] = buildGtPerfQuickPickItems(gtPerfTracker).map(item =>
+        item.isSeparator
+          ? { label: '', kind: vscode.QuickPickItemKind.Separator }
+          : { label: item.label, description: item.description }
+      );
+      const selected = await vscode.window.showQuickPick(items, {
+        title: `GT Perf: ${gtPerfTracker.count} total GCI calls`,
+        placeHolder: 'Choose an action, or press Escape to dismiss',
+      });
+      if (selected?.label === RESET_LABEL) {
+        vscode.commands.executeCommand('gemstone.resetGtPerfCounter');
+      } else if (selected?.label === COPY_LABEL) {
+        await vscode.env.clipboard.writeText(clipboardText);
+        vscode.window.showInformationMessage('GT Perf breakdown copied to clipboard.');
+      }
+    }),
+  );
 
   // ── Shared Helpers ─────────────────────────────────────
 

--- a/client/src/gtInspector.ts
+++ b/client/src/gtInspector.ts
@@ -772,6 +772,12 @@ export class GtInspector {
       const str = textData.string || '';
       const styler = textData.stylerSpecification;
       el.className = 'detail-value';
+      // Clear inline styles left behind by a prior table/tree render into this
+      // shared pane. renderGtTable sets el.style.cssText to include
+      // 'display:flex;flex-direction:column', which (as an inline style) wins
+      // over the .detail-value class and would stack each styled run on its own
+      // line. Reset before laying out the text.
+      el.style.cssText = '';
       el.style.whiteSpace = 'pre-wrap';
       el.style.overflow = 'auto';
       el.style.minHeight = '0';

--- a/client/src/gtPerfTracker.ts
+++ b/client/src/gtPerfTracker.ts
@@ -1,0 +1,128 @@
+// GT Perf Tracker: counts GCI round trips for GT Inspector performance tuning.
+// This module is a singleton — every importer shares the same counter instance.
+// The proxy wraps a GciLibrary instance so all round-trip methods are counted
+// without modifying gciLibrary.ts. Enable/disable via gemstone.gtPerfTracking.
+
+import { GciLibrary } from './gciLibrary';
+
+// Methods that make actual network round trips to the GemStone server.
+// Local-only methods (OopIsSpecial, I32ToOop, Encrypt, CallInProgress, etc.) are excluded.
+const ROUND_TRIP_METHODS = new Set([
+  'GciTsAbort', 'GciTsBegin', 'GciTsCommit',
+  'GciTsExecute', 'GciTsExecute_', 'GciTsExecuteFetchBytes',
+  'GciTsPerform', 'GciTsPerformFetchBytes', 'GciTsPerformFetchOops',
+  'GciTsNbExecute', 'GciTsNbPerform', 'GciTsNbResult',
+  'GciTsFetchBytes', 'GciTsFetchChars', 'GciTsFetchUtf8Bytes',
+  'GciTsFetchOops', 'GciTsFetchNamedOops', 'GciTsFetchVaryingOops',
+  'GciTsFetchObjInfo', 'GciTsFetchGbjInfo',
+  'GciTsFetchSize', 'GciTsFetchVaryingSize', 'GciTsFetchClass',
+  'GciTsFetchUnicode', 'GciTsFetchUtf8',
+  'GciTsIsKindOf', 'GciTsIsSubclassOf', 'GciTsIsKindOfClass', 'GciTsIsSubclassOfClass',
+  'GciTsObjExists',
+  'GciTsResolveSymbol', 'GciTsResolveSymbolObj',
+  'GciTsNewObj', 'GciTsNewByteArray',
+  'GciTsNewString', 'GciTsNewString_',
+  'GciTsNewSymbol',
+  'GciTsNewUnicodeString', 'GciTsNewUnicodeString_',
+  'GciTsNewUtf8String', 'GciTsNewUtf8String_',
+  'GciTsNewStringFromUtf16',
+  'GciTsStoreBytes', 'GciTsStoreOops', 'GciTsStoreNamedOops', 'GciTsStoreIdxOops',
+  'GciTsCompileMethod', 'GciTsClassRemoveAllMethods', 'GciTsProtectMethods',
+  'GciTsFetchTraversal', 'GciTsMoreTraversal', 'GciTsStoreTrav', 'GciTsStoreTravDoTravRefs',
+  'GciTsGetFreeOops', 'GciTsSaveObjs', 'GciTsReleaseObjs', 'GciTsReleaseAllObjs',
+  'GciTsAddOopsToNsc', 'GciTsRemoveOopsFromNsc',
+  'GciTsDirtyObjsInit', 'GciTsDirtyExportedObjs',
+  'GciTsBreak', 'GciTsClearStack', 'GciTsGemTrace',
+  'GciTsContinueWith',
+  'GciTsWaitForEvent', 'GciTsCancelWaitForEvent',
+  'GciTsKeepAliveCount', 'GciTsKeyfilePermissions',
+  'GciTsDebugConnectToGem', 'GciTsDebugStartDebugService',
+  'GciTsDoubleToOop', 'GciTsOopToDouble',
+  'GciTsI64ToOop', 'GciTsOopToI64',
+]);
+
+export interface GtPerfTracker {
+  enabled: boolean;
+  count: number;
+  methodCounts: Map<string, number>;
+  onCountChanged: (() => void) | undefined;
+  increment(methodName: string): void;
+  reset(): void;
+  setEnabled(val: boolean): void;
+}
+
+export interface GtPerfQuickPickItem {
+  label: string;
+  description?: string;
+  isSeparator?: boolean;
+}
+
+export const RESET_LABEL = '$(debug-restart) Reset Counter';
+export const COPY_LABEL  = '$(copy) Copy to Clipboard';
+
+export function buildGtPerfStatusBarText(count: number): string {
+  return `$(record) GT Perf: ${count}`;
+}
+
+export function buildGtPerfClipboardText(tracker: GtPerfTracker): string {
+  const sorted = [...tracker.methodCounts.entries()].sort((a, b) => b[1] - a[1]);
+  return [
+    `GT Perf: ${tracker.count} total GCI calls`,
+    ...sorted.map(([method, count]) => `  ${method}: ${count}`),
+  ].join('\n');
+}
+
+export function buildGtPerfQuickPickItems(tracker: GtPerfTracker): GtPerfQuickPickItem[] {
+  const sorted = [...tracker.methodCounts.entries()].sort((a, b) => b[1] - a[1]);
+  return [
+    { label: RESET_LABEL, description: `clear all ${tracker.count} counts` },
+    { label: COPY_LABEL,  description: 'copy breakdown to clipboard' },
+    { label: '', isSeparator: true },
+    ...sorted.map(([method, count]) => ({ label: method, description: String(count) })),
+  ];
+}
+
+export const gtPerfTracker: GtPerfTracker = {
+  enabled: false,
+  count: 0,
+  methodCounts: new Map(),
+  onCountChanged: undefined,
+
+  increment(methodName: string) {
+    if (this.enabled) {
+      this.count++;
+      this.methodCounts.set(methodName, (this.methodCounts.get(methodName) ?? 0) + 1);
+      this.onCountChanged?.();
+    }
+  },
+
+  reset() {
+    this.count = 0;
+    this.methodCounts.clear();
+    this.onCountChanged?.();
+  },
+
+  setEnabled(val: boolean) {
+    this.enabled = val;
+    if (!val) {
+      this.count = 0;
+      this.methodCounts.clear();
+    }
+    this.onCountChanged?.();
+  },
+};
+
+export function wrapWithGtPerfProxy(gci: GciLibrary): GciLibrary {
+  return new Proxy(gci, {
+    get(target, prop: string | symbol) {
+      const val = (target as unknown as Record<string, unknown>)[prop as string];
+      if (typeof val === 'function' && ROUND_TRIP_METHODS.has(prop as string)) {
+        return (...args: unknown[]) => {
+          gtPerfTracker.increment(prop as string);
+          return (val as (...a: unknown[]) => unknown).apply(target, args);
+        };
+      }
+      return typeof val === 'function' ? (val as Function).bind(target) : val;
+    },
+  }) as GciLibrary;
+}

--- a/client/src/sessionManager.ts
+++ b/client/src/sessionManager.ts
@@ -3,6 +3,7 @@ import { GciLibrary, GciError } from './gciLibrary';
 import { OOP_NIL } from './gciConstants';
 import { GemStoneLogin, loginLabel } from './loginTypes';
 import { logInfo } from './gciLog';
+import { wrapWithGtPerfProxy } from './gtPerfTracker';
 
 export interface ActiveSession {
   id: number;
@@ -105,7 +106,7 @@ export class SessionManager {
   private getGciLibrary(libraryPath: string): GciLibrary {
     let gci = this.gciInstances.get(libraryPath);
     if (!gci) {
-      gci = new GciLibrary(libraryPath);
+      gci = wrapWithGtPerfProxy(new GciLibrary(libraryPath));
       this.gciInstances.set(libraryPath, gci);
     }
     return gci;

--- a/docs/gtSupport/IMCSystem-gtViews.gs
+++ b/docs/gtSupport/IMCSystem-gtViews.gs
@@ -1,0 +1,468 @@
+! ============================================================================
+! Glamorous Toolkit inspector views (<gtView>) for IMCSystem
+! ============================================================================
+!
+! Installs one or more <gtView> Phlow view methods on instances of IMCSystem.
+! Each method adds a tab to the GT Inspect view of an IMCSystem instance.
+!
+! REQUIREMENTS
+!   - GemStone GT remote support must be loaded in the stone
+!     (GtPhlowText / GtPhlowColor must be resolvable). See
+!     docs/gtSupport/load_gemstone_gt_support.sh.
+!   - Class IMCSystem (and any domain classes its views reference) must be present.
+!   - Log in as the GemStone user that OWNS the application (e.g. DataCurator),
+!     NOT SystemUser. If IMCSystem is not in the login user's symbol list, every
+!     `method: IMCSystem` block and the smoke test fail with "undefined symbol
+!     IMCSystem". A .topazini that sets `username SystemUser` can be overridden
+!     with `set username DataCurator` / `set password ...` before `login`.
+!
+! USAGE (topaz)
+!   cd <stone data dir containing .topazini>
+!   $GEMSTONE/bin/topaz -l -I .topazini
+!   topaz> login
+!   topaz> input /path/to/this-file.gs
+!   topaz> logout
+!   topaz> exit
+!
+!   This file commits itself (see `commit` at the end), so a bare `input` is
+!   enough to persist the methods. After loading, abort any connected Jasper
+!   client session and GT Inspect an IMCSystem instance (e.g.
+!   InstalledAcmeSystem) to see the new tab(s).
+! ============================================================================
+
+! --- Customer Invoices: gross totals per currency, then invoices grouped by
+!     month (oldest first), sorted ascending by date within each month, with a
+!     per-month invoice count, currency symbols, color-coded payment status,
+!     and amount-due. ---------------------------------------------------------
+category: 'gt views'
+method: IMCSystem
+gtCustomerInvoicesFor: aView
+	<gtView>
+	^ aView textEditor
+		title: 'Customer Invoices';
+		priority: 40;
+		text: [
+			[
+				| invoices nl s ranges emit fmt statusColor symbolFor euro gray blue red green orange sorted groups totals order text |
+				nl := String with: (Character value: 10).
+				euro := (Character value: 8364) asString.
+				gray := GtPhlowColor named: #gray.
+				blue := GtPhlowColor named: #blue.
+				red := GtPhlowColor named: #red.
+				green := GtPhlowColor named: #green.
+				orange := GtPhlowColor named: #orange.
+				s := WriteStream on: String new.
+				ranges := OrderedCollection new.
+				emit := [:str :colorOrNil |
+					str isEmpty ifFalse: [
+						| startPos |
+						startPos := s position + 1.
+						s nextPutAll: str.
+						colorOrNil ifNotNil: [:c |
+							ranges add: (Array with: startPos with: s position with: c)]]].
+				fmt := [:n |
+					| str digits res |
+					str := n abs printString.
+					digits := str size.
+					res := WriteStream on: String new.
+					1 to: digits do: [:idx |
+						| remaining |
+						remaining := digits - idx.
+						res nextPut: (str at: idx).
+						(remaining > 0 and: [remaining \\ 3 = 0]) ifTrue: [res nextPut: $,]].
+					(n < 0 ifTrue: ['-'] ifFalse: ['']) , res contents].
+				symbolFor := [:name |
+					name = 'Dollar' ifTrue: ['$'] ifFalse: [
+					name = 'Euro' ifTrue: [euro] ifFalse: [
+					name = 'Singapore dollar' ifTrue: ['S$'] ifFalse: [name , ' ']]]].
+				statusColor := [:status |
+					status = 'Paid' ifTrue: [green] ifFalse: [
+					status = 'Not Paid' ifTrue: [red] ifFalse: [
+					status = 'Partially Paid' ifTrue: [orange] ifFalse: [
+					status = 'Over Paid' ifTrue: [blue] ifFalse: [gray]]]]].
+				invoices := invoiceSystem contents.
+				totals := Dictionary new.
+				order := OrderedCollection new.
+				invoices do: [:inv |
+					| cn |
+					cn := inv currency name.
+					(totals includesKey: cn) ifFalse: [order add: cn. totals at: cn put: 0].
+					totals at: cn put: (totals at: cn) + inv grossAmount].
+				emit value: (invoices size printString , ' customer invoices') value: blue.
+				s nextPutAll: nl.
+				emit value: 'Gross totals:' value: gray.
+				s nextPutAll: nl.
+				order do: [:cn |
+					emit value: '   ' value: nil.
+					emit value: ((symbolFor value: cn) , (fmt value: (totals at: cn))) value: nil.
+					s nextPutAll: nl].
+				s nextPutAll: nl.
+				sorted := invoices asSortedCollection: [:a :b | a date < b date].
+				groups := OrderedCollection new.
+				sorted do: [:inv |
+					| key |
+					key := (inv date year number * 100) + inv date month number.
+					(groups isEmpty or: [groups last key ~= key])
+						ifTrue: [groups add: (key -> (OrderedCollection with: inv))]
+						ifFalse: [groups last value add: inv]].
+				groups do: [:grp |
+					| monthInvs first count |
+					monthInvs := grp value.
+					first := monthInvs first.
+					count := monthInvs size.
+					s nextPutAll: nl.
+					emit value: ('-- ' , first date month name , ' ' , first date year number printString
+						, ' (' , count printString , ' invoice' , (count = 1 ifTrue: [''] ifFalse: ['s']) , ') ----------------') value: blue.
+					s nextPutAll: nl.
+					monthInvs do: [:inv |
+						| status due |
+						status := inv paymentStatusDescription.
+						emit value: '  ' value: nil.
+						emit value: inv number value: blue.
+						emit value: '   ' value: nil.
+						emit value: inv licenseeName value: nil.
+						s nextPutAll: nl.
+						emit value: '      ' value: nil.
+						emit value: inv date printString value: gray.
+						emit value: '  ' value: nil.
+						emit value: ((symbolFor value: inv currency name) , (fmt value: inv grossAmount)) value: nil.
+						emit value: '   ' value: nil.
+						emit value: status value: (statusColor value: status).
+						due := inv amountDue.
+						due > 0 ifTrue: [
+							emit value: '   due ' value: gray.
+							emit value: ((symbolFor value: inv currency name) , (fmt value: due)) value: red].
+						s nextPutAll: nl]].
+				text := GtPhlowText forString: s contents.
+				ranges do: [:r | (text from: (r at: 1) to: (r at: 2)) foreground: (r at: 3)].
+				text
+			] on: Error do: [:e |
+				'ERROR: ' , e class name , ': ' , e messageText]
+		]
+%
+
+! --- Contracts: a columned table, one row per contract, ordered by status
+!     (Active, then On Sell Off, then others), then within each status by total
+!     billed descending (mixed currencies, tie-broken by licensee name).
+!     Columns: Status (color-coded), Contract id, Licensee, Licensor, Min
+!     Guaranteed, Billed (both with currency symbol), Invoice count, End date.
+!     Status colors: Active=green, On Sell Off=orange, Canceled=red, else=gray.
+!
+!     NOTE: `state class name` returns a Symbol; `aSymbol = 'aString'` is false
+!     in GemStone, so the state class name is compared with `asString`.
+!     ------------------------------------------------------------------------
+category: 'gt views'
+method: IMCSystem
+gtContractsFor: aView
+	<gtView>
+	| euro symbolFor fmt pretty statePriority statusColor green orange red gray |
+	euro := (Character value: 8364) asString.
+	green := GtPhlowColor named: #green.
+	orange := GtPhlowColor named: #orange.
+	red := GtPhlowColor named: #red.
+	gray := GtPhlowColor named: #gray.
+	fmt := [:n |
+		| str digits res |
+		str := n abs printString.
+		digits := str size.
+		res := WriteStream on: String new.
+		1 to: digits do: [:idx |
+			| rem |
+			rem := digits - idx.
+			res nextPut: (str at: idx).
+			(rem > 0 and: [rem \\ 3 = 0]) ifTrue: [res nextPut: $,]].
+		(n < 0 ifTrue: ['-'] ifFalse: ['']) , res contents].
+	symbolFor := [:name |
+		name = 'Dollar' ifTrue: ['$'] ifFalse: [
+		name = 'Euro' ifTrue: [euro] ifFalse: [
+		name = 'Singapore dollar' ifTrue: ['S$'] ifFalse: [name , ' ']]]].
+	pretty := [:c |
+		| cn suffix res |
+		cn := c state class name asString.
+		suffix := 'ContractState'.
+		(cn size > suffix size and: [(cn copyFrom: cn size - suffix size + 1 to: cn size) = suffix])
+			ifTrue: [cn := cn copyFrom: 1 to: cn size - suffix size].
+		res := WriteStream on: String new.
+		1 to: cn size do: [:i |
+			| ch |
+			ch := cn at: i.
+			(i > 1 and: [ch isUppercase]) ifTrue: [res nextPut: $ ].
+			res nextPut: ch].
+		res contents].
+	statePriority := [:c |
+		| cn |
+		cn := c state class name asString.
+		cn = 'ActiveContractState' ifTrue: [0] ifFalse: [
+		cn = 'OnSellOffContractState' ifTrue: [1] ifFalse: [2]]].
+	statusColor := [:c |
+		| cn |
+		cn := c state class name asString.
+		cn = 'ActiveContractState' ifTrue: [green] ifFalse: [
+		cn = 'OnSellOffContractState' ifTrue: [orange] ifFalse: [
+		cn = 'CanceledContractState' ifTrue: [red] ifFalse: [gray]]]].
+	^ aView columnedList
+		title: 'Contracts';
+		priority: 35;
+		items: [
+			contractSystem contents asSortedCollection: [:a :b |
+				| pa pb |
+				pa := statePriority value: a.
+				pb := statePriority value: b.
+				pa = pb
+					ifTrue: [
+						a totalBilledInContractCurrency = b totalBilledInContractCurrency
+							ifTrue: [a licenseeName asLowercase < b licenseeName asLowercase]
+							ifFalse: [a totalBilledInContractCurrency > b totalBilledInContractCurrency]]
+					ifFalse: [pa < pb]] ];
+		column: 'Status' text: [:c |
+			| label t |
+			label := pretty value: c.
+			t := GtPhlowText forString: label.
+			(t from: 1 to: label size) foreground: (statusColor value: c).
+			t];
+		column: 'Contract' text: [:c | c id];
+		column: 'Licensee' text: [:c | c licenseeName];
+		column: 'Licensor' text: [:c | c licensor name];
+		column: 'Min Guaranteed' text: [:c | (symbolFor value: c currency name) , (fmt value: c minimumGuaranteedTotal)];
+		column: 'Billed' text: [:c | (symbolFor value: c currency name) , (fmt value: c totalBilledInContractCurrency)];
+		column: 'Invoices' text: [:c | c invoices size printString];
+		column: 'Ends' text: [:c | c endDate printString];
+		yourself
+%
+
+! --- Summary: a read-only styled-text dashboard (the "first impression" tab,
+!     priority 25 so it leads). Title and section headers use bold + font size;
+!     status bullets and outstanding receivables are color-coded. Mirrors the
+!     Overview categories but as a polished at-a-glance view (not clickable).
+!     Per-currency totals are summed within a currency; no cross-currency money
+!     is conflated. Uses bold / fontSize: / italic / foreground -- all of which
+!     Jasper renders (phlowFontWeight/FontSize/FontEmphasis/Foreground).
+!     ------------------------------------------------------------------------
+category: 'gt views'
+method: IMCSystem
+gtSummaryFor: aView
+	<gtView>
+	^ aView textEditor
+		title: 'Summary';
+		priority: 25;
+		text: [
+			[
+				| nl s ranges emit fmt symbolFor euro bullet padR plural gray blue green red orange
+				  titleStyle headerStyle boldStyle contracts invoices stateCounts statusCounts gross outstanding curOrder licCon licInv licOrder allLic text |
+				nl := String with: (Character value: 10).
+				euro := (Character value: 8364) asString.
+				bullet := (Character value: 9679) asString.
+				gray := GtPhlowColor named: #gray.
+				blue := GtPhlowColor named: #blue.
+				green := GtPhlowColor named: #green.
+				red := GtPhlowColor named: #red.
+				orange := GtPhlowColor named: #orange.
+				s := WriteStream on: String new.
+				ranges := OrderedCollection new.
+				emit := [:str :styleBlk |
+					str isEmpty ifFalse: [
+						| p |
+						p := s position + 1.
+						s nextPutAll: str.
+						styleBlk ifNotNil: [:blk | ranges add: (Array with: p with: s position with: blk)]]].
+				titleStyle := [:seg | seg bold; fontSize: 17; foreground: blue].
+				headerStyle := [:seg | seg bold; foreground: blue].
+				boldStyle := [:seg | seg bold].
+				fmt := [:n |
+					| str d r |
+					str := n abs printString.
+					d := str size.
+					r := WriteStream on: String new.
+					1 to: d do: [:i |
+						| rem |
+						rem := d - i.
+						r nextPut: (str at: i).
+						(rem > 0 and: [rem \\ 3 = 0]) ifTrue: [r nextPut: $,]].
+					(n < 0 ifTrue: ['-'] ifFalse: ['']) , r contents].
+				symbolFor := [:name |
+					name = 'Dollar' ifTrue: ['$'] ifFalse: [
+					name = 'Euro' ifTrue: [euro] ifFalse: [
+					name = 'Singapore dollar' ifTrue: ['S$'] ifFalse: [name , ' ']]]].
+				padR := [:str :w |
+					| r |
+					r := WriteStream on: String new.
+					r nextPutAll: str.
+					[r contents size < w] whileTrue: [r nextPut: $ ].
+					r contents].
+				plural := [:n :word | n printString , ' ' , word , (n = 1 ifTrue: [''] ifFalse: ['s'])].
+				contracts := contractSystem contents.
+				invoices := invoiceSystem contents.
+				stateCounts := Dictionary new.
+				contracts do: [:c |
+					| cn |
+					cn := c state class name asString = 'ActiveContractState' ifTrue: ['Active'] ifFalse: [
+						c state class name asString = 'OnSellOffContractState' ifTrue: ['On Sell Off'] ifFalse: ['Other']].
+					stateCounts at: cn put: (stateCounts at: cn ifAbsent: [0]) + 1].
+				statusCounts := Dictionary new.
+				gross := Dictionary new.
+				outstanding := Dictionary new.
+				curOrder := OrderedCollection new.
+				invoices do: [:i |
+					| st cn |
+					st := i paymentStatusDescription.
+					cn := i currency name.
+					statusCounts at: st put: (statusCounts at: st ifAbsent: [0]) + 1.
+					(gross includesKey: cn) ifFalse: [curOrder add: cn. gross at: cn put: 0. outstanding at: cn put: 0].
+					gross at: cn put: (gross at: cn) + i grossAmount.
+					outstanding at: cn put: (outstanding at: cn) + i amountDue].
+				licCon := Dictionary new.
+				licInv := Dictionary new.
+				contracts do: [:c | licCon at: c licenseeName put: (licCon at: c licenseeName ifAbsent: [0]) + 1].
+				invoices do: [:i | licInv at: i licenseeName put: (licInv at: i licenseeName ifAbsent: [0]) + 1].
+				allLic := (licCon keys , licInv keys) asSet.
+				licOrder := allLic asSortedCollection: [:a :b |
+					(licCon at: a ifAbsent: [0]) = (licCon at: b ifAbsent: [0])
+						ifTrue: [(licInv at: a ifAbsent: [0]) > (licInv at: b ifAbsent: [0])]
+						ifFalse: [(licCon at: a ifAbsent: [0]) > (licCon at: b ifAbsent: [0])]].
+				emit value: 'SYSTEM SUMMARY' value: titleStyle.
+				s nextPutAll: nl; nextPutAll: nl.
+				emit value: ('CONTRACTS (' , contracts size printString , ')') value: headerStyle.
+				s nextPutAll: nl.
+				#('Active' 'On Sell Off' 'Other') do: [:st |
+					(stateCounts includesKey: st) ifTrue: [
+						| col |
+						col := st = 'Active' ifTrue: [green] ifFalse: [st = 'On Sell Off' ifTrue: [orange] ifFalse: [gray]].
+						emit value: '  ' value: nil.
+						emit value: bullet value: [:seg | seg foreground: col].
+						emit value: ('  ' , (padR value: st value: 16)) value: nil.
+						emit value: (stateCounts at: st) printString value: boldStyle.
+						s nextPutAll: nl]].
+				s nextPutAll: nl.
+				emit value: ('INVOICES (' , invoices size printString , ')') value: headerStyle.
+				s nextPutAll: nl.
+				#('Paid' 'Over Paid' 'Partially Paid' 'Not Paid') do: [:st |
+					(statusCounts includesKey: st) ifTrue: [
+						| col |
+						col := st = 'Paid' ifTrue: [green] ifFalse: [st = 'Over Paid' ifTrue: [blue] ifFalse: [st = 'Partially Paid' ifTrue: [orange] ifFalse: [red]]].
+						emit value: '  ' value: nil.
+						emit value: bullet value: [:seg | seg foreground: col].
+						emit value: ('  ' , (padR value: st value: 16)) value: nil.
+						emit value: (statusCounts at: st) printString value: boldStyle.
+						s nextPutAll: nl]].
+				s nextPutAll: nl.
+				emit value: 'GROSS BILLED' value: headerStyle.
+				s nextPutAll: nl.
+				curOrder do: [:cn |
+					emit value: ('  ' , ((symbolFor value: cn) , (fmt value: (gross at: cn)))) value: nil.
+					s nextPutAll: nl].
+				s nextPutAll: nl.
+				emit value: 'OUTSTANDING RECEIVABLES' value: headerStyle.
+				s nextPutAll: nl.
+				curOrder do: [:cn |
+					emit value: '  ' value: nil.
+					emit value: ((symbolFor value: cn) , (fmt value: (outstanding at: cn))) value: [:seg | seg bold; foreground: red].
+					s nextPutAll: nl].
+				s nextPutAll: nl.
+				emit value: ((plural value: dealMemoSystem contents size value: 'deal memo') , '      '
+					, (plural value: licenseeSystem contents size value: 'licensee') , ' / '
+					, (plural value: licensorSystem contents size value: 'licensor')) value: [:seg | seg foreground: gray].
+				s nextPutAll: nl; nextPutAll: nl.
+				emit value: 'LICENSEE ACTIVITY' value: headerStyle.
+				s nextPutAll: nl.
+				licOrder do: [:ln |
+					emit value: ('  ' , (padR value: ln value: 20)) value: nil.
+					emit value: (padR value: (plural value: (licCon at: ln ifAbsent: [0]) value: 'contract') value: 14) value: [:seg | seg foreground: gray].
+					emit value: (plural value: (licInv at: ln ifAbsent: [0]) value: 'invoice') value: [:seg | seg foreground: gray].
+					s nextPutAll: nl].
+				text := GtPhlowText forString: s contents.
+				ranges do: [:r | (r at: 3) value: (text from: (r at: 1) to: (r at: 2))].
+				text
+			] on: Error do: [:e |
+				'ERROR: ' , e class name , ': ' , e messageText]
+		]
+%
+
+! --- Overview: a clickable summary table. One row per category -- contracts
+!     by state (Active, On Sell Off) then invoices by payment status -- whose
+!     row item IS the filtered collection, so double-clicking (or right-click
+!     -> Inspect) opens an inspector on exactly that subset (e.g. the 8 Paid
+!     invoices). Section column groups the rows; Category cell is color-coded.
+!
+!     NOTE: Jasper inspects a row's `targetObject`, which is the list item
+!     itself -- NOT a per-column `spawn:` target. So each item must BE the
+!     collection you want to drill into; labels are derived from its contents.
+!     ------------------------------------------------------------------------
+category: 'gt views'
+method: IMCSystem
+gtSystemOverviewFor: aView
+	<gtView>
+	| rows green orange red blue gray pretty sectionFor labelFor colorFor |
+	green := GtPhlowColor named: #green.
+	orange := GtPhlowColor named: #orange.
+	red := GtPhlowColor named: #red.
+	blue := GtPhlowColor named: #blue.
+	gray := GtPhlowColor named: #gray.
+	pretty := [:c |
+		| cn suffix res |
+		cn := c state class name asString.
+		suffix := 'ContractState'.
+		(cn size > suffix size and: [(cn copyFrom: cn size - suffix size + 1 to: cn size) = suffix])
+			ifTrue: [cn := cn copyFrom: 1 to: cn size - suffix size].
+		res := WriteStream on: String new.
+		1 to: cn size do: [:i |
+			| ch |
+			ch := cn at: i.
+			(i > 1 and: [ch isUppercase]) ifTrue: [res nextPut: $ ].
+			res nextPut: ch].
+		res contents].
+	sectionFor := [:coll |
+		(coll anyOne isKindOf: Invoice) ifTrue: ['Invoices'] ifFalse: [
+		(coll anyOne isKindOf: Contract) ifTrue: ['Contracts'] ifFalse: ['Other']]].
+	labelFor := [:coll |
+		(coll anyOne isKindOf: Invoice)
+			ifTrue: [coll anyOne paymentStatusDescription]
+			ifFalse: [pretty value: coll anyOne]].
+	colorFor := [:coll |
+		(coll anyOne isKindOf: Invoice)
+			ifTrue: [
+				| st |
+				st := coll anyOne paymentStatusDescription.
+				st = 'Paid' ifTrue: [green] ifFalse: [
+				st = 'Over Paid' ifTrue: [blue] ifFalse: [
+				st = 'Partially Paid' ifTrue: [orange] ifFalse: [red]]]]
+			ifFalse: [
+				| nm |
+				nm := pretty value: coll anyOne.
+				nm = 'Active' ifTrue: [green] ifFalse: [
+				nm = 'On Sell Off' ifTrue: [orange] ifFalse: [gray]]]].
+	rows := OrderedCollection new.
+	#('ActiveContractState' 'OnSellOffContractState') do: [:sc |
+		| sub |
+		sub := contractSystem contents select: [:c | c state class name asString = sc].
+		sub isEmpty ifFalse: [rows add: sub]].
+	#('Paid' 'Over Paid' 'Partially Paid' 'Not Paid') do: [:stat |
+		| sub |
+		sub := invoiceSystem contents select: [:i | i paymentStatusDescription = stat].
+		sub isEmpty ifFalse: [rows add: sub]].
+	^ aView columnedList
+		title: 'Overview';
+		priority: 30;
+		items: [ rows ];
+		column: 'Section' text: [:coll | sectionFor value: coll] width: 110;
+		column: 'Category' text: [:coll |
+			| label t |
+			label := labelFor value: coll.
+			t := GtPhlowText forString: label.
+			(t from: 1 to: label size) foreground: (colorFor value: coll).
+			t] width: 160;
+		column: 'Count' text: [:coll | coll size printString];
+		yourself
+%
+
+! Persist the new method(s).
+commit
+
+! Smoke test: confirm the methods compiled onto the instance side.
+run
+| missing |
+missing := #( #gtSummaryFor: #gtCustomerInvoicesFor: #gtContractsFor: #gtSystemOverviewFor: )
+	reject: [:sel | IMCSystem includesSelector: sel].
+missing isEmpty
+	ifTrue: [ 'OK: all gtView methods installed on IMCSystem' ]
+	ifFalse: [ 'FAIL: missing ' , missing printString ]
+%

--- a/package.json
+++ b/package.json
@@ -189,6 +189,11 @@
                 }
               }
             }
+          },
+          "gemstone.gtPerfTracking": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable GT Perf Tracking: count GCI round trips in the GT Inspector. When enabled, shows a status bar counter and logs to the 'GemStone GT Perf' output channel. Intended for performance tuning only."
           }
         }
       },
@@ -353,6 +358,26 @@
       }
     ],
     "commands": [
+      {
+        "command": "gemstone.enableGtPerfTracking",
+        "title": "Enable GT Perf Tracking",
+        "category": "GemStone GT"
+      },
+      {
+        "command": "gemstone.disableGtPerfTracking",
+        "title": "Disable GT Perf Tracking",
+        "category": "GemStone GT"
+      },
+      {
+        "command": "gemstone.resetGtPerfCounter",
+        "title": "Reset GT Perf Counter",
+        "category": "GemStone GT"
+      },
+      {
+        "command": "gemstone.showGtPerfDetails",
+        "title": "Show GT Perf Details",
+        "category": "GemStone GT"
+      },
       {
         "command": "gemstone.resetGrailNotebookScope",
         "title": "Reset Grail Notebook Scope",
@@ -737,6 +762,24 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "gemstone.enableGtPerfTracking",
+          "when": "!gemstone.gtPerfTracking"
+        },
+        {
+          "command": "gemstone.disableGtPerfTracking",
+          "when": "gemstone.gtPerfTracking"
+        },
+        {
+          "command": "gemstone.resetGtPerfCounter",
+          "when": "false"
+        },
+        {
+          "command": "gemstone.showGtPerfDetails",
+          "when": "false"
+        }
+      ],
       "view/title": [
         {
           "command": "gemstone.addLogin",


### PR DESCRIPTION
## Summary

Two changes, one commit each:

1. **Bug fix** — styled-text inspector tabs broke (each styled run on its own
   line) after viewing a table/tree tab in the same inspector.
2. **Demo** — a self-contained topaz file-in that adds four `<gtView>` tabs to
   `IMCSystem`, exercising text, table, clickable-table, and styled-dashboard
   view types.

> ⚠️ **The demo file must be filed in as `DataCurator` (the app-owning user) —
> NOT `SystemUser`.** `IMCSystem` lives in DataCurator's symbol list; under
> SystemUser every `method: IMCSystem` block and the smoke test fail with
> "undefined symbol IMCSystem". See the demo section for how to override a
> SystemUser `.topazini`.

## Bug fix — `client/src/gtInspector.ts`

**Symptom:** A text/`textEditor` `<gtView>` tab (e.g. Print, Description, or a
custom view) renders correctly on first view, but after switching to a
table/tree tab and back, every styled run stacks onto its own line.

**Root cause:** `renderGtTable` styles the *shared* `#contentPane` with an
inline `display:flex; flex-direction:column`. `renderStyledText` swapped the
element's class but never cleared those inline styles, so the pane stayed a
flex column and laid out each `<span>` as its own flex item. Inline style beat
the `.detail-value` class, so the symptom only appeared *after* a table render
polluted the pane.

**Fix:** `renderStyledText` now resets `el.style.cssText` before laying out the
text. One line; fixes every text tab regardless of what was viewed before it.

**Reproduce (before this change):** open a styled-text tab (fine) → open a
table tab → return to the text tab → runs stack vertically.

## Demo — `docs/gtSupport/IMCSystem-gtViews.gs`

Self-contained topaz installer adding four instance-side `<gtView>` methods to
`IMCSystem`:

- **Summary** — styled-text dashboard (bold/sized headers, color-coded status)
- **Customer Invoices** — styled grouped text, month buckets, currency symbols
- **Contracts** — columned table, grouped/sorted, color-coded status
- **Overview** — clickable summary table; rows drill into the filtered subset

The file commits and runs a smoke test on file-in.

### File in as `DataCurator`, not `SystemUser`

`IMCSystem` (and the rest of the Acme app) is in `DataCurator`'s symbol list, so
the file **must** be filed in under that user. Under `SystemUser` it fails with
`undefined symbol IMCSystem`. If your `.topazini` sets `username SystemUser`,
override it before `login`:

