### PR TITLE
Add method override indicators (▲/▼) with clickable hierarchy navigation

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,9 +23,10 @@ mcp-server/node_modules/**
 !node_modules/koffi/build/**
 
 client/src/**
-# listFilter.js is read at runtime via fs.readFileSync and injected into the webview as a <script> tag.
-# It must ship as a standalone file — it cannot be compiled into the bundle.
+# listFilter.js and methodListView.js are read at runtime via fs.readFileSync and injected into the
+# webview as <script> tags. They must ship as standalone files — they cannot be compiled into the bundle.
 !client/src/listFilter.js
+!client/src/methodListView.js
 server/src/**
 mcp-server/src/**
 

--- a/client/src/__tests__/listFilter.test.ts
+++ b/client/src/__tests__/listFilter.test.ts
@@ -546,4 +546,71 @@ describe('ListFilter', () => {
       vi.useRealTimers();
     });
   });
+
+  // The method list prepends override-indicator arrows (▲/▼) as leading
+  // children of each item. ListFilter rewrites item text on every render, so it
+  // must preserve those arrows rather than wipe them.
+  describe('override-arrow preservation', () => {
+    function makeListWithArrows(
+      id: string, specs: Array<{ selector: string; dirs: Array<'up' | 'down'> }>,
+    ): HTMLDivElement {
+      const list = document.createElement('div');
+      list.id = id;
+      for (const { selector, dirs } of specs) {
+        const div = document.createElement('div');
+        div.className = 'item';
+        div.dataset.value = selector;
+        for (const dir of dirs) {
+          const span = document.createElement('span');
+          span.className = 'override-arrow ' + dir;
+          span.textContent = dir === 'up' ? '▲' : '▼';
+          div.appendChild(span);
+        }
+        div.appendChild(document.createTextNode(selector));
+        list.appendChild(div);
+      }
+      document.body.appendChild(list);
+      return list;
+    }
+
+    it('keeps the arrow and rebuilds selector text on an unmatched (empty) render', () => {
+      makeListWithArrows('items', [{ selector: 'size', dirs: ['up'] }]);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = '';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item') as HTMLElement;
+      expect(item.querySelectorAll('.override-arrow')).toHaveLength(1);
+      expect(item.firstElementChild?.textContent).toBe('▲');
+      expect(item.textContent).toBe('▲size');
+    });
+
+    it('keeps the arrow and still highlights the match on a matched render', () => {
+      makeListWithArrows('items', [{ selector: 'size', dirs: ['down'] }]);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'iz';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item') as HTMLElement;
+      expect(item.querySelectorAll('.override-arrow')).toHaveLength(1);
+      expect(item.firstElementChild?.classList.contains('override-arrow')).toBe(true);
+      expect(item.querySelector('.match-highlight')?.textContent).toBe('iz');
+      // Arrow precedes the rebuilt selector text.
+      expect(item.textContent).toBe('▼size');
+    });
+
+    it('preserves both arrows for a selector that is overridden and overriding', () => {
+      makeListWithArrows('items', [{ selector: 'new', dirs: ['up', 'down'] }]);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = '';
+      filter.applyFilter();
+
+      const arrows = document.querySelectorAll('#items .item .override-arrow');
+      expect([...arrows].map(a => a.textContent)).toEqual(['▲', '▼']);
+      expect((document.querySelector('#items .item') as HTMLElement).textContent).toBe('▲▼new');
+    });
+  });
 });

--- a/client/src/__tests__/methodListView.test.ts
+++ b/client/src/__tests__/methodListView.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Evaluate methodListView.js in jsdom so it registers the global MethodListView,
+// exactly as the webview does when it injects the file as a <script> tag.
+beforeAll(() => {
+  const source = fs.readFileSync(path.resolve(__dirname, '../methodListView.js'), 'utf8');
+  // eslint-disable-next-line no-new-func
+  new Function(source)();
+});
+
+type ClickMessage =
+  | { command: 'showHierarchyImpls'; selector: string; direction: string }
+  | { command: 'selectMethod'; selector: string }
+  | null;
+
+type MethodListViewApi = {
+  makeOverrideArrow(selector: string, dir: 'up' | 'down'): HTMLSpanElement;
+  applyOverrideArrows(div: HTMLElement, selector: string, methodOverrideBit: number): void;
+  methodListClickMessage(event: { target: Element }, listEl: HTMLElement): ClickMessage;
+};
+
+function api(): MethodListViewApi {
+  return (globalThis as unknown as { MethodListView: MethodListViewApi }).MethodListView;
+}
+
+// Build a method-list <div class="item"> the way populateColumn does, applying
+// the override bits so arrows (if any) become real leading children.
+function makeItem(selector: string, methodOverrideBit = 0): HTMLDivElement {
+  const div = document.createElement('div');
+  div.className = 'item';
+  div.dataset.value = selector;
+  if (methodOverrideBit) {
+    api().applyOverrideArrows(div, selector, methodOverrideBit);
+  } else {
+    div.textContent = selector;
+  }
+  return div;
+}
+
+describe('MethodListView.makeOverrideArrow', () => {
+  it('builds an up arrow (▲) carrying the selector and direction', () => {
+    const span = api().makeOverrideArrow('printOn:', 'up');
+    expect(span.textContent).toBe('▲');
+    expect(span.className).toBe('override-arrow up');
+    expect(span.dataset.value).toBe('printOn:');
+    expect(span.dataset.dir).toBe('up');
+    expect(span.title).toContain('Overrides a superclass');
+  });
+
+  it('builds a down arrow (▼) with the subclass tooltip', () => {
+    const span = api().makeOverrideArrow('printOn:', 'down');
+    expect(span.textContent).toBe('▼');
+    expect(span.className).toBe('override-arrow down');
+    expect(span.dataset.dir).toBe('down');
+    expect(span.title).toContain('Overridden in a subclass');
+  });
+});
+
+describe('MethodListView.applyOverrideArrows', () => {
+  it('bit 1 renders only ▲ before the selector text', () => {
+    const div = makeItem('size', 1);
+    expect(div.querySelectorAll('.override-arrow')).toHaveLength(1);
+    expect(div.querySelector('.override-arrow')!.textContent).toBe('▲');
+    expect(div.textContent).toBe('▲size');
+  });
+
+  it('bit 2 renders only ▼ before the selector text', () => {
+    const div = makeItem('size', 2);
+    const arrows = div.querySelectorAll('.override-arrow');
+    expect(arrows).toHaveLength(1);
+    expect(arrows[0].textContent).toBe('▼');
+    expect(div.textContent).toBe('▼size');
+  });
+
+  it('bit 3 renders both ▲ and ▼ (in that order) then the selector', () => {
+    const div = makeItem('new', 3);
+    const arrows = [...div.querySelectorAll('.override-arrow')];
+    expect(arrows.map(a => a.textContent)).toEqual(['▲', '▼']);
+    expect(arrows.map(a => (a as HTMLElement).dataset.dir)).toEqual(['up', 'down']);
+    // Selector text follows the arrows.
+    expect(div.lastChild?.textContent).toBe('new');
+    expect(div.textContent).toBe('▲▼new');
+  });
+
+  it('keeps dataset.value the bare selector so filtering/selection still match', () => {
+    const div = makeItem('at:put:', 3);
+    expect(div.dataset.value).toBe('at:put:');
+  });
+});
+
+describe('MethodListView.methodListClickMessage', () => {
+  it('clicking an arrow posts showHierarchyImpls with selector and direction', () => {
+    const list = document.createElement('div');
+    const item = makeItem('printOn:', 1);
+    list.appendChild(item);
+    const arrow = item.querySelector('.override-arrow')!;
+
+    const msg = api().methodListClickMessage({ target: arrow }, list);
+
+    expect(msg).toEqual({
+      command: 'showHierarchyImpls',
+      selector: 'printOn:',
+      direction: 'up',
+    });
+  });
+
+  it('clicking an arrow does NOT change the row selection', () => {
+    const list = document.createElement('div');
+    const item = makeItem('printOn:', 2);
+    list.appendChild(item);
+    const arrow = item.querySelector('.override-arrow')!;
+
+    api().methodListClickMessage({ target: arrow }, list);
+
+    expect(item.classList.contains('selected')).toBe(false);
+  });
+
+  it('clicking the selector text posts selectMethod and marks the row selected', () => {
+    const list = document.createElement('div');
+    const item = makeItem('size', 0);
+    list.appendChild(item);
+
+    const msg = api().methodListClickMessage({ target: item }, list);
+
+    expect(msg).toEqual({ command: 'selectMethod', selector: 'size' });
+    expect(item.classList.contains('selected')).toBe(true);
+  });
+
+  it('selecting a row clears the previously selected row', () => {
+    const list = document.createElement('div');
+    const first = makeItem('size', 0);
+    const second = makeItem('name', 0);
+    first.classList.add('selected');
+    list.append(first, second);
+
+    api().methodListClickMessage({ target: second }, list);
+
+    expect(first.classList.contains('selected')).toBe(false);
+    expect(second.classList.contains('selected')).toBe(true);
+  });
+
+  it('clicking empty space (neither arrow nor item) returns null', () => {
+    const list = document.createElement('div');
+    const msg = api().methodListClickMessage({ target: list }, list);
+    expect(msg).toBeNull();
+  });
+});

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -347,6 +347,7 @@ describe('SystemBrowser', () => {
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadMethods',
         items: ['=', 'hash', 'name', 'name:'],
+        methodOverrideBits: {},
       });
     });
 
@@ -360,6 +361,99 @@ describe('SystemBrowser', () => {
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadMethods',
         items: ['name', 'name:'],
+        methodOverrideBits: {},
+      });
+    });
+
+    describe('method override bits', () => {
+      type LoadMethodsMsg = { command: string; items: string[]; methodOverrideBits: Record<string, number> };
+
+      beforeEach(() => {
+        vi.mocked(queries.getClassEnvironments).mockReturnValue([
+          { isMeta: false, envId: 0, category: 'Accessing', selectors: ['name', 'name:'],
+            methodOverrideBits: { name: 1 } },
+          { isMeta: false, envId: 0, category: 'Comparing', selectors: ['=', 'hash'],
+            methodOverrideBits: { '=': 3 } },
+          { isMeta: true, envId: 0, category: 'Instance Creation', selectors: ['new', 'new:'],
+            methodOverrideBits: { new: 2 } },
+        ]);
+      });
+
+      function selectArray(): void {
+        messageHandler({ command: 'ready' });
+        messageHandler({ command: 'selectDictionary', index: 1 });
+        messageHandler({ command: 'selectCategory', name: '** ALL CLASSES **' });
+        vi.mocked(fs.existsSync).mockReturnValue(false);
+        messageHandler({ command: 'selectClass', name: 'Array' });
+      }
+
+      function lastLoadMethods(): LoadMethodsMsg {
+        const calls = vi.mocked(mockPanel.webview.postMessage).mock.calls
+          .map(c => c[0] as LoadMethodsMsg)
+          .filter(m => m.command === 'loadMethods');
+        return calls[calls.length - 1];
+      }
+
+      it('attaches bits only for displayed selectors on the current side', () => {
+        selectArray();
+        messageHandler({ command: 'selectMethodCategory', name: 'Accessing' });
+        const msg = lastLoadMethods();
+        expect(msg.items).toEqual(['name', 'name:']);
+        // name: has no entry, so it is absent — only name carries a bit.
+        expect(msg.methodOverrideBits).toEqual({ name: 1 });
+      });
+
+      it('aggregates bits across categories for ALL METHODS', () => {
+        selectArray();
+        messageHandler({ command: 'selectMethodCategory', name: '** ALL METHODS **' });
+        expect(lastLoadMethods().methodOverrideBits).toEqual({ name: 1, '=': 3 });
+      });
+
+      it('uses class-side bits after toggling to the class side', () => {
+        selectArray();
+        messageHandler({ command: 'toggleSide', isMeta: true });
+        messageHandler({ command: 'selectMethodCategory', name: 'Instance Creation' });
+        const msg = lastLoadMethods();
+        expect(msg.items).toEqual(['new', 'new:']);
+        expect(msg.methodOverrideBits).toEqual({ new: 2 });
+      });
+    });
+
+    describe('override-arrow click (showHierarchyImpls)', () => {
+      function selectArray(): void {
+        messageHandler({ command: 'ready' });
+        messageHandler({ command: 'selectDictionary', index: 1 });
+        messageHandler({ command: 'selectCategory', name: '** ALL CLASSES **' });
+        vi.mocked(fs.existsSync).mockReturnValue(false);
+        messageHandler({ command: 'selectClass', name: 'Array' });
+      }
+
+      it('forwards to gemstone.hierarchyImplementorsOf with the current context', () => {
+        selectArray();
+        messageHandler({ command: 'showHierarchyImpls', selector: 'name', direction: 'up' });
+        expect(commands.executeCommand).toHaveBeenCalledWith('gemstone.hierarchyImplementorsOf', {
+          selector: 'name',
+          className: 'Array',
+          dictIndex: 1,
+          isMeta: false,
+          direction: 'up',
+          sessionId: session.id,
+        });
+      });
+
+      it('carries the class side and direction through', () => {
+        selectArray();
+        messageHandler({ command: 'toggleSide', isMeta: true });
+        messageHandler({ command: 'showHierarchyImpls', selector: 'new', direction: 'down' });
+        expect(commands.executeCommand).toHaveBeenCalledWith('gemstone.hierarchyImplementorsOf',
+          expect.objectContaining({ selector: 'new', isMeta: true, direction: 'down' }));
+      });
+
+      it('does nothing when no class is selected', () => {
+        messageHandler({ command: 'ready' });
+        messageHandler({ command: 'showHierarchyImpls', selector: 'name', direction: 'up' });
+        expect(commands.executeCommand).not.toHaveBeenCalledWith(
+          'gemstone.hierarchyImplementorsOf', expect.anything());
       });
     });
 
@@ -1402,6 +1496,7 @@ describe('SystemBrowser', () => {
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadMethods',
         items: ['rb_name'],
+        methodOverrideBits: {},
       });
     });
 
@@ -1531,6 +1626,7 @@ describe('SystemBrowser', () => {
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadMethods',
         items: ['name', 'name:'],
+        methodOverrideBits: {},
       });
     });
 
@@ -1595,6 +1691,7 @@ describe('SystemBrowser', () => {
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadMethods',
         items: ['name', 'name:'],
+        methodOverrideBits: {},
       });
     });
 

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -32,6 +32,7 @@ import {
   searchMethodSource as sharedSearchMethodSource,
   sendersOf as sharedSendersOf,
   implementorsOf as sharedImplementorsOf,
+  hierarchyImplementorsOf as sharedHierarchyImplementorsOf,
   referencesToObject as sharedReferencesToObject,
 } from './queries/methodSearch';
 
@@ -341,6 +342,16 @@ export function implementorsOf(
   session: ActiveSession, selector: string, environmentId: number = 0,
 ) {
   return sharedImplementorsOf(bind(session), selector, environmentId);
+}
+
+export function hierarchyImplementorsOf(
+  session: ActiveSession, dictIndex: number, className: string,
+  selector: string, isMeta: boolean, direction: 'up' | 'down',
+  environmentId: number = 0,
+) {
+  return sharedHierarchyImplementorsOf(
+    bind(session), dictIndex, className, selector, isMeta, direction, environmentId,
+  );
 }
 
 export function referencesToObject(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1005,6 +1005,30 @@ export function activate(context: vscode.ExtensionContext) {
       await showMethodResults(session, results, `Implementors of #${args.selector}`);
     }),
 
+    vscode.commands.registerCommand('gemstone.hierarchyImplementorsOf', async (args: { selector: string; className: string; dictIndex: number; isMeta: boolean; direction: 'up' | 'down'; sessionId: number }) => {
+      const session = sessionManager.getSession(args.sessionId);
+      if (!session) return;
+      const maxEnv = vscode.workspace.getConfiguration('gemstone').get<number>('maxEnvironment', 0);
+      const all: queries.MethodSearchResult[] = [];
+      for (let env = 0; env <= maxEnv; env++) {
+        all.push(...queries.hierarchyImplementorsOf(
+          session, args.dictIndex, args.className, args.selector, args.isMeta, args.direction, env,
+        ));
+      }
+      const seen = new Set<string>();
+      const results = all.filter(r => {
+        const key = `${r.className}|${r.isMeta}|${r.selector}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      const side = args.isMeta ? ' class' : '';
+      const title = args.direction === 'up'
+        ? `${args.className}${side} >> #${args.selector} — superclass implementations`
+        : `${args.className}${side} >> #${args.selector} — subclass overrides`;
+      await showMethodResults(session, results, title);
+    }),
+
     vscode.commands.registerCommand('gemstone.browseReferences', async (args: { objectName: string; sessionId: number }) => {
       const session = sessionManager.getSession(args.sessionId);
       if (!session) return;

--- a/client/src/listFilter.js
+++ b/client/src/listFilter.js
@@ -147,12 +147,21 @@ class ListFilter extends HTMLElement {
 
     // Matched item rendering
 
+    // Clear the item's text while keeping any leading indicator elements
+    // (e.g. override arrows) that were rendered before the selector text.
+    clearItemText(item) {
+        const keep = [...item.querySelectorAll(':scope > .override-arrow')];
+        item.textContent = '';
+        for (const el of keep) item.appendChild(el);
+    }
+
     renderUnmatchedItem(item) {
-        item.textContent = item.dataset.value;
+        this.clearItemText(item);
+        item.appendChild(document.createTextNode(item.dataset.value));
     }
 
     renderMatchedItem(item, match) {
-        item.textContent = '';
+        this.clearItemText(item);
 
         this.renderTextBeforeMatch(item, match);
         this.renderHighlightedMatch(item, match);

--- a/client/src/methodListView.js
+++ b/client/src/methodListView.js
@@ -1,0 +1,63 @@
+/**
+ * Method-list rendering helpers for the System Browser webview.
+ *
+ * Like listFilter.js, this is read at runtime via fs.readFileSync and injected
+ * into the webview as a <script> tag — it is NOT compiled into the bundle. It
+ * lives in its own file so the override-indicator rendering and click dispatch
+ * can be unit-tested in jsdom (see methodListView.test.ts) instead of being
+ * trapped inside the inline webview <script> string.
+ *
+ * The override bitmask carried per selector: bit 1 = overrides a superclass
+ * implementation (▲), bit 2 = overridden in a subclass (▼), 3 = both.
+ *
+ * Exposed as the global `MethodListView` so both the webview (classic <script>)
+ * and tests (new Function(source)()) can reach it.
+ */
+(function () {
+  // Build a clickable override-indicator arrow for one direction.
+  function makeOverrideArrow(selector, dir) {
+    const span = document.createElement('span');
+    span.className = 'override-arrow ' + dir;
+    span.dataset.value = selector;
+    span.dataset.dir = dir;
+    span.textContent = dir === 'up' ? '▲' : '▼';
+    span.title = dir === 'up'
+      ? 'Overrides a superclass implementation — click to view'
+      : 'Overridden in a subclass — click to view';
+    return span;
+  }
+
+  // Render leading arrow(s) followed by the selector text. The arrows are kept
+  // as the item's leading children; ListFilter preserves them when it
+  // re-renders the selector text for filtering/highlighting.
+  function applyOverrideArrows(div, selector, methodOverrideBit) {
+    div.textContent = '';
+    if (methodOverrideBit & 1) div.appendChild(makeOverrideArrow(selector, 'up'));
+    if (methodOverrideBit & 2) div.appendChild(makeOverrideArrow(selector, 'down'));
+    div.appendChild(document.createTextNode(selector));
+  }
+
+  // Decide what a click in the methods column means and update selection.
+  // Returns the message the webview should post, or null if the click hit
+  // neither an arrow nor an item. Clicking an override arrow shows the
+  // hierarchy implementations; clicking elsewhere on a row selects the method.
+  function methodListClickMessage(event, listEl) {
+    const arrow = event.target.closest('.override-arrow');
+    if (arrow) {
+      return {
+        command: 'showHierarchyImpls',
+        selector: arrow.dataset.value,
+        direction: arrow.dataset.dir,
+      };
+    }
+    const item = event.target.closest('.item');
+    if (!item) return null;
+    const prev = listEl.querySelector('.item.selected');
+    if (prev) prev.classList.remove('selected');
+    item.classList.add('selected');
+    return { command: 'selectMethod', selector: item.dataset.value };
+  }
+
+  const root = typeof globalThis !== 'undefined' ? globalThis : window;
+  root.MethodListView = { makeOverrideArrow, applyOverrideArrows, methodListClickMessage };
+})();

