### PR TITLE
Open new method when selector changes on save

### DIFF
--- a/client/src/__tests__/extension.test.ts
+++ b/client/src/__tests__/extension.test.ts
@@ -196,10 +196,14 @@ describe('handleMethodCompiled', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.mocked(vscode.workspace.openTextDocument).mockReset();
+    vi.mocked(vscode.window.showTextDocument).mockReset();
+    vi.mocked(vscode.window.tabGroups.close).mockReset();
     vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
+    (vscode.window.tabGroups as any).all = [];
   });
 
-  it('opens the new uri and then closes the previous uri', async () => {
+  it('opens the new uri and then closes the previous uri when isNewMethod is true', async () => {
     const document = { uri, getText: vi.fn(() => '') } as unknown as vscode.TextDocument;
     vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
     vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as vscode.TextEditor);
@@ -207,12 +211,34 @@ describe('handleMethodCompiled', () => {
     (vscode.window.tabGroups as any).all = [{ tabs: [previousTab] }];
     vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
 
-    await extension.handleMethodCompiled({ uri, previousUri });
+    await extension.handleMethodCompiled({ uri, previousUri, isNewMethod: true });
 
     expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(uri);
     expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(previousTab);
     expect(vi.mocked(vscode.workspace.openTextDocument).mock.invocationCallOrder[0])
       .toBeLessThan(vi.mocked(vscode.window.tabGroups.close).mock.invocationCallOrder[0]);
+  });
+
+  it('does nothing when uri equals previousUri (selector unchanged)', async () => {
+    (vscode.window.tabGroups as any).all = [];
+
+    await extension.handleMethodCompiled({ uri, previousUri: uri, isNewMethod: false });
+
+    expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
+    expect(vscode.window.tabGroups.close).not.toHaveBeenCalled();
+  });
+
+  it('opens the new uri but does not close the previous tab when isNewMethod is false (selector changed)', async () => {
+    const document = { uri, getText: vi.fn(() => '') } as unknown as vscode.TextDocument;
+    vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
+    vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as vscode.TextEditor);
+    const previousTab = { input: new vscode.TabInputText(previousUri) } as unknown as vscode.Tab;
+    (vscode.window.tabGroups as any).all = [{ tabs: [previousTab] }];
+
+    await extension.handleMethodCompiled({ uri, previousUri, isNewMethod: false });
+
+    expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(uri);
+    expect(vscode.window.tabGroups.close).not.toHaveBeenCalled();
   });
 });
 
@@ -252,6 +278,7 @@ describe('onMethodCompiled event subscription (functional)', () => {
     const event = handler.mock.calls[0][0];
     expect(event.previousUri.toString()).toBe(newMethodUri.toString());
     expect(event.uri.toString()).toBe('gemstone://1/Globals/Array/instance/accessing/foo');
+    expect(event.isNewMethod).toBe(true);
   });
 });
 

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -14,7 +14,7 @@ vi.mock('../browserQueries', () => ({
   getMethodSource: vi.fn(() => 'at: index\n  ^self basicAt: index'),
   getClassDefinition: vi.fn(() => "Object subclass: 'Array'\n  instVarNames: #()"),
   getClassComment: vi.fn(() => 'An ordered collection.'),
-  compileMethod: vi.fn(() => 1n),
+  compileMethod: vi.fn(() => 'Compiled: Array >> at:'),
   compileClassDefinition: vi.fn(),
   setClassComment: vi.fn(),
   canClassBeWritten: vi.fn(() => true),
@@ -273,6 +273,39 @@ describe('GemStoneFileSystemProvider', () => {
        const event = listener.mock.calls[0][0];
        expect(event.previousUri.toString()).toBe(newMethodUri.toString());
        expect(event.uri.toString()).toBe('gemstone://1/Globals/Array/instance/accessing/foo');
+       expect(event.isNewMethod).toBe(true);
+     });
+
+     it('emits onMethodCompiled with isNewMethod false when an existing method is saved with unchanged selector', async () => {
+       const methodUri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A');
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >> at:');
+       const listener = vi.fn();
+       provider.onMethodCompiled(listener);
+
+       provider.writeFile(methodUri, encode('at: i\n  ^self basicAt: i'), { create: false, overwrite: true });
+       await new Promise(resolve => setImmediate(resolve));
+
+       expect(listener).toHaveBeenCalledTimes(1);
+       const event = listener.mock.calls[0][0];
+       expect(event.isNewMethod).toBe(false);
+       expect(event.uri.toString()).toBe(methodUri.toString());
+       expect(event.previousUri.toString()).toBe(methodUri.toString());
+     });
+
+     it('emits onMethodCompiled with isNewMethod false when an existing method is saved with a changed selector', async () => {
+       const previousUri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A');
+       vi.mocked(queries.compileMethod).mockReturnValueOnce('Compiled: Array >> newSelector');
+       const listener = vi.fn();
+       provider.onMethodCompiled(listener);
+
+       provider.writeFile(previousUri, encode('newSelector\n  ^42'), { create: false, overwrite: true });
+       await new Promise(resolve => setImmediate(resolve));
+
+       expect(listener).toHaveBeenCalledTimes(1);
+       const event = listener.mock.calls[0][0];
+       expect(event.isNewMethod).toBe(false);
+       expect(event.previousUri.toString()).toBe(previousUri.toString());
+       expect(event.uri.toString()).toBe('gemstone://1/Globals/Array/instance/accessing/newSelector');
      });
 
      it('trims trailing whitespace from the selector when building the compiled method uri', async () => {
@@ -337,7 +370,7 @@ describe('GemStoneFileSystemProvider', () => {
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A');
       provider.writeFile(uri, encode('at: i\n  ^self basicAt: i'), { create: false, overwrite: true });
       expect(window.showInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Compiled Array>>#at:'),
+        expect.stringContaining('Compiled method Array>>#at:'),
       );
     });
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -99,8 +99,15 @@ async function logJasperError(message: string, scope: string, error: unknown) {
 }
 
 export async function handleMethodCompiled(event: MethodCompiledEvent) {
+  if (event.uri.toString() === event.previousUri.toString()) {
+    return;
+  }
+  
   await openTextEditorOn(event.uri);
-  await closeTextEditorOn(event.previousUri);
+  
+  if (event.isNewMethod) {
+    await closeTextEditorOn(event.previousUri);
+  }
 }
 
 export function activate(context: vscode.ExtensionContext) {

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -137,7 +137,8 @@ function assertIsValidUriPath(parameterName: string, value: string) {
 
 export interface MethodCompiledEvent{
   uri: vscode.Uri;
-  previousUri: vscode.Uri
+  previousUri: vscode.Uri;
+  isNewMethod: boolean;
 }
 
 // ── FileSystemProvider ────────────────────────────────────────
@@ -244,12 +245,7 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     try {
       switch (parsed.kind) {
         case 'method':
-          queries.compileMethod(
-            session, parsed.className, parsed.isMeta, parsed.category, source, parsed.environmentId,
-          );
-          vscode.window.showInformationMessage(
-            `Compiled ${parsed.className}${parsed.isMeta ? ' class' : ''}>>#${parsed.selector}`
-          );
+          this.compileMethod(uri, parsed, source, session);
           break;
         case 'definition':
           queries.compileClassDefinition(session, source);
@@ -268,13 +264,7 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
           vscode.window.showInformationMessage('Class created');
           break;
         case 'new-method':
-          const newMethodUri = this.compileMethod(parsed, source, session);
-          
-          // Defer the event to the next event-loop iteration so VS Code has time to
-          // process the completed save and mark the document clean. Firing synchronously
-          // here — before writeFile returns — means the tab is still dirty when
-          // closeTextEditorOn runs, which triggers a "save before closing?" dialog.
-          setImmediate(() => this._onMethodCompiled.fire({uri: newMethodUri, previousUri: uri}));
+          this.compileMethod(uri, parsed, source, session);
           break;
       }
 
@@ -314,7 +304,7 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     }
   }
 
-  private compileMethod(parsedMethodUri: ParsedNewMethodUri, sourceCode: string, session: ActiveSession) : vscode.Uri {
+  private compileMethod(uri: vscode.Uri, parsedMethodUri: ParsedNewMethodUri | ParsedMethodUri, sourceCode: string, session: ActiveSession) {
     const result = queries.compileMethod(
         session, parsedMethodUri.className, parsedMethodUri.isMeta, parsedMethodUri.category, sourceCode, parsedMethodUri.environmentId,
     );
@@ -328,11 +318,21 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
         `Compiled method ${receiver(parsedMethodUri.className, parsedMethodUri.isMeta)}>>#${selector}`
     );
     
-    return buildMethodUri({
+    const newMethodUri = buildMethodUri({
       ...parsedMethodUri,
       kind: 'method',
       selector: selector
     });
+
+    // Defer the event to the next event-loop iteration so VS Code has time to
+    // process the completed save and mark the document clean. Firing synchronously
+    // here — before writeFile returns — means the tab is still dirty when
+    // closeTextEditorOn runs, which triggers a "save before closing?" dialog.
+    setImmediate(() => this._onMethodCompiled.fire({
+      uri: newMethodUri,
+      previousUri: uri,
+      isNewMethod: parsedMethodUri.kind === 'new-method',
+    }));
   }
 
   dispose(): void {


### PR DESCRIPTION
## Summary

- Renaming a selector and saving previously left the old tab showing the new source code under the wrong name, with no tab for the new method
- Jasper now detects when the compiled selector differs from the saved URI and opens a tab for the new method automatically
- The old tab reverts to its original source — the old method still exists in GemStone unchanged

## How it works

`MethodCompiledEvent` gains an `isNewMethod` flag. The existing-method compile path now goes through the same `compileMethod` helper as the new-method path, which fires the event with the correct flag. `handleMethodCompiled` skips navigation when the selector is unchanged, opens the new tab when it changes, and only closes the old tab for the `new-method` placeholder (not for existing methods, since the old method still lives in GemStone).

## Previous Behavior

https://github.com/user-attachments/assets/912e8d01-2eab-4295-8454-8637f05546d1

## Current Behavior

https://github.com/user-attachments/assets/80e187dd-d680-4700-ab22-d10577b13945

## Test plan

- [ ] Open an existing method, change its selector, save — new method tab opens, old tab reverts to original source
- [ ] Open an existing method, save without changing selector — no tab navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)