--- a/client/src/queries/__tests__/methodSearch.test.ts
+++ b/client/src/queries/__tests__/methodSearch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { QueryExecutor } from '../types';
 import {
   searchMethodSource, sendersOf, implementorsOf, referencesToObject,
+  hierarchyImplementorsOf,
 } from '../methodSearch';
 
 const row = 'Globals\tArray\t0\tsize\taccessing\n';
@@ -70,5 +71,76 @@ describe('referencesToObject', () => {
     const code = execute.mock.calls[0][1];
     expect(code).toContain('referencesToObject:');
     expect(code).toContain("objectNamed: #'MyGlobal'");
+  });
+});
+
+// Guards the Python-alias navigation fix: a class's home dictionary must be the
+// one that stores it under its own name, not merely any dict that references it.
+describe('methodSerialization home-dictionary resolution', () => {
+  it('only treats a dict as a class home when keyed by the class name', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    implementorsOf(execute, 'size');
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('k = v name asSymbol');
+  });
+});
+
+describe('hierarchyImplementorsOf', () => {
+  it('walks the full superclass chain for direction up', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    hierarchyImplementorsOf(execute, 1, 'Array', 'at:', false, 'up');
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('superclass');
+    expect(code).toContain('[cur notNil] whileTrue:');
+    expect(code).toContain("includesSelector: #'at:'");
+    expect(code).not.toContain('allSubclasses');
+  });
+
+  it('walks all subclasses for direction down', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    hierarchyImplementorsOf(execute, 1, 'Array', 'at:', false, 'down');
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('allSubclasses do:');
+    expect(code).toContain("includesSelector: #'at:'");
+    expect(code).not.toContain('whileTrue:');
+  });
+
+  it('targets the metaclass side when isMeta is true (up)', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    hierarchyImplementorsOf(execute, 1, 'Array', 'new', true, 'up');
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('(class class) superclass');
+  });
+
+  it('targets each subclass metaclass when isMeta is true (down)', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    hierarchyImplementorsOf(execute, 1, 'Array', 'new', true, 'down');
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('tgt := sub class');
+  });
+
+  it('uses the instance side (class / sub) when isMeta is false', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    hierarchyImplementorsOf(execute, 1, 'Array', 'at:', false, 'down');
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('tgt := sub.');
+    expect(code).not.toContain('sub class');
+  });
+
+  it('embeds the dictIndex and escapes class name and selector', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    hierarchyImplementorsOf(execute, 7, "Foo'Bar", "o'clock", false, 'up');
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('symbolList at: 7');
+    expect(code).toContain("#'Foo''Bar'");
+    expect(code).toContain("#'o''clock'");
+  });
+
+  it('parses returned rows into MethodSearchResult', () => {
+    const raw = 'Globals\tObject\t0\tat:\taccessing\n';
+    const results = hierarchyImplementorsOf(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 'at:', false, 'up');
+    expect(results).toEqual([
+      { dictName: 'Globals', className: 'Object', isMeta: false, selector: 'at:', category: 'accessing' },
+    ]);
   });
 });

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -57,8 +57,9 @@ describe('getAllClassNames', () => {
 
 describe('getClassEnvironments', () => {
   it('detects class side via " class" suffix on receiver name', () => {
-    const raw = 'Array class\t0\tinstance creation\tnew\twith:\n'
-              + 'Array\t0\taccessing\tsize\n';
+    // Each selector token carries a leading override-flag digit (0..3).
+    const raw = 'Array class\t0\tinstance creation\t0new\t0with:\n'
+              + 'Array\t0\taccessing\t0size\n';
     const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
     expect(results).toHaveLength(2);
     expect(results[0]).toMatchObject({
@@ -68,6 +69,28 @@ describe('getClassEnvironments', () => {
     expect(results[1].isMeta).toBe(false);
   });
 
+  it('parses the per-selector override bitmask and strips its prefix', () => {
+    // 1 = overrides super (▲), 2 = overridden in subclass (▼), 3 = both.
+    const raw = 'Array\t0\taccessing\t1at:\t2size\t3printOn:\t0name\n';
+    const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
+    expect(results[0].selectors).toEqual(['at:', 'name', 'printOn:', 'size']);
+    expect(results[0].methodOverrideBits).toEqual({ 'at:': 1, size: 2, 'printOn:': 3 });
+  });
+
+  it('omits zero-bit (neither overrides nor overridden) selectors from the map', () => {
+    const raw = 'Array\t0\taccessing\t0a\t0b\n';
+    const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
+    expect(results[0].selectors).toEqual(['a', 'b']);
+    expect(results[0].methodOverrideBits).toEqual({});
+  });
+
+  it('records override bits on the class side too', () => {
+    const raw = 'Array class\t0\tinstance creation\t3new\t1basicNew\n';
+    const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
+    expect(results[0].isMeta).toBe(true);
+    expect(results[0].methodOverrideBits).toEqual({ new: 3, basicNew: 1 });
+  });
+
   it('embeds dictIndex, escaped class name, and maxEnv', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getClassEnvironments(execute, 3, "Foo'Bar", 2);
@@ -75,6 +98,18 @@ describe('getClassEnvironments', () => {
     expect(code).toContain('symbolList at: 3');
     expect(code).toContain("#'Foo''Bar'");
     expect(code).toContain('envs := 2');
+  });
+
+  it('detects overrides via the full chain, not the immediate neighbour', () => {
+    // Locks in the chain-walking primitives so a regression to a single-level
+    // check (or back to lookupSelector:) is caught here. The actual depth of
+    // detection is exercised by a live-GCI smoke test, not this unit test.
+    const execute = vi.fn<QueryExecutor>(() => '');
+    getClassEnvironments(execute, 1, 'Array', 0);
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('whichClassIncludesSelector:'); // walks all ancestors
+    expect(code).toContain('allSubclasses');               // walks all descendants
+    expect(code).not.toContain('lookupSelector:');         // the rejected approach
   });
 });
 

--- a/client/src/queries/getClassEnvironments.ts
+++ b/client/src/queries/getClassEnvironments.ts
@@ -6,16 +6,36 @@ export interface EnvCategoryLine {
   envId: number;
   category: string;
   selectors: string[];
+  // Per-selector override bitmask keyed by bare selector: bit 1 = overrides a
+  // superclass impl (▲), bit 2 = overridden in a subclass (▼). Selectors with
+  // no indicator are absent. Always populated by the parser below.
+  methodOverrideBits?: Record<string, number>;
 }
 
 export function getClassEnvironments(
   execute: QueryExecutor, dictIndex: number, className: string, maxEnv: number,
 ): EnvCategoryLine[] {
-  const code = `| class envs stream |
+  // Each emitted selector token is prefixed with a single override-flag digit
+  // (0..3) so the indicator rides along on the existing method-list round trip.
+  // "Overridden in a subclass" is computed once by intersecting subclass-local
+  // selectors with this class's own selectors, so the working set stays small
+  // even for classes with thousands of subclasses (e.g. Object).
+  const code = `| class envs stream instOwn metaOwn instSub metaSub |
 envs := ${maxEnv}.
 class := (System myUserProfile symbolList at: ${dictIndex}) at: #'${escapeString(className)}'.
+instOwn := class selectors asIdentitySet.
+metaOwn := class class selectors asIdentitySet.
+instSub := IdentitySet new.
+metaSub := IdentitySet new.
+class allSubclasses do: [:sub |
+  sub selectors do: [:s | (instOwn includes: s) ifTrue: [instSub add: s]].
+  sub class selectors do: [:s | (metaOwn includes: s) ifTrue: [metaSub add: s]]].
 stream := WriteStream on: Unicode7 new.
-{ class class. class. } do: [:eachClass |
+{ class class. class. } doWithIndex: [:eachClass :idx |
+  | isMeta subSel superCls |
+  isMeta := idx = 1.
+  subSel := isMeta ifTrue: [metaSub] ifFalse: [instSub].
+  superCls := eachClass superclass.
   0 to: envs do: [:env |
     (eachClass _unifiedCategorys: env) keysAndValuesDo: [:categoryName :selectors |
       stream
@@ -23,8 +43,12 @@ stream := WriteStream on: Unicode7 new.
         nextPutAll: env printString; tab;
         nextPutAll: categoryName; tab;
         yourself.
-      selectors do: [:each |
-        stream nextPutAll: each; tab.
+      selectors do: [:each | | up down |
+        up := superCls notNil and: [(superCls whichClassIncludesSelector: each) notNil].
+        down := subSel includes: each.
+        stream
+          nextPutAll: ((up ifTrue: [1] ifFalse: [0]) + (down ifTrue: [2] ifFalse: [0])) printString;
+          nextPutAll: each; tab.
       ].
       stream lf.
     ].
@@ -42,9 +66,17 @@ stream contents`;
     const receiverName = parts[0];
     const envId = parseInt(parts[1], 10);
     const category = parts[2];
-    const selectors = parts.slice(3).sort();
+    const methodOverrideBits: Record<string, number> = {};
+    const selectors = parts.slice(3).map((tok) => {
+      // Leading digit is the override bitmask: 1 = overrides super, 2 =
+      // overridden in subclass, 3 = both, 0 = neither.
+      const methodOverrideBit = Number(tok[0]);
+      const sel = tok.slice(1);
+      if (methodOverrideBit) methodOverrideBits[sel] = methodOverrideBit;
+      return sel;
+    }).sort();
     const isMeta = receiverName.endsWith(' class');
-    results.push({ isMeta, envId, category, selectors });
+    results.push({ isMeta, envId, category, selectors, methodOverrideBits });
   }
   return results;
 }

--- a/client/src/queries/methodSearch.ts
+++ b/client/src/queries/methodSearch.ts
@@ -17,7 +17,11 @@ function methodSerialization(envId: number): string {
 classDict := IdentityDictionary new.
 sl do: [:dict |
   dict keysAndValuesDo: [:k :v |
-    (v isBehavior and: [(classDict includesKey: v) not])
+    "Only treat a dict as a class's home when it is stored under its own
+     name. Otherwise an alias entry (e.g. Python's #object -> Object, which
+     sorts before Globals) would mask the real home dictionary and break
+     browser navigation, since the browser keys classes by their name."
+    (v isBehavior and: [(classDict includesKey: v) not and: [k = v name asSymbol]])
       ifTrue: [classDict at: v put: dict name]]].
 stream := WriteStream on: Unicode7 new.
 limit := methods size min: 500.
@@ -89,6 +93,36 @@ ${methodSerialization(environmentId)}`;
 
   return parseMethodSearchResults(
     execute(`implementorsOf(#${selector}, env:${environmentId})`, code),
+  );
+}
+
+// Implementations of `selector` in a class's hierarchy: the full superclass
+// chain (direction 'up') or all subclasses (direction 'down'), on the
+// instance or class side. One round trip; reuses the standard result format.
+export function hierarchyImplementorsOf(
+  execute: QueryExecutor, dictIndex: number, className: string,
+  selector: string, isMeta: boolean, direction: 'up' | 'down',
+  environmentId: number = 0,
+): MethodSearchResult[] {
+  const sel = escapeString(selector);
+  const target = isMeta ? 'class class' : 'class';
+  const collect = direction === 'up'
+    ? `cur := (${target}) superclass.
+[cur notNil] whileTrue: [
+  (cur includesSelector: #'${sel}') ifTrue: [methods add: (cur compiledMethodAt: #'${sel}')].
+  cur := cur superclass].`
+    : `class allSubclasses do: [:sub | | tgt |
+  tgt := ${isMeta ? 'sub class' : 'sub'}.
+  (tgt includesSelector: #'${sel}') ifTrue: [methods add: (tgt compiledMethodAt: #'${sel}')]].`;
+  const code = `| class methods stream limit classDict sl cur |
+class := (System myUserProfile symbolList at: ${dictIndex}) at: #'${escapeString(className)}'.
+methods := OrderedCollection new.
+${collect}
+methods := methods asArray.
+${methodSerialization(environmentId)}`;
+
+  return parseMethodSearchResults(
+    execute(`hierarchyImplementorsOf(#${selector}, ${direction})`, code),
   );
 }
 

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -20,6 +20,7 @@ import {buildNewMethodUri} from './gemstoneFileSystemProvider';
  * Reading the file at runtime is the simplest approach that works in both environments.
  */
 const listFilterJs = fs.readFileSync(path.join(__dirname, '..', 'src', 'listFilter.js'), 'utf8');
+const methodListViewJs = fs.readFileSync(path.join(__dirname, '..', 'src', 'methodListView.js'), 'utf8');
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -392,11 +393,7 @@ export class SystemBrowser {
       items: this.state.methodCategories,
       selected: this.state.selectedMethodCategory,
     });
-    this.panel.webview.postMessage({
-      command: 'loadMethods',
-      items: this.state.methods,
-      selected: selector,
-    });
+    this.postMethods(this.state.methods, selector);
 
     // Update dimming to highlight the current method
     if (cursorRegion) {
@@ -516,6 +513,12 @@ export class SystemBrowser {
           break;
         case 'ctxImplementorsOf':
           this.handleImplementorsOf();
+          break;
+        case 'showHierarchyImpls':
+          this.handleShowHierarchyImpls(
+            message.selector as string,
+            message.direction as 'up' | 'down',
+          );
           break;
         case 'ctxBrowseReferences':
           this.handleBrowseReferences(message.name as string);
@@ -710,10 +713,7 @@ export class SystemBrowser {
     }
     this.state.methods = methods;
 
-    this.panel.webview.postMessage({
-      command: 'loadMethods',
-      items: this.state.methods,
-    });
+    this.postMethods(this.state.methods);
   }
 
   private handleSelectMethod(selector: string): void {
@@ -783,11 +783,7 @@ export class SystemBrowser {
       items: this.state.methodCategories,
       selected: category,
     });
-    this.panel.webview.postMessage({
-      command: 'loadMethods',
-      items: this.state.methods,
-      selected: selector,
-    });
+    this.postMethods(this.state.methods, selector);
 
     if (openFile) this.openClassFile(className, selector, isMeta);
   }
@@ -945,11 +941,7 @@ export class SystemBrowser {
           if (this.state.selectedClass) {
             this.loadMethodCategories(this.state.selectedMethodCategory);
             if (this.state.selectedMethodCategory) {
-              this.panel.webview.postMessage({
-                command: 'loadMethods',
-                items: this.state.methods,
-                selected: this.state.selectedMethod,
-              });
+              this.postMethods(this.state.methods, this.state.selectedMethod);
             }
           }
         }
@@ -1384,6 +1376,22 @@ export class SystemBrowser {
     });
   }
 
+  // Clicking an override arrow: show the implementations of `selector` in the
+  // current class's superclass chain ('up') or its subclasses ('down').
+  private handleShowHierarchyImpls(selector: string, direction: 'up' | 'down'): void {
+    const className = this.state.selectedClass;
+    const dictIndex = this.state.selectedDictIndex;
+    if (!selector || !className || !dictIndex) return;
+    vscode.commands.executeCommand('gemstone.hierarchyImplementorsOf', {
+      selector,
+      className,
+      dictIndex,
+      isMeta: this.state.isMeta,
+      direction,
+      sessionId: this.session.id,
+    });
+  }
+
   private handleBrowseReferences(objectName: string): void {
     if (!objectName) return;
     vscode.commands.executeCommand('gemstone.browseReferences', {
@@ -1459,6 +1467,34 @@ export class SystemBrowser {
       this.envCache.set(key, data);
     }
     return data;
+  }
+
+  // Override indicators (▲ overrides super, ▼ overridden in subclass) for the
+  // currently displayed selectors on the current side. Derived from the cached
+  // env data so it costs no extra round trip.
+  private methodOverrideBitsFor(items: string[]): Record<string, number> {
+    const dictIndex = this.state.selectedDictIndex;
+    const className = this.state.selectedClass;
+    if (!dictIndex || !className || items.length === 0) return {};
+    const itemSet = new Set(items);
+    const bits: Record<string, number> = {};
+    for (const line of this.getCachedEnvData(dictIndex, className)) {
+      if (line.isMeta !== this.state.isMeta || !line.methodOverrideBits) continue;
+      for (const sel of Object.keys(line.methodOverrideBits)) {
+        if (itemSet.has(sel)) bits[sel] = line.methodOverrideBits[sel];
+      }
+    }
+    return bits;
+  }
+
+  // Post the methods column to the webview with override bits attached.
+  private postMethods(items: string[], selected?: string | null): void {
+    this.panel.webview.postMessage({
+      command: 'loadMethods',
+      items,
+      selected: selected ?? undefined,
+      methodOverrideBits: this.methodOverrideBitsFor(items),
+    });
   }
 
   private refreshMethodList(): void {
@@ -1742,6 +1778,31 @@ export class SystemBrowser {
       color: var(--vscode-list-activeSelectionForeground);
     }
 
+    .override-arrow {
+      display: inline-block;
+      width: 0.85em;
+      margin-right: 1px;
+      text-align: center;
+      font-size: 0.72em;
+      line-height: 1;
+      vertical-align: middle;
+      cursor: pointer;
+      opacity: 0.8;
+    }
+
+    .override-arrow.up {
+      color: var(--vscode-charts-blue, var(--vscode-textLink-foreground));
+    }
+
+    .override-arrow.down {
+      color: var(--vscode-charts-orange, var(--vscode-symbolIcon-methodForeground));
+    }
+
+    .override-arrow:hover {
+      opacity: 1;
+      color: var(--vscode-textLink-activeForeground);
+    }
+
     .column-footer {
       padding: 4px 8px;
       border-top: 1px solid var(--vscode-panel-border);
@@ -1869,6 +1930,7 @@ export class SystemBrowser {
     }
   </style>
   <script nonce="${nonce}">${listFilterJs}</script>
+  <script nonce="${nonce}">${methodListViewJs}</script>
 </head>
 <body>
   <div class="error-banner" id="errorBanner"></div>
@@ -1952,20 +2014,25 @@ export class SystemBrowser {
     const hierBtn = document.getElementById('hierBtn');
     const errorBanner = document.getElementById('errorBanner');
     // ── Populate a column with items ───────────────
-    function populateColumn(listEl, items, virtualItems, draggable) {
+    function populateColumn(listEl, items, virtualItems, draggable, methodOverrideBits) {
       listEl.innerHTML = '';
       const virtualSet = new Set(virtualItems || []);
       for (const item of items) {
         const div = document.createElement('div');
         div.className = 'item' + (virtualSet.has(item) ? ' virtual' : '');
-        div.textContent = item;
         div.dataset.value = item;
+        const methodOverrideBit = methodOverrideBits && methodOverrideBits[item];
+        if (methodOverrideBit) {
+          MethodListView.applyOverrideArrows(div, item, methodOverrideBit);
+        } else {
+          div.textContent = item;
+        }
         if (draggable && !virtualSet.has(item)) {
           div.draggable = true;
         }
         listEl.appendChild(div);
       }
-      
+
       ListFilter.refreshFilterOf(listEl);
     }
 
@@ -2019,8 +2086,11 @@ export class SystemBrowser {
       vscode.postMessage({ command: 'selectMethodCategory', name });
     });
 
-    setupClickHandler(cols.methods, (selector) => {
-      vscode.postMessage({ command: 'selectMethod', selector });
+    // Methods column: clicking an override arrow shows the hierarchy
+    // implementations; clicking anywhere else selects the method as usual.
+    cols.methods.addEventListener('click', (e) => {
+      const message = MethodListView.methodListClickMessage(e, cols.methods);
+      if (message) vscode.postMessage(message);
     });
 
     // ── Instance / Class toggle ────────────────────
@@ -2305,7 +2375,7 @@ export class SystemBrowser {
           break;
         case 'loadMethods':
           cols.methods.innerHTML = '';
-          populateColumn(cols.methods, msg.items, [], true);
+          populateColumn(cols.methods, msg.items, [], true, msg.methodOverrideBits);
           if (msg.selected) selectItemInColumn(cols.methods, msg.selected);
           break;
         case 'setViewMode':


### PR DESCRIPTION
## Summary

Adds a per-selector override indicator to the System Browser method list:

- **▲** — the method overrides a superclass implementation
- **▼** — the method is overridden in a subclass
- both glyphs appear when both apply

The indicators are **clickable**: ▲ opens the superclass-chain implementations, ▼ opens the subclass overrides, reusing the existing method-results UI.

Work item: https://code.gemtalksystems.com/GemStone/grail/-/work_items/21

## How it works

- **One round trip.** The override bits are computed server-side and piggyback on the existing method-list query (`getClassEnvironments`) — each selector token is prefixed with a 0–3 bitmask. No extra server call to show the arrows.
- **Full-chain detection.** `whichClassIncludesSelector:` walks the entire superclass chain (not just the immediate parent) and `allSubclasses` covers all descendants, so an override three levels up/down is still detected.
- **Click navigation** uses a new `hierarchyImplementorsOf` query (up = superclass chain, down = all subclasses), correctly targeting the instance or class side.

## Incidental bug fix

Fixes a latent bug in the shared method-search serialization: a class's home dictionary is now resolved by its **own name key** (`k = v name asSymbol`). Previously any dictionary that merely referenced the class could win — e.g. Python's `#object -> Object` alias sorts ahead of `Globals`, so navigating to `Object` selected the wrong dictionary and failed. This also corrects **Find Implementors / Senders / References** for aliased classes.

## Testability refactor

The webview's arrow rendering and click dispatch were extracted into a standalone `methodListView.js` (mirroring `listFilter.js`) so they can be unit-tested in jsdom instead of being trapped in an inline `<script>` string.

## Tests

**31 new tests**, full client suite green (**1772 passing**):

| Area | Coverage |
|---|---|
| Parser | bit decode/strip, zero-bit omitted, instance **and** class side |
| `hierarchyImplementorsOf` query | up/down walks, instance vs meta targeting, escaping, row parsing |
| Override-bit selection | per-side filtering, ALL-METHODS aggregation, class-side toggle |
| ListFilter | arrows preserved across matched/unmatched filter renders |
| Click forwarding | `showHierarchyImpls` → `gemstone.hierarchyImplementorsOf` with correct context (both sides) |
| Glyph rendering | bit 1→▲, 2→▼, 3→▲▼, click → correct message |

## Not covered (by design)

- **End-to-end chain *depth*** (e.g. an override two levels up resolving correctly against a live image) needs a GCI smoke test against a running stone — deferred.
- The `gemstone.hierarchyImplementorsOf` **command body** (env-loop + dedup + results display) isn't unit-tested; there's no `activate()` command-capture harness in `extension.test.ts`, and it mirrors the existing untested `implementorsOfSelector`. Its novel logic (the query) and the browser→command forwarding are both tested.

## Manual verification

Computed override bits and both query directions were exercised against a live GemStone session during development. Recommend a clean F5 to confirm the glyphs render and arrow-clicks navigate (including the `Collection` → ▲ on `auditInformation` → `Object` case that exposed the dictionary bug).
