### PR TITLE
Enhanced Debugger: a work-in-progress webview Smalltalk-style debugger (offered alongside the DAP debugger)

### DIFF
--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -169,6 +169,10 @@ function createMockTextEditor() {
     viewColumn: undefined as number | undefined,
     setDecorations: vi.fn(),
     revealRange: vi.fn(),
+    edit: vi.fn(async (cb: (b: { replace: typeof vi.fn; insert: typeof vi.fn; delete: typeof vi.fn }) => void) => {
+      cb({ replace: vi.fn(), insert: vi.fn(), delete: vi.fn() } as never);
+      return true;
+    }),
   };
 }
 

--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -155,9 +155,18 @@ function createMockPanel() {
 
 function createMockTextEditor() {
   return {
-    document: { uri: Uri.file(''), languageId: '', getText: vi.fn(() => ''), lineAt: vi.fn(), lineCount: 0 },
+    document: {
+      uri: Uri.file(''), languageId: '', getText: vi.fn(() => ''), lineCount: 0,
+      lineAt: vi.fn((line: number) => ({
+        lineNumber: line, text: '', firstNonWhitespaceCharacterIndex: 0,
+        range: new Range(line, 0, line, 0),
+      })),
+      positionAt: vi.fn((offset: number) => new Position(0, offset)),
+      getWordRangeAtPosition: vi.fn(() => undefined),
+    },
     selection: new Selection(new Position(0, 0), new Position(0, 0)),
     selections: [],
+    viewColumn: undefined as number | undefined,
     setDecorations: vi.fn(),
     revealRange: vi.fn(),
   };

--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -1202,6 +1202,71 @@ describe('CodeExecutor', () => {
     });
   });
 
+  // ── Reveal the Run and Debug view when debugging starts ────
+  //
+  // After the user clicks "Debug", the debug session attaches but VSCode does
+  // not switch to the Run and Debug view on its own, so the call stack lands
+  // in a hidden view and the session looks like it did nothing. We explicitly
+  // reveal the view via the workbench.view.debug command. Dismissing the
+  // dialog must NOT reveal the view and must clear the stalled GsProcess.
+
+  describe('reveals the Run and Debug view on Debug', () => {
+    function debuggableGci() {
+      return makeGci({
+        GciTsNbResult: vi.fn(() => ({
+          result: 0x01n,
+          err: {
+            number: 2003,
+            message: 'a UndefinedObject does not understand #foo',
+            context: 0x123n,
+          },
+        })),
+      });
+    }
+
+    function setup() {
+      gci = debuggableGci();
+      session = makeSession(gci);
+      executor = new CodeExecutor(makeSessionManager(session));
+      const editor = makeEditor('nil foo');
+      setActiveEditor(editor);
+    }
+
+    function revealedView(): boolean {
+      return vi.mocked(vscode.commands.executeCommand).mock.calls
+        .some(([cmd]) => cmd === 'workbench.view.debug');
+    }
+
+    it('starts debugging and focuses the Run and Debug view when the user clicks Debug', async () => {
+      vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Debug' as never);
+      vi.mocked(vscode.debug.startDebugging).mockResolvedValue(true as never);
+      setup();
+
+      await executor.executeIt();
+
+      expect(vscode.debug.startDebugging).toHaveBeenCalled();
+      const config = vi.mocked(vscode.debug.startDebugging).mock.calls[0][1] as {
+        type: string; gsProcess: string; sessionId: number;
+      };
+      expect(config.type).toBe('gemstone');
+      expect(config.sessionId).toBe(session.id);
+      expect(config.gsProcess).toBe((0x123n).toString());
+      expect(revealedView()).toBe(true);
+    });
+
+    it('does not reveal the view or start debugging, and clears the stack, when the dialog is dismissed', async () => {
+      vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined as never);
+      setup();
+
+      await executor.executeIt();
+
+      expect(vscode.debug.startDebugging).not.toHaveBeenCalled();
+      expect(revealedView()).toBe(false);
+      // The stalled GsProcess must be released so it does not linger.
+      expect(gci.GciTsClearStack).toHaveBeenCalledWith(session.handle, 0x123n);
+    });
+  });
+
   // ── Result polling: GciTsNbPoll (3.7+) vs GciTsSocket fallback (3.6.2) ──
 
   describe('result polling fallback for GemStone 3.6.2', () => {

--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -1312,20 +1312,31 @@ describe('CodeExecutor', () => {
       expect(DebuggerPanel.create).toHaveBeenCalledWith(session, 0x123n, expect.any(String), expect.any(Function));
     });
 
-    it('the Display It completion callback renders the result back in the workspace', async () => {
+    it('the Display It completion callback renders the result back in the workspace, refocusing the editor', async () => {
       vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Enhanced Debug' as never);
       setup();
       await executor.displayIt();
 
       // Invoke the captured callback exactly as the panel would on Resume/step-
-      // to-completion, and assert the result is displayed (overlay decoration).
+      // to-completion. Rendering is deferred to the next tick (after the panel
+      // disposes) and the editor is refocused first so the result's
+      // Backspace/Enter keybindings (editorTextFocus) work.
       const onComplete = vi.mocked(DebuggerPanel.create).mock.calls.at(-1)![3] as (oop: bigint) => void;
       const editor = vscode.window.activeTextEditor as unknown as { setDecorations: ReturnType<typeof vi.fn> };
       editor.setDecorations.mockClear();
+      // showTextDocument resolves with the same editor (as it would for the same doc).
+      vi.mocked(vscode.window.showTextDocument).mockResolvedValue(editor as unknown as vscode.TextEditor);
 
-      onComplete(0x222n);
+      vi.useFakeTimers();
+      try {
+        onComplete(0x222n);
+        await vi.runAllTimersAsync();
+      } finally {
+        vi.useRealTimers();
+      }
 
-      expect(editor.setDecorations).toHaveBeenCalled(); // result rendered into the workspace
+      expect(vscode.window.showTextDocument).toHaveBeenCalled(); // editor refocused
+      expect(editor.setDecorations).toHaveBeenCalled();          // result rendered into the workspace
     });
   });
 

--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -18,7 +18,12 @@ vi.mock('../socketPoll', () => ({
   pollReadable: vi.fn(() => 1),
 }));
 
+vi.mock('../debuggerPanel', () => ({
+  DebuggerPanel: { create: vi.fn() },
+}));
+
 import { CodeExecutor } from '../codeExecutor';
+import { DebuggerPanel } from '../debuggerPanel';
 import { SessionManager, ActiveSession } from '../sessionManager';
 import * as vscode from 'vscode';
 import { __resetConfig } from '../__mocks__/vscode';
@@ -1155,7 +1160,7 @@ describe('CodeExecutor', () => {
 
       const calls = vi.mocked(vscode.window.showErrorMessage).mock.calls;
       const lastCall = calls[calls.length - 1];
-      expect(lastCall.slice(2)).toEqual(['Debug']);
+      expect(lastCall.slice(2)).toEqual(['Enhanced Debug', 'Debug']);
     });
 
     it('shows a modal dialog when Inspect It raises a DebuggableError', async () => {
@@ -1198,7 +1203,7 @@ describe('CodeExecutor', () => {
 
       const calls = vi.mocked(vscode.window.showErrorMessage).mock.calls;
       const lastCall = calls[calls.length - 1];
-      expect(lastCall.slice(2)).toEqual(['Debug']);
+      expect(lastCall.slice(2)).toEqual(['Enhanced Debug', 'Debug']);
     });
   });
 
@@ -1245,7 +1250,7 @@ describe('CodeExecutor', () => {
       await executor.executeIt();
 
       expect(vscode.debug.startDebugging).toHaveBeenCalled();
-      const config = vi.mocked(vscode.debug.startDebugging).mock.calls[0][1] as {
+      const config = vi.mocked(vscode.debug.startDebugging).mock.calls[0][1] as unknown as {
         type: string; gsProcess: string; sessionId: number;
       };
       expect(config.type).toBe('gemstone');
@@ -1264,6 +1269,21 @@ describe('CodeExecutor', () => {
       expect(revealedView()).toBe(false);
       // The stalled GsProcess must be released so it does not linger.
       expect(gci.GciTsClearStack).toHaveBeenCalledWith(session.handle, 0x123n);
+    });
+
+    it('opens the Enhanced Debugger panel (and not the DAP debugger) when the user clicks Enhanced Debug', async () => {
+      vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Enhanced Debug' as never);
+      setup();
+
+      await executor.executeIt();
+
+      // The webview debugger owns the gsProcess for this error.
+      expect(DebuggerPanel.create).toHaveBeenCalledWith(session, 0x123n, expect.any(String));
+      // The DAP path must not run, and the stack must NOT be cleared — the
+      // panel now owns the suspended process.
+      expect(vscode.debug.startDebugging).not.toHaveBeenCalled();
+      expect(revealedView()).toBe(false);
+      expect(gci.GciTsClearStack).not.toHaveBeenCalled();
     });
   });
 

--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -29,6 +29,7 @@ import * as vscode from 'vscode';
 import { __resetConfig } from '../__mocks__/vscode';
 import { appendTranscript, showTranscript } from '../transcriptChannel';
 import { pollReadable } from '../socketPoll';
+import { GCI_PERFORM_FLAG_ENABLE_DEBUG, GCI_PERFORM_FLAG_SINGLE_STEP } from '../gciConstants';
 
 /** Set the gemstone.displayItMode setting for the current test. */
 function setDisplayItMode(mode: 'overlay' | 'insert'): void {
@@ -449,6 +450,133 @@ describe('CodeExecutor', () => {
       const toggleCalls = (gci.GciTsExecute as Mock).mock.calls.map((c) => c[1] as string);
       expect(toggleCalls.some((c) => c.includes('setBreakAtStepPoint:'))).toBe(true);
       expect(toggleCalls.some((c) => c.includes('clearBreakAtStepPoint:'))).toBe(true);
+    });
+  });
+
+  // ── Debug It ───────────────────────────────────────────────
+  //
+  // Debug It runs the selection with the single-step flag so the server breaks
+  // on the FIRST statement, and opens the Enhanced debugger directly on that
+  // halt. Two things make stepping actually work and must not regress:
+  //   1. the single-step flag is OR'd into the exec flags (display/execute must
+  //      NOT set it), and
+  //   2. the RAW selection is sent — no transcript-capture wrapper — so the
+  //      halt lands on the user's code, not the wrapper's outer block.
+
+  describe('debugIt', () => {
+    /** The flags argument (param 5) of the most recent GciTsNbExecute call. */
+    function lastExecFlags(): number {
+      const calls = (gci.GciTsNbExecute as Mock).mock.calls;
+      return calls[calls.length - 1][5] as number;
+    }
+    /** The code argument (param 1) of the most recent GciTsNbExecute call. */
+    function lastExecCode(): string {
+      const calls = (gci.GciTsNbExecute as Mock).mock.calls;
+      return calls[calls.length - 1][1] as string;
+    }
+
+    it('sets the single-step flag so the server breaks on the first statement', async () => {
+      setActiveEditor(makeEditor('Array new add: 1; add: 2'));
+
+      await executor.debugIt();
+
+      expect(lastExecFlags()).toBe(GCI_PERFORM_FLAG_ENABLE_DEBUG | GCI_PERFORM_FLAG_SINGLE_STEP);
+    });
+
+    it('does NOT set the single-step flag for Execute It or Display It', async () => {
+      setActiveEditor(makeEditor('Array new add: 1; add: 2'));
+      await executor.executeIt();
+      expect(lastExecFlags()).toBe(GCI_PERFORM_FLAG_ENABLE_DEBUG);
+      expect(lastExecFlags() & GCI_PERFORM_FLAG_SINGLE_STEP).toBe(0);
+
+      (gci.GciTsNbExecute as Mock).mockClear();
+      setActiveEditor(makeEditor('3 + 4'));
+      await executor.displayIt();
+      expect(lastExecFlags()).toBe(GCI_PERFORM_FLAG_ENABLE_DEBUG);
+      expect(lastExecFlags() & GCI_PERFORM_FLAG_SINGLE_STEP).toBe(0);
+    });
+
+    it('runs the RAW selection — no transcript-capture wrapper — so the halt lands on user code', async () => {
+      const code = 'Array new add: 1; add: 2';
+      setActiveEditor(makeEditor(code));
+
+      await executor.debugIt();
+
+      // The wrapper nests code in `[[ <code> ] value]` and declares `__vscCapture`
+      // temps; Debug It must send the selection verbatim instead.
+      expect(lastExecCode()).toBe(code);
+      expect(lastExecCode()).not.toContain('__vscCapture');
+    });
+
+    it('still wraps Execute It in the transcript-capture glue (contrast with Debug It)', async () => {
+      setActiveEditor(makeEditor('Array new add: 1; add: 2'));
+
+      await executor.executeIt();
+
+      expect(lastExecCode()).toContain('__vscCapture');
+    });
+  });
+
+  // ── Debug It opens the Enhanced debugger directly on a halt ──
+  //
+  // Unlike Execute It (which prompts the user to pick a debugger on an error),
+  // Debug It's halt is an intentional first-statement stop, so it opens the
+  // Enhanced debugger straight away — no modal chooser, no DAP, and it must NOT
+  // clear the stack (the panel owns the suspended process).
+
+  describe('debugIt opens the Enhanced debugger on the first-statement halt', () => {
+    function debuggableGci() {
+      // Non-nil context (≠ OOP_NIL) makes fetchResultOop throw a DebuggableError,
+      // exactly as the single-step breakpoint would on the server.
+      return makeGci({
+        GciTsNbResult: vi.fn(() => ({
+          result: 0x01n,
+          err: { number: 6001, message: 'halt at step 1', context: 0x123n },
+        })),
+      });
+    }
+
+    function setup() {
+      gci = debuggableGci();
+      session = makeSession(gci);
+      executor = new CodeExecutor(makeSessionManager(session));
+      setActiveEditor(makeEditor('Array new add: 1; add: 2'));
+    }
+
+    it('opens the Enhanced Debugger panel directly, with no completion callback', async () => {
+      setup();
+
+      await executor.debugIt();
+
+      // 3 args: no onComplete (Debug It is silent on resume-to-completion).
+      expect(DebuggerPanel.create).toHaveBeenCalledWith(session, 0x123n, 'Debug It');
+    });
+
+    it('does NOT show the debugger chooser prompt or start the DAP debugger', async () => {
+      setup();
+
+      await executor.debugIt();
+
+      expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+      expect(vscode.debug.startDebugging).not.toHaveBeenCalled();
+    });
+
+    it('does NOT clear the stack — the Enhanced debugger owns the suspended process', async () => {
+      setup();
+
+      await executor.debugIt();
+
+      expect(gci.GciTsClearStack).not.toHaveBeenCalled();
+    });
+
+    it('clears the stack if the Enhanced Debugger panel fails to open', async () => {
+      setup();
+      vi.mocked(DebuggerPanel.create).mockImplementationOnce(() => { throw new Error('panel boom'); });
+
+      await executor.debugIt();
+
+      // Nothing owns the process when the panel throws, so it must be released.
+      expect(gci.GciTsClearStack).toHaveBeenCalledWith(session.handle, 0x123n);
     });
   });
 

--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -52,6 +52,8 @@ function makeGci(overrides: Record<string, unknown> = {}) {
     GciTsClearStack: vi.fn(),
     GciTsObjExists: vi.fn(() => false),
     GciTsFetchClass: vi.fn(() => ({ result: 0n, err: { number: 0 } })),
+    // Used by the native-code stepping toggle (acquire/releaseStepping).
+    GciTsExecute: vi.fn(() => ({ result: 0n, err: { number: 0 } })),
     ...overrides,
   };
 }
@@ -435,6 +437,18 @@ describe('CodeExecutor', () => {
 
       const wrappedCode = (gci.GciTsNbExecute as Mock).mock.calls[0][1] as string;
       expect(wrappedCode).toContain("'hello' reversed");
+    });
+
+    it('runs interpreted (toggles native code off, then back on) so a halt would be steppable', async () => {
+      const editor = makeEditor("'hello' reversed");
+      setActiveEditor(editor);
+
+      await executor.displayIt();
+
+      // acquireStepping/releaseStepping drive GciTsExecute on the benign toggle method.
+      const toggleCalls = (gci.GciTsExecute as Mock).mock.calls.map((c) => c[1] as string);
+      expect(toggleCalls.some((c) => c.includes('setBreakAtStepPoint:'))).toBe(true);
+      expect(toggleCalls.some((c) => c.includes('clearBreakAtStepPoint:'))).toBe(true);
     });
   });
 
@@ -1277,13 +1291,41 @@ describe('CodeExecutor', () => {
 
       await executor.executeIt();
 
-      // The webview debugger owns the gsProcess for this error.
-      expect(DebuggerPanel.create).toHaveBeenCalledWith(session, 0x123n, expect.any(String));
+      // The webview debugger owns the gsProcess for this error. Execute It is
+      // intentionally silent, so no completion callback is passed.
+      expect(DebuggerPanel.create).toHaveBeenCalledWith(session, 0x123n, expect.any(String), undefined);
       // The DAP path must not run, and the stack must NOT be cleared — the
       // panel now owns the suspended process.
       expect(vscode.debug.startDebugging).not.toHaveBeenCalled();
       expect(revealedView()).toBe(false);
       expect(gci.GciTsClearStack).not.toHaveBeenCalled();
+    });
+
+    it('passes a completion callback to the Enhanced Debugger for a halted Display It', async () => {
+      vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Enhanced Debug' as never);
+      setup();
+
+      await executor.displayIt();
+
+      // Display It → on Resume/step-to-completion the result is rendered back in
+      // the workspace, so a completion callback IS provided.
+      expect(DebuggerPanel.create).toHaveBeenCalledWith(session, 0x123n, expect.any(String), expect.any(Function));
+    });
+
+    it('the Display It completion callback renders the result back in the workspace', async () => {
+      vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Enhanced Debug' as never);
+      setup();
+      await executor.displayIt();
+
+      // Invoke the captured callback exactly as the panel would on Resume/step-
+      // to-completion, and assert the result is displayed (overlay decoration).
+      const onComplete = vi.mocked(DebuggerPanel.create).mock.calls.at(-1)![3] as (oop: bigint) => void;
+      const editor = vscode.window.activeTextEditor as unknown as { setDecorations: ReturnType<typeof vi.fn> };
+      editor.setDecorations.mockClear();
+
+      onComplete(0x222n);
+
+      expect(editor.setDecorations).toHaveBeenCalled(); // result rendered into the workspace
     });
   });
 

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -438,6 +438,103 @@ describe('debugQueries', () => {
     });
   });
 
+  // When the frame has *named* args/temps, evaluateInFrame must bind them so a
+  // bare identifier like `amount` resolves — by prepending a transient
+  // SymbolDictionary {name → value} to the user's symbol list and evaluating via
+  // `evaluateInContext:symbolList:` (NOT the self-only `evaluateInContext:`).
+  describe('evaluateInFrame — binds named temps via a symbol-list dictionary', () => {
+    const GS_PROCESS = 9000n;
+    const FRAME_ARRAY = 0xF0n;
+    const NAMES_ARRAY = 0xA1n;
+    const FRAME_RECEIVER = 0x77n;
+    const AMOUNT_NAME = 0xB1n;   // the name string 'amount' in the names array
+    const AMOUNT_VALUE = 0x96n;  // oop of the temp's value (75)
+    const AMOUNT_SYMBOL = 0xC1n; // interned #amount
+    const EXPR_STRING = 0xE0n;
+    const EVAL_RESULT = 0x07n;
+
+    function tempSession() {
+      const gci = {
+        GciTsI64ToOop: vi.fn(() => ({ result: 0xAAn, err: { ...noErr } })),
+        GciTsOopToI64: vi.fn(() => ({ value: 5n, err: { ...noErr } })),
+        GciTsNewString: vi.fn(() => ({ result: EXPR_STRING, err: { ...noErr } })),
+        GciTsNewSymbol: vi.fn(() => ({ result: AMOUNT_SYMBOL, err: { ...noErr } })),
+        GciTsResolveSymbol: vi.fn((_h: unknown, name: string) => ({
+          result: name === 'SymbolDictionary' ? 0xD1n : name === 'SymbolList' ? 0xD2n : 0xD3n,
+          err: { ...noErr },
+        })),
+        // Frame array size = 11 (so values start at slot 11); names array size = 1.
+        GciTsFetchSize: vi.fn((_h: unknown, oop: bigint) =>
+          ({ result: oop === NAMES_ARRAY ? 1n : 11n, err: { ...noErr } })),
+        GciTsFetchOops: vi.fn((_h: unknown, oop: bigint) =>
+          oop === NAMES_ARRAY
+            ? { oops: [AMOUNT_NAME], err: { ...noErr } }
+            : { // frame contents: [9]=names (idx8), [10]=receiver (idx9), [11+]=values
+              oops: [1n, 2n, 0n, 0n, 0n, 0n, 0n, 0n, NAMES_ARRAY, FRAME_RECEIVER, AMOUNT_VALUE],
+              err: { ...noErr },
+            }),
+        GciTsPerform: vi.fn((_h: unknown, _r: bigint, _s: bigint, sel: string | null) => {
+          if (sel === '_frameContentsAt:') return { result: FRAME_ARRAY, err: { ...noErr } };
+          if (sel === 'new') return { result: 0xDD0n, err: { ...noErr } };          // SymbolDictionary new
+          if (sel === 'at:put:') return { result: 0n, err: { ...noErr } };
+          if (sel === 'myUserProfile') return { result: 0xDDdn, err: { ...noErr } };
+          if (sel === 'symbolList') return { result: 0xDDan, err: { ...noErr } };
+          if (sel === 'with:') return { result: 0xDDfn, err: { ...noErr } };
+          if (sel === ',') return { result: 0xDDcn, err: { ...noErr } };
+          if (sel === 'evaluateInContext:symbolList:') return { result: EVAL_RESULT, err: { ...noErr } };
+          return { result: 0n, err: { ...noErr } };
+        }),
+        GciTsPerformFetchBytes: vi.fn((_h: unknown, oop: bigint) =>
+          oop === AMOUNT_NAME
+            ? { bytesReturned: 6, data: 'amount', err: { ...noErr } }
+            : oop === EVAL_RESULT
+              ? { bytesReturned: 3, data: '150', err: { ...noErr } }
+              : { bytesReturned: 0, data: '', err: { ...noErr } }),
+      };
+      return {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: gci as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+    }
+
+    it('evaluates via evaluateInContext:symbolList: (not the self-only path)', () => {
+      const session = tempSession();
+      expect(debug.evaluateInFrame(session, GS_PROCESS, 'amount * 2', 3)).toBe('150');
+
+      const calls = (session.gci.GciTsPerform as ReturnType<typeof vi.fn>).mock.calls;
+      const sels = calls.map((c: unknown[]) => c[3]);
+      expect(sels).toContain('evaluateInContext:symbolList:');
+      expect(sels).not.toContain('evaluateInContext:');
+    });
+
+    it('interns each temp name and stores its value in the dictionary', () => {
+      const session = tempSession();
+      debug.evaluateInFrame(session, GS_PROCESS, 'amount * 2', 3);
+
+      expect(session.gci.GciTsNewSymbol).toHaveBeenCalledWith({}, 'amount');
+      const atPut = (session.gci.GciTsPerform as ReturnType<typeof vi.fn>).mock.calls
+        .find((c: unknown[]) => c[3] === 'at:put:');
+      expect(atPut).toBeDefined();
+      expect(atPut![4]).toEqual([AMOUNT_SYMBOL, AMOUNT_VALUE]); // dict at: #amount put: value
+    });
+
+    it('degrades to self-only evaluateInContext: when a required global will not resolve', () => {
+      const session = tempSession();
+      // SymbolDictionary fails to resolve → no temp dictionary can be built, so
+      // buildFrameSymbolList returns null and the eval falls back to self-only.
+      (session.gci.GciTsResolveSymbol as ReturnType<typeof vi.fn>).mockImplementation(
+        (_h: unknown, name: string) => name === 'SymbolDictionary'
+          ? { result: 0n, err: { ...noErr, number: 2110, message: 'not resolved' } }
+          : { result: 0xD2n, err: { ...noErr } });
+      debug.evaluateInFrame(session, GS_PROCESS, 'amount * 2', 3);
+
+      const sels = (session.gci.GciTsPerform as ReturnType<typeof vi.fn>).mock.calls
+        .map((c: unknown[]) => c[3]);
+      expect(sels).toContain('evaluateInContext:');
+      expect(sels).not.toContain('evaluateInContext:symbolList:');
+    });
+  });
+
   describe('completion result oop', () => {
     const GS_PROCESS = 9000n;
     const RESULT = 0x99n;

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -87,6 +87,84 @@ function receiverClassName(oop: bigint): string {
 }
 
 describe('debugQueries', () => {
+  describe('getStepPoint', () => {
+    const GS_PROCESS = 9000n;
+    const LEVEL_OOP = 0xAAn;
+    const STEP_POINT_OOP = 0xBBn;
+
+    function stepPointSession(stepPointResultOop: bigint) {
+      return {
+        id: 1,
+        handle: {},
+        login: { label: 'T' } as GemStoneLogin,
+        stoneVersion: '3.7.2',
+        gci: {
+          GciTsI64ToOop: vi.fn(() => ({ result: LEVEL_OOP, err: { ...noErr } })),
+          GciTsPerform: vi.fn(() => ({ result: stepPointResultOop, err: { ...noErr } })),
+          GciTsOopToI64: vi.fn(() => ({ value: 2n, err: { ...noErr } })),
+        } as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+    }
+
+    it('sends _stepPointAt: with the frame level and returns the step point', () => {
+      const session = stepPointSession(STEP_POINT_OOP);
+      const result = debug.getStepPoint(session, GS_PROCESS, 3);
+
+      expect(result).toBe(2);
+      const performCalls = (session.gci.GciTsPerform as ReturnType<typeof vi.fn>).mock.calls;
+      expect(performCalls[0][1]).toBe(GS_PROCESS);      // receiver is the process
+      expect(performCalls[0][3]).toBe('_stepPointAt:');  // selector
+      expect(performCalls[0][4]).toEqual([LEVEL_OOP]);   // level arg
+    });
+
+    it('returns undefined (without converting) when the step point is nil', () => {
+      const session = stepPointSession(0x14n /* OOP_NIL */);
+      const result = debug.getStepPoint(session, GS_PROCESS, 3);
+
+      expect(result).toBeUndefined();
+      expect(session.gci.GciTsOopToI64).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMethodBlockInfo', () => {
+    const BLOCK_METHOD_OOP = 5100n;
+    const HOME_METHOD_OOP = 5200n;
+
+    function blockSession(isBlockOop: bigint, homeOop: bigint) {
+      return {
+        id: 1,
+        handle: {},
+        login: { label: 'T' } as GemStoneLogin,
+        stoneVersion: '3.7.2',
+        gci: {
+          GciTsPerform: vi.fn(
+            (_h: unknown, _r: bigint, _s: bigint, selector: string) => {
+              if (selector === 'isMethodForBlock') return { result: isBlockOop, err: { ...noErr } };
+              if (selector === 'homeMethod') return { result: homeOop, err: { ...noErr } };
+              return { result: 0n, err: { ...noErr } };
+            },
+          ),
+        } as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+    }
+
+    it('reports a block method and its distinct home method', () => {
+      const session = blockSession(0x10Cn /* OOP_TRUE */, HOME_METHOD_OOP);
+      const result = debug.getMethodBlockInfo(session, BLOCK_METHOD_OOP);
+
+      expect(result.isBlock).toBe(true);
+      expect(result.homeMethodOop).toBe(HOME_METHOD_OOP);
+    });
+
+    it('reports a non-block method with homeMethod returning self', () => {
+      const session = blockSession(0x0Cn /* OOP_FALSE */, BLOCK_METHOD_OOP);
+      const result = debug.getMethodBlockInfo(session, BLOCK_METHOD_OOP);
+
+      expect(result.isBlock).toBe(false);
+      expect(result.homeMethodOop).toBe(BLOCK_METHOD_OOP);
+    });
+  });
+
   describe('getMethodInfo', () => {
     it('returns class name and selector by chaining single-message sends', () => {
       const session = createMockSession();

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -540,12 +540,19 @@ describe('debugQueries', () => {
     const RESULT = 0x99n;
 
     it('continueExecution returns the result oop when the process completes', () => {
+      const continueWith = vi.fn(() => ({ result: RESULT, err: { ...noErr } }));
       const session = {
         id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
-        gci: { GciTsContinueWith: vi.fn(() => ({ result: RESULT, err: { ...noErr } })) } as unknown as ActiveSession['gci'],
+        gci: { GciTsContinueWith: continueWith } as unknown as ActiveSession['gci'],
       } as ActiveSession;
 
       expect(debug.continueExecution(session, GS_PROCESS)).toEqual({ completed: true, resultOop: RESULT });
+      // Resume as-is: replaceTopOfStack must be OOP_ILLEGAL, NOT OOP_NIL — forcing
+      // TOS := nil corrupts a frame re-entered by trimStackToLevel: and hangs the
+      // gem. (3rd positional arg to GciTsContinueWith.)
+      const args = continueWith.mock.calls[0] as unknown as bigint[];
+      expect(args[2]).toBe(OOP_ILLEGAL);
+      expect(args[2]).not.toBe(0x14n /* OOP_NIL */);
     });
 
     it('continueExecution reports the error (no result oop) when it stops again', () => {

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -565,6 +565,9 @@ describe('debugQueries', () => {
       expect(r.completed).toBe(false);
       expect(r.resultOop).toBeUndefined();
       expect(r.errorMessage).toBe('next error');
+      // The error NUMBER must propagate — the webview's uncontinuable (6011)
+      // guard keys off StepResult.errorNumber, not the (localizable) message.
+      expect(r.errorNumber).toBe(2010);
     });
 
     it('stepOver returns the result oop when the step completes the process', () => {
@@ -577,6 +580,39 @@ describe('debugQueries', () => {
       } as ActiveSession;
 
       expect(debug.stepOver(session, GS_PROCESS, 1)).toEqual({ completed: true, resultOop: RESULT });
+    });
+
+    it('stepOver (blocking) propagates the GemStone error number when the step stops on an error', () => {
+      const session = {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: {
+          GciTsI64ToOop: vi.fn(() => ({ result: 0xAAn, err: { ...noErr } })),
+          GciTsPerform: vi.fn(() => ({ result: 0n, err: { ...noErr, number: 6011, message: 'uncontinuable', context: 0xABn } })),
+        } as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+
+      const r = debug.stepOver(session, GS_PROCESS, 1);
+      expect(r.completed).toBe(false);
+      expect(r.errorNumber).toBe(6011);
+      expect(r.errorContext).toBe(0xABn);
+    });
+
+    it('stepOverNb (non-blocking) propagates the error number on a stop (e.g. 6011 uncontinuable)', async () => {
+      const session = {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: {
+          isAvailable: (n: string) => n === 'GciTsNbPoll',
+          GciTsI64ToOop: vi.fn(() => ({ result: 0xAAn, err: { ...noErr } })),
+          GciTsNbPerform: vi.fn(() => ({ success: true, err: { ...noErr } })),
+          GciTsNbPoll: vi.fn(() => ({ result: 1, err: { ...noErr } })), // ready immediately
+          GciTsNbResult: vi.fn(() => ({ result: 0n, err: { ...noErr, number: 6011, message: 'a UncontinuableError occurred (error 6011)', context: 0xABn } })),
+        } as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+
+      const r = await debug.stepOverNb(session, GS_PROCESS, 1);
+      expect(r.completed).toBe(false);
+      expect(r.errorNumber).toBe(6011);
+      expect(r.errorContext).toBe(0xABn);
     });
   });
 

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -368,4 +368,73 @@ describe('debugQueries', () => {
       expect(varying).not.toHaveBeenCalled();
     });
   });
+
+  // Regression for the eval-bar bug: typing "3 + 4" raised
+  //   NameError 2404, _framePerform:withArgs:onLevel:, There is no Symbol …
+  // because evaluateInFrame called a primitive that does NOT exist on 3.7.x (so
+  // GciTsPerform couldn't resolve the selector). The fix evaluates the
+  // expression via String>>evaluateInContext: with self = the frame receiver.
+  // (We can't run real Smalltalk in unit tests — the live image confirms
+  // `'3 + 4' evaluateInContext: nil` => 7 — so the mock supplies the printString
+  // and we assert the *right call* is made, which is what regressed.)
+  describe('evaluateInFrame ("3 + 4" regression)', () => {
+    const GS_PROCESS = 9000n;
+    const FRAME_ARRAY = 0xF0n;
+    const FRAME_RECEIVER = 0x77n; // becomes `self` for the evaluation
+    const EXPR_STRING = 0xE0n;
+    const EVAL_RESULT = 0x07n;    // the oop the evaluation returned
+
+    function evalSession() {
+      const gci = {
+        GciTsI64ToOop: vi.fn(() => ({ result: 0xAAn, err: { ...noErr } })),
+        GciTsOopToI64: vi.fn(() => ({ value: 5n, err: { ...noErr } })),
+        GciTsNewString: vi.fn(() => ({ result: EXPR_STRING, err: { ...noErr } })),
+        GciTsFetchSize: vi.fn(() => ({ result: 10n, err: { ...noErr } })),
+        // getFrameInfo reads [10]=receiver (0-indexed 9); [9]=names (0-indexed 8) = nil → skip names.
+        GciTsFetchOops: vi.fn(() => ({
+          oops: [1n, 2n, 0n, 0n, 0n, 0n, 0n, 0n, 0x14n /* OOP_NIL names */, FRAME_RECEIVER],
+          err: { ...noErr },
+        })),
+        GciTsPerform: vi.fn((_h: unknown, _r: bigint, _sOop: bigint, sel: string | null) => {
+          if (sel === '_frameContentsAt:') return { result: FRAME_ARRAY, err: { ...noErr } };
+          if (sel === 'evaluateInContext:') return { result: EVAL_RESULT, err: { ...noErr } };
+          return { result: 0n, err: { ...noErr } };
+        }),
+        // printString of the evaluation result (the EVAL_RESULT oop) is "7".
+        GciTsPerformFetchBytes: vi.fn((_h: unknown, oop: bigint) =>
+          oop === EVAL_RESULT
+            ? { bytesReturned: 1, data: '7', err: { ...noErr } }
+            : { bytesReturned: 0, data: '', err: { ...noErr } }),
+      };
+      return {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: gci as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+    }
+
+    it('returns the result printString ("7") for "3 + 4" instead of raising', () => {
+      const session = evalSession();
+      expect(debug.evaluateInFrame(session, GS_PROCESS, '3 + 4', 3)).toBe('7');
+    });
+
+    it('evaluates via String>>evaluateInContext: with self = the frame receiver', () => {
+      const session = evalSession();
+      debug.evaluateInFrame(session, GS_PROCESS, '3 + 4', 3);
+
+      expect(session.gci.GciTsNewString).toHaveBeenCalledWith({}, '3 + 4');
+      const performCalls = (session.gci.GciTsPerform as ReturnType<typeof vi.fn>).mock.calls;
+      const evalCall = performCalls.find((c: unknown[]) => c[3] === 'evaluateInContext:');
+      expect(evalCall).toBeDefined();
+      expect(evalCall![1]).toBe(EXPR_STRING);         // receiver of evaluateInContext: is the expr String
+      expect(evalCall![4]).toEqual([FRAME_RECEIVER]); // arg is the frame's receiver (self)
+    });
+
+    it('never sends the removed _framePerform:withArgs:onLevel: primitive (the original bug)', () => {
+      const session = evalSession();
+      debug.evaluateInFrame(session, GS_PROCESS, '3 + 4', 3);
+
+      const performCalls = (session.gci.GciTsPerform as ReturnType<typeof vi.fn>).mock.calls;
+      expect(performCalls.some((c: unknown[]) => c[3] === '_framePerform:withArgs:onLevel:')).toBe(false);
+    });
+  });
 });

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -282,6 +282,53 @@ describe('debugQueries', () => {
     });
   });
 
+  describe('getDoesNotUnderstandInfo', () => {
+    const GS_PROCESS = 0x123n;
+
+    function sessionReturning(data: string): ActiveSession {
+      const session = createMockSession();
+      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
+        result: 9000n, err: { ...noErr },
+      }));
+      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
+        bytesReturned: 0, data, err: { ...noErr },
+      }));
+      return session;
+    }
+
+    it('parses an instance-side DNU (keyword selector) into DnuInfo', () => {
+      const session = sessionReturning('SmallInteger\tinstance\tGlobals\tfourtyTwo:bar:\t2');
+      expect(debug.getDoesNotUnderstandInfo(session, GS_PROCESS)).toEqual({
+        className: 'SmallInteger', isMeta: false, dictName: 'Globals',
+        selector: 'fourtyTwo:bar:', argCount: 2,
+      });
+    });
+
+    it('parses a class-side DNU (message sent to a class)', () => {
+      const session = sessionReturning('JasperDebugDemo\tclass\tUserGlobals\tmakeWidget\t0');
+      expect(debug.getDoesNotUnderstandInfo(session, GS_PROCESS)).toEqual({
+        className: 'JasperDebugDemo', isMeta: true, dictName: 'UserGlobals',
+        selector: 'makeWidget', argCount: 0,
+      });
+    });
+
+    it('returns undefined when the process is not parked on a doesNotUnderstand:', () => {
+      // The doit returns '' when no DNU frame is found.
+      expect(debug.getDoesNotUnderstandInfo(sessionReturning(''), GS_PROCESS)).toBeUndefined();
+    });
+
+    it('returns undefined when the execute fails', () => {
+      const session = createMockSession();
+      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
+        result: 9000n, err: { ...noErr },
+      }));
+      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
+        bytesReturned: 0, data: '', err: { ...noErr, number: 1, message: 'boom' },
+      }));
+      expect(debug.getDoesNotUnderstandInfo(session, GS_PROCESS)).toBeUndefined();
+    });
+  });
+
   describe('getInstVarNames', () => {
     it('does not send multi-word selectors', () => {
       const session = createMockSession();

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -437,4 +437,109 @@ describe('debugQueries', () => {
       expect(performCalls.some((c: unknown[]) => c[3] === '_framePerform:withArgs:onLevel:')).toBe(false);
     });
   });
+
+  describe('completion result oop', () => {
+    const GS_PROCESS = 9000n;
+    const RESULT = 0x99n;
+
+    it('continueExecution returns the result oop when the process completes', () => {
+      const session = {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: { GciTsContinueWith: vi.fn(() => ({ result: RESULT, err: { ...noErr } })) } as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+
+      expect(debug.continueExecution(session, GS_PROCESS)).toEqual({ completed: true, resultOop: RESULT });
+    });
+
+    it('continueExecution reports the error (no result oop) when it stops again', () => {
+      const session = {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: { GciTsContinueWith: vi.fn(() => ({ result: 0n, err: { ...noErr, number: 2010, message: 'next error', context: 0xABn } })) } as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+
+      const r = debug.continueExecution(session, GS_PROCESS);
+      expect(r.completed).toBe(false);
+      expect(r.resultOop).toBeUndefined();
+      expect(r.errorMessage).toBe('next error');
+    });
+
+    it('stepOver returns the result oop when the step completes the process', () => {
+      const session = {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: {
+          GciTsI64ToOop: vi.fn(() => ({ result: 0xAAn, err: { ...noErr } })),
+          GciTsPerform: vi.fn(() => ({ result: RESULT, err: { ...noErr } })),
+        } as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+
+      expect(debug.stepOver(session, GS_PROCESS, 1)).toEqual({ completed: true, resultOop: RESULT });
+    });
+  });
+
+  // Native-code toggle: a benign breakpoint flips the gem to interpreted so the
+  // debugger can single-step (GemStone can't step native code, error 6014).
+  // Ref-counted per session: set on the first acquire, cleared on the last
+  // release. Each test uses a distinct session id to avoid sharing the
+  // module-level ref counter.
+  describe('stepping native-code toggle (acquire/releaseStepping)', () => {
+    let nextId = 1000;
+    function makeSession(): { session: ActiveSession; exec: ReturnType<typeof vi.fn> } {
+      const exec = vi.fn(() => ({ result: 0n, err: { ...noErr } }));
+      const gci = {
+        GciTsResolveSymbol: vi.fn(() => ({ result: 99n, err: { ...noErr } })),
+        GciTsExecute: exec,
+      };
+      const session = {
+        id: nextId++, gci: gci as unknown as ActiveSession['gci'],
+        handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+      } as ActiveSession;
+      return { session, exec };
+    }
+    const codeOf = (exec: ReturnType<typeof vi.fn>, callIndex: number): string =>
+      exec.mock.calls[callIndex][1] as string;
+
+    it('first acquire sets the breakpoint (disables native code)', () => {
+      const { session, exec } = makeSession();
+      debug.acquireStepping(session);
+      expect(exec).toHaveBeenCalledTimes(1);
+      expect(codeOf(exec, 0)).toContain('setBreakAtStepPoint:');
+      debug.releaseStepping(session); // cleanup
+    });
+
+    it('last release clears the breakpoint (restores native code)', () => {
+      const { session, exec } = makeSession();
+      debug.acquireStepping(session);
+      debug.releaseStepping(session);
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(codeOf(exec, 1)).toContain('clearBreakAtStepPoint:');
+    });
+
+    it('is ref-counted: nested acquires set/clear the break only once (at the edges)', () => {
+      const { session, exec } = makeSession();
+      debug.acquireStepping(session); // 0→1: set
+      debug.acquireStepping(session); // 1→2: no-op
+      debug.releaseStepping(session); // 2→1: no-op
+      expect(exec).toHaveBeenCalledTimes(1); // only the initial set so far
+      debug.releaseStepping(session); // 1→0: clear
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(codeOf(exec, 0)).toContain('setBreakAtStepPoint:');
+      expect(codeOf(exec, 1)).toContain('clearBreakAtStepPoint:');
+    });
+
+    it('tracks sessions independently', () => {
+      const a = makeSession();
+      const b = makeSession();
+      debug.acquireStepping(a.session);
+      expect(a.exec).toHaveBeenCalledTimes(1);
+      expect(b.exec).not.toHaveBeenCalled(); // b untouched
+      debug.releaseStepping(a.session);
+    });
+
+    it('swallows a toggle failure (logs, does not throw)', () => {
+      const { session, exec } = makeSession();
+      exec.mockReturnValue({ result: 0n, err: { ...noErr, number: 2106, message: 'boom' } });
+      expect(() => debug.acquireStepping(session)).not.toThrow();
+      debug.releaseStepping(session);
+    });
+  });
 });

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -31,6 +31,13 @@ vi.mock('../debugQueries', () => ({
   getLineForIp: vi.fn(() => 12),
   getStepPoint: vi.fn(() => 2),
   getMethodSource: vi.fn(() => '| t | t := 6 * 7. t halt'),
+  getObjectPrintString: vi.fn((_s: unknown, oop: bigint) => `<print ${oop}>`),
+  evaluateInFrame: vi.fn(() => '42'),
+  continueExecution: vi.fn(() => ({ completed: true })),
+  stepOver: vi.fn(() => ({ completed: false })),
+  stepInto: vi.fn(() => ({ completed: false })),
+  stepOut: vi.fn(() => ({ completed: false })),
+  trimStackToLevel: vi.fn(),
   clearStack: vi.fn(),
 }));
 
@@ -94,6 +101,19 @@ function initPayload(panel: ReturnType<typeof lastPanel>) {
   const call = panel.webview.postMessage.mock.calls
     .find((c: unknown[]) => (c[0] as { command: string }).command === 'init');
   return call?.[0];
+}
+
+/** All payloads the panel posted to the webview with the given command. */
+function posted(panel: ReturnType<typeof lastPanel>, command: string) {
+  return panel.webview.postMessage.mock.calls
+    .map((c: unknown[]) => c[0] as { command: string })
+    .filter((m: { command: string }) => m.command === command);
+}
+/** The most recent payload posted with the given command (or undefined). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function lastPosted(panel: ReturnType<typeof lastPanel>, command: string): any {
+  const all = posted(panel, command);
+  return all[all.length - 1];
 }
 
 describe('formatFrameLabel', () => {
@@ -195,6 +215,9 @@ describe('DebuggerPanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // tabGroups.all is a plain array on the mock, not a vi.fn — reset it so a
+    // test that populates it doesn't leak into the next.
+    (vscode.window.tabGroups.all as unknown as unknown[]).length = 0;
     session = makeSession();
   });
 
@@ -558,6 +581,76 @@ describe('DebuggerPanel', () => {
 
       expect(editor.setDecorations).toHaveBeenCalledWith(expect.anything(), []);
     });
+
+    // A source editor that reports a real view column (VS Code resolves Active/
+    // Beside to one), so the panel can remember and target its source group.
+    function columnedEditor(viewColumn: number) {
+      return {
+        document: {
+          languageId: 'gemstone-smalltalk',
+          positionAt: (o: number) => new vscode.Position(0, o),
+          getWordRangeAtPosition: () => undefined,
+          lineAt: () => ({ firstNonWhitespaceCharacterIndex: 0 }),
+        },
+        viewColumn,
+        setDecorations: vi.fn(),
+        revealRange: vi.fn(),
+      };
+    }
+
+    it('closes the companion source editor when the panel is closed', async () => {
+      const panel = openPanelWithStack();
+      // Set AFTER ready so these apply to the frame-3 reveal (not the stack walk):
+      // a real gemstone:// method source, shown in source column 9.
+      vi.mocked(vscode.window.showTextDocument).mockResolvedValueOnce(columnedEditor(9) as never);
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO);
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const uri = (vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri).toString();
+      // Same method also open in the user's System Browser (column 1) — must NOT
+      // close. `label` only distinguishes the (structurally identical) tabs here.
+      const sourceTab = { label: 'source', input: new vscode.TabInputText(vscode.Uri.parse(uri)) };
+      const browserTab = { label: 'browser', input: new vscode.TabInputText(vscode.Uri.parse(uri)) };
+      const groups = vscode.window.tabGroups.all as unknown as { viewColumn: number; tabs: unknown[] }[];
+      groups.push({ viewColumn: 1, tabs: [browserTab] }, { viewColumn: 9, tabs: [sourceTab] });
+
+      closePanel(panel);
+
+      expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledWith(sourceTab);
+    });
+
+    it('closes nothing when the debugger never opened a source editor', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel); // no frame selected → no source opened
+      const groups = vscode.window.tabGroups.all as unknown as { viewColumn: number; tabs: unknown[] }[];
+      groups.push({ viewColumn: 9, tabs: [{ input: new vscode.TabInputText(vscode.Uri.parse('gemstone://1/x')) }] });
+
+      closePanel(panel);
+
+      expect(vi.mocked(vscode.window.tabGroups.close)).not.toHaveBeenCalled();
+    });
+
+    it('still closes a read-only (gemstone-debug:) source even when the source column is unknown', async () => {
+      // Default mock editor has no viewColumn → sourceColumn stays undefined. The
+      // read-only scheme is unique to this debugger, so it's safe to close anywhere
+      // (a shared gemstone:// would NOT be — see the previous test's column guard).
+      const panel = openPanelWithStack(); // frame 3 → read-only (base getMethodUriInfo → undefined)
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const uri = (vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri);
+      expect(uri.scheme).toBe('gemstone-debug');
+      const tab = { input: new vscode.TabInputText(vscode.Uri.parse(uri.toString())) };
+      const groups = vscode.window.tabGroups.all as unknown as { viewColumn: number; tabs: unknown[] }[];
+      groups.push({ viewColumn: 1, tabs: [tab] });
+
+      closePanel(panel);
+
+      expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledWith(tab);
+    });
   });
 
   it('terminates the suspended gsProcess (via clearStack) when the panel window is closed', () => {
@@ -567,6 +660,120 @@ describe('DebuggerPanel', () => {
     expect(debug.clearStack).not.toHaveBeenCalled();
     closePanel(panel);
     expect(debug.clearStack).toHaveBeenCalledWith(session, GS_PROCESS);
+  });
+
+  describe('variables / eval / toolbar', () => {
+    // clearAllMocks() doesn't reset return values/implementations, so restore the
+    // base getFrameInfo each test (a test that overrides it would otherwise leak).
+    beforeEach(() => {
+      vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) => ({
+        methodOop: BigInt(level), ipOffset: 5, receiverOop: BigInt(level * 100),
+        argAndTempNames: [], argAndTempOops: [],
+      }));
+    });
+
+    function openPanel() {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      return panel;
+    }
+
+    it('posts the selected frame variables (self first, then args/temps) on selectFrame', () => {
+      // Only server level 2 carries temps; other frames keep the base shape so the
+      // 5-frame stack still renders and level 2 survives filtering (mid-stack).
+      vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) =>
+        level === 2
+          ? { methodOop: 2n, ipOffset: 5, receiverOop: 300n, argAndTempNames: ['amount', 'total'], argAndTempOops: [11n, 22n] }
+          : { methodOop: BigInt(level), ipOffset: 5, receiverOop: BigInt(level * 100), argAndTempNames: [], argAndTempOops: [] });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'selectFrame', level: 2 });
+
+      const vars = lastPosted(panel, 'variables').vars;
+      expect(vars[0]).toEqual({ name: 'self', value: '<print 300>' });
+      expect(vars).toContainEqual({ name: 'amount', value: '<print 11>' });
+      expect(vars).toContainEqual({ name: 'total', value: '<print 22>' });
+    });
+
+    it('evaluates an expression in the selected frame and posts the result', () => {
+      vi.mocked(debug.evaluateInFrame).mockReturnValueOnce('1764');
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: '42 * 42' });
+
+      expect(debug.evaluateInFrame).toHaveBeenCalledWith(session, GS_PROCESS, '42 * 42', 3);
+      expect(lastPosted(panel, 'evalResult')).toMatchObject({ value: '1764', isError: false });
+    });
+
+    it('reports an eval error without throwing', () => {
+      vi.mocked(debug.evaluateInFrame).mockImplementationOnce(() => { throw new Error('doesNotUnderstand'); });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'foo bar' });
+
+      expect(lastPosted(panel, 'evalResult')).toMatchObject({ isError: true });
+      expect(lastPosted(panel, 'evalResult').value).toContain('doesNotUnderstand');
+    });
+
+    it('Resume disposes the panel when execution completes', () => {
+      vi.mocked(debug.continueExecution).mockReturnValueOnce({ completed: true });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'resume' });
+
+      expect(debug.continueExecution).toHaveBeenCalledWith(session, GS_PROCESS);
+      expect(panel.dispose).toHaveBeenCalled();
+    });
+
+    it('Resume refreshes with the new error when it hits another stop', () => {
+      vi.mocked(debug.continueExecution).mockReturnValueOnce({ completed: false, errorMessage: 'next error' });
+      const panel = openPanel();
+      const before = posted(panel, 'init').length;
+      sendMessage(panel, { command: 'resume' });
+
+      expect(panel.dispose).not.toHaveBeenCalled();
+      expect(posted(panel, 'init').length).toBe(before + 1); // refreshed
+      expect(lastPosted(panel, 'init').errorMessage).toBe('next error');
+    });
+
+    it('Step Over steps from the selected frame and refreshes (clearing the error banner)', () => {
+      const panel = openPanel();
+      const before = posted(panel, 'init').length;
+      sendMessage(panel, { command: 'stepOver', level: 3 });
+
+      expect(debug.stepOver).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(posted(panel, 'init').length).toBe(before + 1);
+      expect(lastPosted(panel, 'init').errorMessage).toBe('');
+      expect(panel.dispose).not.toHaveBeenCalled();
+    });
+
+    it('Step disposes the panel when the step completes the process', () => {
+      vi.mocked(debug.stepOver).mockReturnValueOnce({ completed: true });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 3 });
+
+      expect(panel.dispose).toHaveBeenCalled();
+    });
+
+    it('"Through" maps to gciStepThru (debugQueries.stepOut)', () => {
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepThrough', level: 4 });
+
+      expect(debug.stepOut).toHaveBeenCalledWith(session, GS_PROCESS, 4);
+    });
+
+    it('Restart Frame trims the stack to the selected frame and refreshes', () => {
+      const panel = openPanel();
+      const before = posted(panel, 'init').length;
+      sendMessage(panel, { command: 'restartFrame', level: 2 });
+
+      expect(debug.trimStackToLevel).toHaveBeenCalledWith(session, GS_PROCESS, 2);
+      expect(posted(panel, 'init').length).toBe(before + 1);
+    });
+
+    it('Terminate disposes the panel', () => {
+      const panel = openPanel();
+      sendMessage(panel, { command: 'terminate' });
+
+      expect(panel.dispose).toHaveBeenCalled();
+    });
   });
 });
 

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+
+// A controlled five-frame stack, modelled on `JasperDebugDemo new run`:
+//   level 1 — a block frame in JasperDebugDemo>>finish
+//   level 2 — an inherited method: receiver is a SmallInteger, halt is in Object
+//   levels 3-5 — plain recursive frames (JasperDebugDemo>>accumulateFrom:to:)
+//                which also exercise the repeated-label / deep-stack case.
+vi.mock('../debugQueries', () => ({
+  getStackDepth: vi.fn(() => 5),
+  getFrameInfo: vi.fn((_s: unknown, _p: unknown, level: number) => ({
+    methodOop: BigInt(level),
+    ipOffset: 5,
+    receiverOop: BigInt(level * 100),
+    argAndTempNames: [],
+    argAndTempOops: [],
+  })),
+  getMethodBlockInfo: vi.fn((_s: unknown, methodOop: bigint) => ({
+    isBlock: methodOop === 1n,
+    homeMethodOop: methodOop,
+  })),
+  getMethodUriInfo: vi.fn(() => undefined),
+  getMethodInfo: vi.fn((_s: unknown, oop: bigint) => {
+    if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
+    if (oop === 2n) return { className: 'Object', selector: 'halt' };
+    return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+  }),
+  getObjectClassName: vi.fn((_s: unknown, receiverOop: bigint) =>
+    receiverOop === 200n ? 'SmallInteger' : 'JasperDebugDemo'),
+  getLineForIp: vi.fn(() => 12),
+  getStepPoint: vi.fn(() => 2),
+  clearStack: vi.fn(),
+}));
+
+import * as vscode from 'vscode';
+import * as debug from '../debugQueries';
+import {
+  DebuggerPanel, formatFrameLabel, formatFramePosition,
+  formatFrameForClipboard, formatStackForClipboard,
+} from '../debuggerPanel';
+import { ActiveSession } from '../sessionManager';
+import { GemStoneLogin } from '../loginTypes';
+
+const GS_PROCESS = 0x123n;
+const ERROR_MSG = 'a UndefinedObject does not understand #foo';
+
+function makeSession(): ActiveSession {
+  return {
+    id: 1,
+    handle: { h: 1 },
+    login: {
+      label: 'Test', gs_user: 'DataCurator', stone: 'gs64stone', gem_host: 'devhost',
+    } as GemStoneLogin,
+    stoneVersion: '3.7.2',
+    gci: { GciTsClearStack: vi.fn() } as unknown as ActiveSession['gci'],
+  } as ActiveSession;
+}
+
+/** The most recently created webview panel mock. */
+function lastPanel() {
+  const results = vi.mocked(vscode.window.createWebviewPanel).mock.results;
+  return results[results.length - 1].value;
+}
+
+/** Invoke the panel's webview message handler with an arbitrary message. */
+function sendMessage(panel: ReturnType<typeof lastPanel>, msg: unknown) {
+  panel.webview.onDidReceiveMessage.mock.calls[0][0](msg);
+}
+
+/** Simulate the webview finishing load and requesting data. */
+function sendReady(panel: ReturnType<typeof lastPanel>) {
+  sendMessage(panel, { command: 'ready' });
+}
+
+/** Simulate the user closing the panel window. */
+function closePanel(panel: ReturnType<typeof lastPanel>) {
+  const handler = panel.onDidDispose.mock.calls[0][0];
+  handler();
+}
+
+/** The `init` payload the panel posts back to the webview after `ready`. */
+function initPayload(panel: ReturnType<typeof lastPanel>) {
+  const call = panel.webview.postMessage.mock.calls
+    .find((c: unknown[]) => (c[0] as { command: string }).command === 'init');
+  return call?.[0];
+}
+
+describe('formatFrameLabel', () => {
+  it('names a plain frame `Class>>#selector` when receiver matches the defining class', () => {
+    expect(formatFrameLabel({
+      isBlock: false, definingClass: 'JasperDebugDemo', selector: 'finish',
+      receiverClass: 'JasperDebugDemo',
+    })).toBe('JasperDebugDemo>>#finish');
+  });
+
+  it('disambiguates an inherited method as `Receiver (Defining)>>#selector`', () => {
+    expect(formatFrameLabel({
+      isBlock: false, definingClass: 'Object', selector: 'printString',
+      receiverClass: 'Array',
+    })).toBe('Array (Object)>>#printString');
+  });
+
+  it('omits disambiguation when the receiver class is unavailable', () => {
+    expect(formatFrameLabel({
+      isBlock: false, definingClass: 'Object', selector: 'printString',
+    })).toBe('Object>>#printString');
+  });
+
+  it('prefixes a block frame with `[] in ` and never disambiguates the receiver', () => {
+    expect(formatFrameLabel({
+      isBlock: true, definingClass: 'JasperDebugDemo', selector: 'finish',
+      receiverClass: 'SomethingElse',
+    })).toBe('[] in JasperDebugDemo>>#finish');
+  });
+
+  it('handles inherited class-side methods (metaclass names already include " class")', () => {
+    expect(formatFrameLabel({
+      isBlock: false, definingClass: 'Object class', selector: 'new',
+      receiverClass: 'JasperDebugDemo class',
+    })).toBe('JasperDebugDemo class (Object class)>>#new');
+  });
+});
+
+describe('formatFramePosition', () => {
+  it('formats step point and line as `@<step> line <line>`', () => {
+    expect(formatFramePosition(2, 12)).toBe('@2 line 12');
+  });
+
+  it('shows only the step point when the line is unavailable', () => {
+    expect(formatFramePosition(2, undefined)).toBe('@2');
+  });
+
+  it('shows only the line when the step point is unavailable', () => {
+    expect(formatFramePosition(undefined, 12)).toBe('line 12');
+  });
+
+  it('returns an empty string when neither is available', () => {
+    expect(formatFramePosition(undefined, undefined)).toBe('');
+  });
+
+  it('omits a line of 0 (an unmapped IP has no source line)', () => {
+    expect(formatFramePosition(2, 0)).toBe('@2');
+    expect(formatFramePosition(undefined, 0)).toBe('');
+  });
+});
+
+describe('formatFrameForClipboard', () => {
+  it('renders `<label>  <position>` with no leading frame number', () => {
+    expect(formatFrameForClipboard({ level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12' }))
+      .toBe('SmallInteger (Object)>>#halt  @2 line 12');
+  });
+
+  it('omits the position when the frame has none', () => {
+    expect(formatFrameForClipboard({ level: 1, label: 'A>>#x', position: '' })).toBe('A>>#x');
+  });
+});
+
+describe('formatStackForClipboard', () => {
+  const frames = [
+    { level: 1, label: 'A>>#x', position: '@2 line 3' },
+    { level: 2, label: 'B>>#y', position: '' },
+  ];
+
+  it('renders an error header followed by numbered frames with positions', () => {
+    expect(formatStackForClipboard('boom', frames)).toBe(
+      ['GemStone error: boom', '', '1. A>>#x  @2 line 3', '2. B>>#y'].join('\n'),
+    );
+  });
+
+  it('omits the error header when there is no error message', () => {
+    expect(formatStackForClipboard('', frames)).toBe(
+      ['1. A>>#x  @2 line 3', '2. B>>#y'].join('\n'),
+    );
+  });
+
+  it('omits the position when a frame has none', () => {
+    expect(formatStackForClipboard('', [{ level: 1, label: 'A>>#x', position: '' }]))
+      .toBe('1. A>>#x');
+  });
+});
+
+describe('DebuggerPanel', () => {
+  let session: ActiveSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    session = makeSession();
+  });
+
+  it('opens beside the active editor group with the title "Jasper Debugger"', () => {
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+
+    const call = vi.mocked(vscode.window.createWebviewPanel).mock.calls[0];
+    expect(call[1]).toBe('Jasper Debugger');           // tab title
+    expect(call[2]).toBe(vscode.ViewColumn.Beside);    // to the right of the active group
+    expect(call[3]).toMatchObject({ enableScripts: true });
+  });
+
+  it('shows a dimmed "For <user> on <stone> @ <host>" subtitle from the login', () => {
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const html = lastPanel().webview.html;
+
+    expect(html).toContain('For DataCurator on gs64stone @ devhost');
+    // The subtitle uses the dimmed description color.
+    expect(html).toMatch(/\.subtitle\s*\{[^}]*--vscode-descriptionForeground/);
+  });
+
+  it('HTML-escapes session text so it cannot inject markup into the page', () => {
+    session.login = {
+      label: 'T', gs_user: '<img src=x>', stone: 's&s', gem_host: 'h"h',
+    } as GemStoneLogin;
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const html = lastPanel().webview.html;
+
+    expect(html).toContain(
+      '<span class="subtitle">For &lt;img src=x&gt; on s&amp;s @ h&quot;h</span>',
+    );
+    expect(html).not.toContain('<img src=x>');   // raw, unescaped tag must not appear
+  });
+
+  it('builds a partial subtitle when some login fields are missing', () => {
+    session.login = { label: 'T', gs_user: 'solo' } as GemStoneLogin; // no stone / host
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const html = lastPanel().webview.html;
+
+    expect(html).toContain('<span class="subtitle">For solo</span>');
+  });
+
+  it('disposeForSession disposes every panel created for the session', () => {
+    const s = { ...makeSession(), id: 4242 } as ActiveSession;
+    DebuggerPanel.create(s, GS_PROCESS, ERROR_MSG);
+    DebuggerPanel.create(s, 0x456n, 'another error');
+    const results = vi.mocked(vscode.window.createWebviewPanel).mock.results;
+    const p1 = results[results.length - 2].value;
+    const p2 = results[results.length - 1].value;
+
+    DebuggerPanel.disposeForSession(4242);
+
+    expect(p1.dispose).toHaveBeenCalled();
+    expect(p2.dispose).toHaveBeenCalled();
+  });
+
+  it('posts the error string back to the webview unchanged', () => {
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const panel = lastPanel();
+    sendReady(panel);
+
+    expect(initPayload(panel).errorMessage).toBe(ERROR_MSG);
+  });
+
+  describe('copy / context menu', () => {
+    it('provides a Copy Stack button and a Copy Frame popup item, and suppresses the default menu', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const html = lastPanel().webview.html;
+
+      expect(html).toContain('id="copyBtn"');                    // Copy Stack button
+      expect(html).toContain('Copy Stack');
+      expect(html).toContain('id="copyFrameItem"');              // Copy Frame popup item
+      expect(html).toContain('Copy Frame');
+      expect(html).toContain('copyFrame');                       // per-frame copy wiring
+      expect(html).toMatch(/addEventListener\(\s*'contextmenu'/); // default menu suppressed + custom menu
+      expect(html).toContain('preventDefault');
+    });
+
+    it('writes the formatted stack to the clipboard on a copyStack message', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);            // fetches + caches the stack
+      sendMessage(panel, { command: 'copyStack' });
+
+      const expected = [
+        'GemStone error: a UndefinedObject does not understand #foo',
+        '',
+        '1. [] in JasperDebugDemo>>#finish  @2 line 12',
+        '2. SmallInteger (Object)>>#halt  @2 line 12',
+        '3. JasperDebugDemo>>#accumulateFrom:to:  @2 line 12',
+        '4. JasperDebugDemo>>#accumulateFrom:to:  @2 line 12',
+        '5. JasperDebugDemo>>#accumulateFrom:to:  @2 line 12',
+      ].join('\n');
+      expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith(expected);
+    });
+
+    it('writes a single frame (no leading number) to the clipboard on copyFrame', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      sendMessage(panel, { command: 'copyFrame', level: 2 });
+
+      expect(vscode.env.clipboard.writeText)
+        .toHaveBeenCalledWith('SmallInteger (Object)>>#halt  @2 line 12');
+    });
+
+    it('ignores copyFrame for an unknown level without writing the clipboard', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      sendMessage(panel, { command: 'copyFrame', level: 999 });
+
+      expect(vscode.env.clipboard.writeText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('frame list', () => {
+    it('renders step point & line in a dimmed `.pos` element', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const html = lastPanel().webview.html;
+
+      expect(html).toMatch(/\.pos\s*\{[^}]*--vscode-descriptionForeground/);
+    });
+
+    it('numbers the frames 1..N, strictly ascending, for easy reference', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      const levels = initPayload(panel).stack.map((f: { level: number }) => f.level);
+      // A deep stack (>2) so "ascending" is a meaningful assertion, not a coincidence.
+      expect(levels.length).toBeGreaterThan(2);
+      // Numbered 1..N with no gaps, no duplicates, strictly increasing.
+      expect(levels).toEqual(levels.map((_: number, i: number) => i + 1));
+    });
+
+    it('builds frame labels with block prefix, receiver disambiguation, and position', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      expect(initPayload(panel).stack).toEqual([
+        { level: 1, label: '[] in JasperDebugDemo>>#finish', position: '@2 line 12' },
+        { level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12' },
+        { level: 3, label: 'JasperDebugDemo>>#accumulateFrom:to:', position: '@2 line 12' },
+        { level: 4, label: 'JasperDebugDemo>>#accumulateFrom:to:', position: '@2 line 12' },
+        { level: 5, label: 'JasperDebugDemo>>#accumulateFrom:to:', position: '@2 line 12' },
+      ]);
+    });
+
+    // Ported from the DAP stackTraceRequest "doit frame" test: a valid frame
+    // whose method can't be introspected is `Executed Code`, NOT an error.
+    it('labels a frame `Executed Code` when its method cannot be resolved', () => {
+      // getMethodUriInfo already returns undefined in the base mock; make the
+      // getMethodInfo fallback throw for the first frame (as a doit/anon frame).
+      vi.mocked(debug.getMethodInfo).mockImplementationOnce(() => {
+        throw new Error('does not understand #inClass');
+      });
+
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      expect(initPayload(panel).stack[0].label).toBe('Executed Code');
+    });
+
+    // The other fallback branch: when the frame contents themselves can't be
+    // fetched, the frame is `<frame N>` with no position (vs. "unavailable").
+    it('labels a frame `<frame N>` when its contents cannot be fetched', () => {
+      vi.mocked(debug.getFrameInfo).mockImplementationOnce(() => {
+        throw new Error('cannot fetch frame contents');
+      });
+
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      expect(initPayload(panel).stack[0]).toEqual({ level: 1, label: '<frame 1>', position: '' });
+    });
+
+    // An "unprintable" / unresolvable receiver: getObjectClassName throws. The
+    // label must still render (no crash), just without receiver disambiguation.
+    it('falls back to the defining class when the receiver class cannot be fetched', () => {
+      // First non-block frame (level 2) is the only one that queries the
+      // receiver class; make that query throw.
+      vi.mocked(debug.getObjectClassName).mockImplementationOnce(() => {
+        throw new Error('receiver does not understand #class');
+      });
+
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      // Without the receiver class there is no `Receiver (Defining)` form —
+      // just the plain defining-class label.
+      expect(initPayload(panel).stack[1]).toEqual({
+        level: 2, label: 'Object>>#halt', position: '@2 line 12',
+      });
+    });
+
+    // fetchStack's outer guard: if the stack can't even be measured (e.g. the
+    // process died), the panel posts an empty stack rather than throwing.
+    it('returns an empty stack when the stack-depth query fails', () => {
+      vi.mocked(debug.getStackDepth).mockImplementationOnce(() => {
+        throw new Error('process is dead');
+      });
+
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      expect(initPayload(panel).stack).toEqual([]);
+    });
+  });
+
+  it('terminates the suspended gsProcess (via clearStack) when the panel window is closed', () => {
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const panel = lastPanel();
+
+    expect(debug.clearStack).not.toHaveBeenCalled();
+    closePanel(panel);
+    expect(debug.clearStack).toHaveBeenCalledWith(session, GS_PROCESS);
+  });
+});

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -54,7 +54,8 @@ vi.mock('../debugQueries', () => ({
 }));
 
 // Clicking a variable row opens a GT Inspector — stub the static entry point.
-vi.mock('../gtInspector', () => ({ GtInspector: { create: vi.fn() } }));
+// create() returns a closable handle so the debugger can close it on dispose.
+vi.mock('../gtInspector', () => ({ GtInspector: { create: vi.fn(() => ({ close: vi.fn() })) } }));
 
 // Source offsets for the step-point highlight. These are GemStone `_sourceOffsets`,
 // which are 1-BASED (index i = offset of step point i+1); the panel must convert
@@ -69,6 +70,7 @@ import {
   DebuggerPanel, formatFrameLabel, formatFramePosition,
   formatFrameForClipboard, formatStackForClipboard, buildMethodSourceUri,
   filterStack, isExceptionMachinery, RawFrame,
+  flattenLayoutLeaves, sourceRatioFromLayout, setSourceRatioInLayout, EditorGroupLayout,
 } from '../debuggerPanel';
 import { wrapWithTranscriptCapture } from '../transcriptCapture';
 import { GtInspector } from '../gtInspector';
@@ -77,6 +79,21 @@ import { GemStoneLogin } from '../loginTypes';
 
 const GS_PROCESS = 0x123n;
 const ERROR_MSG = 'a UndefinedObject does not understand #foo';
+
+// The static step-point highlight decoration is built once, at module import —
+// i.e. BEFORE the beforeEach vi.clearAllMocks() below wipes the mock's call
+// record. Snapshot the options it was created with here, at top level, so the
+// guard test (see "step-point highlight decoration") can still see them.
+// Identify it by its themed base `backgroundColor` (unique to this decoration).
+const stepPointDecorationOptions = vi
+  .mocked(vscode.window.createTextEditorDecorationType)
+  .mock.calls.map((c) => c[0] as vscode.DecorationRenderOptions)
+  .find(
+    (opts) =>
+      opts?.backgroundColor instanceof vscode.ThemeColor &&
+      (opts.backgroundColor as vscode.ThemeColor).id ===
+        'editor.focusedStackFrameHighlightBackground',
+  );
 
 function makeSession(): ActiveSession {
   return {
@@ -329,7 +346,7 @@ describe('DebuggerPanel', () => {
       expect(html).toContain('id="splitter"');     // draggable column divider
       expect(html).toContain('id="hsplitter"');     // draggable panes-vs-eval divider
       expect(html).toMatch(/--stack-basis:\s*60%/); // default split, injected from the saved static
-      expect(html).toMatch(/--eval-height:\s*7rem/); // default eval-bar height, injected from the saved static
+      expect(html).toMatch(/--eval-height:\s*4rem/); // default eval-bar height, injected from the saved static
     });
 
     it('renders the toolbar as DAP-style icon buttons (codicon SVGs), not text labels', () => {
@@ -531,6 +548,9 @@ describe('DebuggerPanel', () => {
       // Docked below: focus the panel's group, then split a new group beneath it.
       expect(panel.reveal).toHaveBeenCalled();
       expect(vscode.commands.executeCommand).toHaveBeenCalledWith('workbench.action.newGroupBelow');
+      // …then shrink that 50/50 source group toward ~1/3 (item #2). Guards the
+      // resize from being silently dropped — exact ratio is tuned by step count.
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('workbench.action.decreaseViewHeight');
 
       expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
         expect.anything(),
@@ -738,6 +758,61 @@ describe('DebuggerPanel', () => {
       closePanel(panel);
 
       expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledWith(tab);
+    });
+
+    it('closes the source editor AND every GT Inspector it opened, together, on close', async () => {
+      const panel = openPanelWithStack();
+      // A real gemstone:// method source, shown in source column 9.
+      vi.mocked(vscode.window.showTextDocument).mockResolvedValueOnce(columnedEditor(9) as never);
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO);
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      // GT Inspect two variables → two inspectors, each a closable handle.
+      sendMessage(panel, { command: 'inspectVariable', oop: '300', name: 'self' });
+      sendMessage(panel, { command: 'inspectVariable', oop: '901', name: 'total' });
+      const inspectorCloses = vi.mocked(GtInspector.create).mock.results
+        .map((r) => (r.value as { close: ReturnType<typeof vi.fn> }).close);
+      expect(inspectorCloses).toHaveLength(2);
+
+      const uri = (vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri).toString();
+      const sourceTab = { label: 'source', input: new vscode.TabInputText(vscode.Uri.parse(uri)) };
+      const groups = vscode.window.tabGroups.all as unknown as { viewColumn: number; tabs: unknown[] }[];
+      groups.push({ viewColumn: 9, tabs: [sourceTab] });
+
+      closePanel(panel);
+
+      // The companion source tab is closed…
+      expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledWith(sourceTab);
+      // …and BOTH inspectors are closed alongside it.
+      for (const close of inspectorCloses) expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it('sizes the new source group via setEditorLayout to the saved/default ratio (#3)', async () => {
+      // getEditorLayout reports code(1) | debugger(2) / source(3). The source
+      // editor opens in column 3, so it maps to the 99-tall leaf.
+      const layout = { orientation: 0, groups: [{ size: 636 }, { size: 877, groups: [{ size: 749 }, { size: 99 }] }] };
+      // Route getEditorLayout to our sample; everything else returns undefined.
+      // mockImplementation persists past clearAllMocks, so restore it in finally.
+      vi.mocked(vscode.commands.executeCommand).mockImplementation((cmd: string) =>
+        Promise.resolve(cmd === 'vscode.getEditorLayout' ? layout : undefined) as never);
+      try {
+        const panel = openPanelWithStack();
+        vi.mocked(vscode.window.showTextDocument).mockResolvedValueOnce(columnedEditor(3) as never);
+        vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO);
+        sendMessage(panel, { command: 'selectFrame', level: 3 });
+        await flush();
+
+        // Used the precise layout API, not the imprecise step-based fallback.
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('vscode.setEditorLayout', layout);
+        expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith('workbench.action.decreaseViewHeight');
+        // Source (col 3) resized to ~1/3 of its 848-tall column; sibling gets the rest.
+        const column = layout.groups[1].groups!;
+        expect(column[1].size).toBe(Math.round(848 * 0.33));
+        expect(column[0].size).toBe(848 - Math.round(848 * 0.33));
+      } finally {
+        vi.mocked(vscode.commands.executeCommand).mockReset();
+      }
     });
   });
 
@@ -1258,8 +1333,15 @@ describe('DebuggerPanel', () => {
       DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
       expect(lastPanel().webview.html).toMatch(/--eval-height:\s*160px/);
 
-      // Restore the default so later tests see the standard 7rem height.
-      sendMessage(lastPanel(), { command: 'saveLayout', evalHeight: '7rem' });
+      // Restore the default so later tests see the standard 4rem height.
+      sendMessage(lastPanel(), { command: 'saveLayout', evalHeight: '4rem' });
+    });
+
+    it('widens the Beside split toward ~60% on create (item #2)', async () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      await tick(); // the widen runs in a fire-and-forget async IIFE
+      // Best-effort nudge; guards the resize from being silently dropped.
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('workbench.action.increaseViewWidth');
     });
   });
 });
@@ -1359,5 +1441,83 @@ describe('isExceptionMachinery', () => {
     expect(isExceptionMachinery(HALT_STACK[4])).toBe(false); // [] in finish
     expect(isExceptionMachinery(HALT_STACK[6])).toBe(false); // finish
     expect(isExceptionMachinery(HALT_STACK[5])).toBe(false); // Collection>>do:
+  });
+});
+
+describe('source-pane layout persistence (#3)', () => {
+  // A real `vscode.getEditorLayout` result Eric captured: code | (debugger / source).
+  // Leaf order = ViewColumn order, so code=1, debugger=2, source=3.
+  const sample = (): EditorGroupLayout => ({
+    orientation: 0,
+    groups: [
+      { size: 636 },
+      { size: 877, groups: [{ size: 749 }, { size: 99 }] },
+    ],
+  });
+
+  it('flattens leaves in ViewColumn order (depth-first, left-to-right)', () => {
+    const leaves = flattenLayoutLeaves(sample());
+    expect(leaves.map(l => l.node.size)).toEqual([636, 749, 99]);
+  });
+
+  it('reads the source group ratio from its containing column', () => {
+    // Source is ViewColumn 3 → 99 of the 877-wide column's 848 (749+99).
+    expect(sourceRatioFromLayout(sample(), 3)).toBeCloseTo(99 / 848, 5);
+  });
+
+  it('returns undefined when the column is missing or unmeasurable', () => {
+    expect(sourceRatioFromLayout(sample(), 9)).toBeUndefined(); // column past the end
+    expect(sourceRatioFromLayout(undefined, 3)).toBeUndefined(); // no layout
+    expect(sourceRatioFromLayout(sample(), undefined)).toBeUndefined(); // no column
+  });
+
+  it('rewrites the source/sibling sizes to a ratio, preserving their sum and other groups', () => {
+    const layout = sample();
+    expect(setSourceRatioInLayout(layout, 3, 0.5)).toBe(true);
+    const column = layout.groups[1].groups!;
+    expect(column[1].size).toBe(424); // source: round(848 * 0.5)
+    expect(column[0].size).toBe(424); // sibling (debugger): the rest
+    expect(layout.groups[0].size).toBe(636); // code column untouched
+  });
+
+  it('clamps a degenerate ratio so a pane can never collapse', () => {
+    const layout = sample();
+    setSourceRatioInLayout(layout, 3, 0.99);
+    const column = layout.groups[1].groups!;
+    expect(column[1].size).toBe(Math.round(848 * 0.9)); // clamped to 0.9
+  });
+
+  it('refuses to rewrite when the source is not a clean two-way split', () => {
+    // A 3-way column isn't the pair we create (debugger / source), so leave it be.
+    const threeWay: EditorGroupLayout = {
+      orientation: 0,
+      groups: [{ size: 636 }, { size: 877, groups: [{ size: 300 }, { size: 300 }, { size: 200 }] }],
+    };
+    // Leaves: code=1, then 300=2, 300=3, 200=4 → source col 4's parent has 3 kids.
+    expect(setSourceRatioInLayout(threeWay, 4, 0.33)).toBe(false);
+    expect(threeWay.groups[1].groups!.map(g => g.size)).toEqual([300, 300, 200]); // untouched
+  });
+});
+
+describe('step-point highlight decoration', () => {
+  // Guards item #5: light themes render `editor.focusedStackFrameHighlightBackground`
+  // as a near-invisible translucent yellow, and we mark only the step-point token
+  // (not the whole line), so the bare default was almost unreadable. The decoration
+  // therefore carries a `light` override with a stronger fill + solid border. If
+  // someone strips that override (back to the faint default), these fail.
+  it('was created (snapshot captured at import time)', () => {
+    expect(stepPointDecorationOptions).toBeDefined();
+  });
+
+  it('overrides light themes with a stronger fill and a solid (non-themed) border', () => {
+    const light = stepPointDecorationOptions?.light;
+    expect(light).toBeDefined();
+    // A solid colour string, NOT a ThemeColor pointing back at the faint default.
+    expect(typeof light?.backgroundColor).toBe('string');
+    expect(typeof light?.borderColor).toBe('string');
+    expect(light?.borderColor).not.toBeInstanceOf(vscode.ThemeColor);
+    // The fill must be appreciably opaque (the faint default sits near ~0.2 alpha).
+    const alpha = Number(/rgba?\([^)]*,\s*([\d.]+)\s*\)$/.exec(String(light?.backgroundColor))?.[1] ?? '1');
+    expect(alpha).toBeGreaterThanOrEqual(0.4);
   });
 });

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -39,7 +39,12 @@ vi.mock('../debugQueries', () => ({
   stepOver: vi.fn(() => ({ completed: false })),
   stepInto: vi.fn(() => ({ completed: false })),
   stepOut: vi.fn(() => ({ completed: false })),
+  // Non-blocking variants the webview panel now uses (resolve async).
+  stepOverNb: vi.fn(async () => ({ completed: false })),
+  stepIntoNb: vi.fn(async () => ({ completed: false })),
+  stepThruNb: vi.fn(async () => ({ completed: false })),
   trimStackToLevel: vi.fn(),
+  trimStackToLevelNb: vi.fn(async () => {}),
   clearStack: vi.fn(),
   acquireStepping: vi.fn(),
   releaseStepping: vi.fn(),
@@ -123,6 +128,14 @@ function lastPosted(panel: ReturnType<typeof lastPanel>, command: string): any {
   const all = posted(panel, command);
   return all[all.length - 1];
 }
+
+/**
+ * Yield to the microtask/timer queue so an async panel handler (step / restart /
+ * edit-and-continue now route through the awaited non-blocking Nb variants) can
+ * settle before assertions. The mocked Nb fns resolve immediately, so one tick
+ * is enough.
+ */
+const tick = (): Promise<void> => new Promise<void>(resolve => setTimeout(resolve, 0));
 
 describe('formatFrameLabel', () => {
   it('names a plain frame `Class>>#selector` when receiver matches the defining class', () => {
@@ -834,59 +847,65 @@ describe('DebuggerPanel', () => {
       expect(lastPosted(panel, 'init').errorMessage).toBe('next error');
     });
 
-    it('Step Over steps from the selected user frame (display level → server level) and refreshes, clearing the error banner', () => {
+    it('Step Over steps (non-blocking) from the selected user frame and refreshes, clearing the error banner', async () => {
       const panel = openPanel();
       const before = posted(panel, 'init').length;
       sendMessage(panel, { command: 'stepOver', level: 3 }); // display 3 → server level 3
+      await tick();
 
-      expect(debug.stepOver).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(debug.stepOverNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
       expect(posted(panel, 'init').length).toBe(before + 1);
       expect(lastPosted(panel, 'init').errorMessage).toBe('');
       expect(panel.dispose).not.toHaveBeenCalled();
     });
 
-    it('surfaces a clear message when a step hits native-code (error 6014), without disposing', () => {
-      vi.mocked(debug.stepOver).mockReturnValueOnce({
+    it('surfaces a clear message when a step hits native-code (error 6014), without disposing', async () => {
+      vi.mocked(debug.stepOverNb).mockResolvedValueOnce({
         completed: false,
         errorMessage: 'a ImproperOperation occurred (error 6014), Breakpoint and single-step not supported in native code',
       });
       const panel = openPanel();
       sendMessage(panel, { command: 'stepOver', level: 1 });
+      await tick();
 
       expect(panel.dispose).not.toHaveBeenCalled();
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/native code/i);
     });
 
-    it('Step disposes the panel when the step completes the process', () => {
-      vi.mocked(debug.stepOver).mockReturnValueOnce({ completed: true });
+    it('Step disposes the panel when the step completes the process', async () => {
+      vi.mocked(debug.stepOverNb).mockResolvedValueOnce({ completed: true });
       const panel = openPanel();
       sendMessage(panel, { command: 'stepOver', level: 3 });
+      await tick();
 
       expect(panel.dispose).toHaveBeenCalled();
     });
 
-    it('"Through" maps to gciStepThru (debugQueries.stepOut), from the selected user frame', () => {
+    it('"Through" maps to gciStepThru (debugQueries.stepThruNb), from the selected user frame', async () => {
       const panel = openPanel();
       sendMessage(panel, { command: 'stepThrough', level: 4 }); // display 4 → server level 4
+      await tick();
 
-      expect(debug.stepOut).toHaveBeenCalledWith(session, GS_PROCESS, 4);
+      expect(debug.stepThruNb).toHaveBeenCalledWith(session, GS_PROCESS, 4);
     });
 
-    it('Restart Frame trims the stack to the selected (deeper) frame and refreshes', () => {
+    it('Restart Frame trims the stack (non-blocking) to the selected (deeper) frame and refreshes', async () => {
       const panel = openPanel();
       const before = posted(panel, 'init').length;
       sendMessage(panel, { command: 'restartFrame', level: 2 });
+      await tick();
 
-      expect(debug.trimStackToLevel).toHaveBeenCalledWith(session, GS_PROCESS, 2);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2);
       expect(posted(panel, 'init').length).toBe(before + 1);
     });
 
-    it('Restart Frame on the top frame shows an in-panel notice and does not trim (GemStone cannot reset the TOS IP)', () => {
+    it('Restart Frame on the top frame shows an in-panel notice and does not trim (GemStone cannot reset the TOS IP)', async () => {
       const panel = openPanel();
-      vi.mocked(debug.trimStackToLevel).mockClear();
+      vi.mocked(debug.trimStackToLevelNb).mockClear();
       sendMessage(panel, { command: 'restartFrame', level: 1 }); // display 1 → server level 1 (top)
+      await tick();
 
-      expect(debug.trimStackToLevel).not.toHaveBeenCalled();
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/top frame/i);
     });
 
@@ -909,13 +928,14 @@ describe('DebuggerPanel', () => {
       expect(panel.dispose).toHaveBeenCalled();
     });
 
-    it('hands the completed result to onComplete on step-to-completion', () => {
-      vi.mocked(debug.stepOver).mockReturnValueOnce({ completed: true, resultOop: 0x66n });
+    it('hands the completed result to onComplete on step-to-completion', async () => {
+      vi.mocked(debug.stepOverNb).mockResolvedValueOnce({ completed: true, resultOop: 0x66n });
       const onComplete = vi.fn();
       DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG, onComplete);
       const panel = lastPanel();
       sendReady(panel);
       sendMessage(panel, { command: 'stepOver', level: 1 });
+      await tick();
 
       expect(onComplete).toHaveBeenCalledWith(0x66n);
       expect(panel.dispose).toHaveBeenCalled();
@@ -931,6 +951,171 @@ describe('DebuggerPanel', () => {
 
       expect(onComplete).not.toHaveBeenCalled();
       expect(panel.dispose).not.toHaveBeenCalled();
+    });
+
+    it('does NOT silently drop a second op while one is in flight — it posts a busy notice', async () => {
+      let release: (r: debug.StepResult) => void = () => {};
+      vi.mocked(debug.stepOverNb).mockReturnValueOnce(new Promise<debug.StepResult>(res => { release = res; }));
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 3 }); // starts, stays pending
+      await tick();
+      expect(debug.stepOverNb).toHaveBeenCalledTimes(1);
+
+      sendMessage(panel, { command: 'stepOver', level: 3 }); // while the first is in flight
+      await tick();
+      expect(debug.stepOverNb).toHaveBeenCalledTimes(1);                 // not started again
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/still running/i); // user is told
+
+      release({ completed: false }); // let the first finish so the panel settles
+      await tick();
+    });
+
+    it('releases the in-flight guard after a FAILED op so the next op still runs (no permanent wedge)', async () => {
+      vi.mocked(debug.stepOverNb).mockRejectedValueOnce(new Error('boom'));
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 3 });
+      await tick();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/failed/i);
+
+      sendMessage(panel, { command: 'stepOver', level: 3 }); // guard must be released
+      await tick();
+      expect(debug.stepOverNb).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('edit-and-continue (save companion source)', () => {
+    // Let revealFrameSource's awaited openTextDocument/showTextDocument settle so
+    // editableSourceUri is set before we fire the save.
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    const URI_INFO = {
+      dictName: 'UserGlobals', className: 'JasperDebugDemo', isMeta: false,
+      category: 'accessing', selector: 'accumulateFrom:to:',
+    };
+
+    beforeEach(() => {
+      // Restore the base getFrameInfo (mockImplementation leaks past clearAllMocks).
+      vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) => ({
+        methodOop: BigInt(level), ipOffset: 5, receiverOop: BigInt(level * 100),
+        argAndTempNames: [], argAndTempOops: [],
+      }));
+    });
+
+    /** The save listener the panel registered in its constructor. */
+    function saveListener(): (doc: vscode.TextDocument) => void {
+      return vi.mocked(vscode.workspace.onDidSaveTextDocument).mock.calls[0][0];
+    }
+
+    /**
+     * Open a panel, load the 5-frame stack, and select `displayLevel` as an
+     * EDITABLE gemstone:// frame (URI_INFO supplied to the single reveal). Returns
+     * the panel and the source URI the panel opened (== the doc the user saves).
+     */
+    async function openWithEditableFrame(displayLevel: number) {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel); // fetchStack uses the base (undefined URI) mocks
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO); // for the reveal only
+      sendMessage(panel, { command: 'selectFrame', level: displayLevel });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      return { panel, uri };
+    }
+
+    it('re-enters the selected (deeper) frame when its source is saved and recompiled', async () => {
+      const { panel, uri } = await openWithEditableFrame(3); // display 3 → server level 3
+      const before = posted(panel, 'init').length;
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick(); // editAndContinue awaits the non-blocking trim
+
+      // trimStackToLevel installs the recompiled method + resets the frame to its
+      // first instruction (the old activation held the pre-edit GsNMethod).
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(posted(panel, 'init').length).toBe(before + 1); // refreshed
+    });
+
+    it('does NOT re-enter when the recompile failed (GemStone error diagnostic on the URI)', async () => {
+      const { panel, uri } = await openWithEditableFrame(3);
+      // getDiagnostics is overloaded ([Uri, Diagnostic[]][] | Diagnostic[]); cast
+      // past the union to the single-URI Diagnostic[] shape the panel calls with.
+      vi.mocked(vscode.languages.getDiagnostics).mockReturnValueOnce(
+        [{ severity: vscode.DiagnosticSeverity.Error }] as never,
+      );
+      const before = posted(panel, 'init').length;
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      expect(posted(panel, 'init').length).toBe(before); // no refresh
+    });
+
+    it('ignores a save of some OTHER document (not the selected frame source)', async () => {
+      const { panel } = await openWithEditableFrame(3);
+      const before = posted(panel, 'init').length;
+      saveListener()({ uri: vscode.Uri.parse('gemstone://1/Other/Foo/instance/x/bar') } as vscode.TextDocument);
+      await tick();
+
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      expect(posted(panel, 'init').length).toBe(before);
+    });
+
+    it('ignores a save when the selected frame is read-only (no editable gemstone:// source)', async () => {
+      // Frame 3 with the base (undefined URI) mocks resolves read-only.
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+    });
+
+    it('shows an in-panel notice and does NOT trim when the edited frame is the top frame', async () => {
+      const { panel, uri } = await openWithEditableFrame(1); // display 1 → server level 1 (top)
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/top frame/i);
+    });
+
+    it('BLOCKS Resume after a top-frame recompile (continuing the stale activation would hang the gem)', async () => {
+      const { panel, uri } = await openWithEditableFrame(1); // top frame → stale activation
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      vi.mocked(debug.continueExecution).mockClear();
+      sendMessage(panel, { command: 'resume' });
+
+      expect(debug.continueExecution).not.toHaveBeenCalled();
+      expect(panel.dispose).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/recompiled/i);
+    });
+
+    it('BLOCKS Step after a top-frame recompile', async () => {
+      const { panel, uri } = await openWithEditableFrame(1);
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      vi.mocked(debug.stepOverNb).mockClear();
+      sendMessage(panel, { command: 'stepOver', level: 1 });
+      await tick();
+
+      expect(debug.stepOverNb).not.toHaveBeenCalled();
+    });
+
+    it('re-enables Resume once a deeper frame is restarted (the trim discards the stale activation)', async () => {
+      const { panel, uri } = await openWithEditableFrame(1);
+      saveListener()({ uri } as vscode.TextDocument);        // stale top activation (sync guard)
+      await tick();
+      sendMessage(panel, { command: 'restartFrame', level: 2 }); // deeper trim clears it
+      await tick();                                              // let the async trim settle
+      vi.mocked(debug.continueExecution).mockClear();
+      sendMessage(panel, { command: 'resume' });
+
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2);
+      expect(debug.continueExecution).toHaveBeenCalled(); // no longer blocked
     });
   });
 

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -30,15 +30,25 @@ vi.mock('../debugQueries', () => ({
     receiverOop === 200n ? 'SmallInteger' : 'JasperDebugDemo'),
   getLineForIp: vi.fn(() => 12),
   getStepPoint: vi.fn(() => 2),
+  getMethodSource: vi.fn(() => '| t | t := 6 * 7. t halt'),
   clearStack: vi.fn(),
+}));
+
+// Source offsets for the step-point highlight. These are GemStone `_sourceOffsets`,
+// which are 1-BASED (index i = offset of step point i+1); the panel must convert
+// them to 0-based for doc.positionAt.
+vi.mock('../browserQueries', () => ({
+  getSourceOffsets: vi.fn(() => [1, 8, 26]),
 }));
 
 import * as vscode from 'vscode';
 import * as debug from '../debugQueries';
 import {
   DebuggerPanel, formatFrameLabel, formatFramePosition,
-  formatFrameForClipboard, formatStackForClipboard,
+  formatFrameForClipboard, formatStackForClipboard, buildMethodSourceUri,
+  filterStack, isExceptionMachinery, RawFrame,
 } from '../debuggerPanel';
+import { wrapWithTranscriptCapture } from '../transcriptCapture';
 import { ActiveSession } from '../sessionManager';
 import { GemStoneLogin } from '../loginTypes';
 
@@ -400,6 +410,156 @@ describe('DebuggerPanel', () => {
     });
   });
 
+  describe('source pane', () => {
+    // Let revealFrameSource's awaited openTextDocument/showTextDocument settle.
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    const URI_INFO = {
+      dictName: 'UserGlobals', className: 'JasperDebugDemo', isMeta: false,
+      category: 'accessing', selector: 'accumulateFrom:to:',
+    };
+
+    // The editor showTextDocument resolved to on the most recent call.
+    async function shownEditor() {
+      const results = vi.mocked(vscode.window.showTextDocument).mock.results;
+      return await results[results.length - 1].value;
+    }
+
+    // Open the panel and load the (unfiltered, 5-frame) stack so selectFrame can
+    // map a display level back to its server level. Reveal-specific mocks are set
+    // AFTER this — fetchStack consumes only the base mocks, never the per-test
+    // `…Once` ones, which are then picked up by the single revealFrameSource call.
+    function openPanelWithStack() {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      return panel;
+    }
+
+    it('builds a gemstone:// URI of the form scheme/dict/class/side/category/selector', () => {
+      expect(buildMethodSourceUri(7, URI_INFO))
+        .toBe('gemstone://7/UserGlobals/JasperDebugDemo/instance/accessing/accumulateFrom%3Ato%3A');
+    });
+
+    it('uses the "class" side for metaclass methods', () => {
+      expect(buildMethodSourceUri(7, { ...URI_INFO, isMeta: true }))
+        .toContain('/JasperDebugDemo/class/');
+    });
+
+    it('opens the method source (gemstone://) in a group BELOW the panel, keeping focus', async () => {
+      const panel = openPanelWithStack();
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO); // for the reveal of frame 3
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const openUri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      expect(openUri.scheme).toBe('gemstone');
+      expect(openUri.toString()).toContain('JasperDebugDemo');
+
+      // Docked below: focus the panel's group, then split a new group beneath it.
+      expect(panel.reveal).toHaveBeenCalled();
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('workbench.action.newGroupBelow');
+
+      expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ preview: true, preserveFocus: true }),
+      );
+    });
+
+    it('highlights the step-point token, converting the 1-based source offset to 0-based', async () => {
+      const panel = openPanelWithStack();
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO);
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const editor = await shownEditor();
+      // step point 2 → getSourceOffsets()[1] === 8 (1-based) → positionAt(8 - 1) → (0, 7).
+      // Regression guard for C1: dropping the "-1" would land the highlight at column 8.
+      // No word range in the mock → a one-character marker, NOT the whole line.
+      const range = vi.mocked(editor.setDecorations).mock.calls[0][1][0] as vscode.Range;
+      expect(range.start.line).toBe(0);
+      expect(range.start.character).toBe(7);          // 8 (1-based) - 1, NOT 8
+      expect(range.end.character - range.start.character).toBe(1);
+      expect(editor.revealRange).toHaveBeenCalled();
+    });
+
+    it('shows the executed source read-only, stripped of the Transcript-capture glue', async () => {
+      const panel = openPanelWithStack();
+      // A true doit frame: no class>>selector at all (getMethodUriInfo AND
+      // getMethodInfo both fail to resolve a home class). Its stored source is
+      // the wrapped form; the panel must unwrap it.
+      vi.mocked(debug.getMethodInfo).mockImplementationOnce(() => { throw new Error('doit: nil inClass'); });
+      vi.mocked(debug.getMethodSource).mockReturnValueOnce(
+        wrapWithTranscriptCapture('JasperDebugDemo new run').wrappedCode,
+      );
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const openUri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      expect(openUri.scheme).toBe('gemstone-debug');
+      expect(openUri.path).toBe('Executed Code');
+      expect(debug.getMethodSource).toHaveBeenCalled();
+
+      // The content provider serves the UNWRAPPED user code (read-only, never dirty).
+      // (First read-only frame in the suite, so registration happens here.)
+      const reg = vi.mocked(vscode.workspace.registerTextDocumentContentProvider).mock.calls[0];
+      expect(reg[0]).toBe('gemstone-debug');
+      const provider = reg[1] as { provideTextDocumentContent(u: vscode.Uri): string };
+      expect(provider.provideTextDocumentContent(openUri)).toBe('JasperDebugDemo new run');
+    });
+
+    it('titles a read-only NON-symbol-list method by its method name (C3: never mislabel as Executed Code)', async () => {
+      const panel = openPanelWithStack();
+      // Frame 3: no dictName (getMethodUriInfo → undefined) but getMethodInfo
+      // resolves a real class → a method, NOT executed code. It must open titled
+      // by the method, not under "Executed Code".
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const openUri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      expect(openUri.scheme).toBe('gemstone-debug');
+      expect(openUri.path).toBe('JasperDebugDemo>>#accumulateFrom:to:');
+    });
+
+    it('does NOT highlight a read-only frame (C2 — no reliable IP→source mapping)', async () => {
+      // When we add highlighting to the read-only view, THIS test should fail —
+      // that's the reminder to add real highlight coverage for it.
+      const panel = openPanelWithStack(); // frame 3 → read-only (no gemstone:// URI)
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const editor = await shownEditor();
+      expect(vi.mocked(editor.setDecorations).mock.calls[0][1]).toEqual([]); // cleared, not set
+      expect(editor.revealRange).not.toHaveBeenCalled();
+    });
+
+    it('clears the highlight (no reveal) when there is no step point and no source line', async () => {
+      const panel = openPanelWithStack();
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO);
+      vi.mocked(debug.getStepPoint).mockReturnValueOnce(0);   // no step point (reveal)
+      vi.mocked(debug.getLineForIp).mockReturnValueOnce(0);   // unmapped IP   (reveal)
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const editor = await shownEditor();
+      expect(vi.mocked(editor.setDecorations).mock.calls[0][1]).toEqual([]);
+      expect(editor.revealRange).not.toHaveBeenCalled();
+    });
+
+    it('clears the step-point highlight when the panel is closed', async () => {
+      const panel = openPanelWithStack();
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce(URI_INFO);
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+      const editor = await shownEditor();
+      vi.mocked(editor.setDecorations).mockClear();
+
+      closePanel(panel);
+
+      expect(editor.setDecorations).toHaveBeenCalledWith(expect.anything(), []);
+    });
+  });
+
   it('terminates the suspended gsProcess (via clearStack) when the panel window is closed', () => {
     DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
     const panel = lastPanel();
@@ -407,5 +567,103 @@ describe('DebuggerPanel', () => {
     expect(debug.clearStack).not.toHaveBeenCalled();
     closePanel(panel);
     expect(debug.clearStack).toHaveBeenCalledWith(session, GS_PROCESS);
+  });
+});
+
+// ── Stack filtering ────────────────────────────────────────────────
+// Models the real `JasperDebugDemo new run` halt stack (captured live, id 4):
+//   top = AbstractException signal machinery + Object>>halt,
+//   bottom = the transcript-capture doit + its block/ensure: glue.
+const DOIT = 999n;
+
+function raw(p: Partial<RawFrame> & { serverLevel: number; label: string }): RawFrame {
+  return {
+    methodOop: BigInt(p.serverLevel), homeMethodOop: BigInt(p.serverLevel),
+    isBlock: false, definingClassName: '', selector: '', isExecutedCode: false,
+    ...p,
+  };
+}
+
+// level 1 = top.
+const HALT_STACK: RawFrame[] = [
+  raw({ serverLevel: 1, label: 'AbstractException>>#_signalToDebugger', definingClassName: 'AbstractException', selector: '_signalToDebugger' }),
+  raw({ serverLevel: 2, label: 'AbstractException>>#_signal', definingClassName: 'AbstractException', selector: '_signal' }),
+  raw({ serverLevel: 3, label: 'AbstractException class>>#signal', definingClassName: 'AbstractException', selector: 'signal' }),
+  raw({ serverLevel: 4, label: 'SmallInteger (Object)>>#halt', definingClassName: 'Object', selector: 'halt' }),
+  raw({ serverLevel: 5, label: '[] in JasperDebugDemo>>#finish', definingClassName: 'JasperDebugDemo', selector: 'finish', isBlock: true, homeMethodOop: 10n }),
+  raw({ serverLevel: 6, label: 'Array (Collection)>>#do:', definingClassName: 'Collection', selector: 'do:' }),
+  raw({ serverLevel: 7, label: 'JasperDebugDemo>>#finish', definingClassName: 'JasperDebugDemo', selector: 'finish' }),
+  raw({ serverLevel: 8, label: 'JasperDebugDemo>>#accumulateFrom:to:', definingClassName: 'JasperDebugDemo', selector: 'accumulateFrom:to:' }),
+  raw({ serverLevel: 9, label: 'JasperDebugDemo>>#run', definingClassName: 'JasperDebugDemo', selector: 'run' }),
+  raw({ serverLevel: 10, label: 'Executed Code', isBlock: true, homeMethodOop: DOIT, isExecutedCode: true }),
+  raw({ serverLevel: 11, label: 'ExecBlock0 (ExecBlock)>>#ensure:', definingClassName: 'ExecBlock', selector: 'ensure:' }),
+  raw({ serverLevel: 12, label: 'Executed Code', isBlock: true, homeMethodOop: DOIT, isExecutedCode: true }),
+  raw({ serverLevel: 13, label: 'Executed Code', methodOop: DOIT, homeMethodOop: DOIT, isExecutedCode: true }),
+  // GemStone leaves a <Reenter marker> BELOW the doit; getFrameInfo can't resolve
+  // it so buildFrame yields a `<frame N>` (not executed-code). It must not block
+  // the bottom collapse (the original bug) and must itself be dropped.
+  raw({ serverLevel: 14, label: '<frame 14>' }),
+];
+
+describe('filterStack', () => {
+  it('trims halt machinery off the top and the wrapper glue off the bottom', () => {
+    const kept = filterStack(HALT_STACK);
+    // Top = the user block where halt was sent; bottom = the doit (kept); the
+    // signal frames, the wrapper frames (10, 11, 12) AND the reenter marker (14)
+    // are gone. Exactly ONE "Executed Code" frame survives.
+    expect(kept.map(f => f.serverLevel)).toEqual([5, 6, 7, 8, 9, 13]);
+    expect(kept[0].label).toBe('[] in JasperDebugDemo>>#finish');
+    expect(kept[kept.length - 1].label).toBe('Executed Code');
+    expect(kept.filter(f => f.label === 'Executed Code')).toHaveLength(1);
+    expect(kept.some(f => f.serverLevel === 14)).toBe(false); // reenter marker dropped
+  });
+
+  it('collapses the wrapper even when a non-executed-code frame sits below the doit', () => {
+    // Regression: the <Reenter marker> at the very bottom used to make the trim
+    // gate ("deepest frame is the doit") fail, leaving all the glue frames.
+    const kept = filterStack(HALT_STACK);
+    expect(kept.filter(f => f.isExecutedCode)).toHaveLength(1);
+  });
+
+  it('keeps mid-stack kernel frames (only trims contiguously from each end)', () => {
+    // Array>>do: (level 6) sits between user frames and must survive.
+    expect(filterStack(HALT_STACK).map(f => f.serverLevel)).toContain(6);
+  });
+
+  it('leaves a clean stack untouched (no machinery, no doit)', () => {
+    const plain = HALT_STACK.slice(4, 9); // frames 5..9, all user frames
+    expect(filterStack(plain)).toEqual(plain);
+  });
+
+  it('never trims the whole stack, even if every frame looks like machinery', () => {
+    const allMachinery = HALT_STACK.slice(0, 4); // the 4 signal/halt frames
+    const kept = filterStack(allMachinery);
+    expect(kept.length).toBe(1);            // keeps the last as a floor
+    expect(kept[0].serverLevel).toBe(4);
+  });
+
+  it('does not trim the bottom when the deepest frame is not a doit', () => {
+    const noDoit = HALT_STACK.slice(4, 9); // ends at run, not Executed Code
+    expect(filterStack(noDoit).map(f => f.serverLevel)).toEqual([5, 6, 7, 8, 9]);
+  });
+
+  it('returns short stacks unchanged', () => {
+    expect(filterStack([])).toEqual([]);
+    expect(filterStack([HALT_STACK[8]])).toEqual([HALT_STACK[8]]);
+  });
+});
+
+describe('isExceptionMachinery', () => {
+  it('flags AbstractException frames and halt/DNU/signal selectors', () => {
+    expect(isExceptionMachinery(HALT_STACK[0])).toBe(true);  // _signalToDebugger
+    expect(isExceptionMachinery(HALT_STACK[2])).toBe(true);  // class>>signal
+    expect(isExceptionMachinery(HALT_STACK[3])).toBe(true);  // Object>>halt
+    expect(isExceptionMachinery(raw({ serverLevel: 1, label: 'x', selector: 'doesNotUnderstand:' }))).toBe(true);
+  });
+
+  it('does not flag ordinary user/kernel frames', () => {
+    expect(isExceptionMachinery(HALT_STACK[4])).toBe(false); // [] in finish
+    expect(isExceptionMachinery(HALT_STACK[6])).toBe(false); // finish
+    expect(isExceptionMachinery(HALT_STACK[5])).toBe(false); // Collection>>do:
   });
 });

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -298,6 +298,29 @@ describe('DebuggerPanel', () => {
       expect(html).toContain('preventDefault');
     });
 
+    it('renders labelled, splittable Call Stack / Variables panes', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const html = lastPanel().webview.html;
+
+      expect(html).toContain('>Call Stack<');     // pane title
+      expect(html).toContain('>Variables<');       // pane title
+      expect(html).toContain('id="splitter"');     // draggable divider
+      expect(html).toMatch(/--stack-basis:\s*60%/); // default split, injected from the saved static
+    });
+
+    it('renders the toolbar as DAP-style icon buttons (codicon SVGs), not text labels', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const html = lastPanel().webview.html;
+
+      // Each control keeps its data-cmd (wiring) but now carries an inline SVG glyph.
+      for (const cmd of ['resume', 'stepOver', 'stepInto', 'stepThrough', 'restartFrame', 'terminate']) {
+        expect(html).toMatch(new RegExp(`data-cmd="${cmd}"[^>]*>\\s*<svg`));
+      }
+      // The old text labels are gone (names live in title/aria-label tooltips).
+      expect(html).toContain('aria-label="Resume execution"');
+      expect(html).not.toMatch(/data-cmd="resume"[^>]*>Resume</);
+    });
+
     it('writes the formatted stack to the clipboard on a copyStack message', () => {
       DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
       const panel = lastPanel();
@@ -523,6 +546,8 @@ describe('DebuggerPanel', () => {
       const openUri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
       expect(openUri.scheme).toBe('gemstone-debug');
       expect(openUri.path).toBe('Executed Code');
+      // stashReadOnlySource keys each method distinct via the query (session + oop).
+      expect(openUri.query).toMatch(/session=\d+&method=\d+/);
       expect(debug.getMethodSource).toHaveBeenCalled();
 
       // The content provider serves the UNWRAPPED user code (read-only, never dirty).
@@ -833,6 +858,20 @@ describe('DebuggerPanel', () => {
 
       expect(onComplete).not.toHaveBeenCalled();
       expect(panel.dispose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('layout persistence', () => {
+    it('remembers a saved split so the next panel opens with it', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      sendMessage(lastPanel(), { command: 'saveLayout', stackBasis: '42%' });
+
+      // A freshly created panel injects the remembered basis into its HTML.
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      expect(lastPanel().webview.html).toMatch(/--stack-basis:\s*42%/);
+
+      // Restore the default so later tests see the standard 60% split.
+      sendMessage(lastPanel(), { command: 'saveLayout', stackBasis: '60%' });
     });
   });
 });

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -39,6 +39,8 @@ vi.mock('../debugQueries', () => ({
   stepOut: vi.fn(() => ({ completed: false })),
   trimStackToLevel: vi.fn(),
   clearStack: vi.fn(),
+  acquireStepping: vi.fn(),
+  releaseStepping: vi.fn(),
 }));
 
 // Source offsets for the step-point highlight. These are GemStone `_sourceOffsets`,
@@ -662,6 +664,16 @@ describe('DebuggerPanel', () => {
     expect(debug.clearStack).toHaveBeenCalledWith(session, GS_PROCESS);
   });
 
+  it('holds native code off for the session: acquires on open, releases on close', () => {
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const panel = lastPanel();
+
+    expect(debug.acquireStepping).toHaveBeenCalledWith(session);
+    expect(debug.releaseStepping).not.toHaveBeenCalled();
+    closePanel(panel);
+    expect(debug.releaseStepping).toHaveBeenCalledWith(session);
+  });
+
   describe('variables / eval / toolbar', () => {
     // clearAllMocks() doesn't reset return values/implementations, so restore the
     // base getFrameInfo each test (a test that overrides it would otherwise leak).
@@ -733,15 +745,27 @@ describe('DebuggerPanel', () => {
       expect(lastPosted(panel, 'init').errorMessage).toBe('next error');
     });
 
-    it('Step Over steps from the selected frame and refreshes (clearing the error banner)', () => {
+    it('Step Over steps from the selected user frame (display level → server level) and refreshes, clearing the error banner', () => {
       const panel = openPanel();
       const before = posted(panel, 'init').length;
-      sendMessage(panel, { command: 'stepOver', level: 3 });
+      sendMessage(panel, { command: 'stepOver', level: 3 }); // display 3 → server level 3
 
       expect(debug.stepOver).toHaveBeenCalledWith(session, GS_PROCESS, 3);
       expect(posted(panel, 'init').length).toBe(before + 1);
       expect(lastPosted(panel, 'init').errorMessage).toBe('');
       expect(panel.dispose).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a clear message when a step hits native-code (error 6014), without disposing', () => {
+      vi.mocked(debug.stepOver).mockReturnValueOnce({
+        completed: false,
+        errorMessage: 'a ImproperOperation occurred (error 6014), Breakpoint and single-step not supported in native code',
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 1 });
+
+      expect(panel.dispose).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/native code/i);
     });
 
     it('Step disposes the panel when the step completes the process', () => {
@@ -752,9 +776,9 @@ describe('DebuggerPanel', () => {
       expect(panel.dispose).toHaveBeenCalled();
     });
 
-    it('"Through" maps to gciStepThru (debugQueries.stepOut)', () => {
+    it('"Through" maps to gciStepThru (debugQueries.stepOut), from the selected user frame', () => {
       const panel = openPanel();
-      sendMessage(panel, { command: 'stepThrough', level: 4 });
+      sendMessage(panel, { command: 'stepThrough', level: 4 }); // display 4 → server level 4
 
       expect(debug.stepOut).toHaveBeenCalledWith(session, GS_PROCESS, 4);
     });
@@ -773,6 +797,42 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'terminate' });
 
       expect(panel.dispose).toHaveBeenCalled();
+    });
+
+    it('hands the completed result to onComplete on Resume, then disposes', () => {
+      vi.mocked(debug.continueExecution).mockReturnValueOnce({ completed: true, resultOop: 0x55n });
+      const onComplete = vi.fn();
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG, onComplete);
+      const panel = lastPanel();
+      sendReady(panel);
+      sendMessage(panel, { command: 'resume' });
+
+      expect(onComplete).toHaveBeenCalledWith(0x55n);
+      expect(panel.dispose).toHaveBeenCalled();
+    });
+
+    it('hands the completed result to onComplete on step-to-completion', () => {
+      vi.mocked(debug.stepOver).mockReturnValueOnce({ completed: true, resultOop: 0x66n });
+      const onComplete = vi.fn();
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG, onComplete);
+      const panel = lastPanel();
+      sendReady(panel);
+      sendMessage(panel, { command: 'stepOver', level: 1 });
+
+      expect(onComplete).toHaveBeenCalledWith(0x66n);
+      expect(panel.dispose).toHaveBeenCalled();
+    });
+
+    it('does NOT call onComplete when Resume hits another error (refreshes instead)', () => {
+      vi.mocked(debug.continueExecution).mockReturnValueOnce({ completed: false, errorMessage: 'boom2' });
+      const onComplete = vi.fn();
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG, onComplete);
+      const panel = lastPanel();
+      sendReady(panel);
+      sendMessage(panel, { command: 'resume' });
+
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(panel.dispose).not.toHaveBeenCalled();
     });
   });
 });

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 
@@ -51,6 +51,8 @@ vi.mock('../debugQueries', () => ({
   clearStack: vi.fn(),
   acquireStepping: vi.fn(),
   releaseStepping: vi.fn(),
+  // Create-method-from-DNU detection — defaults to "not a DNU" (no Create button).
+  getDoesNotUnderstandInfo: vi.fn(() => undefined),
 }));
 
 // Clicking a variable row opens a GT Inspector — stub the static entry point.
@@ -67,7 +69,7 @@ vi.mock('../browserQueries', () => ({
 import * as vscode from 'vscode';
 import * as debug from '../debugQueries';
 import {
-  DebuggerPanel, formatFrameLabel, formatFramePosition,
+  DebuggerPanel, formatFrameLabel, formatFramePosition, buildMethodStub,
   formatFrameForClipboard, formatStackForClipboard, buildMethodSourceUri,
   filterStack, isExceptionMachinery, RawFrame,
   flattenLayoutLeaves, sourceRatioFromLayout, setSourceRatioInLayout, EditorGroupLayout,
@@ -213,6 +215,24 @@ describe('formatFramePosition', () => {
   it('omits a line of 0 (an unmapped IP has no source line)', () => {
     expect(formatFramePosition(2, 0)).toBe('@2');
     expect(formatFramePosition(undefined, 0)).toBe('');
+  });
+});
+
+describe('buildMethodStub', () => {
+  it('builds a keyword signature pairing each keyword with a generated arg', () => {
+    expect(buildMethodStub('fourtyTwo:bar:', 2)).toMatch(/^fourtyTwo: arg1 bar: arg2\n/);
+  });
+
+  it('builds a binary signature with one argument', () => {
+    expect(buildMethodStub('+', 1)).toMatch(/^\+ arg1\n/);
+  });
+
+  it('builds a bare unary signature', () => {
+    expect(buildMethodStub('makeWidget', 0)).toMatch(/^makeWidget\n/);
+  });
+
+  it('includes a placeholder body so the method compiles as-is', () => {
+    expect(buildMethodStub('foo', 0)).toContain('^nil');
   });
 });
 
@@ -1313,6 +1333,190 @@ describe('DebuggerPanel', () => {
     });
   });
 
+  describe('create-method-from-DNU', () => {
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    const DNU = {
+      className: 'JasperDebugDemo', isMeta: false, dictName: 'UserGlobals',
+      selector: 'fourtyTwo:bar:', argCount: 2,
+    };
+
+    // getDoesNotUnderstandInfo's mockReturnValue persists past clearAllMocks, so
+    // restore "not a DNU" afterwards to keep later describes isolated.
+    afterEach(() => {
+      vi.mocked(debug.getDoesNotUnderstandInfo).mockReturnValue(undefined);
+      // getMethodInfo overrides below leak past clearAllMocks — restore the base.
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
+        if (oop === 2n) return { className: 'Object', selector: 'halt' };
+        return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+      });
+    });
+
+    /**
+     * Open a panel parked on a doesNotUnderstand:. By default the top two frames
+     * are DNU machinery (defaultAction, doesNotUnderstand:) so they're trimmed and
+     * the topmost DISPLAYED frame — the re-enterable sender — is server level 3.
+     */
+    function openWithDnu() {
+      vi.mocked(debug.getDoesNotUnderstandInfo).mockReturnValue(DNU);
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'MessageNotUnderstood', selector: 'defaultAction' };
+        if (oop === 2n) return { className: 'Object', selector: 'doesNotUnderstand:' };
+        return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+      });
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      return panel;
+    }
+
+    function saveListener(): (doc: vscode.TextDocument) => void {
+      return vi.mocked(vscode.workspace.onDidSaveTextDocument).mock.calls[0][0];
+    }
+
+    it('includes the DNU info in the init payload when parked on a doesNotUnderstand:', () => {
+      const panel = openWithDnu();
+      expect(initPayload(panel).dnu).toEqual({
+        selector: 'fourtyTwo:bar:', className: 'JasperDebugDemo', isMeta: false,
+      });
+    });
+
+    it('omits dnu from the init payload when not a DNU', () => {
+      vi.mocked(debug.getDoesNotUnderstandInfo).mockReturnValue(undefined);
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      expect(initPayload(panel).dnu).toBeUndefined();
+    });
+
+    it('opens a pre-filled new-method template BELOW the panel and hints to fill+save', async () => {
+      const panel = openWithDnu();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'createDnuMethod' });
+      await flush();
+
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      // gemstone:// new-method URI for the receiver's class/dict (the FS provider
+      // serves the template; the selector is parsed from the saved source).
+      expect(uri.toString()).toContain('/UserGlobals/JasperDebugDemo/instance/');
+      expect(uri.toString()).toContain('new-method');
+      // Docked BELOW the panel (not Beside) like the companion source.
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('workbench.action.newGroupBelow');
+      // The generic template was replaced with the real signature + body stub.
+      const editor = await vi.mocked(vscode.window.showTextDocument).mock.results.at(-1)!.value;
+      expect(editor.edit).toHaveBeenCalled();
+      // A lightweight banner update (NOT a full init, which would re-select the top
+      // frame and steal focus from the new-method editor) tells the user to fill in
+      // + save (Ctrl+S). The Create button is gone (no init re-render needed).
+      expect(lastPosted(panel, 'banner').text).toMatch(/save.*Ctrl/i);
+      expect(posted(panel, 'init').length).toBe(1); // only the original ready init
+    });
+
+    it('re-enters the sender frame (trim, NOT resume) on a clean compile, leaving Resume to the user', async () => {
+      const panel = openWithDnu();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'createDnuMethod' });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      // Trim re-enters the sender (server level 3, below the trimmed DNU machinery)
+      // so the user's next Resume re-runs the send. We must NOT auto-resume — the
+      // blocking continueExecution of a parked DNU hung the gem and crashed the host.
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(debug.continueExecution).not.toHaveBeenCalled();
+      expect(panel.dispose).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/resume/i);
+    });
+
+    it('closes the created method tab on debugger close (FS-provider URI form, : not %3A)', async () => {
+      const panel = openWithDnu();
+      sendMessage(panel, { command: 'createDnuMethod' });
+      await flush();
+      // The FS provider swaps the template tab to this real method URI on save —
+      // built via vscode.Uri.from (keyword ':' left un-encoded). closeSourceEditors
+      // must match THIS form; buildMethodSourceUri's %3A encoding would not, and the
+      // tab would linger ("stuck around"). Guards that regression.
+      const compiledUri = vscode.Uri.from({
+        scheme: 'gemstone', authority: '1',
+        path: '/UserGlobals/JasperDebugDemo/instance/as yet unclassified/fourtyTwo:bar:',
+      });
+      const methodTab = { label: 'fourtyTwo:bar:', input: new vscode.TabInputText(compiledUri) };
+      const groups = vscode.window.tabGroups.all as unknown as { viewColumn: number; tabs: unknown[] }[];
+      groups.push({ viewColumn: 9, tabs: [methodTab] });
+
+      closePanel(panel);
+      expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledWith(methodTab);
+    });
+
+    it('does NOT trim (and keeps the template pending) when the compile fails', async () => {
+      const panel = openWithDnu();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'createDnuMethod' });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+
+      vi.mocked(vscode.languages.getDiagnostics).mockReturnValueOnce(
+        [{ severity: vscode.DiagnosticSeverity.Error }] as never,
+      );
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+
+      // Re-save after fixing (clean diagnostics) — the pending state survived.
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+    });
+
+    it('does NOT trim a workspace/Executed Code sender — tells the user to re-run', async () => {
+      // All frames resolve as Executed Code (no class) → the sender can't be
+      // re-entered (kernel trim sends compiledMethodAt: to nil); never attempt it.
+      vi.mocked(debug.getDoesNotUnderstandInfo).mockReturnValue(DNU);
+      vi.mocked(debug.getMethodInfo).mockImplementation(() => { throw new Error('doit: no class'); });
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      sendMessage(panel, { command: 'createDnuMethod' });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      expect(debug.continueExecution).not.toHaveBeenCalled();
+      // Doesn't trim, but DOES tell the user to Resume (manual Resume works — the
+      // kernel's defaultAction re-performs the send). Must NOT auto-resume.
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/resume/i);
+    });
+
+    it('refuses to create when the class has no home dictionary (not in the symbol list)', async () => {
+      vi.mocked(debug.getDoesNotUnderstandInfo).mockReturnValue({ ...DNU, dictName: '' });
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'createDnuMethod' });
+      await flush();
+
+      expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/symbol list/i);
+    });
+
+    it('keeps the Create button suppressed once a create is underway (re-detect returns it)', async () => {
+      const panel = openWithDnu();
+      expect(initPayload(panel).dnu).toBeTruthy(); // shown initially
+      sendMessage(panel, { command: 'createDnuMethod' });
+      await flush();
+      // A refresh while editing must NOT re-offer the button (method-in-progress).
+      sendMessage(panel, { command: 'stepOver', level: 1 });
+      await tick();
+      expect(lastPosted(panel, 'init').dnu).toBeUndefined();
+    });
+  });
+
   describe('layout persistence', () => {
     it('remembers a saved split so the next panel opens with it', () => {
       DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
@@ -1426,6 +1630,26 @@ describe('filterStack', () => {
   it('returns short stacks unchanged', () => {
     expect(filterStack([])).toEqual([]);
     expect(filterStack([HALT_STACK[8]])).toEqual([HALT_STACK[8]]);
+  });
+
+  // The real parked doesNotUnderstand: stack (captured live, error 2010): under
+  // GCI debug it parks in the unhandled-error path, so the TOP frame is
+  // MessageNotUnderstood>>defaultAction (NOT signal) — which must still be trimmed
+  // so the debugger opens on the user's frame (here, Executed Code).
+  const DNU_STACK: RawFrame[] = [
+    raw({ serverLevel: 1, label: 'MessageNotUnderstood>>#defaultAction', definingClassName: 'MessageNotUnderstood', selector: 'defaultAction' }),
+    raw({ serverLevel: 2, label: 'MessageNotUnderstood (AbstractException)>>#_defaultAction', definingClassName: 'AbstractException', selector: '_defaultAction' }),
+    raw({ serverLevel: 3, label: 'MessageNotUnderstood (AbstractException)>>#_signal', definingClassName: 'AbstractException', selector: '_signal' }),
+    raw({ serverLevel: 4, label: 'MessageNotUnderstood (AbstractException)>>#signal', definingClassName: 'AbstractException', selector: 'signal' }),
+    raw({ serverLevel: 5, label: 'SmallInteger (Object)>>#doesNotUnderstand:', definingClassName: 'Object', selector: 'doesNotUnderstand:' }),
+    raw({ serverLevel: 6, label: 'SmallInteger (Object)>>#_doesNotUnderstand:args:envId:reason:', definingClassName: 'Object', selector: '_doesNotUnderstand:args:envId:reason:' }),
+    raw({ serverLevel: 7, label: 'Executed Code', methodOop: DOIT, homeMethodOop: DOIT, isExecutedCode: true }),
+  ];
+
+  it('trims the doesNotUnderstand: machinery (incl. defaultAction) down to the user frame', () => {
+    const kept = filterStack(DNU_STACK);
+    expect(kept.map(f => f.serverLevel)).toEqual([7]); // just the Executed Code sender
+    expect(kept[0].label).toBe('Executed Code');
   });
 });
 

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -32,6 +32,8 @@ vi.mock('../debugQueries', () => ({
   getStepPoint: vi.fn(() => 2),
   getMethodSource: vi.fn(() => '| t | t := 6 * 7. t halt'),
   getObjectPrintString: vi.fn((_s: unknown, oop: bigint) => `<print ${oop}>`),
+  getInstVarNames: vi.fn(() => [] as string[]),
+  getNamedInstVarOops: vi.fn(() => [] as bigint[]),
   evaluateInFrame: vi.fn(() => '42'),
   continueExecution: vi.fn(() => ({ completed: true })),
   stepOver: vi.fn(() => ({ completed: false })),
@@ -42,6 +44,9 @@ vi.mock('../debugQueries', () => ({
   acquireStepping: vi.fn(),
   releaseStepping: vi.fn(),
 }));
+
+// Clicking a variable row opens a GT Inspector — stub the static entry point.
+vi.mock('../gtInspector', () => ({ GtInspector: { create: vi.fn() } }));
 
 // Source offsets for the step-point highlight. These are GemStone `_sourceOffsets`,
 // which are 1-BASED (index i = offset of step point i+1); the panel must convert
@@ -58,6 +63,7 @@ import {
   filterStack, isExceptionMachinery, RawFrame,
 } from '../debuggerPanel';
 import { wrapWithTranscriptCapture } from '../transcriptCapture';
+import { GtInspector } from '../gtInspector';
 import { ActiveSession } from '../sessionManager';
 import { GemStoneLogin } from '../loginTypes';
 
@@ -304,8 +310,10 @@ describe('DebuggerPanel', () => {
 
       expect(html).toContain('>Call Stack<');     // pane title
       expect(html).toContain('>Variables<');       // pane title
-      expect(html).toContain('id="splitter"');     // draggable divider
+      expect(html).toContain('id="splitter"');     // draggable column divider
+      expect(html).toContain('id="hsplitter"');     // draggable panes-vs-eval divider
       expect(html).toMatch(/--stack-basis:\s*60%/); // default split, injected from the saved static
+      expect(html).toMatch(/--eval-height:\s*7rem/); // default eval-bar height, injected from the saved static
     });
 
     it('renders the toolbar as DAP-style icon buttons (codicon SVGs), not text labels', () => {
@@ -716,7 +724,7 @@ describe('DebuggerPanel', () => {
       return panel;
     }
 
-    it('posts the selected frame variables (self first, then args/temps) on selectFrame', () => {
+    it('posts the selected frame variables, grouped (Receiver + Arguments & Temps with oops) on selectFrame', () => {
       // Only server level 2 carries temps; other frames keep the base shape so the
       // 5-frame stack still renders and level 2 survives filtering (mid-stack).
       vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) =>
@@ -726,10 +734,66 @@ describe('DebuggerPanel', () => {
       const panel = openPanel();
       sendMessage(panel, { command: 'selectFrame', level: 2 });
 
-      const vars = lastPosted(panel, 'variables').vars;
-      expect(vars[0]).toEqual({ name: 'self', value: '<print 300>' });
-      expect(vars).toContainEqual({ name: 'amount', value: '<print 11>' });
-      expect(vars).toContainEqual({ name: 'total', value: '<print 22>' });
+      const groups = lastPosted(panel, 'variables').groups;
+      const receiver = groups.find((g: { kind: string }) => g.kind === 'receiver');
+      expect(receiver.vars[0]).toEqual({ name: 'self', value: '<print 300>', oop: '300' });
+      const argtemps = groups.find((g: { kind: string }) => g.kind === 'argtemps');
+      expect(argtemps.vars).toEqual([
+        { name: 'amount', value: '<print 11>', oop: '11' },
+        { name: 'total', value: '<print 22>', oop: '22' },
+      ]);
+    });
+
+    it('splits named temps from the synthetic .tN eval-stack temps into a separate group', () => {
+      vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) =>
+        level === 2
+          ? { methodOop: 2n, ipOffset: 5, receiverOop: 300n, argAndTempNames: ['amount', '.t1'], argAndTempOops: [11n, 99n] }
+          : { methodOop: BigInt(level), ipOffset: 5, receiverOop: BigInt(level * 100), argAndTempNames: [], argAndTempOops: [] });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'selectFrame', level: 2 });
+
+      const groups = lastPosted(panel, 'variables').groups;
+      expect(groups.find((g: { kind: string }) => g.kind === 'argtemps').vars)
+        .toEqual([{ name: 'amount', value: '<print 11>', oop: '11' }]);
+      const stack = groups.find((g: { kind: string }) => g.kind === 'stacktemps');
+      expect(stack.collapsed).toBe(true);
+      expect(stack.vars).toEqual([{ name: '.t1', value: '<print 99>', oop: '99' }]);
+    });
+
+    it('hides the __vsc transcript-capture glue temps from an executed-code frame', () => {
+      vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) =>
+        level === 2
+          ? { methodOop: 2n, ipOffset: 5, receiverOop: 300n,
+            argAndTempNames: ['__vscCapture', '__vscResult', 'amount'], argAndTempOops: [1n, 2n, 11n] }
+          : { methodOop: BigInt(level), ipOffset: 5, receiverOop: BigInt(level * 100), argAndTempNames: [], argAndTempOops: [] });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'selectFrame', level: 2 });
+
+      const groups = lastPosted(panel, 'variables').groups;
+      const argtemps = groups.find((g: { kind: string }) => g.kind === 'argtemps');
+      expect(argtemps.vars).toEqual([{ name: 'amount', value: '<print 11>', oop: '11' }]);
+      // None of the glue names leak into any group.
+      const allNames = groups.flatMap((g: { vars: { name: string }[] }) => g.vars.map(v => v.name));
+      expect(allNames.some((n: string) => n.startsWith('__vsc'))).toBe(false);
+    });
+
+    it('includes the receiver instance variables as their own group', () => {
+      vi.mocked(debug.getInstVarNames).mockReturnValueOnce(['count', 'sum']);
+      vi.mocked(debug.getNamedInstVarOops).mockReturnValueOnce([7n, 8n]);
+      const panel = openPanel();
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+
+      const groups = lastPosted(panel, 'variables').groups;
+      expect(groups.find((g: { kind: string }) => g.kind === 'instvars').vars).toEqual([
+        { name: 'count', value: '<print 7>', oop: '7' },
+        { name: 'sum', value: '<print 8>', oop: '8' },
+      ]);
+    });
+
+    it('opens a GT Inspector for a clicked variable via inspectVariable', () => {
+      const panel = openPanel();
+      sendMessage(panel, { command: 'inspectVariable', oop: '300', name: 'self' });
+      expect(GtInspector.create).toHaveBeenCalledWith(session, 300n, 'self');
     });
 
     it('evaluates an expression in the selected frame and posts the result', () => {
@@ -808,13 +872,22 @@ describe('DebuggerPanel', () => {
       expect(debug.stepOut).toHaveBeenCalledWith(session, GS_PROCESS, 4);
     });
 
-    it('Restart Frame trims the stack to the selected frame and refreshes', () => {
+    it('Restart Frame trims the stack to the selected (deeper) frame and refreshes', () => {
       const panel = openPanel();
       const before = posted(panel, 'init').length;
       sendMessage(panel, { command: 'restartFrame', level: 2 });
 
       expect(debug.trimStackToLevel).toHaveBeenCalledWith(session, GS_PROCESS, 2);
       expect(posted(panel, 'init').length).toBe(before + 1);
+    });
+
+    it('Restart Frame on the top frame shows an in-panel notice and does not trim (GemStone cannot reset the TOS IP)', () => {
+      const panel = openPanel();
+      vi.mocked(debug.trimStackToLevel).mockClear();
+      sendMessage(panel, { command: 'restartFrame', level: 1 }); // display 1 → server level 1 (top)
+
+      expect(debug.trimStackToLevel).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/top frame/i);
     });
 
     it('Terminate disposes the panel', () => {
@@ -872,6 +945,17 @@ describe('DebuggerPanel', () => {
 
       // Restore the default so later tests see the standard 60% split.
       sendMessage(lastPanel(), { command: 'saveLayout', stackBasis: '60%' });
+    });
+
+    it('remembers a saved eval-bar height for the next panel', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      sendMessage(lastPanel(), { command: 'saveLayout', evalHeight: '160px' });
+
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      expect(lastPanel().webview.html).toMatch(/--eval-height:\s*160px/);
+
+      // Restore the default so later tests see the standard 7rem height.
+      sendMessage(lastPanel(), { command: 'saveLayout', evalHeight: '7rem' });
     });
   });
 });

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -30,6 +30,9 @@ vi.mock('../debugQueries', () => ({
     receiverOop === 200n ? 'SmallInteger' : 'JasperDebugDemo'),
   getLineForIp: vi.fn(() => 12),
   getStepPoint: vi.fn(() => 2),
+  // Source offsets fetched straight from a method OOP (read-only doit / non-
+  // symbol-list method). Same 1-based shape as browserQueries.getSourceOffsets.
+  getSourceOffsetsForMethod: vi.fn(() => [1, 8, 26]),
   getMethodSource: vi.fn(() => '| t | t := 6 * 7. t halt'),
   getObjectPrintString: vi.fn((_s: unknown, oop: bigint) => `<print ${oop}>`),
   getInstVarNames: vi.fn(() => [] as string[]),
@@ -592,10 +595,47 @@ describe('DebuggerPanel', () => {
       expect(openUri.path).toBe('JasperDebugDemo>>#accumulateFrom:to:');
     });
 
-    it('does NOT highlight a read-only frame (C2 — no reliable IP→source mapping)', async () => {
-      // When we add highlighting to the read-only view, THIS test should fail —
-      // that's the reminder to add real highlight coverage for it.
-      const panel = openPanelWithStack(); // frame 3 → read-only (no gemstone:// URI)
+    it('highlights a read-only frame whose source matches the server source 1:1', async () => {
+      // A non-symbol-list method (or a raw Debug It doit) is shown unmodified —
+      // nothing was unwrapped — so the server step-point offsets map onto the
+      // displayed source directly and the step point IS highlighted.
+      const panel = openPanelWithStack(); // frame 3 → read-only, source has no wrapper
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const editor = await shownEditor();
+      // step point 2 → getSourceOffsetsForMethod()[1] === 8 (1-based) → positionAt(7) → (0, 7).
+      const range = vi.mocked(editor.setDecorations).mock.calls[0][1][0] as vscode.Range;
+      expect(range.start.line).toBe(0);
+      expect(range.start.character).toBe(7);
+      expect(editor.revealRange).toHaveBeenCalled();
+    });
+
+    it('highlights a read-only BLOCK frame from its HOME method, not the block method', async () => {
+      // Regression: a block's own GsNMethod carries a SHORT _sourceOffsets (its
+      // own step points only), but _stepPointAt: reports the frame's step point
+      // in HOME-method numbering. Pairing a home step point with the block's
+      // short offsets overruns the array → undefined → highlight collapses to the
+      // line. Source AND offsets must come from the home method. Here the block's
+      // method (frame 3 → 3n) differs from its home (999n).
+      const panel = openPanelWithStack();
+      vi.mocked(debug.getMethodBlockInfo).mockReturnValueOnce({ isBlock: true, homeMethodOop: 999n });
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      expect(debug.getMethodSource).toHaveBeenCalledWith(session, 999n);
+      expect(debug.getSourceOffsetsForMethod).toHaveBeenCalledWith(session, 999n);
+    });
+
+    it('does NOT highlight a read-only frame whose source was unwrapped', async () => {
+      // A true doit whose stored source is the transcript-capture-wrapped form:
+      // the panel unwraps it for display, so the server's offsets refer to the
+      // wrapped source and no longer line up — highlighting stays off.
+      const panel = openPanelWithStack();
+      vi.mocked(debug.getMethodInfo).mockImplementationOnce(() => { throw new Error('doit: nil inClass'); });
+      vi.mocked(debug.getMethodSource).mockReturnValueOnce(
+        wrapWithTranscriptCapture('JasperDebugDemo new run').wrappedCode,
+      );
       sendMessage(panel, { command: 'selectFrame', level: 3 });
       await flush();
 
@@ -872,6 +912,77 @@ describe('DebuggerPanel', () => {
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/native code/i);
     });
 
+    it('guides the user (no dispose, no refresh) when a step hits an unhandled halt (error 6011)', async () => {
+      // Stepping OVER an unhandled halt drives the signal to _uncontinuableError
+      // (rtErrUncontinuable = 6011). The process is dead-ended: don't refresh into
+      // that machinery wall — keep the pre-step stack and steer to Terminate.
+      vi.mocked(debug.stepOverNb).mockResolvedValueOnce({
+        completed: false,
+        errorNumber: 6011,
+        errorMessage: 'a UncontinuableError occurred (error 6011), reason:rtErrUncontinuable',
+      });
+      const panel = openPanel();
+      vi.mocked(debug.getStackDepth).mockClear(); // refresh() re-walks the stack via fetchStack
+      sendMessage(panel, { command: 'stepOver', level: 1 });
+      await tick();
+
+      expect(panel.dispose).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/uncontinuable/i);
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/Terminate/i);
+      expect(debug.getStackDepth).not.toHaveBeenCalled(); // did NOT refresh into the new stack
+    });
+
+    it('once uncontinuable (6011), refuses a later Resume and Step with NO further GCI call (no growing message)', async () => {
+      vi.mocked(debug.stepOverNb).mockResolvedValueOnce({
+        completed: false, errorNumber: 6011, errorMessage: 'a UncontinuableError occurred (error 6011)',
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 1 }); // sets the uncontinuable flag
+      await tick();
+
+      // A retry must NOT hit the server again — that's what grows GemStone's
+      // accumulating exception-chain message that Eric saw.
+      vi.mocked(debug.continueExecution).mockClear();
+      vi.mocked(debug.stepOverNb).mockClear();
+      sendMessage(panel, { command: 'resume' });
+      sendMessage(panel, { command: 'stepOver', level: 1 });
+      await tick();
+
+      expect(debug.continueExecution).not.toHaveBeenCalled();
+      expect(debug.stepOverNb).not.toHaveBeenCalled();
+      expect(panel.dispose).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/uncontinuable/i);
+    });
+
+    it('Resume that hits 6011 shows the Terminate-only banner without refreshing', () => {
+      vi.mocked(debug.continueExecution).mockReturnValueOnce({
+        completed: false, errorNumber: 6011, errorMessage: 'a UncontinuableError occurred (error 6011)',
+      });
+      const panel = openPanel();
+      const before = posted(panel, 'init').length;
+      sendMessage(panel, { command: 'resume' });
+
+      expect(panel.dispose).not.toHaveBeenCalled();
+      expect(posted(panel, 'init').length).toBe(before + 1); // postInit, not a stack refresh
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/uncontinuable/i);
+    });
+
+    it('re-enables Resume after an uncontinuable (6011) once a deeper frame is restarted', async () => {
+      vi.mocked(debug.stepOverNb).mockResolvedValueOnce({
+        completed: false, errorNumber: 6011, errorMessage: 'a UncontinuableError occurred (error 6011)',
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 1 }); // → uncontinuable
+      await tick();
+      sendMessage(panel, { command: 'restartFrame', level: 2 }); // deeper trim clears the flag
+      await tick();
+      vi.mocked(debug.continueExecution).mockClear();
+      sendMessage(panel, { command: 'resume' });
+
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2);
+      expect(debug.continueExecution).toHaveBeenCalled(); // no longer guarded
+    });
+
     it('Step disposes the panel when the step completes the process', async () => {
       vi.mocked(debug.stepOverNb).mockResolvedValueOnce({ completed: true });
       const panel = openPanel();
@@ -879,6 +990,14 @@ describe('DebuggerPanel', () => {
       await tick();
 
       expect(panel.dispose).toHaveBeenCalled();
+    });
+
+    it('"Into" maps to gciStepInto (debugQueries.stepIntoNb), from the selected user frame', async () => {
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepInto', level: 3 }); // display 3 → server level 3
+      await tick();
+
+      expect(debug.stepIntoNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
     });
 
     it('"Through" maps to gciStepThru (debugQueries.stepThruNb), from the selected user frame', async () => {

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Evaluate debuggerView.js in jsdom so it registers the global DebuggerView,
+// exactly as the webview does when it injects the file as a <script> tag.
+beforeAll(() => {
+  const source = fs.readFileSync(path.resolve(__dirname, '../debuggerView.js'), 'utf8');
+  // eslint-disable-next-line no-new-func
+  new Function(source)();
+});
+
+interface FrameSummary { level: number; label: string; position: string; }
+
+interface DebuggerViewApi {
+  renderStack(listEl: HTMLElement, stack: FrameSummary[]): void;
+  selectFrame(listEl: HTMLElement, level: number): HTMLElement | null;
+  showMenu(menuEl: HTMLElement, x: number, y: number): void;
+  hideMenu(menuEl: HTMLElement): void;
+  frameLevelOf(target: Element | null): number | null;
+  init(refs: Refs, vscode: { postMessage: (m: unknown) => void }): {
+    selectedLevel(): number | null;
+    select(level: number): void;
+  };
+}
+
+interface Refs {
+  list: HTMLElement;
+  menu: HTMLElement;
+  copyFrameItem: HTMLElement;
+  copyBtn: HTMLElement;
+  error: HTMLElement;
+}
+
+function api(): DebuggerViewApi {
+  return (globalThis as unknown as { DebuggerView: DebuggerViewApi }).DebuggerView;
+}
+
+const STACK: FrameSummary[] = [
+  { level: 1, label: '[] in JasperDebugDemo>>#finish', position: '@2 line 12' },
+  { level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12' },
+  { level: 3, label: 'JasperDebugDemo>>#accumulateFrom:to:', position: '' },
+];
+
+// Build the panel's DOM (the elements debuggerPanel.ts's getHtml renders) and
+// wire DebuggerView to a fake vscode whose postMessage we can assert on.
+function setup(stack: FrameSummary[] = STACK) {
+  document.body.innerHTML = `
+    <button id="copyBtn">Copy Stack</button>
+    <div id="error"></div>
+    <ul id="stack"></ul>
+    <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div></div>`;
+  const refs: Refs = {
+    list: document.getElementById('stack')!,
+    menu: document.getElementById('ctxmenu')!,
+    copyFrameItem: document.getElementById('copyFrameItem')!,
+    copyBtn: document.getElementById('copyBtn')!,
+    error: document.getElementById('error')!,
+  };
+  const vscode = { postMessage: vi.fn() };
+  const ctrl = api().init(refs, vscode);
+  // Deliver the host's init payload, as the webview does on load.
+  window.dispatchEvent(new MessageEvent('message', {
+    data: { command: 'init', errorMessage: 'boom', stack },
+  }));
+  return { refs, vscode, ctrl };
+}
+
+function frame(refs: Refs, level: number): HTMLElement {
+  return refs.list.querySelector(`.frame[data-level="${level}"]`) as HTMLElement;
+}
+
+describe('DebuggerView.renderStack', () => {
+  beforeEach(() => { document.body.innerHTML = '<ul id="stack"></ul>'; });
+
+  it('renders one .frame per stack entry, tagged with its level', () => {
+    const list = document.getElementById('stack')!;
+    api().renderStack(list, STACK);
+
+    const frames = list.querySelectorAll('.frame');
+    expect(frames).toHaveLength(3);
+    expect([...frames].map(f => (f as HTMLElement).dataset.level)).toEqual(['1', '2', '3']);
+    expect(frames[0].querySelector('.level')!.textContent).toBe('1');
+    expect(frames[0].querySelector('.label')!.textContent).toBe('[] in JasperDebugDemo>>#finish');
+  });
+
+  it('renders a dimmed .pos only when the frame has a position', () => {
+    const list = document.getElementById('stack')!;
+    api().renderStack(list, STACK);
+
+    expect(list.querySelector('.frame[data-level="1"] .pos')!.textContent).toBe('@2 line 12');
+    expect(list.querySelector('.frame[data-level="3"] .pos')).toBeNull();
+  });
+
+  it('shows an empty-state message for an empty stack', () => {
+    const list = document.getElementById('stack')!;
+    api().renderStack(list, []);
+
+    expect(list.querySelectorAll('.frame')).toHaveLength(0);
+    expect(list.querySelector('.empty')!.textContent).toBe('No stack frames available.');
+  });
+
+  it('clears prior content on re-render', () => {
+    const list = document.getElementById('stack')!;
+    api().renderStack(list, STACK);
+    api().renderStack(list, [STACK[0]]);
+    expect(list.querySelectorAll('.frame')).toHaveLength(1);
+  });
+});
+
+describe('DebuggerView.init — init payload', () => {
+  it('renders the stack, shows the error, default-selects the top frame, and posts selectFrame', () => {
+    const { refs, ctrl, vscode } = setup();
+
+    expect(refs.error.textContent).toBe('boom');
+    expect(refs.list.querySelectorAll('.frame')).toHaveLength(3);
+    expect(frame(refs, 1).classList.contains('selected')).toBe(true);
+    expect(ctrl.selectedLevel()).toBe(1);
+    // Default-selecting the top frame drives the companion source editor.
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'selectFrame', level: 1 });
+  });
+
+  it('does not select anything when the stack is empty', () => {
+    const { refs, ctrl } = setup([]);
+    expect(refs.list.querySelector('.selected')).toBeNull();
+    expect(ctrl.selectedLevel()).toBeNull();
+  });
+});
+
+describe('DebuggerView.init — frame selection', () => {
+  it('left-click selects a frame, moves selection off the previous one, and posts selectFrame', () => {
+    const { refs, ctrl, vscode } = setup();      // top frame (1) selected by default
+    frame(refs, 3).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(frame(refs, 1).classList.contains('selected')).toBe(false);
+    expect(frame(refs, 3).classList.contains('selected')).toBe(true);
+    expect(ctrl.selectedLevel()).toBe(3);
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'selectFrame', level: 3 });
+  });
+});
+
+describe('DebuggerView.init — right-click copy popup', () => {
+  it('right-click selects the frame and shows the menu at the cursor', () => {
+    const { refs, ctrl, vscode } = setup();
+    const evt = new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 40, clientY: 60 });
+    frame(refs, 2).dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(true);           // native menu suppressed
+    expect(frame(refs, 2).classList.contains('selected')).toBe(true);
+    expect(ctrl.selectedLevel()).toBe(2);
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'selectFrame', level: 2 });
+    expect(refs.menu.classList.contains('show')).toBe(true);
+    expect(refs.menu.style.left).toBe('40px');
+    expect(refs.menu.style.top).toBe('60px');
+  });
+
+  it('Copy Frame posts copyFrame for the selected level and hides the menu', () => {
+    const { refs, vscode } = setup();
+    frame(refs, 2).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    refs.copyFrameItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'copyFrame', level: 2 });
+    expect(refs.menu.classList.contains('show')).toBe(false);
+  });
+
+  it('an outside click hides the menu', () => {
+    const { refs } = setup();
+    api().showMenu(refs.menu, 0, 0);
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(refs.menu.classList.contains('show')).toBe(false);
+  });
+
+  it('Escape hides the menu', () => {
+    const { refs } = setup();
+    api().showMenu(refs.menu, 0, 0);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(refs.menu.classList.contains('show')).toBe(false);
+  });
+
+  it('a scroll hides the menu', () => {
+    const { refs } = setup();
+    api().showMenu(refs.menu, 0, 0);
+    window.dispatchEvent(new Event('scroll'));
+    expect(refs.menu.classList.contains('show')).toBe(false);
+  });
+
+  it('a right-click outside any frame does not open the menu', () => {
+    const { refs } = setup();
+    refs.list.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    expect(refs.menu.classList.contains('show')).toBe(false);
+  });
+});
+
+describe('DebuggerView.init — copy stack button', () => {
+  it('posts copyStack and flashes "Copied" on the button', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs, vscode } = setup();
+      refs.copyBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'copyStack' });
+      expect(refs.copyBtn.textContent).toBe('Copied');
+      vi.advanceTimersByTime(1200);
+      expect(refs.copyBtn.textContent).toBe('Copy Stack');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -20,7 +20,11 @@ interface DebuggerViewApi {
   showMenu(menuEl: HTMLElement, x: number, y: number): void;
   hideMenu(menuEl: HTMLElement): void;
   frameLevelOf(target: Element | null): number | null;
-  init(refs: Refs, vscode: { postMessage: (m: unknown) => void }): {
+  init(refs: Refs, vscode: {
+    postMessage: (m: unknown) => void;
+    getState?: () => unknown;
+    setState?: (s: unknown) => void;
+  }): {
     selectedLevel(): number | null;
     select(level: number): void;
   };
@@ -36,6 +40,8 @@ interface Refs {
   variables: HTMLElement;
   evalInput: HTMLInputElement;
   evalResult: HTMLElement;
+  main?: HTMLElement;
+  splitter?: HTMLElement;
 }
 
 function api(): DebuggerViewApi {
@@ -265,6 +271,17 @@ describe('DebuggerView.init — toolbar', () => {
     click('terminate');
     expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'terminate', level: 1 });
   });
+
+  it('resolves the command when the click lands on a child of the button (the SVG icon)', () => {
+    const { refs, vscode } = setup(); // default-selects top frame (level 1)
+    const btn = refs.toolbar.querySelector('button[data-cmd="stepInto"]')!;
+    // Production buttons hold an inline <svg> glyph, so the real click target is
+    // the child element, not the button — the handler must walk up via closest().
+    const icon = document.createElement('span');
+    btn.appendChild(icon);
+    icon.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'stepInto', level: 1 });
+  });
 });
 
 describe('DebuggerView.init — eval bar', () => {
@@ -328,5 +345,91 @@ describe('DebuggerView.init — inbound variables / evalResult', () => {
     expect(refs.variables.querySelector('.var')).toBeNull();
     expect(refs.evalResult.textContent).toBe('');
     expect(refs.evalResult.classList.contains('error')).toBe(false);
+  });
+});
+
+describe('DebuggerView.init — resizable splitter', () => {
+  // Build a panel DOM that includes the .main container + splitter, and a fake
+  // vscode that records postMessage and round-trips getState/setState. jsdom
+  // getBoundingClientRect returns zeros, so stub .main's rect to a real width.
+  function setupSplit(initialState?: { stackBasis?: string }) {
+    document.body.innerHTML = `
+      <div id="error"></div>
+      <div class="main" id="main" style="--stack-basis: 60%;">
+        <ul id="stack"></ul>
+        <div id="splitter"></div>
+        <div id="variables"></div>
+      </div>
+      <div id="ctxmenu"><div id="copyFrameItem"></div></div>
+      <button id="copyBtn"></button><div id="toolbar"></div>
+      <input id="evalInput"><div id="evalResult"></div>`;
+    const main = document.getElementById('main')!;
+    main.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 200, bottom: 100, width: 200, height: 100, x: 0, y: 0, toJSON() {} });
+    const refs: Refs = {
+      list: document.getElementById('stack')!,
+      menu: document.getElementById('ctxmenu')!,
+      copyFrameItem: document.getElementById('copyFrameItem')!,
+      copyBtn: document.getElementById('copyBtn')!,
+      error: document.getElementById('error')!,
+      toolbar: document.getElementById('toolbar')!,
+      variables: document.getElementById('variables')!,
+      evalInput: document.getElementById('evalInput') as HTMLInputElement,
+      evalResult: document.getElementById('evalResult')!,
+      main,
+      splitter: document.getElementById('splitter')!,
+    };
+    let state: unknown = initialState;
+    const vscode = {
+      postMessage: vi.fn(),
+      getState: vi.fn(() => state),
+      setState: vi.fn((s: unknown) => { state = s; }),
+    };
+    api().init(refs, vscode);
+    return { refs, vscode, main };
+  }
+
+  function drag(splitter: HTMLElement, toClientX: number) {
+    splitter.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 120, clientY: 50 }));
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: toClientX, clientY: 50 }));
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: toClientX, clientY: 50 }));
+  }
+
+  it('restores a previously saved stack basis from webview state on init', () => {
+    const { main } = setupSplit({ stackBasis: '35%' });
+    expect(main.style.getPropertyValue('--stack-basis').trim()).toBe('35%');
+  });
+
+  it('updates --stack-basis while dragging, clamped to 20–80%', () => {
+    const { refs, main } = setupSplit();
+    // 50px / 200px width → 25%.
+    drag(refs.splitter!, 50);
+    expect(main.style.getPropertyValue('--stack-basis').trim()).toBe('25.0%');
+    // Dragging past the right edge clamps to 80%.
+    drag(refs.splitter!, 400);
+    expect(main.style.getPropertyValue('--stack-basis').trim()).toBe('80.0%');
+  });
+
+  it('persists the basis on drag end via setState and a saveLayout message', () => {
+    const { refs, vscode } = setupSplit();
+    drag(refs.splitter!, 100); // 100/200 → 50%
+    expect(vscode.setState).toHaveBeenCalledWith({ stackBasis: '50.0%' });
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'saveLayout', stackBasis: '50.0%' });
+  });
+
+  it('a mousemove with no active drag does nothing', () => {
+    const { main } = setupSplit();
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 10, clientY: 10 }));
+    expect(main.style.getPropertyValue('--stack-basis').trim()).toBe('60%');
+  });
+
+  it('a bare click on the splitter (no movement) does not persist', () => {
+    const { refs, vscode } = setupSplit();
+    refs.splitter!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 120, clientY: 50 }));
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: 120, clientY: 50 }));
+    expect(vscode.setState).not.toHaveBeenCalled();
+    expect(vscode.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'saveLayout' }),
+    );
   });
 });

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -21,6 +21,11 @@ interface DebuggerViewApi {
       vars: { name: string; value: string; oop: string }[] }[],
     onInspect?: (oop: string, name: string) => void,
   ): void;
+  renderDnu(
+    dnuBarEl: HTMLElement,
+    dnu: { selector: string; className: string; isMeta: boolean } | null | undefined,
+    onCreate?: () => void,
+  ): void;
   selectFrame(listEl: HTMLElement, level: number): HTMLElement | null;
   showMenu(menuEl: HTMLElement, x: number, y: number): void;
   hideMenu(menuEl: HTMLElement): void;
@@ -41,6 +46,7 @@ interface Refs {
   copyFrameItem: HTMLElement;
   copyBtn: HTMLElement;
   error: HTMLElement;
+  dnuBar?: HTMLElement;
   toolbar: HTMLElement;
   variables: HTMLElement;
   evalInput: HTMLInputElement;
@@ -63,7 +69,7 @@ const STACK: FrameSummary[] = [
 
 // Build the panel's DOM (the elements debuggerPanel.ts's getHtml renders) and
 // wire DebuggerView to a fake vscode whose postMessage we can assert on.
-function setup(stack: FrameSummary[] = STACK) {
+function setup(stack: FrameSummary[] = STACK, dnu?: { selector: string; className: string; isMeta: boolean }) {
   document.body.innerHTML = `
     <button id="copyBtn">Copy Stack</button>
     <div id="toolbar">
@@ -75,6 +81,7 @@ function setup(stack: FrameSummary[] = STACK) {
       <button data-cmd="terminate">Terminate</button>
     </div>
     <div id="error"></div>
+    <div id="dnuBar"></div>
     <div class="main"><ul id="stack"></ul><div id="variables"></div></div>
     <input id="evalInput"><div id="evalResult"></div>
     <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div></div>`;
@@ -84,6 +91,7 @@ function setup(stack: FrameSummary[] = STACK) {
     copyFrameItem: document.getElementById('copyFrameItem')!,
     copyBtn: document.getElementById('copyBtn')!,
     error: document.getElementById('error')!,
+    dnuBar: document.getElementById('dnuBar')!,
     toolbar: document.getElementById('toolbar')!,
     variables: document.getElementById('variables')!,
     evalInput: document.getElementById('evalInput') as HTMLInputElement,
@@ -93,7 +101,7 @@ function setup(stack: FrameSummary[] = STACK) {
   const ctrl = api().init(refs, vscode);
   // Deliver the host's init payload, as the webview does on load.
   window.dispatchEvent(new MessageEvent('message', {
-    data: { command: 'init', errorMessage: 'boom', stack },
+    data: { command: 'init', errorMessage: 'boom', stack, dnu },
   }));
   return { refs, vscode, ctrl };
 }
@@ -525,5 +533,64 @@ describe('DebuggerView.init — resizable splitter', () => {
     hdrag(refs.hsplitter!, 20); // → 130px
     expect(vscode.setState).toHaveBeenCalledWith({ evalHeight: '130px' });
     expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'saveLayout', evalHeight: '130px' });
+  });
+});
+
+describe('DebuggerView.renderDnu (create-method-from-DNU)', () => {
+  beforeEach(() => { document.body.innerHTML = '<div id="dnuBar"></div>'; });
+
+  it('renders a "Create #selector in Class" button for an instance-side DNU', () => {
+    const bar = document.getElementById('dnuBar')!;
+    api().renderDnu(bar, { selector: 'fourtyTwo:bar:', className: 'SmallInteger', isMeta: false });
+    const btn = bar.querySelector('button.dnu-btn') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toBe('Create #fourtyTwo:bar: in SmallInteger');
+  });
+
+  it('appends " class" to the class name for a class-side DNU', () => {
+    const bar = document.getElementById('dnuBar')!;
+    api().renderDnu(bar, { selector: 'makeWidget', className: 'JasperDebugDemo', isMeta: true });
+    expect(bar.querySelector('button.dnu-btn')!.textContent).toBe('Create #makeWidget in JasperDebugDemo class');
+  });
+
+  it('clears the bar (no button) when there is no DNU', () => {
+    const bar = document.getElementById('dnuBar')!;
+    api().renderDnu(bar, { selector: 'x', className: 'Y', isMeta: false });
+    api().renderDnu(bar, null);
+    expect(bar.querySelector('button.dnu-btn')).toBeNull();
+  });
+
+  it('invokes onCreate when the button is clicked', () => {
+    const bar = document.getElementById('dnuBar')!;
+    const onCreate = vi.fn();
+    api().renderDnu(bar, { selector: 'x', className: 'Y', isMeta: false }, onCreate);
+    (bar.querySelector('button.dnu-btn') as HTMLButtonElement).click();
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+});
+
+describe('DebuggerView init — DNU button wiring', () => {
+  it('renders the Create button from the init payload and posts createDnuMethod on click', () => {
+    const { refs, vscode } = setup(STACK, { selector: 'foo:', className: 'Array', isMeta: false });
+    const btn = refs.dnuBar!.querySelector('button.dnu-btn') as HTMLButtonElement;
+    expect(btn.textContent).toBe('Create #foo: in Array');
+    btn.click();
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'createDnuMethod' });
+  });
+
+  it('shows no Create button when the init payload has no dnu', () => {
+    const { refs } = setup(); // dnu omitted
+    expect(refs.dnuBar!.querySelector('button.dnu-btn')).toBeNull();
+  });
+
+  it('a "banner" message sets the error text and clears the Create button (no re-render)', () => {
+    const { refs } = setup(STACK, { selector: 'foo:', className: 'Array', isMeta: false });
+    expect(refs.dnuBar!.querySelector('button.dnu-btn')).toBeTruthy();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'banner', text: 'Fill in the body, then save (Ctrl+S).' },
+    }));
+    expect(refs.error.textContent).toBe('Fill in the body, then save (Ctrl+S).');
+    expect(refs.dnuBar!.querySelector('button.dnu-btn')).toBeNull(); // button cleared
   });
 });

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -15,7 +15,12 @@ interface FrameSummary { level: number; label: string; position: string; }
 
 interface DebuggerViewApi {
   renderStack(listEl: HTMLElement, stack: FrameSummary[]): void;
-  renderVariables(varsEl: HTMLElement, vars: { name: string; value: string }[]): void;
+  renderVariables(
+    varsEl: HTMLElement,
+    groups: { title: string; kind: string; collapsed?: boolean;
+      vars: { name: string; value: string; oop: string }[] }[],
+    onInspect?: (oop: string, name: string) => void,
+  ): void;
   selectFrame(listEl: HTMLElement, level: number): HTMLElement | null;
   showMenu(menuEl: HTMLElement, x: number, y: number): void;
   hideMenu(menuEl: HTMLElement): void;
@@ -40,8 +45,10 @@ interface Refs {
   variables: HTMLElement;
   evalInput: HTMLInputElement;
   evalResult: HTMLElement;
+  evalbar?: HTMLElement;
   main?: HTMLElement;
   splitter?: HTMLElement;
+  hsplitter?: HTMLElement;
 }
 
 function api(): DebuggerViewApi {
@@ -236,21 +243,49 @@ describe('DebuggerView.init — copy stack button', () => {
 describe('DebuggerView.renderVariables', () => {
   beforeEach(() => { document.body.innerHTML = '<div id="variables"></div>'; });
 
-  it('renders self first (italic) then each variable name/value', () => {
+  it('renders each group with a title and its rows (name / value / dim oop)', () => {
     const el = document.getElementById('variables')!;
     api().renderVariables(el, [
-      { name: 'self', value: 'a JasperDebugDemo' },
-      { name: 'amount', value: '75' },
+      { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'a JasperDebugDemo', oop: '100' }] },
+      { title: 'Arguments & Temps', kind: 'argtemps', vars: [{ name: 'amount', value: '75', oop: '124' }] },
     ]);
+    const titles = el.querySelectorAll('.var-group-title');
+    expect([...titles].map(t => t.textContent)).toEqual(['Receiver', 'Arguments & Temps']);
+
     const rows = el.querySelectorAll('.var');
     expect(rows).toHaveLength(2);
     expect(rows[0].querySelector('.var-name')!.classList.contains('self')).toBe(true);
     expect(rows[0].querySelector('.var-name')!.textContent).toBe('self');
     expect(rows[0].querySelector('.var-value')!.textContent).toBe('a JasperDebugDemo');
+    expect(rows[0].querySelector('.var-oop')!.textContent).toBe('100');
+    expect((rows[0] as HTMLElement).dataset.oop).toBe('100');
     expect(rows[1].querySelector('.var-name')!.textContent).toBe('amount');
+    expect(rows[1].querySelector('.var-oop')!.textContent).toBe('124');
   });
 
-  it('shows an empty-state message when there are no variables', () => {
+  it('renders the stack-temps group collapsed; clicking its title expands it', () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, [
+      { title: '(stack temps)', kind: 'stacktemps', collapsed: true,
+        vars: [{ name: '.t1', value: '7', oop: '36' }] },
+    ]);
+    const group = el.querySelector('.var-group')!;
+    expect(group.classList.contains('collapsed')).toBe(true);
+    (group.querySelector('.var-group-title') as HTMLElement).click();
+    expect(group.classList.contains('collapsed')).toBe(false);
+  });
+
+  it('clicking a variable row calls onInspect with the row oop + name', () => {
+    const el = document.getElementById('variables')!;
+    const onInspect = vi.fn();
+    api().renderVariables(el, [
+      { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'x', oop: '100' }] },
+    ], onInspect);
+    (el.querySelector('.var') as HTMLElement).click();
+    expect(onInspect).toHaveBeenCalledWith('100', 'self');
+  });
+
+  it('shows an empty-state message when there are no groups', () => {
     const el = document.getElementById('variables')!;
     api().renderVariables(el, []);
     expect(el.querySelector('.empty')!.textContent).toBe('No variables.');
@@ -302,12 +337,27 @@ describe('DebuggerView.init — eval bar', () => {
 });
 
 describe('DebuggerView.init — inbound variables / evalResult', () => {
-  it('renders variables pushed from the host', () => {
+  it('renders grouped variables pushed from the host', () => {
     const { refs } = setup();
     window.dispatchEvent(new MessageEvent('message', {
-      data: { command: 'variables', vars: [{ name: 'self', value: 'x' }, { name: 'n', value: '7' }] },
+      data: { command: 'variables', groups: [
+        { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'x', oop: '100' }] },
+        { title: 'Arguments & Temps', kind: 'argtemps', vars: [{ name: 'n', value: '7', oop: '20' }] },
+      ] },
     }));
     expect(refs.variables.querySelectorAll('.var')).toHaveLength(2);
+  });
+
+  it('clicking a pushed variable row posts inspectVariable to the host', () => {
+    const { refs, vscode } = setup();
+    vi.mocked(vscode.postMessage).mockClear();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'variables', groups: [
+        { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'x', oop: '100' }] },
+      ] },
+    }));
+    (refs.variables.querySelector('.var') as HTMLElement).click();
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'inspectVariable', oop: '100', name: 'self' });
   });
 
   it('shows an eval result, flagging errors', () => {
@@ -352,7 +402,7 @@ describe('DebuggerView.init — resizable splitter', () => {
   // Build a panel DOM that includes the .main container + splitter, and a fake
   // vscode that records postMessage and round-trips getState/setState. jsdom
   // getBoundingClientRect returns zeros, so stub .main's rect to a real width.
-  function setupSplit(initialState?: { stackBasis?: string }) {
+  function setupSplit(initialState?: { stackBasis?: string; evalHeight?: string }) {
     document.body.innerHTML = `
       <div id="error"></div>
       <div class="main" id="main" style="--stack-basis: 60%;">
@@ -360,12 +410,20 @@ describe('DebuggerView.init — resizable splitter', () => {
         <div id="splitter"></div>
         <div id="variables"></div>
       </div>
+      <div id="hsplitter"></div>
+      <div id="evalbar" style="--eval-height: 7rem;">
+        <input id="evalInput"><div id="evalResult"></div>
+      </div>
       <div id="ctxmenu"><div id="copyFrameItem"></div></div>
-      <button id="copyBtn"></button><div id="toolbar"></div>
-      <input id="evalInput"><div id="evalResult"></div>`;
+      <button id="copyBtn"></button><div id="toolbar"></div>`;
     const main = document.getElementById('main')!;
     main.getBoundingClientRect = () =>
       ({ left: 0, top: 0, right: 200, bottom: 100, width: 200, height: 100, x: 0, y: 0, toJSON() {} });
+    const evalbar = document.getElementById('evalbar')!;
+    // jsdom rects are all-zero; give the eval bar a real height so the hsplitter
+    // baseline (the live eval-bar height at mousedown) is meaningful.
+    evalbar.getBoundingClientRect = () =>
+      ({ left: 0, top: 100, right: 200, bottom: 200, width: 200, height: 100, x: 0, y: 100, toJSON() {} });
     const refs: Refs = {
       list: document.getElementById('stack')!,
       menu: document.getElementById('ctxmenu')!,
@@ -376,8 +434,10 @@ describe('DebuggerView.init — resizable splitter', () => {
       variables: document.getElementById('variables')!,
       evalInput: document.getElementById('evalInput') as HTMLInputElement,
       evalResult: document.getElementById('evalResult')!,
+      evalbar,
       main,
       splitter: document.getElementById('splitter')!,
+      hsplitter: document.getElementById('hsplitter')!,
     };
     let state: unknown = initialState;
     const vscode = {
@@ -431,5 +491,39 @@ describe('DebuggerView.init — resizable splitter', () => {
     expect(vscode.postMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({ command: 'saveLayout' }),
     );
+  });
+
+  // Drag the horizontal splitter from y=50 to the given clientY. The eval bar's
+  // baseline height is the stubbed 100px; dragging UP (smaller clientY) grows it.
+  function hdrag(hsplitter: HTMLElement, toClientY: number) {
+    hsplitter.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 50 }));
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 10, clientY: toClientY }));
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: 10, clientY: toClientY }));
+  }
+
+  it('restores a previously saved eval-height from webview state on init', () => {
+    const { refs } = setupSplit({ evalHeight: '12rem' });
+    expect(refs.evalbar!.style.getPropertyValue('--eval-height').trim()).toBe('12rem');
+  });
+
+  it('grows --eval-height when dragging the splitter up (baseline + (startY - y))', () => {
+    const { refs } = setupSplit();
+    // baseline 100 + (50 - 20) = 130px.
+    hdrag(refs.hsplitter!, 20);
+    expect(refs.evalbar!.style.getPropertyValue('--eval-height').trim()).toBe('130px');
+  });
+
+  it('clamps --eval-height to a 42px floor when dragging down past it', () => {
+    const { refs } = setupSplit();
+    // baseline 100 + (50 - 300) → below the floor.
+    hdrag(refs.hsplitter!, 300);
+    expect(refs.evalbar!.style.getPropertyValue('--eval-height').trim()).toBe('42px');
+  });
+
+  it('persists the eval-height on horizontal drag end via setState and saveLayout', () => {
+    const { refs, vscode } = setupSplit();
+    hdrag(refs.hsplitter!, 20); // → 130px
+    expect(vscode.setState).toHaveBeenCalledWith({ evalHeight: '130px' });
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'saveLayout', evalHeight: '130px' });
   });
 });

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -15,6 +15,7 @@ interface FrameSummary { level: number; label: string; position: string; }
 
 interface DebuggerViewApi {
   renderStack(listEl: HTMLElement, stack: FrameSummary[]): void;
+  renderVariables(varsEl: HTMLElement, vars: { name: string; value: string }[]): void;
   selectFrame(listEl: HTMLElement, level: number): HTMLElement | null;
   showMenu(menuEl: HTMLElement, x: number, y: number): void;
   hideMenu(menuEl: HTMLElement): void;
@@ -31,6 +32,10 @@ interface Refs {
   copyFrameItem: HTMLElement;
   copyBtn: HTMLElement;
   error: HTMLElement;
+  toolbar: HTMLElement;
+  variables: HTMLElement;
+  evalInput: HTMLInputElement;
+  evalResult: HTMLElement;
 }
 
 function api(): DebuggerViewApi {
@@ -48,8 +53,17 @@ const STACK: FrameSummary[] = [
 function setup(stack: FrameSummary[] = STACK) {
   document.body.innerHTML = `
     <button id="copyBtn">Copy Stack</button>
+    <div id="toolbar">
+      <button data-cmd="resume">Resume</button>
+      <button data-cmd="stepOver">Over</button>
+      <button data-cmd="stepInto">Into</button>
+      <button data-cmd="stepThrough">Through</button>
+      <button data-cmd="restartFrame">Restart Frame</button>
+      <button data-cmd="terminate">Terminate</button>
+    </div>
     <div id="error"></div>
-    <ul id="stack"></ul>
+    <div class="main"><ul id="stack"></ul><div id="variables"></div></div>
+    <input id="evalInput"><div id="evalResult"></div>
     <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div></div>`;
   const refs: Refs = {
     list: document.getElementById('stack')!,
@@ -57,6 +71,10 @@ function setup(stack: FrameSummary[] = STACK) {
     copyFrameItem: document.getElementById('copyFrameItem')!,
     copyBtn: document.getElementById('copyBtn')!,
     error: document.getElementById('error')!,
+    toolbar: document.getElementById('toolbar')!,
+    variables: document.getElementById('variables')!,
+    evalInput: document.getElementById('evalInput') as HTMLInputElement,
+    evalResult: document.getElementById('evalResult')!,
   };
   const vscode = { postMessage: vi.fn() };
   const ctrl = api().init(refs, vscode);
@@ -206,5 +224,109 @@ describe('DebuggerView.init — copy stack button', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('DebuggerView.renderVariables', () => {
+  beforeEach(() => { document.body.innerHTML = '<div id="variables"></div>'; });
+
+  it('renders self first (italic) then each variable name/value', () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, [
+      { name: 'self', value: 'a JasperDebugDemo' },
+      { name: 'amount', value: '75' },
+    ]);
+    const rows = el.querySelectorAll('.var');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].querySelector('.var-name')!.classList.contains('self')).toBe(true);
+    expect(rows[0].querySelector('.var-name')!.textContent).toBe('self');
+    expect(rows[0].querySelector('.var-value')!.textContent).toBe('a JasperDebugDemo');
+    expect(rows[1].querySelector('.var-name')!.textContent).toBe('amount');
+  });
+
+  it('shows an empty-state message when there are no variables', () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, []);
+    expect(el.querySelector('.empty')!.textContent).toBe('No variables.');
+  });
+});
+
+describe('DebuggerView.init — toolbar', () => {
+  it('posts each toolbar command with the selected frame level', () => {
+    const { refs, vscode } = setup(); // default-selects top frame (level 1)
+    const click = (cmd: string) =>
+      refs.toolbar.querySelector(`button[data-cmd="${cmd}"]`)!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    click('stepOver');
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'stepOver', level: 1 });
+    click('resume');
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'resume', level: 1 });
+    click('terminate');
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'terminate', level: 1 });
+  });
+});
+
+describe('DebuggerView.init — eval bar', () => {
+  it('posts evalInFrame for the selected frame on Enter (trimmed, non-empty)', () => {
+    const { refs, vscode } = setup();
+    refs.evalInput.value = '  amount * 2  ';
+    refs.evalInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'evalInFrame', level: 1, expr: 'amount * 2' });
+  });
+
+  it('does not post on Enter when the input is blank', () => {
+    const { refs, vscode } = setup();
+    vi.mocked(vscode.postMessage).mockClear();
+    refs.evalInput.value = '   ';
+    refs.evalInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(vscode.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('DebuggerView.init — inbound variables / evalResult', () => {
+  it('renders variables pushed from the host', () => {
+    const { refs } = setup();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'variables', vars: [{ name: 'self', value: 'x' }, { name: 'n', value: '7' }] },
+    }));
+    expect(refs.variables.querySelectorAll('.var')).toHaveLength(2);
+  });
+
+  it('shows an eval result, flagging errors', () => {
+    const { refs } = setup();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'evalResult', value: '150', isError: false },
+    }));
+    expect(refs.evalResult.textContent).toBe('150');
+    expect(refs.evalResult.classList.contains('error')).toBe(false);
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'evalResult', value: 'Error: nope', isError: true },
+    }));
+    expect(refs.evalResult.textContent).toBe('Error: nope');
+    expect(refs.evalResult.classList.contains('error')).toBe(true);
+  });
+
+  it('renders an empty string (not "undefined") when an evalResult has no value', () => {
+    const { refs } = setup();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'evalResult', isError: false },
+    }));
+    expect(refs.evalResult.textContent).toBe('');
+  });
+
+  it('clears stale variables and eval output on a fresh init (refresh)', () => {
+    const { refs } = setup();
+    refs.variables.innerHTML = '<div class="var">stale</div>';
+    refs.evalResult.textContent = 'stale';
+    refs.evalResult.classList.add('error');
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'init', errorMessage: '', stack: STACK },
+    }));
+    expect(refs.variables.querySelector('.var')).toBeNull();
+    expect(refs.evalResult.textContent).toBe('');
+    expect(refs.evalResult.classList.contains('error')).toBe(false);
   });
 });

--- a/client/src/__tests__/editorContextMenu.test.ts
+++ b/client/src/__tests__/editorContextMenu.test.ts
@@ -18,8 +18,8 @@ function getMenuItem(command: string): MenuItem | undefined {
 }
 
 describe('editor/context menu', () => {
-  it('shows exactly seven GemStone actions in the editor context menu', () => {
-    expect(editorContext).toHaveLength(7);
+  it('shows exactly eight GemStone actions in the editor context menu', () => {
+    expect(editorContext).toHaveLength(8);
   });
 
   it('shows "Display It" in gemstone documents when code execution is available', () => {
@@ -39,6 +39,11 @@ describe('editor/context menu', () => {
 
   it('shows "Execute It" in gemstone documents when code execution is available', () => {
     expect(getMenuItem('gemstone.executeIt')?.when)
+      .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing`);
+  });
+
+  it('shows "Debug It" in gemstone documents when code execution is available', () => {
+    expect(getMenuItem('gemstone.debugIt')?.when)
       .toBe(`editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing`);
   });
 

--- a/client/src/__tests__/keybindings.test.ts
+++ b/client/src/__tests__/keybindings.test.ts
@@ -49,6 +49,7 @@ describe('keybindings', () => {
     const expected: Record<string, string> = {
       d: 'gemstone.displayIt',
       e: 'gemstone.executeIt',
+      r: 'gemstone.debugIt',
       i: 'gemstone.inspectIt',
       o: 'gemstone.superInspectIt',
       b: 'gemstone.openBrowser',
@@ -96,7 +97,7 @@ describe('keybindings', () => {
   });
 
   it('should gate editor commands on editorTextFocus and !executing', () => {
-    const editorCommands = ['gemstone.displayIt', 'gemstone.executeIt', 'gemstone.inspectIt'];
+    const editorCommands = ['gemstone.displayIt', 'gemstone.executeIt', 'gemstone.debugIt', 'gemstone.inspectIt'];
     for (const kb of keybindings) {
       if (editorCommands.includes(kb.command)) {
         expect(kb.when).toContain('editorTextFocus');

--- a/client/src/__tests__/nbRunner.test.ts
+++ b/client/src/__tests__/nbRunner.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+
+import * as vscode from 'vscode';
+import { runNbCall, pollNbResultReady, NbCancelledError } from '../nbRunner';
+import { ActiveSession } from '../sessionManager';
+
+const noErr = { number: 0 } as const;
+
+/**
+ * Fake session whose gci returns a scripted sequence of poll results. Each
+ * pollNbResultReady consumes the next entry (1 = ready, 0 = pending, -1 = error).
+ */
+function makeSession(pollResults: { result: number; err?: unknown }[]): ActiveSession {
+  let i = 0;
+  const gci = {
+    isAvailable: (name: string) => name === 'GciTsNbPoll',
+    GciTsNbPoll: vi.fn(() => {
+      const r = pollResults[Math.min(i, pollResults.length - 1)];
+      i++;
+      return { result: r.result, err: (r.err ?? noErr) };
+    }),
+    GciTsBreak: vi.fn(() => ({ result: 0, err: noErr })),
+    GciTsSocket: vi.fn(() => ({ fd: 3, err: noErr })),
+  };
+  return { id: 1, handle: { h: 1 }, gci } as unknown as ActiveSession;
+}
+
+describe('runNbCall', () => {
+  it('rejects if the start call fails (no polling)', async () => {
+    const session = makeSession([{ result: 1 }]);
+    const onReady = vi.fn();
+    await expect(
+      runNbCall(session, () => ({ success: false, err: { number: 5, message: 'boom' } as never }), onReady),
+    ).rejects.toThrow('boom');
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it('calls onReady and resolves with its value once the poll reports ready', async () => {
+    const session = makeSession([{ result: 1 }]); // ready on first poll
+    const result = await runNbCall(
+      session,
+      () => ({ success: true, err: noErr as never }),
+      () => 'the-result',
+    );
+    expect(result).toBe('the-result');
+  });
+
+  it('rejects when polling reports an error (-1)', async () => {
+    const session = makeSession([{ result: -1, err: { number: 7, message: 'pollbad' } }]);
+    await expect(
+      runNbCall(session, () => ({ success: true, err: noErr as never }), () => 'unused'),
+    ).rejects.toThrow('pollbad');
+  });
+
+  it('keeps polling while pending, then resolves when ready', async () => {
+    const session = makeSession([{ result: 0 }, { result: 0 }, { result: 1 }]);
+    const result = await runNbCall(
+      session,
+      () => ({ success: true, err: noErr as never }),
+      () => 42,
+    );
+    expect(result).toBe(42);
+    expect(session.gci.GciTsNbPoll).toHaveBeenCalledTimes(3);
+  });
+
+  it('propagates an error thrown by onReady (e.g. a fetch failure)', async () => {
+    const session = makeSession([{ result: 1 }]);
+    await expect(
+      runNbCall(session, () => ({ success: true, err: noErr as never }), () => { throw new Error('fetch failed'); }),
+    ).rejects.toThrow('fetch failed');
+  });
+});
+
+describe('pollNbResultReady', () => {
+  it('uses GciTsNbPoll when available', () => {
+    const session = makeSession([{ result: 1 }]);
+    expect(pollNbResultReady(session).result).toBe(1);
+    expect(session.gci.GciTsNbPoll).toHaveBeenCalled();
+  });
+
+  it('falls back to the session socket when GciTsNbPoll is unavailable', () => {
+    const gci = {
+      isAvailable: () => false, // GciTsNbPoll absent (pre-3.7)
+      GciTsSocket: vi.fn(() => ({ fd: -1, err: { number: 0 } })), // bad fd → -1
+    };
+    const session = { id: 1, handle: { h: 1 }, gci } as unknown as ActiveSession;
+    expect(pollNbResultReady(session).result).toBe(-1);
+    expect(gci.GciTsSocket).toHaveBeenCalled();
+  });
+});
+
+describe('runNbCall — cancellation', () => {
+  // Drive the progress/cancel path: override withProgress to capture the
+  // cancellation handler the loop registers, and use fake timers to cross the
+  // ~2s progress threshold without real waiting.
+  it('first cancel soft-breaks + reports progress; second hard-breaks + rejects NbCancelledError', async () => {
+    vi.useFakeTimers();
+    try {
+      const session = makeSession([{ result: 0 }]); // always pending → loop keeps polling
+      const reportSpy = vi.fn();
+      let cancelHandler: (() => void) | undefined;
+      vi.mocked(vscode.window.withProgress).mockImplementation((_opts: unknown, task: unknown) => {
+        const token = { onCancellationRequested: (cb: () => void) => { cancelHandler = cb; return { dispose() {} }; } };
+        return (task as (p: unknown, t: unknown) => Promise<unknown>)({ report: reportSpy }, token);
+      });
+
+      const p = runNbCall(session, () => ({ success: true, err: noErr as never }), () => 'unused');
+      // Advance past PROGRESS_THRESHOLD_MS (2000) so the progress block runs and
+      // registers the cancellation handler.
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(cancelHandler).toBeTypeOf('function');
+
+      cancelHandler!(); // first cancel → soft break + acknowledgement
+      expect(session.gci.GciTsBreak).toHaveBeenCalledWith(session.handle, false);
+      expect(reportSpy).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringMatching(/break/i) }));
+
+      cancelHandler!(); // second cancel → hard break + reject
+      expect(session.gci.GciTsBreak).toHaveBeenCalledWith(session.handle, true);
+      await expect(p).rejects.toBeInstanceOf(NbCancelledError);
+
+      vi.clearAllTimers();
+    } finally {
+      vi.useRealTimers();
+      vi.mocked(vscode.window.withProgress).mockReset();
+    }
+  });
+});

--- a/client/src/__tests__/openWorkspace.test.ts
+++ b/client/src/__tests__/openWorkspace.test.ts
@@ -3,36 +3,52 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 vi.mock('../gciLog', () => ({ logInfo: vi.fn() }));
 
-import { workspace, window } from '../__mocks__/vscode';
-import {openWorkspace, WORKSPACE_TEMPLATE} from '../workspace';
+import { workspace, window, languages, Uri } from '../__mocks__/vscode';
+import { openWorkspace, WORKSPACE_TEMPLATE } from '../workspace';
 
 describe('openWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('opens a gemstone-smalltalk document', async () => {
+  it('opens the NAMED untitled document "Workspace" (not Untitled-N)', async () => {
     await openWorkspace();
-    
-    expect(workspace.openTextDocument).toHaveBeenCalledWith(
-      { content: WORKSPACE_TEMPLATE, language: 'gemstone-smalltalk' },
+
+    const uri = vi.mocked(workspace.openTextDocument).mock.calls[0][0] as Uri;
+    expect(uri.scheme).toBe('untitled');
+    expect(uri.path).toBe('Workspace');
+  });
+
+  it('sets the document language to gemstone-smalltalk', async () => {
+    await openWorkspace();
+    expect(languages.setTextDocumentLanguage).toHaveBeenCalledWith(
+      expect.anything(), 'gemstone-smalltalk',
     );
   });
 
-  it('shows the document with preview disabled', async () => {
+  it('seeds the workspace template into a fresh, empty buffer', async () => {
     await openWorkspace();
-    
+    // The template is inserted via a WorkspaceEdit (keeps the named doc, no Untitled-N).
+    expect(workspace.applyEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT re-seed a buffer that hot-exit already restored with content', async () => {
+    vi.mocked(workspace.openTextDocument).mockResolvedValueOnce({
+      uri: Uri.from({ scheme: 'untitled', path: 'Workspace' }),
+      languageId: 'gemstone-smalltalk',
+      getText: () => WORKSPACE_TEMPLATE, // already has the user's content
+    } as never);
+
+    await openWorkspace();
+
+    expect(workspace.applyEdit).not.toHaveBeenCalled();
+  });
+
+  it('shows the document with preview disabled (a permanent tab)', async () => {
+    await openWorkspace();
     expect(window.showTextDocument).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ preview: false }),
     );
-  });
-
-  it('opens a new workspace document each time it is called', async () => {
-    await openWorkspace();
-    
-    await openWorkspace();
-    
-    expect(workspace.openTextDocument).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/src/__tests__/transcriptCapture.test.ts
+++ b/client/src/__tests__/transcriptCapture.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  wrapWithTranscriptCapture, unwrapTranscriptCapture, TRANSCRIPT_CAPTURE_PREFIX,
+} from '../transcriptCapture';
+
+describe('transcriptCapture', () => {
+  it('wrap then unwrap is a round trip (recovers the exact user code)', () => {
+    const code = 'JasperDebugDemo new run';
+    const { wrappedCode } = wrapWithTranscriptCapture(code);
+    expect(unwrapTranscriptCapture(wrappedCode)).toBe(code);
+  });
+
+  it('codeOffset points at where the user code begins in the wrapped source', () => {
+    const code = '6 * 7';
+    const { wrappedCode, codeOffset } = wrapWithTranscriptCapture(code);
+    expect(codeOffset).toBe(TRANSCRIPT_CAPTURE_PREFIX.length);
+    expect(wrappedCode.slice(codeOffset, codeOffset + code.length)).toBe(code);
+  });
+
+  it('unwraps multi-statement user code', () => {
+    const code = '| x | x := 6 * 7.\nx printNl.\nx';
+    expect(unwrapTranscriptCapture(wrapWithTranscriptCapture(code).wrappedCode)).toBe(code);
+  });
+
+  it('tolerates surrounding whitespace the compiler may add to stored source', () => {
+    const wrapped = wrapWithTranscriptCapture('foo bar').wrappedCode;
+    expect(unwrapTranscriptCapture(`\n${wrapped}\n`)).toBe('foo bar');
+  });
+
+  it('leaves non-wrapped source unchanged (plain doit / unrecognised glue)', () => {
+    const plain = 'JasperDebugDemo new run';
+    expect(unwrapTranscriptCapture(plain)).toBe(plain);
+  });
+
+  it('leaves source that only has the prefix (no matching suffix) unchanged', () => {
+    const partial = `${TRANSCRIPT_CAPTURE_PREFIX}JasperDebugDemo new run`;
+    expect(unwrapTranscriptCapture(partial)).toBe(partial);
+  });
+});

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { SessionManager, ActiveSession } from './sessionManager';
-import { OOP_ILLEGAL, OOP_NIL, GCI_PERFORM_FLAG_ENABLE_DEBUG } from './gciConstants';
+import { OOP_ILLEGAL, OOP_NIL, GCI_PERFORM_FLAG_ENABLE_DEBUG, GCI_PERFORM_FLAG_SINGLE_STEP } from './gciConstants';
 import { logQuery, logResult, logError, logInfo } from './gciLog';
 import { InspectorTreeProvider } from './inspectorTreeProvider';
 import { GtInspector } from './gtInspector';
@@ -110,14 +110,19 @@ export class CodeExecutor {
   }
 
   async displayIt(): Promise<void> {
-    return this.execute(true);
+    return this.execute('display');
   }
 
   async executeIt(): Promise<void> {
-    return this.execute(false);
+    return this.execute('execute');
   }
 
-  private async execute(displayResult: boolean): Promise<void> {
+  async debugIt(): Promise<void> {
+    return this.execute('debug');
+  }
+
+  private async execute(mode: 'display' | 'execute' | 'debug'): Promise<void> {
+    const displayResult = mode === 'display';
     const session = await this.sessionManager.resolveSession();
     if (!session) return;
 
@@ -149,9 +154,19 @@ export class CodeExecutor {
     const oopClassString = this.resolveOopClassString(session);
     if (oopClassString === undefined) return;
 
-    const label = displayResult ? 'Display It' : 'Execute It';
+    const label = mode === 'display' ? 'Display It'
+      : mode === 'debug' ? 'Debug It' : 'Execute It';
     logQuery(session.id, label, code);
-    const { wrappedCode, codeOffset } = this.wrapWithTranscriptCapture(code);
+    // Debug It runs the raw selection, NOT the transcript-capture wrapper. The
+    // wrapper nests the code as `[[ <code> ] value] ensure: [...]`, so a
+    // single-step halt lands on the OUTER block and Step Over treats the inner
+    // `[<code>] value` send as one atomic unit — stepping clean over all the
+    // user's code into the ensure: cleanup. Running unwrapped makes step point 1
+    // the user's first statement so stepping advances through it. (Transcript
+    // capture is sacrificed while debugging — an acceptable trade.)
+    const { wrappedCode, codeOffset } = mode === 'debug'
+      ? { wrappedCode: code, codeOffset: 0 }
+      : this.wrapWithTranscriptCapture(code);
 
     // Dim the selected code while executing
     const execRange = new vscode.Range(selection.start, selection.end);
@@ -163,10 +178,14 @@ export class CodeExecutor {
     // must START interpreted. Released in finally; if it halts, the debugger
     // panel holds its own ref to keep native off while it's open.
     acquireStepping(session);
+    // Debug It adds the single-step flag so the server breaks on the first
+    // statement of the compiled code and we open the debugger sitting there.
+    const execFlags = GCI_PERFORM_FLAG_ENABLE_DEBUG
+      | (mode === 'debug' ? GCI_PERFORM_FLAG_SINGLE_STEP : 0);
     try {
       const { success, err: startErr } = session.gci.GciTsNbExecute(
         session.handle, wrappedCode, oopClassString,
-        OOP_ILLEGAL, OOP_NIL, GCI_PERFORM_FLAG_ENABLE_DEBUG, 0,
+        OOP_ILLEGAL, OOP_NIL, execFlags, 0,
       );
       if (!success) {
         const msg = startErr.message || `error ${startErr.number}`;
@@ -194,6 +213,20 @@ export class CodeExecutor {
       logError(session.id, msg);
 
       if (e instanceof DebuggableError) {
+        if (mode === 'debug') {
+          // Debug It: the single-step flag halted on the first statement —
+          // this is an intentional stop, not an error. Open the Enhanced
+          // debugger directly on that halt, with no inline diagnostic and no
+          // chooser prompt. The panel takes its own stepping ref; if it fails
+          // to open, release the suspended process so it doesn't stall.
+          try {
+            DebuggerPanel.create(session, e.context, 'Debug It');
+          } catch (panelErr: unknown) {
+            logError(session.id, panelErr instanceof Error ? panelErr.message : String(panelErr));
+            clearStack(session, e.context);
+          }
+          return;
+        }
         // Try to show as inline diagnostic first; fall back to debug dialog
         this.showCompileError(editor, selection, code, codeOffset, msg);
         // For a Display It, resuming/stepping to completion should render the

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -4,6 +4,8 @@ import { OOP_ILLEGAL, OOP_NIL, GCI_PERFORM_FLAG_ENABLE_DEBUG } from './gciConsta
 import { logQuery, logResult, logError, logInfo } from './gciLog';
 import { InspectorTreeProvider } from './inspectorTreeProvider';
 import { GtInspector } from './gtInspector';
+import { DebuggerPanel } from './debuggerPanel';
+import { clearStack } from './debugQueries';
 import { appendTranscript, showTranscript } from './transcriptChannel';
 import { GciError } from './gciLibrary';
 import { pollReadable } from './socketPoll';
@@ -205,7 +207,7 @@ export class CodeExecutor {
       if (e instanceof DebuggableError) {
         // Try to show as inline diagnostic first; fall back to debug dialog
         this.showCompileError(editor, selection, code, codeOffset, msg);
-        await this.handleDebuggableError(session, e, msg);
+        await this.promptDebuggableError(session, e.context, msg);
       } else {
         this.showCompileError(editor, selection, code, codeOffset, msg);
       }
@@ -516,9 +518,20 @@ __t`;
     });
   }
 
-  private async handleDebuggableError(session: ActiveSession, e: DebuggableError, msg: string): Promise<void> {
+  /**
+   * Single shared notifier for a debuggable GemStone error. Offers two
+   * debuggers — the DAP "Debug" (Run and Debug view) and the webview
+   * "Enhanced Debug" — plus the implicit Cancel/dismiss. Whichever debugger the
+   * user picks OWNS the suspended `gsProcess`; dismissing clears the stack so
+   * the process is released. The two debuggers never coexist on one process.
+   */
+  private async promptDebuggableError(
+    session: ActiveSession, gsProcess: bigint, msg: string,
+  ): Promise<void> {
+    // Button array order maps to right-to-left placement in the modal, so
+    // 'Enhanced Debug' first puts it to the RIGHT of 'Debug'.
     const choice = await vscode.window.showErrorMessage(
-      `GemStone error: ${msg}`, { modal: true }, 'Debug'
+      `GemStone error: ${msg}`, { modal: true }, 'Enhanced Debug', 'Debug',
     );
     if (choice === 'Debug') {
       await vscode.debug.startDebugging(undefined, {
@@ -526,14 +539,23 @@ __t`;
         name: 'GemStone Error',
         request: 'attach',
         sessionId: session.id,
-        gsProcess: e.context.toString(),
+        gsProcess: gsProcess.toString(),
         errorMessage: msg,
       }, { suppressSaveBeforeStart: true });
       // Reveal the Run and Debug view so the call stack is immediately visible
       // instead of silently populating a hidden view.
       await vscode.commands.executeCommand('workbench.view.debug');
+    } else if (choice === 'Enhanced Debug') {
+      try {
+        DebuggerPanel.create(session, gsProcess, msg);
+      } catch (err: unknown) {
+        // If the panel fails to open, nothing owns the suspended process, so
+        // release it rather than leaving it stalled on the server.
+        logError(session.id, err instanceof Error ? err.message : String(err));
+        clearStack(session, gsProcess);
+      }
     } else {
-      try { session.gci.GciTsClearStack(session.handle, e.context); } catch { /* ignore */ }
+      clearStack(session, gsProcess);
     }
   }
 
@@ -779,21 +801,7 @@ __t`;
       logError(session.id, msg);
 
       if (e instanceof DebuggableError) {
-        const choice = await vscode.window.showErrorMessage(
-          `GemStone error: ${msg}`, { modal: true }, 'Debug', 'Dismiss',
-        );
-        if (choice === 'Debug') {
-          vscode.debug.startDebugging(undefined, {
-            type: 'gemstone',
-            name: 'GemStone Error',
-            request: 'attach',
-            sessionId: session.id,
-            gsProcess: e.context.toString(),
-            errorMessage: msg,
-          }, { suppressSaveBeforeStart: true });
-        } else {
-          try { session.gci.GciTsClearStack(session.handle, e.context); } catch { /* ignore */ }
-        }
+        await this.promptDebuggableError(session, e.context, msg);
       } else {
         vscode.window.showErrorMessage(`GemStone execution error: ${msg}`);
       }
@@ -896,7 +904,7 @@ __t`;
       logError(session.id, msg);
 
       if (e instanceof DebuggableError) {
-        await this.handleDebuggableError(session, e, msg);
+        await this.promptDebuggableError(session, e.context, msg);
       } else {
         vscode.window.showErrorMessage(`GemStone execution error: ${msg}`);
       }

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -7,6 +7,7 @@ import { GtInspector } from './gtInspector';
 import { DebuggerPanel } from './debuggerPanel';
 import { clearStack } from './debugQueries';
 import { appendTranscript, showTranscript } from './transcriptChannel';
+import { wrapWithTranscriptCapture } from './transcriptCapture';
 import { GciError } from './gciLibrary';
 import { pollReadable } from './socketPoll';
 
@@ -410,31 +411,9 @@ export class CodeExecutor {
   }
 
   private wrapWithTranscriptCapture(code: string): { wrappedCode: string; codeOffset: number } {
-    // Wrap user code so that Transcript writes are captured into SessionTemps.
-    // The wrapped code:
-    //   1. Creates a capture WriteStream
-    //   2. Saves the original Transcript
-    //   3. Installs the capture stream as Transcript in SessionTemps
-    //   4. Evaluates the user code inside an ensure: block
-    //   5. Restores the original Transcript and stores captured text
-    //
-    // The user code is embedded directly in Smalltalk source (inside a block),
-    // NOT inside a string literal, so single quotes must NOT be escaped.
-    const prefix = `| __vscCapture __vscOriginal __vscResult |
-__vscCapture := WriteStream on: String new.
-__vscOriginal := SessionTemps current at: #Transcript ifAbsent: [nil].
-SessionTemps current at: #Transcript put: __vscCapture.
-[__vscResult := [`;
-    const suffix = `] value]
-  ensure: [
-    SessionTemps current at: #Transcript put: __vscOriginal.
-    SessionTemps current at: #'__vscTranscriptResult' put: __vscCapture contents.
-  ].
-__vscResult`;
-    return {
-      wrappedCode: prefix + code + suffix,
-      codeOffset: prefix.length,
-    };
+    // Delegate to the shared wrapper so the Enhanced Debugger's unwrap
+    // (transcriptCapture.unwrapTranscriptCapture) stays in lock step with it.
+    return wrapWithTranscriptCapture(code);
   }
 
   private fetchTranscriptOutput(session: ActiveSession): string {

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -8,12 +8,8 @@ import { DebuggerPanel } from './debuggerPanel';
 import { clearStack, getObjectPrintString, acquireStepping, releaseStepping } from './debugQueries';
 import { appendTranscript, showTranscript } from './transcriptChannel';
 import { wrapWithTranscriptCapture } from './transcriptCapture';
-import { GciError } from './gciLibrary';
-import { pollReadable } from './socketPoll';
+import { pollNbToCompletion, NbCancelledError } from './nbRunner';
 
-const BACKOFF_INTERVALS = [10, 10, 20, 40, 80, 160, 320, 500];
-const MAX_INTERVAL = 500;
-const PROGRESS_THRESHOLD_MS = 2000;
 const MAX_RESULT_SIZE = 64 * 1024;
 
 // Decoration type for Display It results.
@@ -57,12 +53,6 @@ const DISPLAY_RESULT_CONTEXT = 'gemstone.displayResultVisible';
 // Max characters shown in the inline overlay before truncating (full value
 // is always available via the hover and the Expand action).
 const MAX_OVERLAY_PREVIEW = 100;
-
-class ExecutionCancelledError extends Error {
-  constructor() {
-    super('Execution cancelled');
-  }
-}
 
 class DebuggableError extends Error {
   constructor(message: string, public readonly context: bigint) {
@@ -199,7 +189,7 @@ export class CodeExecutor {
         vscode.window.setStatusBarMessage('GemStone: Executed successfully.', 3000);
       }
     } catch (e: unknown) {
-      if (e instanceof ExecutionCancelledError) return;
+      if (e instanceof NbCancelledError) return;
       const msg = e instanceof Error ? e.message : String(e);
       logError(session.id, msg);
 
@@ -636,107 +626,14 @@ __t`;
     return new vscode.Range(pos, lineEnd);
   }
 
-  /**
-   * Checks whether a non-blocking call's result is ready, returning the same
-   * { result: 1=ready, 0=pending, -1=error } shape as GciTsNbPoll.
-   *
-   * GciTsNbPoll doesn't exist before GemStone 3.7. When it's unavailable we
-   * poll the session socket directly (GciTsSocket + native poll), exactly as
-   * the GciTsNbResult docs prescribe.
-   */
-  private pollNbResultReady(session: ActiveSession): { result: number; err: GciError } {
-    if (session.gci.isAvailable('GciTsNbPoll')) {
-      return session.gci.GciTsNbPoll(session.handle, 0);
-    }
-    const { fd, err } = session.gci.GciTsSocket(session.handle);
-    if (err.number !== 0 || fd < 0) {
-      return { result: -1, err };
-    }
-    const ready = pollReadable(fd, 0);
-    return {
-      result: ready,
-      err: ready === -1
-        ? ({ number: -1, message: 'Failed to poll the GemStone session socket' } as GciError)
-        : err,
-    };
-  }
-
   private pollForCompletion<T>(
     session: ActiveSession, onReady: () => T,
   ): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      let pollIndex = 0;
-      let elapsedMs = 0;
-      let progressShown = false;
-      let softBreakSent = false;
-      let progressResolve: (() => void) | null = null;
-
-      const finishProgress = () => {
-        if (progressResolve) {
-          progressResolve();
-          progressResolve = null;
-        }
-      };
-
-      const doPoll = () => {
-        const { result: pollResult, err: pollErr } = this.pollNbResultReady(session);
-
-        if (pollResult === 1) {
-          finishProgress();
-          try {
-            resolve(onReady());
-          } catch (e) {
-            reject(e);
-          }
-          return;
-        }
-
-        if (pollResult === -1) {
-          finishProgress();
-          const msg = pollErr.message || `GemStone poll error ${pollErr.number}`;
-          reject(new Error(msg));
-          return;
-        }
-
-        const interval = pollIndex < BACKOFF_INTERVALS.length
-          ? BACKOFF_INTERVALS[pollIndex]
-          : MAX_INTERVAL;
-        pollIndex++;
-        elapsedMs += interval;
-
-        if (elapsedMs >= PROGRESS_THRESHOLD_MS && !progressShown) {
-          progressShown = true;
-          vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: softBreakSent
-                ? 'GemStone: Soft break sent. Waiting...'
-                : 'GemStone: Executing...',
-              cancellable: true,
-            },
-            (_progress, token) => {
-              token.onCancellationRequested(() => {
-                if (!softBreakSent) {
-                  session.gci.GciTsBreak(session.handle, false);
-                  softBreakSent = true;
-                } else {
-                  session.gci.GciTsBreak(session.handle, true);
-                  finishProgress();
-                  reject(new ExecutionCancelledError());
-                }
-              });
-              return new Promise<void>(res => {
-                progressResolve = res;
-              });
-            },
-          );
-        }
-
-        setTimeout(doPoll, interval);
-      };
-
-      doPoll();
-    });
+    // Delegates to the shared non-blocking poll loop (nbRunner) so Execute/Display
+    // It and the debugger's step/trim share ONE cancel/break/backoff/progress
+    // implementation (no divergence). The Nb call is already started by the caller
+    // (GciTsNbExecute above), so we only poll it to completion here.
+    return pollNbToCompletion(session, onReady, { title: 'GemStone: Executing…' });
   }
 
   private pollForResult(session: ActiveSession): Promise<string> {
@@ -851,7 +748,7 @@ __t`;
       logResult(session.id, `OOP ${oop}`);
       GtInspector.create(session, oop, label);
     } catch (e: unknown) {
-      if (e instanceof ExecutionCancelledError) return;
+      if (e instanceof NbCancelledError) return;
       const msg = e instanceof Error ? e.message : String(e);
       logError(session.id, msg);
 
@@ -966,7 +863,7 @@ __t`;
       logResult(session.id, `OOP ${oop}`);
       inspectorProvider.addRoot(session.id, oop, label);
     } catch (e: unknown) {
-      if (e instanceof ExecutionCancelledError) return;
+      if (e instanceof NbCancelledError) return;
       const msg = e instanceof Error ? e.message : String(e);
       logError(session.id, msg);
 

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -5,7 +5,7 @@ import { logQuery, logResult, logError, logInfo } from './gciLog';
 import { InspectorTreeProvider } from './inspectorTreeProvider';
 import { GtInspector } from './gtInspector';
 import { DebuggerPanel } from './debuggerPanel';
-import { clearStack } from './debugQueries';
+import { clearStack, getObjectPrintString, acquireStepping, releaseStepping } from './debugQueries';
 import { appendTranscript, showTranscript } from './transcriptChannel';
 import { wrapWithTranscriptCapture } from './transcriptCapture';
 import { GciError } from './gciLibrary';
@@ -168,6 +168,11 @@ export class CodeExecutor {
     editor.setDecorations(executingDecorationType, [execRange]);
     
     this.setExecuting(session.id, true);
+    // Run interpreted (native code off) so a halt/error is steppable in the
+    // debugger — GemStone can't step native code (error 6014), and the process
+    // must START interpreted. Released in finally; if it halts, the debugger
+    // panel holds its own ref to keep native off while it's open.
+    acquireStepping(session);
     try {
       const { success, err: startErr } = session.gci.GciTsNbExecute(
         session.handle, wrappedCode, oopClassString,
@@ -189,14 +194,7 @@ export class CodeExecutor {
       this.diagnostics.delete(editor.document.uri);
 
       if (displayResult) {
-        const mode = vscode.workspace
-          .getConfiguration('gemstone')
-          .get<string>('displayItMode', 'overlay');
-        if (mode === 'insert') {
-          await this.insertResult(editor, selection, resultString);
-        } else {
-          this.showResultOverlay(editor, selection, resultString);
-        }
+        await this.displayExecutionResult(editor, selection, resultString);
       } else {
         vscode.window.setStatusBarMessage('GemStone: Executed successfully.', 3000);
       }
@@ -208,13 +206,46 @@ export class CodeExecutor {
       if (e instanceof DebuggableError) {
         // Try to show as inline diagnostic first; fall back to debug dialog
         this.showCompileError(editor, selection, code, codeOffset, msg);
-        await this.promptDebuggableError(session, e.context, msg);
+        // For a Display It, resuming/stepping to completion should render the
+        // result back in the workspace, just as if it had never halted. (Execute
+        // It is intentionally silent, so no callback.)
+        const onComplete = displayResult
+          ? (resultOop: bigint): void => {
+              const transcript = this.fetchTranscriptOutput(session);
+              if (transcript) appendTranscript(transcript);
+              const resultString = getObjectPrintString(session, resultOop, MAX_RESULT_SIZE);
+              void this.displayExecutionResult(editor, selection, resultString);
+            }
+          : undefined;
+        await this.promptDebuggableError(session, e.context, msg, onComplete);
       } else {
         this.showCompileError(editor, selection, code, codeOffset, msg);
       }
     } finally {
       editor.setDecorations(executingDecorationType, []);
+      releaseStepping(session);
       this.setExecuting(session.id, false);
+    }
+  }
+
+  /**
+   * Display a Display-It result in the editor — overlay (non-destructive,
+   * default) or inline insert, per the `gemstone.displayItMode` setting. Shared
+   * by the normal Display It and the debugger's resume-to-completion path so a
+   * halted Display It renders its result identically once resumed.
+   */
+  private async displayExecutionResult(
+    editor: vscode.TextEditor,
+    selection: vscode.Selection,
+    resultString: string,
+  ): Promise<void> {
+    const mode = vscode.workspace
+      .getConfiguration('gemstone')
+      .get<string>('displayItMode', 'overlay');
+    if (mode === 'insert') {
+      await this.insertResult(editor, selection, resultString);
+    } else {
+      this.showResultOverlay(editor, selection, resultString);
     }
   }
 
@@ -506,6 +537,7 @@ __t`;
    */
   private async promptDebuggableError(
     session: ActiveSession, gsProcess: bigint, msg: string,
+    onComplete?: (resultOop: bigint) => void,
   ): Promise<void> {
     // Button array order maps to right-to-left placement in the modal, so
     // 'Enhanced Debug' first puts it to the RIGHT of 'Debug'.
@@ -526,7 +558,7 @@ __t`;
       await vscode.commands.executeCommand('workbench.view.debug');
     } else if (choice === 'Enhanced Debug') {
       try {
-        DebuggerPanel.create(session, gsProcess, msg);
+        DebuggerPanel.create(session, gsProcess, msg, onComplete);
       } catch (err: unknown) {
         // If the panel fails to open, nothing owns the suspended process, so
         // release it rather than leaving it stalled on the server.
@@ -755,6 +787,11 @@ __t`;
       editor.setDecorations(executingDecorationType, [editor.selection]);
     }
 
+    // Run interpreted (native code off) so a halt/error is steppable in the
+    // debugger — GemStone can't step native code (error 6014), and the process
+    // must START interpreted. Released in finally; if it halts, the debugger
+    // panel holds its own ref to keep native off while it's open.
+    acquireStepping(session);
     try {
       const { success, err: startErr } = session.gci.GciTsNbExecute(
         session.handle, wrappedCode, oopClassString,
@@ -780,7 +817,13 @@ __t`;
       logError(session.id, msg);
 
       if (e instanceof DebuggableError) {
-        await this.promptDebuggableError(session, e.context, msg);
+        // If it halts, resuming/stepping to completion should still open the
+        // GT inspector on the result — mirroring the success path above.
+        await this.promptDebuggableError(session, e.context, msg, (resultOop: bigint) => {
+          const transcript = this.fetchTranscriptOutput(session);
+          if (transcript) appendTranscript(transcript);
+          GtInspector.create(session, resultOop, label);
+        });
       } else {
         vscode.window.showErrorMessage(`GemStone execution error: ${msg}`);
       }
@@ -788,6 +831,7 @@ __t`;
       if (editor) {
         editor.setDecorations(executingDecorationType, []);
       }
+      releaseStepping(session);
       this.setExecuting(session.id, false);
     }
   }
@@ -858,6 +902,11 @@ __t`;
     }
 
     this.setExecuting(session.id, true);
+    // Run interpreted (native code off) so a halt/error is steppable in the
+    // debugger — GemStone can't step native code (error 6014), and the process
+    // must START interpreted. Released in finally; if it halts, the debugger
+    // panel holds its own ref to keep native off while it's open.
+    acquireStepping(session);
     try {
       const { success, err: startErr } = session.gci.GciTsNbExecute(
         session.handle, wrappedCode, oopClassString,
@@ -883,7 +932,13 @@ __t`;
       logError(session.id, msg);
 
       if (e instanceof DebuggableError) {
-        await this.promptDebuggableError(session, e.context, msg);
+        // If it halts, resuming/stepping to completion should still inspect the
+        // result — mirroring the success path above.
+        await this.promptDebuggableError(session, e.context, msg, (resultOop: bigint) => {
+          const transcript = this.fetchTranscriptOutput(session);
+          if (transcript) appendTranscript(transcript);
+          inspectorProvider.addRoot(session.id, resultOop, label);
+        });
       } else {
         vscode.window.showErrorMessage(`GemStone execution error: ${msg}`);
       }
@@ -891,6 +946,7 @@ __t`;
       if (editor) {
         editor.setDecorations(executingDecorationType, []);
       }
+      releaseStepping(session);
       this.setExecuting(session.id, false);
     }
   }

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -521,7 +521,7 @@ __t`;
       `GemStone error: ${msg}`, { modal: true }, 'Debug'
     );
     if (choice === 'Debug') {
-      vscode.debug.startDebugging(undefined, {
+      await vscode.debug.startDebugging(undefined, {
         type: 'gemstone',
         name: 'GemStone Error',
         request: 'attach',
@@ -529,6 +529,9 @@ __t`;
         gsProcess: e.context.toString(),
         errorMessage: msg,
       }, { suppressSaveBeforeStart: true });
+      // Reveal the Run and Debug view so the call stack is immediately visible
+      // instead of silently populating a hidden view.
+      await vscode.commands.executeCommand('workbench.view.debug');
     } else {
       try { session.gci.GciTsClearStack(session.handle, e.context); } catch { /* ignore */ }
     }

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -214,7 +214,19 @@ export class CodeExecutor {
               const transcript = this.fetchTranscriptOutput(session);
               if (transcript) appendTranscript(transcript);
               const resultString = getObjectPrintString(session, resultOop, MAX_RESULT_SIZE);
-              void this.displayExecutionResult(editor, selection, resultString);
+              // Capture the editor's column now, while it is still visible — by the
+              // next tick (after the panel disposes) editor.viewColumn may be
+              // undefined and the result would drift to whatever column is active.
+              const column = editor.viewColumn ?? vscode.ViewColumn.Active;
+              // The debugger panel disposes immediately after this callback,
+              // stealing focus from the workspace editor. Render once that has
+              // settled (next tick), refocusing the editor first — the result's
+              // Backspace/Enter keybindings require editorTextFocus, so otherwise
+              // the result shows but can't be dismissed/expanded from the keyboard.
+              setTimeout(() => {
+                this.renderResultWithFocus(editor, selection, resultString, column)
+                  .catch(err => logError(session.id, err instanceof Error ? err.message : String(err)));
+              }, 0);
             }
           : undefined;
         await this.promptDebuggableError(session, e.context, msg, onComplete);
@@ -226,6 +238,33 @@ export class CodeExecutor {
       releaseStepping(session);
       this.setExecuting(session.id, false);
     }
+  }
+
+  /**
+   * Render a Display-It result after refocusing its editor. Used only by the
+   * debugger's resume-to-completion path: the Enhanced Debugger panel takes
+   * focus and then disposes, so the workspace editor must be re-focused before
+   * the result is shown — the Backspace (dismiss) / Enter (expand) keybindings
+   * are gated on editorTextFocus. Falls back to the captured editor reference if
+   * the document can no longer be shown (e.g. it was closed).
+   */
+  private async renderResultWithFocus(
+    editor: vscode.TextEditor,
+    selection: vscode.Selection,
+    resultString: string,
+    column: vscode.ViewColumn,
+  ): Promise<void> {
+    let target = editor;
+    try {
+      target = await vscode.window.showTextDocument(editor.document, {
+        viewColumn: column,
+        preserveFocus: false,
+        preview: false,
+      });
+    } catch {
+      // Document gone/unopenable — render on the captured editor as a fallback.
+    }
+    await this.displayExecutionResult(target, selection, resultString);
   }
 
   /**

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -230,6 +230,98 @@ export function getMethodSource(session: ActiveSession, methodOop: bigint): stri
 }
 
 /**
+ * The pieces needed to create the method a `doesNotUnderstand:` is asking for.
+ * `className` is the (non-meta) name of the class the method should be added to;
+ * `isMeta` is true when the unknown message was sent to a *class* (so a
+ * class-side method is wanted). `dictName` is the dictionary that class lives in
+ * (for the gemstone:// new-method URI); '' when the class isn't in the user's
+ * symbol list. `selector` / `argCount` come straight from the failed send.
+ */
+export interface DnuInfo {
+  className: string;
+  isMeta: boolean;
+  dictName: string;
+  selector: string;
+  argCount: number;
+}
+
+/**
+ * If the suspended process is parked on a `doesNotUnderstand:` (a
+ * MessageNotUnderstood), return what's needed to create the missing method;
+ * otherwise undefined. Walks the process's frames top-down for the
+ * `Object>>doesNotUnderstand: aMessageDescriptor` frame, then reads the receiver
+ * and the descriptor (`aMessageDescriptor at: 1` is the selector, `at: 2` the
+ * args — see Object>>doesNotUnderstand:). A class receiver means the missing
+ * method is class-side.
+ *
+ * One Smalltalk round-trip (mirrors getMethodUriInfo's execute-and-split shape);
+ * returns undefined on any failure so callers degrade to "no Create button".
+ */
+export function getDoesNotUnderstandInfo(
+  session: ActiveSession, gsProcess: bigint,
+): DnuInfo | undefined {
+  try {
+    const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
+      session.handle, 'Utf8', OOP_NIL,
+    );
+    if (resErr.number !== 0) return undefined;
+
+    // Walk all frames for the doesNotUnderstand:/_doesNotUnderstand:… machinery
+    // (selectors containing 'doesNotUnderstand'). `dnuTop` is the `doesNotUnderstand:`
+    // frame (it carries `aMessageDescriptor` — `at: 1` selector, `at: 2` args);
+    // `dnuBot` is the deepest such frame, so `dnuBot + 1` is the sender frame that
+    // made the failing send (the one to restart). A class receiver ⇒ class-side.
+    const code = `| p depth dnuTop dnuBot |
+p := Object _objectForOop: ${gsProcess}.
+depth := p localStackDepth.
+dnuTop := nil. dnuBot := nil.
+1 to: depth do: [:i | | m sel |
+  m := (p _frameContentsAt: i) at: 1.
+  sel := m isNil ifTrue: [nil] ifFalse: [m selector].
+  (sel notNil and: [ (sel asString indexOfSubCollection: 'doesNotUnderstand') > 0 ]) ifTrue: [
+    dnuTop isNil ifTrue: [ dnuTop := i ].
+    dnuBot := i ] ].
+dnuTop isNil
+  ifTrue: [ '' ]
+  ifFalse: [ | arr rcvr descr sel base meta dn |
+    arr := p _frameContentsAt: dnuTop.
+    rcvr := arr at: 10.
+    descr := arr at: 11.
+    sel := descr at: 1.
+    (rcvr isKindOf: Class)
+      ifTrue: [ base := rcvr. meta := true ]
+      ifFalse: [ base := rcvr class. meta := false ].
+    dn := ''.
+    System myUserProfile symbolList do: [:d |
+      (d includesKey: base name asSymbol) ifTrue: [ dn := d name ] ].
+    base name asString, String tab,
+      (meta ifTrue: ['class'] ifFalse: ['instance']), String tab,
+      dn, String tab,
+      sel asString, String tab,
+      (descr at: 2) size printString ]`;
+
+    const { data, err } = session.gci.GciTsExecuteFetchBytes(
+      session.handle, code, -1, classUtf8, OOP_ILLEGAL, OOP_NIL, 64 * 1024,
+    );
+    if (err.number !== 0) return undefined;
+    if (data === '') return undefined; // not parked on a doesNotUnderstand:
+
+    const parts = data.split('\t');
+    if (parts.length < 5) return undefined;
+    const argCount = parseInt(parts[4], 10);
+    return {
+      className: parts[0],
+      isMeta: parts[1] === 'class',
+      dictName: parts[2],
+      selector: parts[3],
+      argCount: Number.isNaN(argCount) ? 0 : argCount,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Maps an IP offset to a source line number.
  */
 export function getLineForIp(

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -1,6 +1,7 @@
 import { ActiveSession } from './sessionManager';
 import { OOP_NIL, OOP_TRUE, OOP_ILLEGAL, GCI_PERFORM_FLAG_ENABLE_DEBUG } from './gciConstants';
 import { logInfo, logError } from './gciLog';
+import { runNbCall, NbRunOptions } from './nbRunner';
 
 const MAX_RESULT = 256 * 1024;
 
@@ -570,6 +571,66 @@ export function stepOut(
   return performStep(session, gsProcess, 'gciStepThruFromLevel:', [levelOop]);
 }
 
+// ── Non-blocking step variants ──────────────────────────
+//
+// Same step messages as performStep, but issued via GciTsNbPerform and polled to
+// completion off the main thread (see nbRunner.ts) so a slow step — crawling
+// hidden machinery, or stepping a method that loops — never freezes the whole
+// extension host, and can be cancelled. Used by the webview debugger; the DAP
+// session keeps the simpler blocking variants (intentionally left alone).
+
+/**
+ * Issue a step message non-blocking and resolve with its StepResult. A halt /
+ * breakpoint / error stopping the process is a normal outcome (completed=false
+ * with errorMessage), NOT a thrown error — only an outright GCI failure rejects.
+ */
+function performStepNb(
+  session: ActiveSession, gsProcess: bigint, selector: string, args: bigint[], opts: NbRunOptions,
+): Promise<StepResult> {
+  return runNbCall(
+    session,
+    () => session.gci.GciTsNbPerform(
+      session.handle, gsProcess, OOP_ILLEGAL, selector, args, GCI_PERFORM_FLAG_ENABLE_DEBUG, 0,
+    ),
+    () => {
+      const { result, err } = session.gci.GciTsNbResult(session.handle);
+      if (err.number !== 0) {
+        return {
+          completed: false,
+          errorMessage: err.message || `GemStone error ${err.number}`,
+          errorContext: err.context,
+        };
+      }
+      return { completed: true, resultOop: result };
+    },
+    opts,
+  );
+}
+
+export function stepOverNb(
+  session: ActiveSession, gsProcess: bigint, level: number,
+): Promise<StepResult> {
+  const levelOop = intToOop(session, level);
+  logInfo(`[Session ${session.id}] Debug: stepOver (nb) from level ${level}`);
+  return performStepNb(session, gsProcess, 'gciStepOverFromLevel:', [levelOop], { title: 'GemStone: stepping over…' });
+}
+
+export function stepIntoNb(
+  session: ActiveSession, gsProcess: bigint, level: number,
+): Promise<StepResult> {
+  const levelOop = intToOop(session, level);
+  logInfo(`[Session ${session.id}] Debug: stepInto (nb) from level ${level}`);
+  return performStepNb(session, gsProcess, 'gciStepIntoFromLevel:', [levelOop], { title: 'GemStone: stepping into…' });
+}
+
+export function stepThruNb(
+  session: ActiveSession, gsProcess: bigint, level: number,
+): Promise<StepResult> {
+  const levelOop = intToOop(session, level);
+  logInfo(`[Session ${session.id}] Debug: stepThru (nb) from level ${level}`);
+  return performStepNb(session, gsProcess, 'gciStepThruFromLevel:', [levelOop], { title: 'GemStone: stepping through…' });
+}
+
 // ── Continue / Terminate ────────────────────────────────
 
 /**
@@ -582,8 +643,19 @@ export function continueExecution(
   session: ActiveSession, gsProcess: bigint,
 ): StepResult {
   logInfo(`[Session ${session.id}] Debug: continue`);
+  // replaceTopOfStack = OOP_ILLEGAL means "resume as-is, don't touch the top
+  // frame's evaluation stack". Per the GciTsContinueWith contract that is also
+  // the right value for a normal halt: when the top frame is AbstractException
+  // >>signal it auto-replaces TOS with nil (same as AbstractException>>resume).
+  //
+  // We previously passed OOP_NIL, which *forces* TOS := nil. That happens to be
+  // harmless for a halt (top frame is a signal frame), but after an edit-and-
+  // continue / restart-frame `trimStackToLevel:` the top frame is a method reset
+  // to its FIRST instruction with a fresh, empty evaluation stack — clobbering
+  // its TOS with nil corrupts the frame, so continuing it never returns (the gem
+  // hangs). OOP_ILLEGAL handles both cases correctly.
   const { result, err } = session.gci.GciTsContinueWith(
-    session.handle, gsProcess, OOP_NIL, null, GCI_PERFORM_FLAG_ENABLE_DEBUG,
+    session.handle, gsProcess, OOP_ILLEGAL, null, GCI_PERFORM_FLAG_ENABLE_DEBUG,
   );
   if (err.number !== 0) {
     return {
@@ -617,6 +689,33 @@ export function trimStackToLevel(
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: trimStackToLevel ${level}`);
   gciPerform(session, gsProcess, 'trimStackToLevel:', [levelOop]);
+}
+
+/**
+ * Non-blocking trimStackToLevel: (restart-frame / edit-and-continue). The public
+ * `trimStackToLevel:` evaluates unwind/ensure: blocks with an INFINITE timeout,
+ * so a hung unwind block would freeze the host on the blocking path — running it
+ * non-blocking (and cancellable) avoids that. Flags 0, matching the blocking
+ * variant (no debug-stop during the trim's unwind).
+ */
+export function trimStackToLevelNb(
+  session: ActiveSession, gsProcess: bigint, level: number,
+): Promise<void> {
+  const levelOop = intToOop(session, level);
+  logInfo(`[Session ${session.id}] Debug: trimStackToLevel (nb) ${level}`);
+  return runNbCall(
+    session,
+    () => session.gci.GciTsNbPerform(
+      session.handle, gsProcess, OOP_ILLEGAL, 'trimStackToLevel:', [levelOop], 0, 0,
+    ),
+    () => {
+      const { err } = session.gci.GciTsNbResult(session.handle);
+      if (err.number !== 0) {
+        throw new Error(err.message || `GemStone error ${err.number} in trimStackToLevel:`);
+      }
+    },
+    { title: 'GemStone: restarting frame…' },
+  );
 }
 
 // ── Evaluate ────────────────────────────────────────────

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -1,6 +1,6 @@
 import { ActiveSession } from './sessionManager';
 import { OOP_NIL, OOP_TRUE, OOP_ILLEGAL, GCI_PERFORM_FLAG_ENABLE_DEBUG } from './gciConstants';
-import { logInfo, logError } from './gciLog';
+import { logInfo } from './gciLog';
 
 const MAX_RESULT = 256 * 1024;
 
@@ -544,13 +544,23 @@ export function trimStackToLevel(
 // ── Evaluate ────────────────────────────────────────────
 
 /**
- * Evaluates an expression in the context of a stack frame.
- * Returns the printString of the result.
+ * Evaluates an expression in the context of a stack frame, with `self` bound to
+ * that frame's receiver, and returns the printString of the result.
+ *
+ * Implemented via `String>>evaluateInContext:` (which compiles the expression
+ * and runs it with `self` = the given object, resolving globals through the
+ * session's symbol list). The earlier `_framePerform:withArgs:onLevel:`
+ * primitive does NOT exist in GemStone 3.7.x — and it performs a *selector*,
+ * not an expression, so it raised a NameError trying to intern the source as a
+ * Symbol. Frame arguments/temps are not yet bound here (only `self`, instVars,
+ * and globals resolve); binding temps is a later enhancement.
  */
 export function evaluateInFrame(
   session: ActiveSession, gsProcess: bigint, expression: string, level: number,
 ): string {
-  // Create a String object for the expression
+  // The frame's receiver becomes `self` for the evaluation.
+  const { receiverOop } = getFrameInfo(session, gsProcess, level);
+
   const { result: exprOop, err: strErr } = session.gci.GciTsNewString(
     session.handle, expression,
   );
@@ -558,23 +568,7 @@ export function evaluateInFrame(
     throw new Error(strErr.message || 'Cannot create expression string');
   }
 
-  // Create an empty Array for args
-  const { result: argsOop, err: arrErr } = session.gci.GciTsResolveSymbol(
-    session.handle, 'Array', OOP_NIL,
-  );
-  if (arrErr.number !== 0) {
-    throw new Error(arrErr.message || 'Cannot resolve Array class');
-  }
-  const emptyArray = gciPerform(session, argsOop, 'new');
-
-  const levelOop = intToOop(session, level);
-
-  // Send: gsProcess _framePerform: expression withArgs: #() onLevel: level
-  const resultOop = gciPerform(
-    session, gsProcess, '_framePerform:withArgs:onLevel:',
-    [exprOop, emptyArray, levelOop],
-  );
-
-  // Get printString of the result
+  // exprString evaluateInContext: receiver  →  compile + run with self = receiver.
+  const resultOop = gciPerform(session, exprOop, 'evaluateInContext:', [receiverOop]);
   return getObjectPrintString(session, resultOop);
 }

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -622,22 +622,29 @@ export function trimStackToLevel(
 // ── Evaluate ────────────────────────────────────────────
 
 /**
- * Evaluates an expression in the context of a stack frame, with `self` bound to
- * that frame's receiver, and returns the printString of the result.
+ * Evaluates an expression in the context of a stack frame and returns the
+ * printString of the result.
  *
- * Implemented via `String>>evaluateInContext:` (which compiles the expression
- * and runs it with `self` = the given object, resolving globals through the
- * session's symbol list). The earlier `_framePerform:withArgs:onLevel:`
- * primitive does NOT exist in GemStone 3.7.x — and it performs a *selector*,
- * not an expression, so it raised a NameError trying to intern the source as a
- * Symbol. Frame arguments/temps are not yet bound here (only `self`, instVars,
- * and globals resolve); binding temps is a later enhancement.
+ * `self` is always bound to the frame's receiver (so instVars and globals
+ * resolve too), via `String>>evaluateInContext:`. When the frame has named
+ * arguments/temps, they are *also* bound: a transient `SymbolDictionary`
+ * mapping each name → its current value is prepended to the user's symbol list
+ * so a bare identifier like `amount` resolves to the frame's temp
+ * (`evaluateInContext:symbolList:`). The dictionary shadows globals, while
+ * globals still resolve through the appended user list.
+ *
+ * Limitation: temps are bound for *reads* only — assigning to a temp in the
+ * eval bar writes the transient dictionary, not the live frame.
+ *
+ * (The earlier `_framePerform:withArgs:onLevel:` primitive does NOT exist on
+ * GemStone 3.7.x — and it performed a *selector*, not an expression, so it
+ * raised a NameError trying to intern the source as a Symbol.)
  */
 export function evaluateInFrame(
   session: ActiveSession, gsProcess: bigint, expression: string, level: number,
 ): string {
   // The frame's receiver becomes `self` for the evaluation.
-  const { receiverOop } = getFrameInfo(session, gsProcess, level);
+  const { receiverOop, argAndTempNames, argAndTempOops } = getFrameInfo(session, gsProcess, level);
 
   const { result: exprOop, err: strErr } = session.gci.GciTsNewString(
     session.handle, expression,
@@ -646,7 +653,61 @@ export function evaluateInFrame(
     throw new Error(strErr.message || 'Cannot create expression string');
   }
 
-  // exprString evaluateInContext: receiver  →  compile + run with self = receiver.
-  const resultOop = gciPerform(session, exprOop, 'evaluateInContext:', [receiverOop]);
+  // Bind the frame's named args/temps when present; otherwise keep the lean
+  // single-arg path (self + instVars + globals via the session's symbol list).
+  const symbolListOop = buildFrameSymbolList(session, argAndTempNames, argAndTempOops);
+  const resultOop = symbolListOop === null
+    ? gciPerform(session, exprOop, 'evaluateInContext:', [receiverOop])
+    : gciPerform(session, exprOop, 'evaluateInContext:symbolList:', [receiverOop, symbolListOop]);
   return getObjectPrintString(session, resultOop);
+}
+
+/** Resolve a global (e.g. a class name) to its OOP; null if it doesn't resolve. */
+function resolveGlobalOop(session: ActiveSession, name: string): bigint | null {
+  const { result, err } = session.gci.GciTsResolveSymbol(session.handle, name, OOP_NIL);
+  if (err.number !== 0) return null;
+  return result;
+}
+
+/**
+ * Builds a SymbolList whose first entry is a transient SymbolDictionary mapping
+ * each *named* (non-synthetic) arg/temp to its current value, prepended to the
+ * user's own symbol list — so bare identifiers like `amount` resolve to the
+ * frame's temps while globals still resolve through the appended user list.
+ * Returns null when the frame has no bindable named temps (the caller then uses
+ * the simpler `evaluateInContext:`), or if any of the required globals can't be
+ * resolved (degrade to the self-only eval rather than fail).
+ *
+ * The synthetic `.tN` eval-stack temporaries have no source name (and `.t1`
+ * isn't a legal identifier), so they are skipped.
+ */
+function buildFrameSymbolList(
+  session: ActiveSession, names: string[], oops: bigint[],
+): bigint | null {
+  const bindings: { name: string; oop: bigint }[] = [];
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    const oop = oops[i];
+    if (!name || name.startsWith('.') || oop === undefined) continue;
+    bindings.push({ name, oop });
+  }
+  if (bindings.length === 0) return null;
+
+  const symDictClass = resolveGlobalOop(session, 'SymbolDictionary');
+  const symListClass = resolveGlobalOop(session, 'SymbolList');
+  const systemClass = resolveGlobalOop(session, 'System');
+  if (symDictClass === null || symListClass === null || systemClass === null) return null;
+
+  const dictOop = gciPerform(session, symDictClass, 'new');
+  for (const { name, oop } of bindings) {
+    const { result: symOop, err } = session.gci.GciTsNewSymbol(session.handle, name);
+    if (err.number !== 0) continue; // skip un-internable names defensively
+    gciPerform(session, dictOop, 'at:put:', [symOop, oop]);
+  }
+
+  // (SymbolList with: dict) , (System myUserProfile symbolList)
+  const profileOop = gciPerform(session, systemClass, 'myUserProfile');
+  const userListOop = gciPerform(session, profileOop, 'symbolList');
+  const frontOop = gciPerform(session, symListClass, 'with:', [dictOop]);
+  return gciPerform(session, frontOop, ',', [userListOop]);
 }

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -1,5 +1,5 @@
 import { ActiveSession } from './sessionManager';
-import { OOP_NIL, OOP_ILLEGAL, GCI_PERFORM_FLAG_ENABLE_DEBUG } from './gciConstants';
+import { OOP_NIL, OOP_TRUE, OOP_ILLEGAL, GCI_PERFORM_FLAG_ENABLE_DEBUG } from './gciConstants';
 import { logInfo, logError } from './gciLog';
 
 const MAX_RESULT = 256 * 1024;
@@ -59,6 +59,18 @@ export interface FrameInfo {
 export interface MethodInfo {
   className: string;
   selector: string;
+}
+
+export interface MethodBlockInfo {
+  /** True when the frame's method is the compiled method of a block. */
+  isBlock: boolean;
+  /**
+   * Oop of the home (enclosing) method. GsNMethod>>homeMethod returns self for
+   * non-block methods, so this is always safe to use for naming. A block
+   * method's own inClass/selector are NOT the displayable class/selector
+   * (inClass returns the home method), so resolve names from this oop.
+   */
+  homeMethodOop: bigint;
 }
 
 export interface MethodUriInfo {
@@ -152,6 +164,20 @@ export function getMethodInfo(session: ActiveSession, methodOop: bigint): Method
 }
 
 /**
+ * Reports whether a frame's method is a block method, plus the oop of its home
+ * (enclosing) method. Used to render block frames as `[] in Class>>selector`,
+ * mirroring GsNMethod>>printOn:. Resolve the displayed class/selector from
+ * homeMethodOop, not the block method itself.
+ */
+export function getMethodBlockInfo(
+  session: ActiveSession, methodOop: bigint,
+): MethodBlockInfo {
+  const isBlock = gciPerform(session, methodOop, 'isMethodForBlock') === OOP_TRUE;
+  const homeMethodOop = gciPerform(session, methodOop, 'homeMethod');
+  return { isBlock, homeMethodOop };
+}
+
+/**
  * Returns everything needed to construct a gemstone:// URI for a method.
  * Uses a single Smalltalk execution to minimise GCI round-trips.
  */
@@ -211,6 +237,21 @@ export function getLineForIp(
   const ipOop = intToOop(session, ipOffset);
   const lineOop = gciPerform(session, methodOop, '_lineNumberForIp:', [ipOop]);
   return oopToInt(session, lineOop);
+}
+
+/**
+ * Returns the step point for the frame at the given level (1-based, 1 = top),
+ * or undefined when the frame has no step point. Uses GsProcess>>_stepPointAt:,
+ * the same primitive the topaz debugger uses — it accounts for native-stack
+ * and async-callee frames, which a raw ipOffset→stepPoint mapping would not.
+ */
+export function getStepPoint(
+  session: ActiveSession, gsProcess: bigint, level: number,
+): number | undefined {
+  const levelOop = intToOop(session, level);
+  const resultOop = gciPerform(session, gsProcess, '_stepPointAt:', [levelOop]);
+  if (resultOop === OOP_NIL) return undefined;
+  return oopToInt(session, resultOop);
 }
 
 // ── Variables ───────────────────────────────────────────

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -241,6 +241,29 @@ export function getLineForIp(
 }
 
 /**
+ * Returns a method's source offsets — GemStone `_sourceOffsets`, a 1-based array
+ * where index i holds the source-string character offset of step point i. Mirrors
+ * queries.getSourceOffsets but works straight from the method OOP, so it serves
+ * executed-code (doit) frames, which have no class>>selector to look up. Returns
+ * an empty array on any failure (best-effort; callers fall back to line-level).
+ */
+export function getSourceOffsetsForMethod(
+  session: ActiveSession, methodOop: bigint,
+): number[] {
+  const arrayOop = gciPerform(session, methodOop, '_sourceOffsets');
+  if (arrayOop === OOP_NIL) return [];
+  const { result: sizeRaw, err: sizeErr } = session.gci.GciTsFetchSize(session.handle, arrayOop);
+  if (sizeErr.number !== 0) return [];
+  const size = Number(sizeRaw);
+  if (size <= 0) return [];
+  const { oops, err: fetchErr } = session.gci.GciTsFetchOops(
+    session.handle, arrayOop, 1n, size,
+  );
+  if (fetchErr.number !== 0) return [];
+  return oops.map(oop => oopToInt(session, oop));
+}
+
+/**
  * Returns the step point for the frame at the given level (1-based, 1 = top),
  * or undefined when the frame has no step point. Uses GsProcess>>_stepPointAt:,
  * the same primitive the topaz debugger uses — it accounts for native-stack
@@ -458,6 +481,8 @@ export interface StepResult {
   resultOop?: bigint;
   errorMessage?: string;
   errorContext?: bigint;
+  /** GemStone error number when the op stopped on an error (0/undefined otherwise). */
+  errorNumber?: number;
 }
 
 // ── Native-code toggle for stepping ─────────────────────────────────────────
@@ -541,6 +566,7 @@ function performStep(
       completed: false,
       errorMessage: err.message || `GemStone error ${err.number}`,
       errorContext: err.context,
+      errorNumber: err.number,
     };
   }
   // gciStep…FromLevel: returns the completion result when the process finishes.
@@ -599,6 +625,7 @@ function performStepNb(
           completed: false,
           errorMessage: err.message || `GemStone error ${err.number}`,
           errorContext: err.context,
+          errorNumber: err.number,
         };
       }
       return { completed: true, resultOop: result };
@@ -662,6 +689,7 @@ export function continueExecution(
       completed: false,
       errorMessage: err.message || `GemStone error ${err.number}`,
       errorContext: err.context,
+      errorNumber: err.number,
     };
   }
   // On normal completion GciTsContinueWith returns the process's result oop.

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -1,6 +1,6 @@
 import { ActiveSession } from './sessionManager';
 import { OOP_NIL, OOP_TRUE, OOP_ILLEGAL, GCI_PERFORM_FLAG_ENABLE_DEBUG } from './gciConstants';
-import { logInfo } from './gciLog';
+import { logInfo, logError } from './gciLog';
 
 const MAX_RESULT = 256 * 1024;
 
@@ -447,6 +447,82 @@ export function getDictionaryEntries(
 // ── Stepping ────────────────────────────────────────────
 
 /**
+ * Outcome of a step/continue. `completed` means the process ran to completion
+ * (not stopped at another step point/error); when it does, `resultOop` is the
+ * process's result — for a wrapped doit, the user code's value — which the
+ * caller can display (e.g. a halted Display It that the user resumes).
+ */
+export interface StepResult {
+  completed: boolean;
+  resultOop?: bigint;
+  errorMessage?: string;
+  errorContext?: bigint;
+}
+
+// ── Native-code toggle for stepping ─────────────────────────────────────────
+//
+// GemStone cannot single-step or set breakpoints in NATIVE code (error 6014):
+// a `halt`/error parks execution in native signal machinery that can't be
+// stepped while the gem runs native code (GemNativeCodeEnabled, on by default).
+// Setting ANY breakpoint flips the gem to interpreted execution, which makes
+// stepping work — this is how topaz steps. So we toggle a breakpoint in a
+// benign kernel method as the switch, and clear it once the last debugger for a
+// session closes, restoring native-code performance for normal execution.
+//
+// Ref-counted per session: concurrent debuggers share one toggle — the break is
+// set on the first acquire and cleared on the last release. Best-effort:
+// failures are logged, not thrown (the debugger still opens; stepping degrades).
+
+/** Benign kernel method whose breakpoint we toggle to disable/enable native code. */
+const NATIVE_CODE_TOGGLE = 'GsSshSocket class>>exampleUserId';
+const steppingRefs = new Map<number, number>();
+
+function setNativeCodeBreak(session: ActiveSession, on: boolean): void {
+  const selector = on ? 'setBreakAtStepPoint:' : 'clearBreakAtStepPoint:';
+  const code = `(GsSshSocket class compiledMethodAt: #exampleUserId) ${selector} 1`;
+  // sourceOop is the class of the source string (String); contextObject is
+  // OOP_ILLEGAL — matching the working GciTsExecute calling convention.
+  const { result: strClass, err: resErr } = session.gci.GciTsResolveSymbol(
+    session.handle, 'String', OOP_NIL,
+  );
+  if (resErr.number !== 0) {
+    logError(session.id, `[Jasper Debugger] could not resolve String for native-code toggle: ${resErr.message || resErr.number}`);
+    return;
+  }
+  const { err } = session.gci.GciTsExecute(
+    session.handle, code, strClass, OOP_ILLEGAL, OOP_NIL, 0, 0,
+  );
+  if (err.number !== 0) {
+    logError(session.id, `[Jasper Debugger] could not ${on ? 'set' : 'clear'} native-code toggle (${NATIVE_CODE_TOGGLE}): ${err.message || err.number}`);
+  }
+}
+
+/**
+ * Disable native code for the session so the debugger can single-step. Sets the
+ * benign toggle breakpoint on the first hold for the session. Ref-counted —
+ * pair every call with releaseStepping.
+ */
+export function acquireStepping(session: ActiveSession): void {
+  const n = steppingRefs.get(session.id) ?? 0;
+  if (n === 0) setNativeCodeBreak(session, true);
+  steppingRefs.set(session.id, n + 1);
+}
+
+/**
+ * Release one stepping hold; restores native code (clears the toggle) once the
+ * last debugger for the session closes.
+ */
+export function releaseStepping(session: ActiveSession): void {
+  const n = steppingRefs.get(session.id) ?? 0;
+  if (n <= 1) {
+    steppingRefs.delete(session.id);
+    if (n === 1) setNativeCodeBreak(session, false);
+  } else {
+    steppingRefs.set(session.id, n - 1);
+  }
+}
+
+/**
  * Sends a step message (e.g. gciStepOverFromLevel:) to the GsProcess
  * via blocking GciTsPerform. The step message both configures and
  * executes the step — it blocks until the process stops at the next
@@ -454,8 +530,8 @@ export function getDictionaryEntries(
  */
 function performStep(
   session: ActiveSession, gsProcess: bigint, selector: string, args: bigint[],
-): { completed: boolean; errorMessage?: string; errorContext?: bigint } {
-  const { err } = session.gci.GciTsPerform(
+): StepResult {
+  const { result, err } = session.gci.GciTsPerform(
     session.handle, gsProcess, OOP_ILLEGAL, selector, args,
     GCI_PERFORM_FLAG_ENABLE_DEBUG, 0,
   );
@@ -466,12 +542,13 @@ function performStep(
       errorContext: err.context,
     };
   }
-  return { completed: true };
+  // gciStep…FromLevel: returns the completion result when the process finishes.
+  return { completed: true, resultOop: result };
 }
 
 export function stepOver(
   session: ActiveSession, gsProcess: bigint, level: number,
-): { completed: boolean; errorMessage?: string; errorContext?: bigint } {
+): StepResult {
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: stepOver from level ${level}`);
   return performStep(session, gsProcess, 'gciStepOverFromLevel:', [levelOop]);
@@ -479,7 +556,7 @@ export function stepOver(
 
 export function stepInto(
   session: ActiveSession, gsProcess: bigint, level: number,
-): { completed: boolean; errorMessage?: string; errorContext?: bigint } {
+): StepResult {
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: stepInto from level ${level}`);
   return performStep(session, gsProcess, 'gciStepIntoFromLevel:', [levelOop]);
@@ -487,7 +564,7 @@ export function stepInto(
 
 export function stepOut(
   session: ActiveSession, gsProcess: bigint, level: number,
-): { completed: boolean; errorMessage?: string; errorContext?: bigint } {
+): StepResult {
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: stepThru from level ${level}`);
   return performStep(session, gsProcess, 'gciStepThruFromLevel:', [levelOop]);
@@ -503,9 +580,9 @@ export function stepOut(
  */
 export function continueExecution(
   session: ActiveSession, gsProcess: bigint,
-): { completed: boolean; errorMessage?: string; errorContext?: bigint } {
+): StepResult {
   logInfo(`[Session ${session.id}] Debug: continue`);
-  const { err } = session.gci.GciTsContinueWith(
+  const { result, err } = session.gci.GciTsContinueWith(
     session.handle, gsProcess, OOP_NIL, null, GCI_PERFORM_FLAG_ENABLE_DEBUG,
   );
   if (err.number !== 0) {
@@ -515,7 +592,8 @@ export function continueExecution(
       errorContext: err.context,
     };
   }
-  return { completed: true };
+  // On normal completion GciTsContinueWith returns the process's result oop.
+  return { completed: true, resultOop: result };
 }
 
 /**

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -16,6 +16,26 @@ import { logError } from './gciLog';
 const debuggerViewJs = fs.readFileSync(path.join(__dirname, '..', 'src', 'debuggerView.js'), 'utf8');
 
 /**
+ * Toolbar glyphs, keyed by `data-cmd`. These are the exact VS Code `codicon`
+ * debug-control SVGs the DAP debug toolbar uses (debug-continue / -step-over /
+ * -step-into / -step-out / -restart-frame / -stop), inlined so they need no font
+ * load or extra `localResourceRoots` and stay within the strict webview CSP
+ * (inline SVG markup, not a fetched resource). `fill="currentColor"` lets each
+ * button's text colour drive the glyph (so the danger Terminate renders red).
+ */
+const TOOLBAR_ICONS: Record<string, string> = {
+  resume: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M14.578 7.149L7.578 2.186C7.397 2.058 7.198 2 7.003 2C6.484 2 6 2.411 6 3.002V13.003C6 13.594 6.485 14.005 7.004 14.005C7.201 14.005 7.403 13.946 7.585 13.815L14.585 8.777C15.142 8.376 15.139 7.546 14.579 7.15L14.578 7.149ZM7.5 12.027V3.969L13.14 7.968L7.5 12.027ZM3.5 2.75V13.25C3.5 13.664 3.164 14 2.75 14C2.336 14 2 13.664 2 13.25V2.75C2 2.336 2.336 2 2.75 2C3.164 2 3.5 2.336 3.5 2.75Z"/></svg>',
+  stepOver: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M9.99993 13C9.99993 14.103 9.10293 15 7.99993 15C6.89693 15 5.99993 14.103 5.99993 13C5.99993 11.897 6.89693 11 7.99993 11C9.10293 11 9.99993 11.897 9.99993 13ZM13.2499 2C12.8359 2 12.4999 2.336 12.4999 2.75V4.027C11.3829 2.759 9.75993 2 7.99993 2C5.03293 2 2.47993 4.211 2.06093 7.144C2.00193 7.554 2.28793 7.934 2.69793 7.993C2.73393 7.999 2.76993 8.001 2.80493 8.001C3.17193 8.001 3.49293 7.731 3.54693 7.357C3.86093 5.159 5.77593 3.501 8.00093 3.501C9.52993 3.501 10.9199 4.264 11.7439 5.501H9.75093C9.33693 5.501 9.00093 5.837 9.00093 6.251C9.00093 6.665 9.33693 7.001 9.75093 7.001H13.2509C13.6649 7.001 14.0009 6.665 14.0009 6.251V2.751C14.0009 2.337 13.6649 2.001 13.2509 2.001L13.2499 2Z"/></svg>',
+  stepInto: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M10 13C10 14.103 9.10304 15 8.00004 15C6.89704 15 6.00004 14.103 6.00004 13C6.00004 11.897 6.89704 11 8.00004 11C9.10304 11 10 11.897 10 13ZM12.03 5.22C11.737 4.927 11.262 4.927 10.969 5.22L8.74904 7.44V1.75C8.74904 1.336 8.41304 1 7.99904 1C7.58504 1 7.24904 1.336 7.24904 1.75V7.439L5.02904 5.219C4.73604 4.926 4.26104 4.926 3.96804 5.219C3.67504 5.512 3.67504 5.987 3.96804 6.28L7.46804 9.78C7.61404 9.926 7.80604 10 7.99804 10C8.19004 10 8.38204 9.927 8.52804 9.78L12.028 6.28C12.321 5.987 12.321 5.512 12.028 5.219L12.03 5.22Z"/></svg>',
+  // "Through" = step through blocks (gciStepThru). The `indent` arrow (turns down
+  // into a nested position) reads as stepping into a block, and stays visually
+  // distinct from Into's debug-step-into glyph.
+  stepThrough: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M2.50002 3C2.77602 3 3.00002 3.224 3.00002 3.5V6.5C3.00002 7.327 3.67302 8 4.50002 8H12.293L9.64702 5.354C9.45202 5.159 9.45202 4.842 9.64702 4.647C9.84202 4.452 10.159 4.452 10.354 4.647L13.854 8.147C14.049 8.342 14.049 8.659 13.854 8.854L10.354 12.354C10.256 12.452 10.128 12.5 10 12.5C9.87202 12.5 9.74402 12.451 9.64602 12.354C9.45102 12.159 9.45102 11.842 9.64602 11.647L12.292 9.001H4.49902C3.12002 9.001 1.99902 7.88 1.99902 6.501V3.501C1.99902 3.225 2.22302 3.001 2.49902 3.001L2.50002 3Z"/></svg>',
+  restartFrame: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M1 3.5C1 3.22386 1.22386 3 1.5 3H14.5C14.7761 3 15 3.22386 15 3.5C15 3.77614 14.7761 4 14.5 4H1.5C1.22386 4 1 3.77614 1 3.5Z"/><path d="M1 7.5C1 7.22386 1.22386 7 1.5 7H14.5C14.7761 7 15 7.22386 15 7.5C15 7.77614 14.7761 8 14.5 8H1.5C1.22386 8 1 7.77614 1 7.5Z"/><path d="M1 11.5C1 11.2239 1.22386 11 1.5 11H7.99939V11.4994C7.99939 11.6716 8.02899 11.8407 8.08538 12H1.5C1.22386 12 1 11.7761 1 11.5Z"/><path d="M8.99939 9.49939V11.4994C8.99939 11.632 9.05207 11.7592 9.14584 11.8529C9.2396 11.9467 9.36678 11.9994 9.49939 11.9994H11.4994C11.632 11.9994 11.7592 11.9467 11.8529 11.8529C11.9467 11.7592 11.9994 11.632 11.9994 11.4994C11.9994 11.3668 11.9467 11.2396 11.8529 11.1458C11.7592 11.0521 11.632 10.9994 11.4994 10.9994H10.4994C10.5702 10.9049 10.6477 10.8157 10.7314 10.7324C11.2078 10.2778 11.8409 10.0242 12.4994 10.0242C13.1579 10.0242 13.791 10.2778 14.2674 10.7324C14.4996 10.9645 14.6838 11.2402 14.8095 11.5435C14.9352 11.8469 14.9999 12.172 14.9999 12.5004C14.9999 12.8287 14.9352 13.1539 14.8095 13.4573C14.6838 13.7606 14.4996 14.0362 14.2674 14.2684C13.7909 14.7227 13.1578 14.9762 12.4994 14.9762C11.841 14.9762 11.2079 14.7227 10.7314 14.2684C10.6371 14.1773 10.5108 14.1269 10.3797 14.1281C10.2486 14.1292 10.1232 14.1818 10.0305 14.2745C9.93778 14.3672 9.88519 14.4926 9.88405 14.6237C9.88291 14.7548 9.93331 14.8811 10.0244 14.9754C10.6808 15.6318 11.5711 16.0006 12.4994 16.0006C13.4277 16.0006 14.318 15.6318 14.9744 14.9754C15.6308 14.319 15.9996 13.4287 15.9996 12.5004C15.9996 11.5721 15.6308 10.6818 14.9744 10.0254C14.3075 9.38902 13.4212 9.03396 12.4994 9.03396C11.5776 9.03396 10.6912 9.38902 10.0244 10.0254L9.99939 10.0514V9.49939C9.99939 9.36678 9.94671 9.2396 9.85294 9.14584C9.75918 9.05207 9.632 8.99939 9.49939 8.99939C9.36678 8.99939 9.2396 9.05207 9.14584 9.14584C9.05207 9.2396 8.99939 9.36678 8.99939 9.49939Z"/></svg>',
+  terminate: '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M12.5 3.5V12.5H3.5V3.5H12.5ZM12.5 2H3.5C2.672 2 2 2.672 2 3.5V12.5C2 13.328 2.672 14 3.5 14H12.5C13.328 14 14 13.328 14 12.5V3.5C14 2.672 13.328 2 12.5 2Z"/></svg>',
+};
+
+/**
  * Jasper Debugger — a roomy, Smalltalk-style debugger rendered as a VS Code
  * webview, offered *alongside* the existing DAP debugger. Whichever entry point
  * the user picks (DAP "Debug" vs. this "Enhanced Debug") owns the suspended
@@ -45,7 +65,8 @@ type DebuggerInbound =
   | { command: 'stepOver'; level: number }
   | { command: 'stepInto'; level: number }
   | { command: 'stepThrough'; level: number }
-  | { command: 'restartFrame'; level: number };
+  | { command: 'restartFrame'; level: number }
+  | { command: 'saveLayout'; stackBasis: string };
 
 /**
  * Build the `gemstone://` URI for a method's source, in the exact form the
@@ -272,6 +293,15 @@ export class DebuggerPanel {
   private static readOnlySources = new Map<string, string>();
   private static providerRegistered = false;
 
+  /**
+   * The Call-Stack-vs-Variables split, as a CSS width for the stack pane
+   * (`--stack-basis`). Remembered across panels for the lifetime of this VS Code
+   * window so a resize sticks from one debugger to the next; the webview also
+   * persists it via getState/setState so it survives a webview reload. (Full
+   * cross-restart persistence would need globalState — deferred.) Default 60%.
+   */
+  private static savedStackBasis = '60%';
+
   private static ensureReadOnlySourceProvider(): void {
     if (DebuggerPanel.providerRegistered) return;
     DebuggerPanel.providerRegistered = true;
@@ -405,6 +435,11 @@ export class DebuggerPanel {
       case 'restartFrame': {
         const frame = this.frames.find(f => f.level === msg.level);
         if (frame) this.restartFrame(frame.serverLevel);
+        return;
+      }
+      case 'saveLayout': {
+        // Remember the stack/variables split so the next panel opens the same way.
+        DebuggerPanel.savedStackBasis = msg.stackBasis;
         return;
       }
     }
@@ -823,6 +858,7 @@ export class DebuggerPanel {
   private getHtml(): string {
     const nonce = crypto.randomBytes(16).toString('hex');
     const subtitle = escapeHtml(this.sessionSubtitle());
+    const stackBasis = DebuggerPanel.savedStackBasis;
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -889,23 +925,58 @@ export class DebuggerPanel {
     .frame .level { color: var(--vscode-descriptionForeground); margin-right: 0.6rem; }
     .frame .pos { color: var(--vscode-descriptionForeground); margin-left: 0.6rem; }
     .empty { color: var(--vscode-descriptionForeground); font-style: italic; }
-    /* Toolbar: Resume / step verbs / Restart Frame / Terminate. */
-    .toolbar { display: flex; gap: 0.3rem; margin: 0 0 0.6rem; flex-wrap: wrap; }
-    .toolbar button {
-      font-family: var(--vscode-font-family); font-size: 0.85rem;
-      color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
-      background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
-      border: none; padding: 0.25rem 0.7rem; border-radius: 2px; cursor: pointer;
+    /* Pane labels above the Call Stack / Variables panes. */
+    .pane-title {
+      font-size: 0.9rem; font-weight: 600; margin: 0 0 0.3rem;
+      color: var(--vscode-foreground);
     }
-    .toolbar button:hover { background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground)); }
-    .toolbar button.danger { color: var(--vscode-errorForeground); }
-    /* Stack (left) + variables (right). */
-    .main { display: flex; gap: 0.8rem; align-items: flex-start; }
-    .main .stack { flex: 1 1 60%; min-width: 0; }
+    /* Toolbar: icon-only debug controls (the DAP toolbar's codicon glyphs) so it
+       stays compact. Tooltips/aria-labels carry the names. */
+    .toolbar { display: flex; gap: 0.15rem; margin: 0 0 0.6rem; flex-wrap: wrap; }
+    .toolbar button {
+      display: flex; align-items: center; justify-content: center;
+      color: var(--vscode-icon-foreground, var(--vscode-foreground));
+      background: transparent;
+      border: none; padding: 0.3rem; border-radius: 4px; cursor: pointer;
+    }
+    .toolbar button svg { width: 16px; height: 16px; display: block; }
+    .toolbar button:hover { background: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground)); }
+    .toolbar button.danger { color: var(--vscode-debugIcon-stopForeground, var(--vscode-errorForeground)); }
+    /* Call Stack (left) + Variables (right), divided by a draggable splitter.
+       --stack-basis is the stack pane's width; the splitter drag rewrites it and
+       it's persisted (see debuggerView.js / the saveLayout message). */
+    .main { display: flex; align-items: stretch; --stack-basis: 60%; }
+    .pane { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+    .stack-pane { flex: 0 0 var(--stack-basis); }
+    .vars-pane { flex: 1 1 0; }
+    .main .stack { min-width: 0; max-height: 22rem; overflow: auto; }
+    /* Draggable divider: a thin hit area with a centred 1px rule that thickens
+       and lights up on hover / while dragging. */
+    .splitter {
+      flex: 0 0 9px; align-self: stretch; cursor: col-resize; position: relative;
+      margin-top: 1.7rem; /* skip past the pane titles so the rule spans the lists */
+    }
+    .splitter::before {
+      content: ''; position: absolute; top: 0; bottom: 0; left: 4px; width: 1px;
+      background: var(--vscode-panel-border, transparent);
+    }
+    .splitter:hover::before, .splitter.dragging::before {
+      left: 3px; width: 3px; background: var(--vscode-focusBorder);
+    }
     .vars {
-      flex: 1 1 40%; min-width: 0; max-height: 18rem; overflow: auto;
-      border-left: 1px solid var(--vscode-panel-border, transparent); padding-left: 0.6rem;
+      min-width: 0; max-height: 22rem; overflow: auto;
       font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85rem;
+    }
+    /* Only when the column is genuinely tiny: stack the Variables pane under the
+       Call Stack and hide the splitter (a horizontal drag is meaningless in a
+       vertical layout). A debugger webview usually lives in a Beside column a few
+       hundred px wide, so this threshold stays low — otherwise the side-by-side
+       layout would never apply and the panel would be needlessly tall. */
+    @media (max-width: 340px) {
+      .main { flex-direction: column; }
+      .stack-pane, .vars-pane { flex: 0 0 auto; }
+      .splitter { display: none; }
+      .vars-pane { margin-top: 0.6rem; }
     }
     .vars .var { padding: 0.15rem 0.2rem; display: flex; gap: 0.5rem; }
     .vars .var-name { color: var(--vscode-symbolIcon-variableForeground, var(--vscode-foreground)); white-space: nowrap; }
@@ -934,17 +1005,24 @@ export class DebuggerPanel {
     <button id="copyBtn" class="copy-btn" title="Copy the whole stack to the clipboard">Copy Stack</button>
   </div>
   <div class="toolbar" id="toolbar">
-    <button data-cmd="resume" title="Resume execution">Resume</button>
-    <button data-cmd="stepOver" title="Step over (from the selected frame)">Over</button>
-    <button data-cmd="stepInto" title="Step into">Into</button>
-    <button data-cmd="stepThrough" title="Step through blocks">Through</button>
-    <button data-cmd="restartFrame" title="Restart the selected frame">Restart Frame</button>
-    <button data-cmd="terminate" class="danger" title="Terminate the process">Terminate</button>
+    <button data-cmd="resume" title="Resume execution" aria-label="Resume execution">${TOOLBAR_ICONS.resume}</button>
+    <button data-cmd="stepOver" title="Step over (from the selected frame)" aria-label="Step over">${TOOLBAR_ICONS.stepOver}</button>
+    <button data-cmd="stepInto" title="Step into" aria-label="Step into">${TOOLBAR_ICONS.stepInto}</button>
+    <button data-cmd="stepThrough" title="Step through blocks" aria-label="Step through blocks">${TOOLBAR_ICONS.stepThrough}</button>
+    <button data-cmd="restartFrame" title="Restart the selected frame" aria-label="Restart the selected frame">${TOOLBAR_ICONS.restartFrame}</button>
+    <button data-cmd="terminate" class="danger" title="Terminate the process" aria-label="Terminate the process">${TOOLBAR_ICONS.terminate}</button>
   </div>
   <div class="error" id="error"></div>
-  <div class="main">
-    <ul class="stack" id="stack"></ul>
-    <div class="vars" id="variables"></div>
+  <div class="main" id="main" style="--stack-basis: ${stackBasis};">
+    <div class="pane stack-pane">
+      <div class="pane-title">Call Stack</div>
+      <ul class="stack" id="stack"></ul>
+    </div>
+    <div class="splitter" id="splitter" title="Drag to resize"></div>
+    <div class="pane vars-pane">
+      <div class="pane-title">Variables</div>
+      <div class="vars" id="variables"></div>
+    </div>
   </div>
   <div class="evalbar">
     <input id="evalInput" type="text" autocomplete="off" spellcheck="false"
@@ -967,6 +1045,8 @@ export class DebuggerPanel {
       variables: document.getElementById('variables'),
       evalInput: document.getElementById('evalInput'),
       evalResult: document.getElementById('evalResult'),
+      main: document.getElementById('main'),
+      splitter: document.getElementById('splitter'),
     }, vscode);
     vscode.postMessage({ command: 'ready' });
   </script>

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -298,6 +298,91 @@ export function filterStack(raws: RawFrame[]): RawFrame[] {
   return [...kept.slice(0, u + 1), kept[doitIdx]];
 }
 
+/**
+ * Initial-layout nudges. VS Code's stable API can't set an exact editor-group
+ * size, only step it via the relative `increase/decreaseView{Width,Height}`
+ * commands, so these are best-effort approximations (tune the step counts here):
+ *  - PANEL_WIDEN_STEPS: widen the Beside split from 50/50 toward ~60% for the
+ *    debugger (its Call Stack + Variables sit side-by-side and want the room).
+ *  - SOURCE_SHRINK_STEPS: shrink the companion source group from the 50/50
+ *    `newGroupBelow` split toward ~1/3, leaving ~2/3 for the stack/variables.
+ */
+const PANEL_WIDEN_STEPS = 2;
+const SOURCE_SHRINK_STEPS = 2;
+/** Source-group fraction of its column on first open when nothing's been saved (~1/3). */
+const DEFAULT_SOURCE_RATIO = 0.33;
+
+/**
+ * VS Code editor-group layout, as returned by the `vscode.getEditorLayout`
+ * command and accepted by `vscode.setEditorLayout`. A tree of groups; a leaf has
+ * a `size`, a branch has nested `groups`. Sizes round-trip in pixels but are
+ * treated as relative weights, so preserving their sum preserves the layout.
+ */
+export interface EditorGroupNode { size?: number; groups?: EditorGroupNode[]; }
+export interface EditorGroupLayout { orientation?: number; groups: EditorGroupNode[]; }
+
+/**
+ * Flatten a layout's leaf groups in depth-first, left-to-right order — the same
+ * order VS Code assigns ViewColumns (1-based), so leaf N maps to ViewColumn N+1.
+ * Each entry carries its parent branch so callers can find a leaf's siblings.
+ */
+export function flattenLayoutLeaves(
+  layout: EditorGroupLayout,
+): { node: EditorGroupNode; parent: EditorGroupNode }[] {
+  const acc: { node: EditorGroupNode; parent: EditorGroupNode }[] = [];
+  const root: EditorGroupNode = { groups: layout.groups };
+  const walk = (node: EditorGroupNode, parent: EditorGroupNode): void => {
+    if (node.groups && node.groups.length) {
+      for (const child of node.groups) walk(child, node);
+    } else {
+      acc.push({ node, parent });
+    }
+  };
+  for (const g of layout.groups) walk(g, root);
+  return acc;
+}
+
+/**
+ * The source group's fraction of its containing branch, or undefined if the
+ * column can't be located / measured. `sourceColumn` is 1-based (a ViewColumn).
+ */
+export function sourceRatioFromLayout(
+  layout: EditorGroupLayout | undefined, sourceColumn: number | undefined,
+): number | undefined {
+  if (!layout || !sourceColumn) return undefined;
+  const leaves = flattenLayoutLeaves(layout);
+  const leaf = leaves[sourceColumn - 1];
+  if (!leaf || leaf.node.size == null || !leaf.parent.groups) return undefined;
+  const total = leaf.parent.groups.reduce((s, g) => s + (g.size ?? 0), 0);
+  if (total <= 0) return undefined;
+  return leaf.node.size / total;
+}
+
+/**
+ * Set the source group to `ratio` of its containing branch, giving the rest to
+ * its sibling (the debugger group). Mutates `layout` in place; returns false
+ * (leaving it untouched) when the source isn't a clean two-way split we created
+ * — so an unusual user layout falls back to the step-based resize. `ratio` is
+ * clamped to a sane band so a degenerate save can't collapse a pane.
+ */
+export function setSourceRatioInLayout(
+  layout: EditorGroupLayout | undefined, sourceColumn: number | undefined, ratio: number,
+): boolean {
+  if (!layout || !sourceColumn) return false;
+  const leaves = flattenLayoutLeaves(layout);
+  const leaf = leaves[sourceColumn - 1];
+  if (!leaf || !leaf.parent.groups || leaf.parent.groups.length !== 2) return false;
+  const total = leaf.parent.groups.reduce((s, g) => s + (g.size ?? 0), 0);
+  if (total <= 0) return false;
+  const clamped = Math.max(0.1, Math.min(0.9, ratio));
+  const sourceSize = Math.round(total * clamped);
+  const sibling = leaf.parent.groups.find(g => g !== leaf.node);
+  if (!sibling) return false;
+  leaf.node.size = sourceSize;
+  sibling.size = total - sourceSize;
+  return true;
+}
+
 export class DebuggerPanel {
   private static panels = new Map<number, Set<DebuggerPanel>>();
   /**
@@ -306,6 +391,12 @@ export class DebuggerPanel {
    * and on the overview ruler. It marks just the step-point token (NOT the whole
    * line), so a line with several sends shows exactly where execution paused.
    * One type shared by all panels (a decoration type is a style, not per-editor).
+   *
+   * Dark themes use the standard `editor.focusedStackFrameHighlightBackground`
+   * theme colour. In LIGHT themes that colour is a very faint translucent yellow
+   * — and since we mark only the step-point token (not the whole line) it nearly
+   * vanishes — so the `light` override gives a stronger, more opaque fill plus a
+   * solid dark-goldenrod border to clearly box the paused token.
    */
   private static readonly stepPointDecoration = vscode.window.createTextEditorDecorationType({
     backgroundColor: new vscode.ThemeColor('editor.focusedStackFrameHighlightBackground'),
@@ -314,6 +405,11 @@ export class DebuggerPanel {
     borderRadius: '2px',
     overviewRulerColor: new vscode.ThemeColor('editor.focusedStackFrameHighlightBackground'),
     overviewRulerLane: vscode.OverviewRulerLane.Full,
+    light: {
+      backgroundColor: 'rgba(255, 197, 0, 0.45)',
+      borderColor: '#b8860b',
+      overviewRulerColor: '#b8860b',
+    },
   });
 
   // ── Read-only source for frames with no gemstone:// editor ──────────
@@ -337,9 +433,22 @@ export class DebuggerPanel {
    * The eval bar's height (`--eval-height`); the hsplitter resizes it, trading
    * space with the panes (which flex-fill the rest). Like `savedStackBasis`,
    * remembered across panels for this window and persisted webview-side via
-   * getState/setState. Default 7rem.
+   * getState/setState. Default 4rem — just the input plus a slim result strip;
+   * the old 7rem left a tall empty band below the input on first open. The
+   * hsplitter still grows it on demand (e.g. for a multi-line eval result).
    */
-  private static savedEvalHeight = '7rem';
+  private static savedEvalHeight = '4rem';
+
+  /**
+   * The companion source group's fraction of its column, remembered across
+   * debugger opens for this window so the user's drag of the panel↔source
+   * divider sticks. Unlike the two webview splitters (which we own and can read
+   * on drag-end), this is an editor-group split VS Code owns: there's no resize
+   * event, so we sample it with `vscode.getEditorLayout` on a low-frequency timer
+   * while the panel is open and re-apply it with `vscode.setEditorLayout` on the
+   * next open. Undefined until first sampled → DEFAULT_SOURCE_RATIO is used.
+   */
+  private static savedSourceRatio: number | undefined;
 
   private static ensureReadOnlySourceProvider(): void {
     if (DebuggerPanel.providerRegistered) return;
@@ -370,6 +479,21 @@ export class DebuggerPanel {
   private frames: DisplayFrame[] = [];
   /** Column the companion source editor lives in, reused across frame selects. */
   private sourceColumn: vscode.ViewColumn | undefined;
+  /**
+   * The most recent companion source editor. Its live `.viewColumn` is the
+   * authoritative current column of the source group at dispose time — VS Code
+   * renumbers ViewColumns positionally as groups are added/removed (e.g. when a
+   * GT Inspector opens Beside), so the captured `sourceColumn` number can go
+   * stale. We read this editor's column when closing so the right group matches.
+   */
+  private sourceEditor: vscode.TextEditor | undefined;
+  /** Low-frequency sampler of the source-group ratio (see savedSourceRatio); cleared on dispose. */
+  private layoutSampler: ReturnType<typeof setInterval> | undefined;
+  /**
+   * GT Inspectors opened from this debugger's Variables pane. They're artifacts
+   * of this debugger, so they're closed when it closes (see dispose).
+   */
+  private openedInspectors = new Set<GtInspector>();
   /** The editor currently carrying the step-point highlight, if any. */
   private decoratedEditor: vscode.TextEditor | undefined;
   /** Virtual read-only source URIs this panel stashed (pruned on dispose). */
@@ -430,6 +554,15 @@ export class DebuggerPanel {
       vscode.ViewColumn.Beside,
       { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
     );
+    // The Beside split is 50/50; nudge the (now-focused) debugger group wider
+    // toward ~60% — its stack/variables panes want more room than the code.
+    void (async () => {
+      try {
+        for (let i = 0; i < PANEL_WIDEN_STEPS; i++) {
+          await vscode.commands.executeCommand('workbench.action.increaseViewWidth');
+        }
+      } catch { /* best-effort layout */ }
+    })();
     const debugger_ = new DebuggerPanel(panel, session, gsProcess, errorMessage, onComplete);
     if (!DebuggerPanel.panels.has(session.id)) {
       DebuggerPanel.panels.set(session.id, new Set());
@@ -523,8 +656,9 @@ export class DebuggerPanel {
       }
       case 'inspectVariable': {
         // Open the clicked variable in a GT Inspector (beside), like GT Inspect.
+        // Track it so it closes with the debugger (it's an artifact of it).
         try {
-          GtInspector.create(this.session, BigInt(msg.oop), msg.name);
+          this.openedInspectors.add(GtInspector.create(this.session, BigInt(msg.oop), msg.name));
         } catch (e: unknown) {
           logError(this.sessionId, e instanceof Error ? e.message : String(e));
         }
@@ -1007,7 +1141,8 @@ export class DebuggerPanel {
    * frames stays fluid, and the doc opens as a reused preview tab (no pile-up).
    */
   private async showSourceEditor(uri: vscode.Uri): Promise<vscode.TextEditor> {
-    if (this.sourceColumn === undefined) {
+    const firstOpen = this.sourceColumn === undefined;
+    if (firstOpen) {
       try {
         this.panel.reveal(this.panel.viewColumn, false); // focus the panel's group…
         await vscode.commands.executeCommand('workbench.action.newGroupBelow'); // …then split below it
@@ -1021,12 +1156,69 @@ export class DebuggerPanel {
     });
     this.shownSourceUris.add(uri.toString()); // closed with the panel (see dispose)
     this.sourceColumn = editor.viewColumn ?? this.sourceColumn;
+    this.sourceEditor = editor; // live .viewColumn used at close time (see field doc)
+    // Size the brand-new source group: re-apply the user's remembered ratio (or
+    // the ~1/3 default). Only on first open — never override a mid-session drag.
+    if (firstOpen) {
+      await this.applySourcePaneRatio();
+      this.startLayoutSampler();
+    }
     // gemstone:// docs get their language from the FS provider; the read-only
     // executed-code scheme does not, so set it so the source is highlighted.
     if (doc.languageId !== 'gemstone-smalltalk') {
       await vscode.languages.setTextDocumentLanguage(doc, 'gemstone-smalltalk');
     }
     return editor;
+  }
+
+  /** The live column of the companion source group (survives ViewColumn renumbering). */
+  private get liveSourceColumn(): number | undefined {
+    return this.sourceEditor?.viewColumn ?? this.sourceColumn;
+  }
+
+  /**
+   * Size the (just-created) source group to the remembered ratio, or the ~1/3
+   * default. Uses `vscode.setEditorLayout` for an exact split that preserves all
+   * other groups' sizes; falls back to the imprecise relative-resize command
+   * when the layout can't be read/mapped (older VS Code, or an unusual layout).
+   */
+  private async applySourcePaneRatio(): Promise<void> {
+    const ratio = DebuggerPanel.savedSourceRatio ?? DEFAULT_SOURCE_RATIO;
+    try {
+      const layout = await vscode.commands.executeCommand<EditorGroupLayout>('vscode.getEditorLayout');
+      if (setSourceRatioInLayout(layout, this.liveSourceColumn, ratio)) {
+        await vscode.commands.executeCommand('vscode.setEditorLayout', layout);
+        return;
+      }
+    } catch { /* fall through to the step-based resize */ }
+    // The new group is still focused (showTextDocument kept focus there), so the
+    // relative resize targets it. newGroupBelow split 50/50; shrink toward ~1/3.
+    try {
+      for (let i = 0; i < SOURCE_SHRINK_STEPS; i++) {
+        await vscode.commands.executeCommand('workbench.action.decreaseViewHeight');
+      }
+    } catch { /* best-effort */ }
+  }
+
+  /**
+   * Sample the source-group ratio periodically and remember it. VS Code gives no
+   * editor-group resize event, so a low-frequency poll is the only way to capture
+   * a drag of the panel↔source divider before the panel closes (at which point
+   * the group is gone). `unref` so it never keeps the host alive.
+   */
+  private startLayoutSampler(): void {
+    if (this.layoutSampler) return;
+    this.layoutSampler = setInterval(() => void this.captureSourceRatio(), 2000);
+    this.layoutSampler.unref?.();
+  }
+
+  private async captureSourceRatio(): Promise<void> {
+    if (this.disposed || this.liveSourceColumn === undefined) return;
+    try {
+      const layout = await vscode.commands.executeCommand<EditorGroupLayout>('vscode.getEditorLayout');
+      const ratio = sourceRatioFromLayout(layout, this.liveSourceColumn);
+      if (ratio !== undefined) DebuggerPanel.savedSourceRatio = ratio;
+    } catch { /* best-effort sampling */ }
   }
 
   /**
@@ -1396,7 +1588,7 @@ export class DebuggerPanel {
     /* Eval-in-frame bar: a fixed-height region at the bottom (the hsplitter
        resizes it). The result area scrolls within it. */
     .evalbar {
-      flex: 0 0 var(--eval-height, 7rem); min-height: 2.6rem; overflow: hidden;
+      flex: 0 0 var(--eval-height, 4rem); min-height: 2.6rem; overflow: hidden;
       display: flex; flex-direction: column;
     }
     .evalbar input {
@@ -1475,6 +1667,7 @@ export class DebuggerPanel {
 
   private dispose(): void {
     this.disposed = true; // an in-flight Nb step/trim continuation must skip the dead panel
+    if (this.layoutSampler) { clearInterval(this.layoutSampler); this.layoutSampler = undefined; }
     DebuggerPanel.panels.get(this.sessionId)?.delete(this);
     // Restore native code once the last debugger for this session closes
     // (paired with acquireStepping in create).
@@ -1483,9 +1676,11 @@ export class DebuggerPanel {
     // the panel) so a stale highlight doesn't linger after the debugger closes.
     this.decoratedEditor?.setDecorations(DebuggerPanel.stepPointDecoration, []);
     this.decoratedEditor = undefined;
-    // Close the companion source editor — it's an artifact of this debugger,
-    // so it shouldn't outlive the panel.
+    // Close the companion source editor and any GT Inspectors this debugger
+    // opened — they're artifacts of this debugger and shouldn't outlive it.
     this.closeSourceEditors();
+    for (const inspector of this.openedInspectors) inspector.close();
+    this.openedInspectors.clear();
     // Release this panel's stashed read-only source.
     for (const key of this.stashedSourceKeys) DebuggerPanel.readOnlySources.delete(key);
     this.stashedSourceKeys.clear();
@@ -1507,8 +1702,13 @@ export class DebuggerPanel {
    */
   private closeSourceEditors(): void {
     if (this.shownSourceUris.size === 0) return;
+    // The source group's ViewColumn can have been renumbered since we captured
+    // it (VS Code reassigns columns positionally when groups open/close — e.g. a
+    // GT Inspector opening Beside). The live source editor reports its CURRENT
+    // column, so prefer that; fall back to the captured number.
+    const sourceColumn = this.sourceEditor?.viewColumn ?? this.sourceColumn;
     for (const group of vscode.window.tabGroups.all) {
-      const inOurColumn = this.sourceColumn !== undefined && group.viewColumn === this.sourceColumn;
+      const inOurColumn = sourceColumn !== undefined && group.viewColumn === sourceColumn;
       for (const tab of group.tabs) {
         if (!(tab.input instanceof vscode.TabInputText)) continue;
         if (!this.shownSourceUris.has(tab.input.uri.toString())) continue;
@@ -1518,5 +1718,6 @@ export class DebuggerPanel {
       }
     }
     this.shownSourceUris.clear();
+    this.sourceEditor = undefined;
   }
 }

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -38,7 +38,14 @@ type DebuggerInbound =
   | { command: 'ready' }
   | { command: 'copyStack' }
   | { command: 'copyFrame'; level: number }
-  | { command: 'selectFrame'; level: number };
+  | { command: 'selectFrame'; level: number }
+  | { command: 'evalInFrame'; level: number; expr: string }
+  | { command: 'resume' }
+  | { command: 'terminate' }
+  | { command: 'stepOver'; level: number }
+  | { command: 'stepInto'; level: number }
+  | { command: 'stepThrough'; level: number }
+  | { command: 'restartFrame'; level: number };
 
 /**
  * Build the `gemstone://` URI for a method's source, in the exact form the
@@ -298,6 +305,8 @@ export class DebuggerPanel {
   private decoratedEditor: vscode.TextEditor | undefined;
   /** Virtual read-only source URIs this panel stashed (pruned on dispose). */
   private stashedSourceKeys = new Set<string>();
+  /** Every source URI shown in the companion editor (closed on dispose). */
+  private shownSourceUris = new Set<string>();
 
   static create(session: ActiveSession, gsProcess: bigint, errorMessage: string): void {
     const panel = vscode.window.createWebviewPanel(
@@ -325,7 +334,8 @@ export class DebuggerPanel {
     panel: vscode.WebviewPanel,
     private readonly session: ActiveSession,
     private readonly gsProcess: bigint,
-    private readonly errorMessage: string,
+    // Mutable: resume-into-another-error updates it; step/restart clear it.
+    private errorMessage: string,
   ) {
     this.panel = panel;
     this.sessionId = session.id;
@@ -342,12 +352,7 @@ export class DebuggerPanel {
     switch (msg.command) {
       case 'ready': {
         this.frames = this.fetchStack();
-        this.panel.webview.postMessage({
-          command: 'init',
-          errorMessage: this.errorMessage,
-          // Send only the display shape; serverLevel stays host-side.
-          stack: this.frames.map(f => ({ level: f.level, label: f.label, position: f.position })),
-        });
+        this.postInit();
         return;
       }
       case 'copyStack': {
@@ -362,12 +367,126 @@ export class DebuggerPanel {
         return;
       }
       case 'selectFrame': {
-        // Map the display level the webview reported back to the server level.
+        // Map the display level the webview reported back to the server level,
+        // then drive the source pane AND the variables pane for that frame.
         const frame = this.frames.find(f => f.level === msg.level);
-        if (frame) void this.revealFrameSource(frame.serverLevel);
+        if (frame) {
+          void this.revealFrameSource(frame.serverLevel);
+          this.postVariables(frame.serverLevel);
+        }
+        return;
+      }
+      case 'evalInFrame': {
+        const frame = this.frames.find(f => f.level === msg.level);
+        this.evalInFrame(frame?.serverLevel, msg.expr);
+        return;
+      }
+      case 'resume': { this.resume(); return; }
+      case 'terminate': { this.panel.dispose(); return; } // dispose → clearStack
+      case 'stepOver':
+      case 'stepInto':
+      case 'stepThrough': {
+        const frame = this.frames.find(f => f.level === msg.level);
+        if (frame) this.step(msg.command, frame.serverLevel);
+        return;
+      }
+      case 'restartFrame': {
+        const frame = this.frames.find(f => f.level === msg.level);
+        if (frame) this.restartFrame(frame.serverLevel);
         return;
       }
     }
+  }
+
+  /** Post the current (filtered) stack to the webview; it re-renders + re-selects top. */
+  private postInit(): void {
+    this.panel.webview.postMessage({
+      command: 'init',
+      errorMessage: this.errorMessage,
+      // Send only the display shape; serverLevel stays host-side.
+      stack: this.frames.map(f => ({ level: f.level, label: f.label, position: f.position })),
+    });
+  }
+
+  /** Re-walk the (advanced) stack and re-render — used after a step / restart / resume-with-error. */
+  private refresh(): void {
+    this.frames = this.fetchStack();
+    this.postInit();
+  }
+
+  /** Fetch the selected frame's variables (self + args/temps) and post them. */
+  private postVariables(serverLevel: number): void {
+    let vars: { name: string; value: string }[] = [];
+    try {
+      vars = this.fetchVariables(serverLevel);
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+    }
+    this.panel.webview.postMessage({ command: 'variables', vars });
+  }
+
+  /**
+   * Basic variables for a frame: `self` followed by the frame's args and temps,
+   * each with its printString. (Stage 2 adds Receiver/Args grouping, the oop
+   * column, and click-to-inspect.) Each printString is best-effort.
+   */
+  private fetchVariables(serverLevel: number): { name: string; value: string }[] {
+    const info = debug.getFrameInfo(this.session, this.gsProcess, serverLevel);
+    const safePrint = (oop: bigint): string => {
+      try { return debug.getObjectPrintString(this.session, oop); }
+      catch { return '<unprintable>'; }
+    };
+    const vars = [{ name: 'self', value: safePrint(info.receiverOop) }];
+    for (let i = 0; i < info.argAndTempNames.length; i++) {
+      vars.push({ name: info.argAndTempNames[i], value: safePrint(info.argAndTempOops[i]) });
+    }
+    return vars;
+  }
+
+  /** Evaluate an expression in the selected frame and post the printString back. */
+  private evalInFrame(serverLevel: number | undefined, expr: string): void {
+    if (serverLevel == null) return;
+    let value: string;
+    let isError = false;
+    try {
+      value = debug.evaluateInFrame(this.session, this.gsProcess, expr, serverLevel);
+    } catch (e: unknown) {
+      value = `Error: ${e instanceof Error ? e.message : String(e)}`;
+      isError = true;
+    }
+    this.panel.webview.postMessage({ command: 'evalResult', expr, value, isError });
+  }
+
+  /** Resume execution: closes the panel if the process completes, else refreshes on the new error. */
+  private resume(): void {
+    const result = debug.continueExecution(this.session, this.gsProcess);
+    if (result.completed) {
+      this.panel.dispose();
+    } else {
+      this.errorMessage = result.errorMessage || 'GemStone error';
+      this.refresh();
+    }
+  }
+
+  /** Step (over/into/through) from the selected frame: dispose on completion, else refresh. */
+  private step(command: 'stepOver' | 'stepInto' | 'stepThrough', serverLevel: number): void {
+    const fn = command === 'stepOver' ? debug.stepOver
+      : command === 'stepInto' ? debug.stepInto
+        : debug.stepOut; // "Through" == gciStepThru (debugQueries.stepOut)
+    const result = fn(this.session, this.gsProcess, serverLevel);
+    if (result.completed) {
+      this.panel.dispose();
+    } else {
+      this.errorMessage = ''; // no longer at the original halt — clear the banner
+      this.refresh();
+    }
+  }
+
+  /** Restart the selected frame (trim the stack to it) and refresh. */
+  private restartFrame(serverLevel: number): void {
+    debug.trimStackToLevel(this.session, this.gsProcess, serverLevel);
+    this.errorMessage = '';
+    this.refresh();
   }
 
   /**
@@ -459,6 +578,7 @@ export class DebuggerPanel {
       preview: true,
       preserveFocus: true,
     });
+    this.shownSourceUris.add(uri.toString()); // closed with the panel (see dispose)
     this.sourceColumn = editor.viewColumn ?? this.sourceColumn;
     // gemstone:// docs get their language from the FS provider; the read-only
     // executed-code scheme does not, so set it so the source is highlighted.
@@ -720,6 +840,42 @@ export class DebuggerPanel {
     .frame .level { color: var(--vscode-descriptionForeground); margin-right: 0.6rem; }
     .frame .pos { color: var(--vscode-descriptionForeground); margin-left: 0.6rem; }
     .empty { color: var(--vscode-descriptionForeground); font-style: italic; }
+    /* Toolbar: Resume / step verbs / Restart Frame / Terminate. */
+    .toolbar { display: flex; gap: 0.3rem; margin: 0 0 0.6rem; flex-wrap: wrap; }
+    .toolbar button {
+      font-family: var(--vscode-font-family); font-size: 0.85rem;
+      color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+      background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+      border: none; padding: 0.25rem 0.7rem; border-radius: 2px; cursor: pointer;
+    }
+    .toolbar button:hover { background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground)); }
+    .toolbar button.danger { color: var(--vscode-errorForeground); }
+    /* Stack (left) + variables (right). */
+    .main { display: flex; gap: 0.8rem; align-items: flex-start; }
+    .main .stack { flex: 1 1 60%; min-width: 0; }
+    .vars {
+      flex: 1 1 40%; min-width: 0; max-height: 18rem; overflow: auto;
+      border-left: 1px solid var(--vscode-panel-border, transparent); padding-left: 0.6rem;
+      font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85rem;
+    }
+    .vars .var { padding: 0.15rem 0.2rem; display: flex; gap: 0.5rem; }
+    .vars .var-name { color: var(--vscode-symbolIcon-variableForeground, var(--vscode-foreground)); white-space: nowrap; }
+    .vars .var-name.self { font-style: italic; }
+    .vars .var-value { color: var(--vscode-descriptionForeground); white-space: pre; overflow: hidden; text-overflow: ellipsis; }
+    /* Eval-in-frame bar. */
+    .evalbar { margin-top: 0.8rem; }
+    .evalbar input {
+      width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text;
+      font-family: var(--vscode-editor-font-family, monospace);
+      color: var(--vscode-input-foreground); background: var(--vscode-input-background);
+      border: 1px solid var(--vscode-input-border, var(--vscode-panel-border, transparent));
+      padding: 0.3rem 0.5rem; border-radius: 2px;
+    }
+    .eval-result {
+      font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85rem;
+      white-space: pre-wrap; margin-top: 0.35rem; user-select: text; -webkit-user-select: text;
+    }
+    .eval-result.error { color: var(--vscode-errorForeground); }
   </style>
 </head>
 <body>
@@ -728,8 +884,24 @@ export class DebuggerPanel {
     <span class="subtitle">${subtitle}</span>
     <button id="copyBtn" class="copy-btn" title="Copy the whole stack to the clipboard">Copy Stack</button>
   </div>
+  <div class="toolbar" id="toolbar">
+    <button data-cmd="resume" title="Resume execution">Resume</button>
+    <button data-cmd="stepOver" title="Step over (from the selected frame)">Over</button>
+    <button data-cmd="stepInto" title="Step into">Into</button>
+    <button data-cmd="stepThrough" title="Step through blocks">Through</button>
+    <button data-cmd="restartFrame" title="Restart the selected frame">Restart Frame</button>
+    <button data-cmd="terminate" class="danger" title="Terminate the process">Terminate</button>
+  </div>
   <div class="error" id="error"></div>
-  <ul class="stack" id="stack"></ul>
+  <div class="main">
+    <ul class="stack" id="stack"></ul>
+    <div class="vars" id="variables"></div>
+  </div>
+  <div class="evalbar">
+    <input id="evalInput" type="text" autocomplete="off" spellcheck="false"
+           placeholder="Evaluate in the selected frame — press Enter">
+    <div class="eval-result" id="evalResult"></div>
+  </div>
   <div id="ctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="copyFrameItem" role="menuitem">Copy Frame</div>
   </div>
@@ -742,6 +914,10 @@ export class DebuggerPanel {
       copyFrameItem: document.getElementById('copyFrameItem'),
       copyBtn: document.getElementById('copyBtn'),
       error: document.getElementById('error'),
+      toolbar: document.getElementById('toolbar'),
+      variables: document.getElementById('variables'),
+      evalInput: document.getElementById('evalInput'),
+      evalResult: document.getElementById('evalResult'),
     }, vscode);
     vscode.postMessage({ command: 'ready' });
   </script>
@@ -755,6 +931,9 @@ export class DebuggerPanel {
     // the panel) so a stale highlight doesn't linger after the debugger closes.
     this.decoratedEditor?.setDecorations(DebuggerPanel.stepPointDecoration, []);
     this.decoratedEditor = undefined;
+    // Close the companion source editor — it's an artifact of this debugger,
+    // so it shouldn't outlive the panel.
+    this.closeSourceEditors();
     // Release this panel's stashed read-only source.
     for (const key of this.stashedSourceKeys) DebuggerPanel.readOnlySources.delete(key);
     this.stashedSourceKeys.clear();
@@ -764,5 +943,28 @@ export class DebuggerPanel {
     // releasing the stalled GsProcess on the server (same as dismissing the
     // error notifier). clearStack is best-effort: the session may already be gone.
     debug.clearStack(this.session, this.gsProcess);
+  }
+
+  /**
+   * Close the companion source tabs this panel opened. A `gemstone://` method is
+   * closed ONLY in our own source column — never the user's own copy of the same
+   * method open elsewhere (e.g. the System Browser). Our private read-only scheme
+   * is unique to this debugger, so it's safe to close in any column. When the
+   * source column is unknown we therefore close only the read-only tabs (closing
+   * a shared `gemstone://` everywhere would be the very bug the guard prevents).
+   */
+  private closeSourceEditors(): void {
+    if (this.shownSourceUris.size === 0) return;
+    for (const group of vscode.window.tabGroups.all) {
+      const inOurColumn = this.sourceColumn !== undefined && group.viewColumn === this.sourceColumn;
+      for (const tab of group.tabs) {
+        if (!(tab.input instanceof vscode.TabInputText)) continue;
+        if (!this.shownSourceUris.has(tab.input.uri.toString())) continue;
+        if (inOurColumn || tab.input.uri.scheme === READONLY_SOURCE_SCHEME) {
+          void vscode.window.tabGroups.close(tab);
+        }
+      }
+    }
+    this.shownSourceUris.clear();
   }
 }

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -69,6 +69,7 @@ type DebuggerInbound =
   | { command: 'stepThrough'; level: number }
   | { command: 'restartFrame'; level: number }
   | { command: 'inspectVariable'; oop: string; name: string }
+  | { command: 'createDnuMethod' }
   | { command: 'saveLayout'; stackBasis?: string; evalHeight?: string };
 
 /** A single variable row (name / printString / oop) sent to the webview. */
@@ -156,6 +157,34 @@ export function formatFramePosition(stepPoint?: number, line?: number): string {
   return parts.join(' ');
 }
 
+/** Default category for a method created from a `doesNotUnderstand:`. */
+const DNU_METHOD_CATEGORY = 'as yet unclassified';
+
+/**
+ * Build a method-template stub for a selector that wasn't understood: the real
+ * signature on the first line (so saving compiles the intended method) followed
+ * by a comment and a `^nil` placeholder body the user fills in. Handles all three
+ * selector shapes — unary (`foo`), binary (`+ arg1`), and keyword
+ * (`at: arg1 put: arg2`). Pure/exported so the templating is unit-testable.
+ */
+export function buildMethodStub(selector: string, argCount: number): string {
+  let signature: string;
+  if (selector.includes(':')) {
+    // Keyword selector: pair each keyword with a generated argument name.
+    const keywords = selector.split(':').filter(k => k.length > 0);
+    signature = keywords.map((kw, i) => `${kw}: arg${i + 1}`).join(' ');
+  } else if (argCount > 0) {
+    signature = `${selector} arg1`; // binary selector (e.g. + or <=)
+  } else {
+    signature = selector; // unary
+  }
+  // Keep the comment short so it fits a normal-width source pane (the long
+  // version ran off the right edge), and have it state the save step explicitly.
+  return `${signature}\n`
+    + '\t"Fill in the body, then save (Ctrl+S) to create this method."\n'
+    + '\t^nil\n';
+}
+
 /** Minimal HTML-escape for interpolating session text into the page. */
 function escapeHtml(s: string): string {
   return s
@@ -181,6 +210,8 @@ interface FrameSummary {
  */
 interface DisplayFrame extends FrameSummary {
   serverLevel: number;
+  /** True for a doit / "Executed Code" frame (no class → can't be restarted/re-entered). */
+  isExecutedCode: boolean;
 }
 
 /**
@@ -233,8 +264,12 @@ export interface RawFrame {
 // opens on the user's frame (e.g. `[] in Foo>>bar`) instead of `signal`/`halt`.
 // `AbstractException` covers signal/_signal/_signalToDebugger/_executeHandler:
 // (instance and class side); the selectors cover Object>>halt and friends.
+// `defaultAction`/`_defaultAction` are the unhandled-error path a `doesNotUnderstand:`
+// parks in under GCI debug (MessageNotUnderstood>>defaultAction → _defaultAction →
+// _signal → signal → doesNotUnderstand: → _doesNotUnderstand:…); trimming them opens
+// the debugger on the user's frame (e.g. Executed Code) rather than this machinery.
 const MACHINERY_SELECTORS = new Set([
-  'halt', 'halt:', 'pause', 'error:', 'signal', 'signal:',
+  'halt', 'halt:', 'pause', 'error:', 'signal', 'signal:', 'defaultAction', '_defaultAction',
 ]);
 // Kernel block-invocation selectors that appear as transcript-capture-wrapper
 // glue at the BOTTOM (the doit evaluates its blocks via these).
@@ -509,6 +544,33 @@ export class DebuggerPanel {
    */
   private editableSourceUri: string | undefined;
   /**
+   * When the suspended process is parked on a `doesNotUnderstand:`, the info
+   * needed to offer "Create #<selector> in <Class>" — re-detected whenever the
+   * stack is (re)fetched, undefined otherwise. Drives the webview's Create button.
+   */
+  private dnuInfo: debug.DnuInfo | undefined;
+  /**
+   * While a create-method-from-DNU template is being edited, the `gemstone://`
+   * new-method URI of that template, and the server level of the frame that made
+   * the failed send. Saving the template (a clean compile) restarts that sender
+   * frame so the send re-dispatches into the freshly-created method.
+   */
+  private pendingDnuMethodUri: string | undefined;
+  private pendingDnuSelector: string | undefined;
+  /**
+   * Suppresses the "Create #sel" button once a create is underway or resolved, so
+   * it never reappears for the SAME parked doesNotUnderstand: (the method now
+   * exists, but the suspended process still has the DNU frame on its stack). Reset
+   * when a successful trim rebuilds the stack (a genuinely new DNU may then appear).
+   */
+  private dnuSuppressed = false;
+  /**
+   * gemstone:// URIs of DNU method templates this panel opened AND the methods
+   * they compile to — closed on dispose regardless of column (we created them, so
+   * unlike a shared method open in the System Browser they're safe to close).
+   */
+  private dnuMethodUris = new Set<string>();
+  /**
    * True once the TOP frame's method has been recompiled in place but could not
    * be re-entered (GemStone has no primitive to reset the top-of-stack IP — see
    * editAndContinue). The suspended top activation is then stale: continuing or
@@ -611,6 +673,7 @@ export class DebuggerPanel {
     switch (msg.command) {
       case 'ready': {
         this.frames = this.fetchStack();
+        this.dnuInfo = this.detectDnu();
         this.postInit();
         return;
       }
@@ -654,6 +717,7 @@ export class DebuggerPanel {
         if (frame) void this.restartFrame(frame.serverLevel);
         return;
       }
+      case 'createDnuMethod': { void this.createDnuMethod(); return; }
       case 'inspectVariable': {
         // Open the clicked variable in a GT Inspector (beside), like GT Inspect.
         // Track it so it closes with the debugger (it's an artifact of it).
@@ -681,13 +745,190 @@ export class DebuggerPanel {
       errorMessage: this.errorMessage,
       // Send only the display shape; serverLevel stays host-side.
       stack: this.frames.map(f => ({ level: f.level, label: f.label, position: f.position })),
+      // When parked on a doesNotUnderstand:, drive the "Create #sel in Class" button.
+      dnu: this.dnuInfo
+        ? { selector: this.dnuInfo.selector, className: this.dnuInfo.className, isMeta: this.dnuInfo.isMeta }
+        : undefined,
     });
   }
 
   /** Re-walk the (advanced) stack and re-render — used after a step / restart / resume-with-error. */
   private refresh(): void {
     this.frames = this.fetchStack();
+    this.dnuInfo = this.detectDnu();
     this.postInit();
+  }
+
+  /**
+   * Detect whether the process is parked on a `doesNotUnderstand:` and, if so,
+   * what method the user could create. Best-effort: any failure → undefined (the
+   * Create button just doesn't appear).
+   */
+  private detectDnu(): debug.DnuInfo | undefined {
+    // Suppress the Create button while a create is being edited (pendingDnuMethodUri)
+    // or after one is resolved for this parked DNU (dnuSuppressed) — the method now
+    // exists, but the suspended process still has the doesNotUnderstand: frame, so
+    // re-detecting it would wrongly re-offer "Create".
+    if (this.pendingDnuMethodUri !== undefined || this.dnuSuppressed) return undefined;
+    try {
+      return debug.getDoesNotUnderstandInfo(this.session, this.gsProcess);
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      return undefined;
+    }
+  }
+
+  /**
+   * Create-method-from-DNU. Open a `gemstone://` new-method template pre-filled
+   * with the unknown selector's signature in the receiver's class, then remember
+   * it so the next save (a clean compile) restarts the frame that made the failed
+   * send — re-dispatching it into the new method. The user fills in the body.
+   */
+  /**
+   * Build a `gemstone://` method URI EXACTLY as GemStoneFileSystemProvider's
+   * `buildMethodUri` does — `vscode.Uri.from` (which leaves `:` un-encoded in the
+   * path), NOT `buildMethodSourceUri`'s `encodeURIComponent` (which yields `%3A`).
+   * The two produce different `.toString()`s for keyword selectors, so matching
+   * the FS provider's form is what lets us recognise (and close) the tab it opens.
+   * `selector` may be `new-method` for the template URI. Env 0 (no query).
+   */
+  private gemstoneMethodUri(dictName: string, className: string, isMeta: boolean, selector: string): vscode.Uri {
+    return vscode.Uri.from({
+      scheme: 'gemstone',
+      authority: String(this.session.id),
+      path: `/${dictName}/${className}/${isMeta ? 'class' : 'instance'}/${DNU_METHOD_CATEGORY}/${selector}`,
+    });
+  }
+
+  private async createDnuMethod(): Promise<void> {
+    const dnu = this.dnuInfo;
+    if (!dnu) return;
+    if (!dnu.dictName) {
+      // No home dictionary → we can't build an editable gemstone:// URI for it.
+      this.errorMessage = `Can't create #${dnu.selector}: ${dnu.className} isn't in your symbol `
+        + 'list, so its source has no home dictionary. Add the class to a dictionary first.';
+      this.postInit();
+      return;
+    }
+    // selector 'new-method' makes this the FS provider's new-method template URI.
+    const uri = this.gemstoneMethodUri(dnu.dictName, dnu.className, dnu.isMeta, 'new-method');
+    // On a clean save the FS provider swaps the template tab to this real method
+    // URI — built EXACTLY as the provider builds it (vscode.Uri.from leaves ':'
+    // un-encoded, unlike buildMethodSourceUri's encodeURIComponent → '%3A'), so the
+    // strings match and closeSourceEditors actually closes it (else it lingered).
+    const compiledUri = this.gemstoneMethodUri(dnu.dictName, dnu.className, dnu.isMeta, dnu.selector);
+    try {
+      await this.openTemplateEditor(uri, buildMethodStub(dnu.selector, dnu.argCount));
+      this.pendingDnuMethodUri = uri.toString();
+      this.dnuMethodUris.add(uri.toString());
+      this.dnuMethodUris.add(compiledUri.toString());
+      this.pendingDnuSelector = dnu.selector;
+      // Replace the DNU error with what-to-do guidance — the most visible spot, and
+      // the next step is the user's (the original complaint was that nothing said to
+      // fill in + save). Use a lightweight banner update (NOT postInit): postInit
+      // re-renders the stack and re-selects the top frame, which reopens the frame
+      // source in the source column and steals focus from the new-method editor we
+      // just opened. The banner update clears the Create button and keeps focus on
+      // the new-method tab so the user can type immediately.
+      this.errorMessage = `Editing new method #${dnu.selector} below — fill in the body, then save it `
+        + '(Ctrl+S / Cmd+S) to create the method. Then press Resume (▶) to run it.';
+      this.panel.webview.postMessage({ command: 'banner', text: this.errorMessage });
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      this.errorMessage = `Could not open a method template: ${e instanceof Error ? e.message : String(e)}`;
+      this.postInit();
+    }
+  }
+
+  /**
+   * Open a new-method template editor in the companion source group docked BELOW
+   * the panel (the same place frame source opens — not Beside, which the user saw
+   * as "to the side"), focused so they can type, and replace the FS provider's
+   * generic template with `stub` (the real selector signature + a placeholder
+   * body). Mirrors showSourceEditor's docking so the first open splits a group
+   * beneath the panel; later opens reuse that group.
+   */
+  private async openTemplateEditor(uri: vscode.Uri, stub: string): Promise<vscode.TextEditor> {
+    const firstOpen = this.sourceColumn === undefined;
+    if (firstOpen) {
+      try {
+        this.panel.reveal(this.panel.viewColumn, false); // focus the panel's group…
+        await vscode.commands.executeCommand('workbench.action.newGroupBelow'); // …split below it
+      } catch { /* best-effort layout; fall back to the active group */ }
+    }
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(doc, {
+      viewColumn: this.sourceColumn ?? vscode.ViewColumn.Active,
+      preview: false,        // a real tab the user edits, not a throwaway preview
+      preserveFocus: false,  // focus the editor so the user can fill in the body
+    });
+    this.sourceColumn = editor.viewColumn ?? this.sourceColumn;
+    this.sourceEditor = editor;
+    // Replace the whole document with the pre-filled stub.
+    const lastLine = Math.max(0, editor.document.lineCount - 1);
+    const end = editor.document.lineAt(lastLine).range.end;
+    await editor.edit(b => b.replace(new vscode.Range(new vscode.Position(0, 0), end), stub));
+    this.shownSourceUris.add(uri.toString()); // closed with the panel
+    if (firstOpen) await this.applySourcePaneRatio();
+    return editor;
+  }
+
+  /**
+   * True if the last compile of `uri` failed — the FS provider left an
+   * Error-severity diagnostic (and did NOT rethrow, so the save still fired).
+   */
+  private recompileFailed(uri: vscode.Uri): boolean {
+    return vscode.languages
+      .getDiagnostics(uri)
+      .some((d) => d.severity === vscode.DiagnosticSeverity.Error);
+  }
+
+  /**
+   * After a DNU method is created (clean compile), re-enter the frame that made
+   * the send so a (user-initiated) Resume re-dispatches into the new method —
+   * then leave the process suspended for the user to press Resume. We do NOT
+   * auto-resume: resuming the parked doesNotUnderstand: machinery directly
+   * (continueExecution / forcing a value) hung the gem and crashed the host.
+   *
+   * `this.frames[0]` is the topmost user frame (the DNU machinery is trimmed from
+   * the display), i.e. the sender. Trimming to it (`trimStackToLevel:`,
+   * non-blocking) resets it to its method's first instruction, so the user's next
+   * Resume is an ordinary resume of a clean frame — which re-runs the send.
+   *
+   * A workspace/"Executed Code" sender has no class, so GemStone can't re-enter it
+   * (the kernel trim does `oldHome inClass compiledMethodAt:…`, which is sent to
+   * nil). The method still exists — tell the user to re-run their expression.
+   */
+  private async finishDnuMethod(selector: string): Promise<void> {
+    const sel = selector ? `#${selector}` : 'the method';
+    this.dnuSuppressed = true; // method exists now; never re-offer Create for this DNU
+    const sender = this.frames[0];
+    // Either way, the user finishes with Resume (▶): GemStone's
+    // MessageNotUnderstood>>defaultAction re-performs the now-understood send on
+    // resume, so the original expression evaluates to the new method's result.
+    // (We never auto-resume — resuming the parked DNU machinery from the save
+    // handler hung the gem and crashed the host. Manual Resume is safe.)
+    if (!sender || sender.isExecutedCode || sender.serverLevel <= 1) {
+      // Workspace/"Executed Code" (or top) sender — can't be re-entered in place
+      // (the kernel trim sends compiledMethodAt: to its nil class), so don't trim.
+      this.errorMessage = `Created ${sel} — press Resume (▶) to re-run the send into the new method.`;
+      this.postInit();
+      return;
+    }
+    // A real method sender — re-enter it (non-blocking trim) so the user's Resume
+    // re-runs the send from a clean frame, and they can also step into the method.
+    await this.runNb('Create method', async () => {
+      await debug.trimStackToLevelNb(this.session, this.gsProcess, sender.serverLevel);
+      if (this.disposed) return;
+      this.staleTopActivation = false; // the trim rebuilt the stack from a fresh activation
+      this.uncontinuable = false;
+      this.dnuSuppressed = false;       // fresh stack — a new DNU may legitimately appear
+      this.frames = this.fetchStack();
+      this.dnuInfo = this.detectDnu();
+      this.errorMessage = `Created ${sel} — re-entered the frame where it was sent. `
+        + 'Press Resume (▶) to run the new method, or step into it.';
+      this.postInit(); // re-selects the re-entered sender frame + shows the banner
+    });
   }
 
   /** Fetch the selected frame's grouped variables and post them. */
@@ -993,15 +1234,25 @@ export class DebuggerPanel {
    * fires) — we detect that and do nothing, so the user just fixes and re-saves.
    */
   private onSourceSaved(doc: vscode.TextDocument): void {
+    // Create-method-from-DNU: saving the pre-filled template compiles the new
+    // method; on a clean compile, resume so the send re-dispatches into it. A bad
+    // compile keeps the pending state so the user can fix the squiggle and re-save.
+    if (this.pendingDnuMethodUri !== undefined && doc.uri.toString() === this.pendingDnuMethodUri) {
+      if (this.recompileFailed(doc.uri)) return;
+      const selector = this.pendingDnuSelector ?? '';
+      this.pendingDnuMethodUri = undefined;
+      this.pendingDnuSelector = undefined;
+      this.dnuInfo = undefined; // the method now exists
+      this.finishDnuMethod(selector);
+      return;
+    }
+
     if (this.editableSourceUri === undefined || this.selectedServerLevel === undefined) return;
     if (doc.uri.toString() !== this.editableSourceUri) return;
     // The recompile failed if the FS provider left an error diagnostic on the URI
     // (it sets one and does NOT rethrow, so this save still fires) — then we leave
     // the old method installed and do nothing; the user fixes and re-saves.
-    const failed = vscode.languages
-      .getDiagnostics(doc.uri)
-      .some((d) => d.severity === vscode.DiagnosticSeverity.Error);
-    if (failed) return;
+    if (this.recompileFailed(doc.uri)) return;
     void this.editAndContinue(this.selectedServerLevel);
   }
 
@@ -1296,6 +1547,7 @@ export class DebuggerPanel {
       level: i + 1,
       serverLevel: r.serverLevel,
       label: r.label,
+      isExecutedCode: r.isExecutedCode,
       // Executed-code frames have no meaningful step point/line once unwrapped (#3).
       position: r.isExecutedCode ? '' : formatFramePosition(r.stepPoint, r.line),
     }));
@@ -1468,6 +1720,17 @@ export class DebuggerPanel {
          panel stays non-selectable to keep the custom copy menu the only path. */
       user-select: text; -webkit-user-select: text; cursor: text;
     }
+    /* "Create #selector in Class" action shown when parked on a doesNotUnderstand:.
+       Styled as a prominent primary button just below the error banner. */
+    .dnu-bar { margin: 0 0 0.75rem; }
+    .dnu-bar:empty { display: none; }
+    .dnu-btn {
+      font-family: var(--vscode-font-family);
+      color: var(--vscode-button-foreground);
+      background: var(--vscode-button-background);
+      border: none; padding: 0.3rem 0.8rem; border-radius: 2px; cursor: pointer;
+    }
+    .dnu-btn:hover { background: var(--vscode-button-hoverBackground); }
     .stack { list-style: none; margin: 0; padding: 0; }
     .frame {
       font-family: var(--vscode-editor-font-family, monospace);
@@ -1621,6 +1884,7 @@ export class DebuggerPanel {
     <button data-cmd="terminate" class="danger" title="Terminate the process" aria-label="Terminate the process">${TOOLBAR_ICONS.terminate}</button>
   </div>
   <div class="error" id="error"></div>
+  <div class="dnu-bar" id="dnuBar"></div>
   <div class="main" id="main" style="--stack-basis: ${stackBasis};">
     <div class="pane stack-pane">
       <div class="pane-title">Call Stack</div>
@@ -1650,6 +1914,7 @@ export class DebuggerPanel {
       copyFrameItem: document.getElementById('copyFrameItem'),
       copyBtn: document.getElementById('copyBtn'),
       error: document.getElementById('error'),
+      dnuBar: document.getElementById('dnuBar'),
       toolbar: document.getElementById('toolbar'),
       variables: document.getElementById('variables'),
       evalInput: document.getElementById('evalInput'),
@@ -1701,7 +1966,7 @@ export class DebuggerPanel {
    * a shared `gemstone://` everywhere would be the very bug the guard prevents).
    */
   private closeSourceEditors(): void {
-    if (this.shownSourceUris.size === 0) return;
+    if (this.shownSourceUris.size === 0 && this.dnuMethodUris.size === 0) return;
     // The source group's ViewColumn can have been renumbered since we captured
     // it (VS Code reassigns columns positionally when groups open/close — e.g. a
     // GT Inspector opening Beside). The live source editor reports its CURRENT
@@ -1711,13 +1976,19 @@ export class DebuggerPanel {
       const inOurColumn = sourceColumn !== undefined && group.viewColumn === sourceColumn;
       for (const tab of group.tabs) {
         if (!(tab.input instanceof vscode.TabInputText)) continue;
-        if (!this.shownSourceUris.has(tab.input.uri.toString())) continue;
+        const uriStr = tab.input.uri.toString();
+        // A DNU template / its compiled method was created BY this debugger, so
+        // it's safe to close in ANY column (the FS provider may have swapped the
+        // template tab to the compiled method, and possibly into another column).
+        if (this.dnuMethodUris.has(uriStr)) { void vscode.window.tabGroups.close(tab); continue; }
+        if (!this.shownSourceUris.has(uriStr)) continue;
         if (inOurColumn || tab.input.uri.scheme === READONLY_SOURCE_SCHEME) {
           void vscode.window.tabGroups.close(tab);
         }
       }
     }
     this.shownSourceUris.clear();
+    this.dnuMethodUris.clear();
     this.sourceEditor = undefined;
   }
 }

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -8,6 +8,7 @@ import * as queries from './browserQueries';
 import { unwrapTranscriptCapture } from './transcriptCapture';
 import { GtInspector } from './gtInspector';
 import { logError } from './gciLog';
+import { NbCancelledError } from './nbRunner';
 
 // The webview's DOM behavior lives in a standalone file (like listFilter.js /
 // methodListView.js) so it gets IDE support and can be jsdom-tested in isolation
@@ -368,6 +369,33 @@ export class DebuggerPanel {
   private stashedSourceKeys = new Set<string>();
   /** Every source URI shown in the companion editor (closed on dispose). */
   private shownSourceUris = new Set<string>();
+  /** Server level of the currently-selected frame (drives edit-and-continue). */
+  private selectedServerLevel: number | undefined;
+  /**
+   * The `gemstone://` URI of the selected frame's source IFF it is an editable
+   * method — set by revealFrameSource, cleared for read-only (doit) frames.
+   * Saving this exact document triggers edit-and-continue for the selected frame.
+   */
+  private editableSourceUri: string | undefined;
+  /**
+   * True once the TOP frame's method has been recompiled in place but could not
+   * be re-entered (GemStone has no primitive to reset the top-of-stack IP — see
+   * editAndContinue). The suspended top activation is then stale: continuing or
+   * stepping it via GciTsContinueWith / gciStep… does NOT return (it hangs the
+   * gem, freezing the whole extension host — confirmed 2026-06-22). So while this
+   * is set, Resume/Step are refused with guidance; it clears the moment a trim
+   * (Restart a deeper frame / deep edit-and-continue) rebuilds the stack.
+   */
+  private staleTopActivation = false;
+  /**
+   * True while a non-blocking GCI operation (step / trim) is in flight. Only one
+   * GciTsNb… call may be outstanding per session, and overlapping a blocking
+   * Resume on top of one is illegal — so step/resume/restart are ignored while
+   * set. Cleared when the operation settles (resolve / reject / cancel).
+   */
+  private nbBusy = false;
+  /** Set in dispose() so an in-flight Nb op's continuation skips touching a dead panel. */
+  private disposed = false;
 
   /**
    * @param onComplete called with the process's result oop when execution
@@ -420,6 +448,13 @@ export class DebuggerPanel {
       null,
       this.disposables,
     );
+    // Edit-and-continue: saving the selected frame's source recompiles it (the
+    // gemstone:// FS provider) and then re-enters the recompiled method.
+    vscode.workspace.onDidSaveTextDocument(
+      (doc) => this.onSourceSaved(doc),
+      null,
+      this.disposables,
+    );
   }
 
   private handleMessage(msg: DebuggerInbound): void {
@@ -445,6 +480,7 @@ export class DebuggerPanel {
         // then drive the source pane AND the variables pane for that frame.
         const frame = this.frames.find(f => f.level === msg.level);
         if (frame) {
+          this.selectedServerLevel = frame.serverLevel;
           void this.revealFrameSource(frame.serverLevel);
           this.postVariables(frame.serverLevel);
         }
@@ -460,12 +496,12 @@ export class DebuggerPanel {
       case 'stepOver':
       case 'stepInto':
       case 'stepThrough': {
-        this.step(msg.command, msg.level);
+        void this.step(msg.command, msg.level);
         return;
       }
       case 'restartFrame': {
         const frame = this.frames.find(f => f.level === msg.level);
-        if (frame) this.restartFrame(frame.serverLevel);
+        if (frame) void this.restartFrame(frame.serverLevel);
         return;
       }
       case 'inspectVariable': {
@@ -584,6 +620,15 @@ export class DebuggerPanel {
 
   /** Resume execution: closes the panel if the process completes, else refreshes on the new error. */
   private resume(): void {
+    if (this.guardStaleTopActivation('Resume')) return;
+    // Don't issue a blocking continue while a non-blocking step/trim is in flight
+    // (only one GCI call per session). Resume itself is still BLOCKING — 3.7.x has
+    // no GciTsNbContinue — so a long/looping Resume can still stall the host until
+    // it returns; making Resume non-blocking needs a worker thread (tracked).
+    if (this.nbBusy) {
+      this.notifyBusy('Resume');
+      return;
+    }
     const result = debug.continueExecution(this.session, this.gsProcess);
     if (result.completed) {
       this.onCompleted(result);
@@ -591,6 +636,22 @@ export class DebuggerPanel {
       this.errorMessage = result.errorMessage || 'GemStone error';
       this.refresh();
     }
+  }
+
+  /**
+   * Refuse a Resume/Step when the top activation is stale (its method was
+   * recompiled in place and couldn't be re-entered). Continuing/stepping it would
+   * hang the gem and freeze the extension host. Returns true if the action was
+   * blocked (the caller must bail). The only safe escapes are Restart on a deeper
+   * frame (re-enters the recompiled code) or Terminate.
+   */
+  private guardStaleTopActivation(action: string): boolean {
+    if (!this.staleTopActivation) return false;
+    this.errorMessage = `${action} is unavailable: the top frame's method was recompiled, so its `
+      + 'suspended activation can no longer be continued (GemStone would hang). Restart a deeper '
+      + 'frame to re-enter the recompiled code, or Terminate the process.';
+    this.postInit();
+    return true;
   }
 
   /**
@@ -620,25 +681,79 @@ export class DebuggerPanel {
    * 6014). If a step still hits that, we surface a clear message rather than
    * fail silently. Resume is unaffected.
    */
-  private step(command: 'stepOver' | 'stepInto' | 'stepThrough', displayLevel?: number): void {
-    const fn = command === 'stepOver' ? debug.stepOver
-      : command === 'stepInto' ? debug.stepInto
-        : debug.stepOut; // "Through" == gciStepThru (debugQueries.stepOut)
+  private async step(command: 'stepOver' | 'stepInto' | 'stepThrough', displayLevel?: number): Promise<void> {
+    if (this.guardStaleTopActivation('Step')) return;
+    const fn = command === 'stepOver' ? debug.stepOverNb
+      : command === 'stepInto' ? debug.stepIntoNb
+        : debug.stepThruNb; // "Through" == gciStepThru
     const frame = this.frames.find(f => f.level === displayLevel) ?? this.frames[0];
     const level = frame?.serverLevel ?? 1;
-    const result = fn(this.session, this.gsProcess, level);
-    if (result.completed) {
-      this.onCompleted(result);
-      return;
+    await this.runNb('Step', async () => {
+      // Non-blocking + cancellable: a step that crawls hidden machinery or steps
+      // a looping method no longer freezes the extension host (see nbRunner.ts).
+      const result = await fn(this.session, this.gsProcess, level);
+      if (this.disposed) return; // panel closed while the step ran
+      if (result.completed) {
+        this.onCompleted(result);
+        return;
+      }
+      if (result.errorMessage && /native code/i.test(result.errorMessage)) {
+        this.errorMessage = 'Stepping is unavailable while the gem runs native code '
+          + '(GEM_NATIVE_CODE_ENABLED). Use Resume — or run the gem with native code disabled to step.';
+        this.postInit(); // show the note; the stack is unchanged
+        return;
+      }
+      this.errorMessage = ''; // stepped to a new point — clear the original halt banner
+      this.refresh();
+    });
+  }
+
+  /**
+   * Report a failed/cancelled non-blocking op in the panel banner (best-effort —
+   * does nothing if the panel was disposed mid-flight). A user cancel (hard
+   * break) is surfaced as "<action> cancelled", anything else as a failure.
+   */
+  private handleNbError(action: string, e: unknown): void {
+    if (this.disposed) return;
+    if (e instanceof NbCancelledError) {
+      this.errorMessage = `${action} cancelled.`;
+    } else {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      this.errorMessage = `${action} failed: ${e instanceof Error ? e.message : String(e)}`;
     }
-    if (result.errorMessage && /native code/i.test(result.errorMessage)) {
-      this.errorMessage = 'Stepping is unavailable while the gem runs native code '
-        + '(GEM_NATIVE_CODE_ENABLED). Use Resume — or run the gem with native code disabled to step.';
-      this.postInit(); // show the note; the stack is unchanged
-      return;
-    }
-    this.errorMessage = ''; // stepped to a new point — clear the original halt banner
     this.refresh();
+  }
+
+  /**
+   * Run a non-blocking debugger op (step / trim) under the single-in-flight
+   * guard. Owns the `nbBusy` lifecycle in a `finally` so it can NEVER leak — a
+   * leaked flag would silently wedge the debugger (every later step/resume/
+   * restart becomes a no-op). `op` does the work and its own post-processing; a
+   * thrown error (including a user cancel) is surfaced via handleNbError. If an
+   * op is already in flight the request is NOT silently dropped — the user is
+   * told to retry (otherwise a save-driven edit-and-continue or a click would
+   * just vanish).
+   */
+  private async runNb(action: string, op: () => Promise<void>): Promise<void> {
+    if (this.nbBusy) {
+      this.notifyBusy(action);
+      return;
+    }
+    this.nbBusy = true;
+    try {
+      await op();
+    } catch (e: unknown) {
+      this.handleNbError(action, e);
+    } finally {
+      this.nbBusy = false;
+    }
+  }
+
+  /** Tell the user another debugger op is still running rather than dropping theirs. */
+  private notifyBusy(action: string): void {
+    if (this.disposed) return;
+    this.errorMessage = `Another debugger operation is still running — wait for it to finish, then retry ${action}.`;
+    this.postInit();
   }
 
   /**
@@ -654,7 +769,7 @@ export class DebuggerPanel {
    * works on any deeper frame (for a recursive call, restarting the caller frame
    * re-enters the same method one level up).
    */
-  private restartFrame(serverLevel: number): void {
+  private async restartFrame(serverLevel: number): Promise<void> {
     if (serverLevel <= 1) {
       // Show the notice IN the panel (the banner) — a toast is easy to miss while
       // the webview has focus. It clears on the next step/resume/restart.
@@ -663,9 +778,73 @@ export class DebuggerPanel {
       this.postInit();
       return;
     }
-    debug.trimStackToLevel(this.session, this.gsProcess, serverLevel);
-    this.errorMessage = '';
-    this.refresh();
+    await this.runNb('Restart frame', async () => {
+      await debug.trimStackToLevelNb(this.session, this.gsProcess, serverLevel);
+      if (this.disposed) return;
+      this.staleTopActivation = false; // the trim discarded any stale top activation
+      this.errorMessage = '';
+      this.refresh();
+    });
+  }
+
+  /**
+   * Edit-and-continue. The companion source editor IS a real `gemstone://`
+   * editor, so saving it already recompiles the method (the FS provider's
+   * writeFile). We hook the *post*-save moment: when the saved document is the
+   * selected frame's editable source AND the recompile succeeded, re-enter the
+   * recompiled method so execution picks up the new code.
+   *
+   * Only the selected frame's editable source counts — a read-only doit, or a
+   * save of some unrelated method, is ignored (`editableSourceUri` gates it).
+   *
+   * A failed recompile leaves the OLD method installed and an error diagnostic
+   * on the URI (the FS provider sets it and does NOT rethrow, so this save still
+   * fires) — we detect that and do nothing, so the user just fixes and re-saves.
+   */
+  private onSourceSaved(doc: vscode.TextDocument): void {
+    if (this.editableSourceUri === undefined || this.selectedServerLevel === undefined) return;
+    if (doc.uri.toString() !== this.editableSourceUri) return;
+    // The recompile failed if the FS provider left an error diagnostic on the URI
+    // (it sets one and does NOT rethrow, so this save still fires) — then we leave
+    // the old method installed and do nothing; the user fixes and re-saves.
+    const failed = vscode.languages
+      .getDiagnostics(doc.uri)
+      .some((d) => d.severity === vscode.DiagnosticSeverity.Error);
+    if (failed) return;
+    void this.editAndContinue(this.selectedServerLevel);
+  }
+
+  /**
+   * Re-enter the (just-recompiled) selected frame's method. Reuses the restart
+   * mechanism: `trimStackToLevel:` installs the recompiled home method on the
+   * frame and resets it to its method's first instruction (the running activation
+   * still held the OLD GsNMethod and could not continue on it). Execution then
+   * flows into the new code on the next step/resume.
+   *
+   * Same GemStone limitation as Restart Frame: the primitive is a guarded no-op
+   * for the absolute top frame (level 1), so an edit there can't be re-entered in
+   * place — we tell the user instead of silently doing nothing. (After a halt/
+   * error the user's frame is normally below the trimmed signal machinery, so its
+   * server level is ≥ 2 and edit-and-continue works.)
+   */
+  private async editAndContinue(serverLevel: number): Promise<void> {
+    if (serverLevel <= 1) {
+      // The top method is now recompiled but its activation can't be re-entered;
+      // mark it stale so Resume/Step refuse to continue it (would hang the gem).
+      this.staleTopActivation = true;
+      this.errorMessage = 'Saved and recompiled — but GemStone cannot re-enter the top frame in '
+        + 'place, so its suspended activation can no longer be continued. Restart a deeper frame '
+        + 'to re-enter the recompiled code, or Terminate the process. (Resume/Step are disabled.)';
+      this.postInit();
+      return;
+    }
+    await this.runNb('Edit-and-continue', async () => {
+      await debug.trimStackToLevelNb(this.session, this.gsProcess, serverLevel);
+      if (this.disposed) return;
+      this.staleTopActivation = false; // the trim rebuilt the stack from a fresh activation
+      this.errorMessage = '';
+      this.refresh();
+    });
   }
 
   /**
@@ -701,7 +880,11 @@ export class DebuggerPanel {
         // In the symbol list → the real editable gemstone:// editor.
         uri = vscode.Uri.parse(buildMethodSourceUri(this.session.id, home.uriInfo));
         methodForOffsets = { className: home.uriInfo.className, isMeta: home.uriInfo.isMeta, selector: home.uriInfo.selector };
+        // Saving this document triggers edit-and-continue for the selected frame.
+        this.editableSourceUri = uri.toString();
       } else {
+        // A read-only doit / non-symbol-list method can't be edited-and-continued.
+        this.editableSourceUri = undefined;
         // No gemstone:// URI: show the source read-only. Strip the Transcript-
         // capture glue so a doit shows just the user's code (e.g.
         // `JasperDebugDemo new run`). Title by the method when we have one, so a
@@ -1206,6 +1389,7 @@ export class DebuggerPanel {
   }
 
   private dispose(): void {
+    this.disposed = true; // an in-flight Nb step/trim continuation must skip the dead panel
     DebuggerPanel.panels.get(this.sessionId)?.delete(this);
     // Restore native code once the last debugger for this session closes
     // (paired with acquireStepping in create).

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -6,6 +6,7 @@ import { ActiveSession } from './sessionManager';
 import * as debug from './debugQueries';
 import * as queries from './browserQueries';
 import { unwrapTranscriptCapture } from './transcriptCapture';
+import { GtInspector } from './gtInspector';
 import { logError } from './gciLog';
 
 // The webview's DOM behavior lives in a standalone file (like listFilter.js /
@@ -66,7 +67,29 @@ type DebuggerInbound =
   | { command: 'stepInto'; level: number }
   | { command: 'stepThrough'; level: number }
   | { command: 'restartFrame'; level: number }
-  | { command: 'saveLayout'; stackBasis: string };
+  | { command: 'inspectVariable'; oop: string; name: string }
+  | { command: 'saveLayout'; stackBasis?: string; evalHeight?: string };
+
+/** A single variable row (name / printString / oop) sent to the webview. */
+interface VarRow {
+  name: string;
+  value: string;
+  /** The variable's OOP as a decimal string (drives the dim column + GT Inspect). */
+  oop: string;
+}
+
+/**
+ * A named group of variable rows. Stage 2 splits the flat list into Receiver
+ * (`self`), Instance variables, Arguments & Temps, and a collapsed
+ * `(stack temps)` group for the synthetic eval-stack temporaries.
+ */
+interface VarGroup {
+  title: string;
+  kind: 'receiver' | 'instvars' | 'argtemps' | 'stacktemps';
+  vars: VarRow[];
+  /** Rendered collapsed by default (used for the noisy `(stack temps)` group). */
+  collapsed?: boolean;
+}
 
 /**
  * Build the `gemstone://` URI for a method's source, in the exact form the
@@ -302,6 +325,14 @@ export class DebuggerPanel {
    */
   private static savedStackBasis = '60%';
 
+  /**
+   * The eval bar's height (`--eval-height`); the hsplitter resizes it, trading
+   * space with the panes (which flex-fill the rest). Like `savedStackBasis`,
+   * remembered across panels for this window and persisted webview-side via
+   * getState/setState. Default 7rem.
+   */
+  private static savedEvalHeight = '7rem';
+
   private static ensureReadOnlySourceProvider(): void {
     if (DebuggerPanel.providerRegistered) return;
     DebuggerPanel.providerRegistered = true;
@@ -437,9 +468,20 @@ export class DebuggerPanel {
         if (frame) this.restartFrame(frame.serverLevel);
         return;
       }
+      case 'inspectVariable': {
+        // Open the clicked variable in a GT Inspector (beside), like GT Inspect.
+        try {
+          GtInspector.create(this.session, BigInt(msg.oop), msg.name);
+        } catch (e: unknown) {
+          logError(this.sessionId, e instanceof Error ? e.message : String(e));
+        }
+        return;
+      }
       case 'saveLayout': {
-        // Remember the stack/variables split so the next panel opens the same way.
-        DebuggerPanel.savedStackBasis = msg.stackBasis;
+        // Remember the splits (stack-vs-variables width, eval-bar height) so the
+        // next panel opens the same way. Each is sent only when it changed.
+        if (msg.stackBasis != null) DebuggerPanel.savedStackBasis = msg.stackBasis;
+        if (msg.evalHeight != null) DebuggerPanel.savedEvalHeight = msg.evalHeight;
         return;
       }
     }
@@ -461,33 +503,69 @@ export class DebuggerPanel {
     this.postInit();
   }
 
-  /** Fetch the selected frame's variables (self + args/temps) and post them. */
+  /** Fetch the selected frame's grouped variables and post them. */
   private postVariables(serverLevel: number): void {
-    let vars: { name: string; value: string }[] = [];
+    let groups: VarGroup[] = [];
     try {
-      vars = this.fetchVariables(serverLevel);
+      groups = this.fetchVariables(serverLevel);
     } catch (e: unknown) {
       logError(this.sessionId, e instanceof Error ? e.message : String(e));
     }
-    this.panel.webview.postMessage({ command: 'variables', vars });
+    this.panel.webview.postMessage({ command: 'variables', groups });
   }
 
   /**
-   * Basic variables for a frame: `self` followed by the frame's args and temps,
-   * each with its printString. (Stage 2 adds Receiver/Args grouping, the oop
-   * column, and click-to-inspect.) Each printString is best-effort.
+   * The selected frame's variables, split into Receiver (`self`), Instance
+   * variables (the receiver's named instVars), Arguments & Temps (the frame's
+   * *named* args/temps), and a collapsed `(stack temps)` group for the synthetic
+   * `.tN` eval-stack temporaries (which have no source name). Each printString
+   * and the instVar resolution are best-effort so one bad slot can't blank the
+   * whole pane. Each row carries its OOP for the dim column + click-to-inspect.
    */
-  private fetchVariables(serverLevel: number): { name: string; value: string }[] {
+  private fetchVariables(serverLevel: number): VarGroup[] {
     const info = debug.getFrameInfo(this.session, this.gsProcess, serverLevel);
     const safePrint = (oop: bigint): string => {
       try { return debug.getObjectPrintString(this.session, oop); }
       catch { return '<unprintable>'; }
     };
-    const vars = [{ name: 'self', value: safePrint(info.receiverOop) }];
-    for (let i = 0; i < info.argAndTempNames.length; i++) {
-      vars.push({ name: info.argAndTempNames[i], value: safePrint(info.argAndTempOops[i]) });
+    const row = (name: string, oop: bigint): VarRow =>
+      ({ name, value: safePrint(oop), oop: oop.toString() });
+
+    const groups: VarGroup[] = [];
+
+    // 1. Receiver — `self`.
+    groups.push({ title: 'Receiver', kind: 'receiver', vars: [row('self', info.receiverOop)] });
+
+    // 2. Instance variables — the receiver's named instVars (none for immediates).
+    try {
+      const ivNames = debug.getInstVarNames(this.session, info.receiverOop);
+      if (ivNames.length > 0) {
+        const ivOops = debug.getNamedInstVarOops(this.session, info.receiverOop, ivNames.length);
+        const ivVars = ivNames.map((n, i) => row(n, ivOops[i]));
+        groups.push({ title: 'Instance variables', kind: 'instvars', vars: ivVars });
+      }
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
     }
-    return vars;
+
+    // 3 + 4. Args/temps — real source names vs synthetic `.tN` eval-stack temps.
+    // `__vsc…` temps are the Transcript-capture wrapper's glue (see
+    // transcriptCapture.ts); they're hidden, just like the glue is stripped from
+    // an executed-code frame's source.
+    const named: VarRow[] = [];
+    const stackTemps: VarRow[] = [];
+    for (let i = 0; i < info.argAndTempNames.length; i++) {
+      const name = info.argAndTempNames[i];
+      if (name.startsWith('__vsc')) continue;
+      (name.startsWith('.') ? stackTemps : named).push(row(name, info.argAndTempOops[i]));
+    }
+    if (named.length > 0) {
+      groups.push({ title: 'Arguments & Temps', kind: 'argtemps', vars: named });
+    }
+    if (stackTemps.length > 0) {
+      groups.push({ title: '(stack temps)', kind: 'stacktemps', collapsed: true, vars: stackTemps });
+    }
+    return groups;
   }
 
   /** Evaluate an expression in the selected frame and post the printString back. */
@@ -563,8 +641,28 @@ export class DebuggerPanel {
     this.refresh();
   }
 
-  /** Restart the selected frame (trim the stack to it) and refresh. */
+  /**
+   * Restart the selected frame: re-enter its method from the first statement,
+   * keeping the receiver + arguments. GemStone does this via
+   * `GsProcess>>trimStackToLevel:` (the same primitive GT's `restartFrameLevel:`
+   * uses), which trims the calls made from the frame and resets the new
+   * top-of-stack to its method's first instruction.
+   *
+   * That primitive is a guarded no-op for level 1, and there is no primitive to
+   * reset the *top* frame's IP in place — so the absolute top frame can't be
+   * restarted. Tell the user instead of silently doing nothing; restart still
+   * works on any deeper frame (for a recursive call, restarting the caller frame
+   * re-enters the same method one level up).
+   */
   private restartFrame(serverLevel: number): void {
+    if (serverLevel <= 1) {
+      // Show the notice IN the panel (the banner) — a toast is easy to miss while
+      // the webview has focus. It clears on the next step/resume/restart.
+      this.errorMessage = 'Cannot restart the top frame: GemStone can only restart a frame '
+        + 'that has called another. Select a deeper frame to restart it.';
+      this.postInit();
+      return;
+    }
     debug.trimStackToLevel(this.session, this.gsProcess, serverLevel);
     this.errorMessage = '';
     this.refresh();
@@ -859,6 +957,7 @@ export class DebuggerPanel {
     const nonce = crypto.randomBytes(16).toString('hex');
     const subtitle = escapeHtml(this.sessionSubtitle());
     const stackBasis = DebuggerPanel.savedStackBasis;
+    const evalHeight = DebuggerPanel.savedEvalHeight;
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -867,10 +966,20 @@ export class DebuggerPanel {
         content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
+    /* Fill the webview column as a flex column so the panes take all available
+       height (more stack frames visible) and the eval bar stays pinned at the
+       bottom — it can never overlap the companion source editor group below. */
+    html, body { height: 100%; }
     body {
       font-family: var(--vscode-font-family);
       color: var(--vscode-foreground);
       padding: 0.75rem 1rem;
+      box-sizing: border-box;
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
     }
     /* Suppress text selection / the default Cut-Copy-Paste affordances; the
        Copy button is the supported way to copy the stack. */
@@ -945,11 +1054,13 @@ export class DebuggerPanel {
     /* Call Stack (left) + Variables (right), divided by a draggable splitter.
        --stack-basis is the stack pane's width; the splitter drag rewrites it and
        it's persisted (see debuggerView.js / the saveLayout message). */
-    .main { display: flex; align-items: stretch; --stack-basis: 60%; }
+    /* The panes row fills the leftover vertical space (flex:1) so the Call Stack /
+       Variables get as much room as the column allows. */
+    .main { display: flex; align-items: stretch; --stack-basis: 60%; flex: 1 1 auto; min-height: 0; }
     .pane { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
     .stack-pane { flex: 0 0 var(--stack-basis); }
     .vars-pane { flex: 1 1 0; }
-    .main .stack { min-width: 0; max-height: 22rem; overflow: auto; }
+    .main .stack { min-width: 0; flex: 1 1 0; min-height: 0; overflow: auto; }
     /* Draggable divider: a thin hit area with a centred 1px rule that thickens
        and lights up on hover / while dragging. */
     .splitter {
@@ -964,8 +1075,21 @@ export class DebuggerPanel {
       left: 3px; width: 3px; background: var(--vscode-focusBorder);
     }
     .vars {
-      min-width: 0; max-height: 22rem; overflow: auto;
+      min-width: 0; flex: 1 1 0; min-height: 0; overflow: auto;
       font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85rem;
+    }
+    /* Horizontal divider between the panes and the eval bar: drag up to give the
+       eval bar more room (e.g. for a long result), drag down to give the panes
+       more room. Rewrites the --eval-height var (the eval bar's fixed height). */
+    .hsplitter {
+      flex: 0 0 auto; height: 9px; cursor: row-resize; position: relative; margin: 0.2rem 0;
+    }
+    .hsplitter::before {
+      content: ''; position: absolute; left: 0; right: 0; top: 4px; height: 1px;
+      background: var(--vscode-panel-border, transparent);
+    }
+    .hsplitter:hover::before, .hsplitter.dragging::before {
+      top: 3px; height: 3px; background: var(--vscode-focusBorder);
     }
     /* Only when the column is genuinely tiny: stack the Variables pane under the
        Call Stack and hide the splitter (a horizontal drag is meaningless in a
@@ -974,26 +1098,50 @@ export class DebuggerPanel {
        layout would never apply and the panel would be needlessly tall. */
     @media (max-width: 340px) {
       .main { flex-direction: column; }
-      .stack-pane, .vars-pane { flex: 0 0 auto; }
+      .stack-pane, .vars-pane { flex: 1 1 0; }
       .splitter { display: none; }
       .vars-pane { margin-top: 0.6rem; }
     }
-    .vars .var { padding: 0.15rem 0.2rem; display: flex; gap: 0.5rem; }
-    .vars .var-name { color: var(--vscode-symbolIcon-variableForeground, var(--vscode-foreground)); white-space: nowrap; }
+    /* Variable groups (Receiver / Instance variables / Arguments & Temps /
+       stack temps). Titles toggle their body; the stack-temps group is collapsed. */
+    .var-group { margin-bottom: 0.25rem; }
+    .var-group-title {
+      font-weight: 600; font-size: 0.82rem; cursor: pointer; user-select: none;
+      color: var(--vscode-foreground); padding: 0.15rem 0.2rem;
+    }
+    .var-group-title::before { content: '\\25BE\\00a0'; color: var(--vscode-descriptionForeground); }
+    .var-group.collapsed .var-group-title::before { content: '\\25B8\\00a0'; }
+    .var-group.collapsed .var-group-body { display: none; }
+    .vars .var {
+      padding: 0.15rem 0.2rem; display: flex; gap: 0.5rem; align-items: baseline;
+      cursor: pointer; border-radius: 3px;
+    }
+    .vars .var:hover { background: var(--vscode-list-hoverBackground); }
+    .vars .var-name { color: var(--vscode-symbolIcon-variableForeground, var(--vscode-foreground)); white-space: nowrap; flex: 0 0 auto; }
     .vars .var-name.self { font-style: italic; }
-    .vars .var-value { color: var(--vscode-descriptionForeground); white-space: pre; overflow: hidden; text-overflow: ellipsis; }
-    /* Eval-in-frame bar. */
-    .evalbar { margin-top: 0.8rem; }
+    .vars .var-value { color: var(--vscode-descriptionForeground); white-space: pre; overflow: hidden; text-overflow: ellipsis; flex: 1 1 auto; }
+    /* OOP shown dim at the row end, matching the GT Inspector header convention. */
+    .vars .var-oop {
+      flex: 0 0 auto; margin-left: auto; white-space: nowrap;
+      font-size: 0.78em; color: var(--vscode-descriptionForeground); opacity: 0.75;
+    }
+    /* Eval-in-frame bar: a fixed-height region at the bottom (the hsplitter
+       resizes it). The result area scrolls within it. */
+    .evalbar {
+      flex: 0 0 var(--eval-height, 7rem); min-height: 2.6rem; overflow: hidden;
+      display: flex; flex-direction: column;
+    }
     .evalbar input {
       width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text;
       font-family: var(--vscode-editor-font-family, monospace);
       color: var(--vscode-input-foreground); background: var(--vscode-input-background);
       border: 1px solid var(--vscode-input-border, var(--vscode-panel-border, transparent));
-      padding: 0.3rem 0.5rem; border-radius: 2px;
+      padding: 0.3rem 0.5rem; border-radius: 2px; flex: 0 0 auto;
     }
     .eval-result {
       font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85rem;
       white-space: pre-wrap; margin-top: 0.35rem; user-select: text; -webkit-user-select: text;
+      flex: 1 1 auto; min-height: 0; overflow: auto;
     }
     .eval-result.error { color: var(--vscode-errorForeground); }
   </style>
@@ -1024,7 +1172,8 @@ export class DebuggerPanel {
       <div class="vars" id="variables"></div>
     </div>
   </div>
-  <div class="evalbar">
+  <div class="hsplitter" id="hsplitter" title="Drag to resize the panes vs the eval bar"></div>
+  <div class="evalbar" id="evalbar" style="--eval-height: ${evalHeight};">
     <input id="evalInput" type="text" autocomplete="off" spellcheck="false"
            placeholder="Evaluate in the selected frame — press Enter">
     <div class="eval-result" id="evalResult"></div>
@@ -1045,8 +1194,10 @@ export class DebuggerPanel {
       variables: document.getElementById('variables'),
       evalInput: document.getElementById('evalInput'),
       evalResult: document.getElementById('evalResult'),
+      evalbar: document.getElementById('evalbar'),
       main: document.getElementById('main'),
       splitter: document.getElementById('splitter'),
+      hsplitter: document.getElementById('hsplitter'),
     }, vscode);
     vscode.postMessage({ command: 'ready' });
   </script>

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -308,18 +308,30 @@ export class DebuggerPanel {
   /** Every source URI shown in the companion editor (closed on dispose). */
   private shownSourceUris = new Set<string>();
 
-  static create(session: ActiveSession, gsProcess: bigint, errorMessage: string): void {
+  /**
+   * @param onComplete called with the process's result oop when execution
+   *   completes via Resume or step-to-completion (e.g. so a halted Display It
+   *   can render its result back in the workspace). Omitted when there's no
+   *   result to surface (Execute It, or a halt not originating from a doit).
+   */
+  static create(
+    session: ActiveSession, gsProcess: bigint, errorMessage: string,
+    onComplete?: (resultOop: bigint) => void,
+  ): void {
     const panel = vscode.window.createWebviewPanel(
       'gemstoneEnhancedDebugger',
       'Jasper Debugger',
       vscode.ViewColumn.Beside,
       { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
     );
-    const debugger_ = new DebuggerPanel(panel, session, gsProcess, errorMessage);
+    const debugger_ = new DebuggerPanel(panel, session, gsProcess, errorMessage, onComplete);
     if (!DebuggerPanel.panels.has(session.id)) {
       DebuggerPanel.panels.set(session.id, new Set());
     }
     DebuggerPanel.panels.get(session.id)!.add(debugger_);
+    // Disable native code for this session so the debugger can single-step
+    // (GemStone can't step native code — error 6014). Released on dispose.
+    debug.acquireStepping(session);
   }
 
   static disposeForSession(sessionId: number): void {
@@ -336,6 +348,7 @@ export class DebuggerPanel {
     private readonly gsProcess: bigint,
     // Mutable: resume-into-another-error updates it; step/restart clear it.
     private errorMessage: string,
+    private readonly onComplete?: (resultOop: bigint) => void,
   ) {
     this.panel = panel;
     this.sessionId = session.id;
@@ -386,8 +399,7 @@ export class DebuggerPanel {
       case 'stepOver':
       case 'stepInto':
       case 'stepThrough': {
-        const frame = this.frames.find(f => f.level === msg.level);
-        if (frame) this.step(msg.command, frame.serverLevel);
+        this.step(msg.command, msg.level);
         return;
       }
       case 'restartFrame': {
@@ -461,25 +473,59 @@ export class DebuggerPanel {
   private resume(): void {
     const result = debug.continueExecution(this.session, this.gsProcess);
     if (result.completed) {
-      this.panel.dispose();
+      this.onCompleted(result);
     } else {
       this.errorMessage = result.errorMessage || 'GemStone error';
       this.refresh();
     }
   }
 
-  /** Step (over/into/through) from the selected frame: dispose on completion, else refresh. */
-  private step(command: 'stepOver' | 'stepInto' | 'stepThrough', serverLevel: number): void {
+  /**
+   * The process ran to completion (via Resume or step). Hand its result to the
+   * onComplete callback (e.g. a halted Display It rendering its value back in
+   * the workspace) — BEFORE dispose, while the result oop is still fetchable —
+   * then close the panel.
+   */
+  private onCompleted(result: debug.StepResult): void {
+    if (result.resultOop != null) this.onComplete?.(result.resultOop);
+    this.panel.dispose();
+  }
+
+  /**
+   * Step over/into/through, then dispose on completion / else refresh.
+   *
+   * Steps from the selected (or topmost) USER frame's server level — NOT the
+   * process top (level 1). After a `halt`/error the process top is exception/
+   * signal machinery (which we filter out of the view); stepping over from a
+   * user frame runs that machinery to completion and stops at the next step
+   * point in the user code (e.g. the statement after `halt`), which is what the
+   * user expects from one Step Over. Stepping from level 1 would instead crawl
+   * one step point at a time through the hidden machinery.
+   *
+   * Requires native code OFF (codeExecutor toggles it before a debuggable run;
+   * the panel holds it off while open) — GemStone can't step native code (error
+   * 6014). If a step still hits that, we surface a clear message rather than
+   * fail silently. Resume is unaffected.
+   */
+  private step(command: 'stepOver' | 'stepInto' | 'stepThrough', displayLevel?: number): void {
     const fn = command === 'stepOver' ? debug.stepOver
       : command === 'stepInto' ? debug.stepInto
         : debug.stepOut; // "Through" == gciStepThru (debugQueries.stepOut)
-    const result = fn(this.session, this.gsProcess, serverLevel);
+    const frame = this.frames.find(f => f.level === displayLevel) ?? this.frames[0];
+    const level = frame?.serverLevel ?? 1;
+    const result = fn(this.session, this.gsProcess, level);
     if (result.completed) {
-      this.panel.dispose();
-    } else {
-      this.errorMessage = ''; // no longer at the original halt — clear the banner
-      this.refresh();
+      this.onCompleted(result);
+      return;
     }
+    if (result.errorMessage && /native code/i.test(result.errorMessage)) {
+      this.errorMessage = 'Stepping is unavailable while the gem runs native code '
+        + '(GEM_NATIVE_CODE_ENABLED). Use Resume — or run the gem with native code disabled to step.';
+      this.postInit(); // show the note; the stack is unchanged
+      return;
+    }
+    this.errorMessage = ''; // stepped to a new point — clear the original halt banner
+    this.refresh();
   }
 
   /** Restart the selected frame (trim the stack to it) and refresh. */
@@ -813,6 +859,9 @@ export class DebuggerPanel {
       font-family: var(--vscode-editor-font-family, monospace);
       white-space: pre-wrap;
       margin-bottom: 1rem;
+      /* Selectable so the error text can be copied (Ctrl/Cmd+C); the rest of the
+         panel stays non-selectable to keep the custom copy menu the only path. */
+      user-select: text; -webkit-user-select: text; cursor: text;
     }
     .stack { list-style: none; margin: 0; padding: 0; }
     .frame {
@@ -927,6 +976,9 @@ export class DebuggerPanel {
 
   private dispose(): void {
     DebuggerPanel.panels.get(this.sessionId)?.delete(this);
+    // Restore native code once the last debugger for this session closes
+    // (paired with acquireStepping in create).
+    debug.releaseStepping(this.session);
     // Drop the step-point highlight from the companion editor (which outlives
     // the panel) so a stale highlight doesn't linger after the debugger closes.
     this.decoratedEditor?.setDecorations(DebuggerPanel.stepPointDecoration, []);

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -242,6 +242,13 @@ const BLOCK_EVAL_SELECTORS = new Set([
   'value', 'value:', 'value:value:', 'value:value:value:', 'ensure:', 'ifCurtailed:', 'on:do:',
 ]);
 
+// GemStone rtErrUncontinuable (ErrorSymbols #rtErrUncontinuable → 6011): raised
+// when execution is asked to continue past an uncontinuable point — e.g. trying
+// to single-step *over* an unhandled `halt`/error. The step drives the signal to
+// `_uncontinuableError` rather than returning, so the user must Resume or
+// Terminate instead. ("Not trappable with Exceptions" per the kernel.)
+const GS_ERR_UNCONTINUABLE = 6011;
+
 /** True when a frame is exception-signalling / halt machinery. */
 export function isExceptionMachinery(f: RawFrame): boolean {
   return f.definingClassName === 'AbstractException'
@@ -387,6 +394,16 @@ export class DebuggerPanel {
    * (Restart a deeper frame / deep edit-and-continue) rebuilds the stack.
    */
   private staleTopActivation = false;
+  /**
+   * True once the process has hit an uncontinuable state (GemStone error 6011 —
+   * e.g. a step drove an unhandled `halt`/error to `_uncontinuableError`). The
+   * process is then dead-ended: neither Resume nor Step can recover it (each
+   * retry just re-signals 6011 and GemStone grows the exception-chain message),
+   * so while set we refuse both with a Terminate-only banner and make NO further
+   * GCI call. Cleared by a trim (Restart a deeper frame / deep edit-and-continue),
+   * which rebuilds the stack from a fresh activation.
+   */
+  private uncontinuable = false;
   /**
    * True while a non-blocking GCI operation (step / trim) is in flight. Only one
    * GciTsNb… call may be outstanding per session, and overlapping a blocking
@@ -621,6 +638,7 @@ export class DebuggerPanel {
   /** Resume execution: closes the panel if the process completes, else refreshes on the new error. */
   private resume(): void {
     if (this.guardStaleTopActivation('Resume')) return;
+    if (this.guardUncontinuable()) return;
     // Don't issue a blocking continue while a non-blocking step/trim is in flight
     // (only one GCI call per session). Resume itself is still BLOCKING — 3.7.x has
     // no GciTsNbContinue — so a long/looping Resume can still stall the host until
@@ -632,6 +650,12 @@ export class DebuggerPanel {
     const result = debug.continueExecution(this.session, this.gsProcess);
     if (result.completed) {
       this.onCompleted(result);
+    } else if (result.errorNumber === GS_ERR_UNCONTINUABLE) {
+      // The process is dead-ended; don't refresh (that would surface the
+      // uncontinuable machinery wall) — show the fixed Terminate-only banner.
+      this.uncontinuable = true;
+      this.errorMessage = DebuggerPanel.UNCONTINUABLE_MSG;
+      this.postInit();
     } else {
       this.errorMessage = result.errorMessage || 'GemStone error';
       this.refresh();
@@ -645,6 +669,27 @@ export class DebuggerPanel {
    * blocked (the caller must bail). The only safe escapes are Restart on a deeper
    * frame (re-enters the recompiled code) or Terminate.
    */
+  // Shown whenever the process is uncontinuable (error 6011). Fixed text so
+  // retrying Resume/Step never grows GemStone's accumulating exception-chain
+  // message — and steers the user to the only thing that works: Terminate.
+  private static readonly UNCONTINUABLE_MSG =
+    "Execution can't be continued — this stepped into an unhandled halt or error and GemStone "
+    + 'marked the process uncontinuable (error 6011). Terminate (■) and re-run; Resume and Step '
+    + 'cannot recover it. (To pass a halt next time, use Resume instead of Step.)';
+
+  /**
+   * Refuse a Resume/Step once the process is uncontinuable (6011). Returns true
+   * if the action was blocked (caller must bail). Makes NO GCI call — so a retry
+   * can't re-signal 6011 and grow GemStone's exception-chain message. The only
+   * escape is Restart a deeper frame (which clears the flag) or Terminate.
+   */
+  private guardUncontinuable(): boolean {
+    if (!this.uncontinuable) return false;
+    this.errorMessage = DebuggerPanel.UNCONTINUABLE_MSG;
+    this.postInit();
+    return true;
+  }
+
   private guardStaleTopActivation(action: string): boolean {
     if (!this.staleTopActivation) return false;
     this.errorMessage = `${action} is unavailable: the top frame's method was recompiled, so its `
@@ -683,6 +728,7 @@ export class DebuggerPanel {
    */
   private async step(command: 'stepOver' | 'stepInto' | 'stepThrough', displayLevel?: number): Promise<void> {
     if (this.guardStaleTopActivation('Step')) return;
+    if (this.guardUncontinuable()) return;
     const fn = command === 'stepOver' ? debug.stepOverNb
       : command === 'stepInto' ? debug.stepIntoNb
         : debug.stepThruNb; // "Through" == gciStepThru
@@ -695,6 +741,16 @@ export class DebuggerPanel {
       if (this.disposed) return; // panel closed while the step ran
       if (result.completed) {
         this.onCompleted(result);
+        return;
+      }
+      if (result.errorNumber === GS_ERR_UNCONTINUABLE) {
+        // Stepping *over* an unhandled halt/error drove its signal to
+        // `_uncontinuableError`; the process is now dead-ended. Mark it so
+        // Resume/Step are refused (no GCI retry → no growing message), keep the
+        // pre-step stack, and steer the user to Terminate.
+        this.uncontinuable = true;
+        this.errorMessage = DebuggerPanel.UNCONTINUABLE_MSG;
+        this.postInit(); // show the note; the stack is unchanged
         return;
       }
       if (result.errorMessage && /native code/i.test(result.errorMessage)) {
@@ -782,6 +838,7 @@ export class DebuggerPanel {
       await debug.trimStackToLevelNb(this.session, this.gsProcess, serverLevel);
       if (this.disposed) return;
       this.staleTopActivation = false; // the trim discarded any stale top activation
+      this.uncontinuable = false;      // …and a fresh activation is continuable again
       this.errorMessage = '';
       this.refresh();
     });
@@ -842,6 +899,7 @@ export class DebuggerPanel {
       await debug.trimStackToLevelNb(this.session, this.gsProcess, serverLevel);
       if (this.disposed) return;
       this.staleTopActivation = false; // the trim rebuilt the stack from a fresh activation
+      this.uncontinuable = false;      // …which is continuable again
       this.errorMessage = '';
       this.refresh();
     });
@@ -876,6 +934,11 @@ export class DebuggerPanel {
 
       let uri: vscode.Uri;
       let methodForOffsets: { className: string; isMeta: boolean; selector: string } | undefined;
+      // For a read-only view we can still highlight the step point IF the
+      // displayed source matches the server's method source 1:1 (a raw Debug It
+      // doit). Set to the frame's method OOP in that case; left undefined when
+      // the source was unwrapped (offsets would point into the wrapped source).
+      let readOnlyOffsetMethodOop: bigint | undefined;
       if (home.uriInfo) {
         // In the symbol list → the real editable gemstone:// editor.
         uri = vscode.Uri.parse(buildMethodSourceUri(this.session.id, home.uriInfo));
@@ -889,21 +952,37 @@ export class DebuggerPanel {
         // capture glue so a doit shows just the user's code (e.g.
         // `JasperDebugDemo new run`). Title by the method when we have one, so a
         // non-symbol-list method isn't mislabelled "Executed Code".
-        const source = unwrapTranscriptCapture(debug.getMethodSource(this.session, info.methodOop));
+        //
+        // Source AND offsets come from the HOME method, never the block's own
+        // GsNMethod. A block's `_sourceOffsets` covers only its own step points,
+        // but `_stepPointAt:` reports the frame's step point in HOME-method
+        // numbering — so pairing a home step point with a block's short offsets
+        // array overruns it (undefined) and the highlight collapses to the line.
+        // The home method's offsets include every block's step points, so they
+        // line up. (This mirrors the editable path, which uses home offsets.)
+        const rawSource = debug.getMethodSource(this.session, homeMethodOop);
+        const source = unwrapTranscriptCapture(rawSource);
+        // If unwrapping was a no-op the displayed source is the server source,
+        // so the server's step-point offsets map onto it directly (Debug It).
+        // If it stripped a wrapper, the offsets refer to the wrapped source and
+        // would mis-highlight, so leave highlighting off (as before).
+        if (source === rawSource) readOnlyOffsetMethodOop = homeMethodOop;
         const title = home.isExecutedCode ? 'Executed Code' : `${home.definingClassName}>>#${home.selector}`;
-        uri = DebuggerPanel.stashReadOnlySource(this.session.id, info.methodOop, title, source);
+        uri = DebuggerPanel.stashReadOnlySource(this.session.id, homeMethodOop, title, source);
         this.stashedSourceKeys.add(uri.toString());
       }
 
       const editor = await this.showSourceEditor(uri);
 
-      // Only the editable gemstone:// method gets a step-point highlight (C2):
-      // the read-only view has no reliable IP→source mapping (executed code is
-      // unwrapped; a non-symbol-list method has no step-point offsets here).
-      // TODO(Stage "Hardening"): revisit highlighting the read-only view.
+      // Highlight the current step point: from class>>selector offsets for an
+      // editable method, or from the method OOP for an un-wrapped read-only doit
+      // (Debug It). A wrapped/unwrappable read-only view stays un-highlighted —
+      // its offsets wouldn't line up with the displayed source.
       const range = methodForOffsets
         ? this.stepPointRange(editor.document, info, level, methodForOffsets)
-        : undefined;
+        : readOnlyOffsetMethodOop !== undefined
+          ? this.stepPointRange(editor.document, info, level, undefined, readOnlyOffsetMethodOop)
+          : undefined;
       // Clear a stale highlight if the source moved to a different editor.
       if (this.decoratedEditor && this.decoratedEditor !== editor) {
         this.decoratedEditor.setDecorations(DebuggerPanel.stepPointDecoration, []);
@@ -962,18 +1041,24 @@ export class DebuggerPanel {
     info: debug.FrameInfo,
     level: number,
     method: { className: string; isMeta: boolean; selector: string } | undefined,
+    readOnlyMethodOop?: bigint,
   ): vscode.Range | undefined {
     let pos: vscode.Position | undefined;
 
-    // Exact step-point offset → the precise sub-expression start.
-    if (method) {
+    // Exact step-point offset → the precise sub-expression start. The offsets
+    // come from class>>selector for an editable method, or straight from the
+    // method OOP for a raw doit (Debug It), whose displayed source matches the
+    // server source 1:1 so the offsets line up.
+    if (method || readOnlyMethodOop !== undefined) {
       try {
         const stepPoint = debug.getStepPoint(this.session, this.gsProcess, level);
         if (stepPoint) {
           // getSourceOffsets returns GemStone `_sourceOffsets`, which are
           // 1-BASED (see getStepPointSelectorRanges.ts). doc.positionAt is
           // 0-based, so convert — otherwise the highlight sits one char too far.
-          const offsets = queries.getSourceOffsets(this.session, method.className, method.isMeta, method.selector);
+          const offsets = method
+            ? queries.getSourceOffsets(this.session, method.className, method.isMeta, method.selector)
+            : debug.getSourceOffsetsForMethod(this.session, readOnlyMethodOop!);
           const offset = offsets[stepPoint - 1];
           if (offset != null && offset >= 1 && doc.positionAt) pos = doc.positionAt(offset - 1);
         }

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -1,0 +1,456 @@
+import * as vscode from 'vscode';
+import * as crypto from 'crypto';
+import { ActiveSession } from './sessionManager';
+import * as debug from './debugQueries';
+import { logError } from './gciLog';
+
+/**
+ * Jasper Debugger — a roomy, Smalltalk-style debugger rendered as a VS Code
+ * webview, offered *alongside* the existing DAP debugger. Whichever entry point
+ * the user picks (DAP "Debug" vs. this "Enhanced Debug") owns the suspended
+ * `gsProcess` for that error, so the two never coexist on the same process.
+ * Closing the panel releases (terminates) that suspended process.
+ *
+ * This panel is a SECOND consumer of the DAP-free data layer in
+ * `debugQueries.ts` (the DAP `GemStoneDebugSession` is the first). It mirrors
+ * the webview wiring conventions established in `gtInspector.ts`
+ * (createWebviewPanel + enableScripts + retainContextWhenHidden +
+ * postMessage/onDidReceiveMessage).
+ *
+ * Stage 0: foundation only — panel lifecycle + a message-handler skeleton that
+ * proves the data-layer pipe end-to-end by listing the stack. The real
+ * show-everything layout (source / variables / eval / toolbar) lands in Stage 1.
+ */
+
+/** Messages the webview sends to the extension host. */
+type DebuggerInbound =
+  | { command: 'ready' }
+  | { command: 'copyStack' }
+  | { command: 'copyFrame'; level: number };
+
+/** Resolved pieces of a frame label, before formatting. */
+export interface FrameLabelParts {
+  /** True when the frame's method is a block method. */
+  isBlock: boolean;
+  /** Class that defines the (home) method, e.g. "Object" or "Foo class". */
+  definingClass: string;
+  /** The (home) method's selector. */
+  selector: string;
+  /** Class of the frame's receiver, when available. */
+  receiverClass?: string;
+}
+
+/**
+ * Format a frame label, mirroring GsNMethod>>_descrForStackPadTo:rcvr:
+ *   - block frames are prefixed `[] in ` and named by their home method;
+ *   - for non-block frames whose receiver's class differs from the class that
+ *     defines the method, the receiver is disambiguated as
+ *     `ReceiverClass (DefiningClass)` (the standard Smalltalk convention);
+ *   - block frames are NOT receiver-disambiguated (the home receiver may not
+ *     correspond to the block's defining class).
+ */
+export function formatFrameLabel(p: FrameLabelParts): string {
+  const prefix = p.isBlock ? '[] in ' : '';
+  let classPart = p.definingClass;
+  if (!p.isBlock && p.receiverClass && p.receiverClass !== p.definingClass) {
+    classPart = `${p.receiverClass} (${p.definingClass})`;
+  }
+  return `${prefix}${classPart}>>#${p.selector}`;
+}
+
+/**
+ * Format a frame's position annotation as `@<stepPoint> line <line>` — e.g.
+ * `@2 line 12`. Either part is omitted when unavailable; returns '' when both
+ * are missing. Kept pure (no `debug`/webview dependency) so it is unit-testable
+ * and shared by the data layer rather than reimplemented in the webview script.
+ */
+export function formatFramePosition(stepPoint?: number, line?: number): string {
+  const parts: string[] = [];
+  if (stepPoint != null) parts.push(`@${stepPoint}`);
+  // A line of 0 means the IP has no source mapping — omit it (don't show "line 0").
+  if (line) parts.push(`line ${line}`);
+  return parts.join(' ');
+}
+
+/** Minimal HTML-escape for interpolating session text into the page. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** A single stack frame summary sent to the webview. */
+interface FrameSummary {
+  /** 1-based frame number (1 = top), shown so frames are easy to refer to. */
+  level: number;
+  label: string;
+  /** Pre-formatted `@<stepPoint> line <line>` annotation; '' when unavailable. */
+  position: string;
+}
+
+/**
+ * Render a single frame for the clipboard — `<label>  <position>` (no leading
+ * frame number, since a lone frame has no stack context). Pure/exported for
+ * unit-testing and reuse by formatStackForClipboard.
+ */
+export function formatFrameForClipboard(frame: FrameSummary): string {
+  return frame.position ? `${frame.label}  ${frame.position}` : frame.label;
+}
+
+/**
+ * Render the whole stack as plain text for the clipboard — one frame per line,
+ * `<n>. <label>  <position>`, preceded by the error message. Pure and
+ * exported so the copy format is unit-testable.
+ */
+export function formatStackForClipboard(errorMessage: string, frames: FrameSummary[]): string {
+  const lines: string[] = [];
+  if (errorMessage) lines.push(`GemStone error: ${errorMessage}`, '');
+  for (const f of frames) lines.push(`${f.level}. ${formatFrameForClipboard(f)}`);
+  return lines.join('\n');
+}
+
+export class DebuggerPanel {
+  private static panels = new Map<number, Set<DebuggerPanel>>();
+  private readonly panel: vscode.WebviewPanel;
+  private readonly sessionId: number;
+  private disposables: vscode.Disposable[] = [];
+  /** Last fetched stack, cached so 'copyStack' need not re-query the server. */
+  private frames: FrameSummary[] = [];
+
+  static create(session: ActiveSession, gsProcess: bigint, errorMessage: string): void {
+    const panel = vscode.window.createWebviewPanel(
+      'gemstoneEnhancedDebugger',
+      'Jasper Debugger',
+      vscode.ViewColumn.Beside,
+      { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
+    );
+    const debugger_ = new DebuggerPanel(panel, session, gsProcess, errorMessage);
+    if (!DebuggerPanel.panels.has(session.id)) {
+      DebuggerPanel.panels.set(session.id, new Set());
+    }
+    DebuggerPanel.panels.get(session.id)!.add(debugger_);
+  }
+
+  static disposeForSession(sessionId: number): void {
+    const set = DebuggerPanel.panels.get(sessionId);
+    if (set) {
+      for (const dbg of set) dbg.panel.dispose();
+      DebuggerPanel.panels.delete(sessionId);
+    }
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    private readonly session: ActiveSession,
+    private readonly gsProcess: bigint,
+    private readonly errorMessage: string,
+  ) {
+    this.panel = panel;
+    this.sessionId = session.id;
+    this.panel.webview.html = this.getHtml();
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+    this.panel.webview.onDidReceiveMessage(
+      (msg: DebuggerInbound) => this.handleMessage(msg),
+      null,
+      this.disposables,
+    );
+  }
+
+  private handleMessage(msg: DebuggerInbound): void {
+    switch (msg.command) {
+      case 'ready': {
+        this.frames = this.fetchStack();
+        this.panel.webview.postMessage({
+          command: 'init',
+          errorMessage: this.errorMessage,
+          stack: this.frames,
+        });
+        return;
+      }
+      case 'copyStack': {
+        void vscode.env.clipboard.writeText(
+          formatStackForClipboard(this.errorMessage, this.frames),
+        );
+        return;
+      }
+      case 'copyFrame': {
+        const frame = this.frames.find(f => f.level === msg.level);
+        if (frame) void vscode.env.clipboard.writeText(formatFrameForClipboard(frame));
+        return;
+      }
+    }
+  }
+
+  /**
+   * Walk the suspended process's stack and build a label per frame. The naming
+   * logic deliberately mirrors the DAP `stackTraceRequest`
+   * (gemstoneDebugSession.ts) so the Enhanced Debugger's stack matches the Run
+   * and Debug Call Stack frame-for-frame. Proves the `debugQueries` pipe works
+   * from this second consumer before Stage 1 builds the real layout on top.
+   */
+  private fetchStack(): FrameSummary[] {
+    const frames: FrameSummary[] = [];
+    try {
+      const depth = debug.getStackDepth(this.session, this.gsProcess);
+      for (let level = 1; level <= depth; level++) {
+        frames.push(this.buildFrame(level));
+      }
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+    }
+    return frames;
+  }
+
+  /**
+   * Build a single frame summary: a `Class[ class]>>#selector` label plus the
+   * step point and source line. The label logic mirrors the DAP path exactly
+   * — only frames whose contents can't be fetched are `<frame N>`; a valid
+   * frame with no introspectable method (e.g. an executed-code or block
+   * context) is `Executed Code`, NOT "unavailable". Step point / line are
+   * best-effort and simply omitted when unavailable.
+   */
+  private buildFrame(level: number): FrameSummary {
+    let info: debug.FrameInfo;
+    try {
+      info = debug.getFrameInfo(this.session, this.gsProcess, level);
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      return { level, label: `<frame ${level}>`, position: '' };
+    }
+
+    let label: string;
+    try {
+      // For a block frame, name the enclosing (home) method and prefix `[] in `,
+      // matching GsNMethod>>printOn:. homeMethodOop == methodOop for non-blocks.
+      const { isBlock, homeMethodOop } = debug.getMethodBlockInfo(this.session, info.methodOop);
+
+      // Defining class + selector come from the home method.
+      let definingClass: string;
+      let selector: string;
+      const uriInfo = debug.getMethodUriInfo(this.session, homeMethodOop);
+      if (uriInfo && uriInfo.dictName) {
+        definingClass = `${uriInfo.className}${uriInfo.isMeta ? ' class' : ''}`;
+        selector = uriInfo.selector;
+      } else {
+        const methodInfo = debug.getMethodInfo(this.session, homeMethodOop);
+        definingClass = methodInfo.className;
+        selector = methodInfo.selector;
+      }
+
+      // Receiver class drives the `Receiver (Defining)` disambiguation for
+      // inherited methods (non-block frames only — see formatFrameLabel).
+      let receiverClass: string | undefined;
+      if (!isBlock) {
+        try {
+          receiverClass = debug.getObjectClassName(this.session, info.receiverOop);
+        } catch { /* best-effort; fall back to defining class only */ }
+      }
+
+      label = formatFrameLabel({ isBlock, definingClass, selector, receiverClass });
+    } catch {
+      label = 'Executed Code';
+    }
+
+    let line: number | undefined;
+    try {
+      line = debug.getLineForIp(this.session, info.methodOop, info.ipOffset);
+    } catch { /* best-effort */ }
+
+    let stepPoint: number | undefined;
+    try {
+      stepPoint = debug.getStepPoint(this.session, this.gsProcess, level);
+    } catch { /* best-effort */ }
+
+    return { level, label, position: formatFramePosition(stepPoint, line) };
+  }
+
+  /** Dimmed "For <user> on <stone> @ <host>" subtitle from the login. */
+  private sessionSubtitle(): string {
+    const { gs_user, stone, gem_host } = this.session.login;
+    const parts: string[] = [];
+    if (gs_user) parts.push(`For ${gs_user}`);
+    if (stone) parts.push(`on ${stone}`);
+    if (gem_host) parts.push(`@ ${gem_host}`);
+    return parts.join(' ');
+  }
+
+  private getHtml(): string {
+    const nonce = crypto.randomBytes(16).toString('hex');
+    const subtitle = escapeHtml(this.sessionSubtitle());
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: var(--vscode-font-family);
+      color: var(--vscode-foreground);
+      padding: 0.75rem 1rem;
+    }
+    /* Suppress text selection / the default Cut-Copy-Paste affordances; the
+       Copy button is the supported way to copy the stack. */
+    body { user-select: none; -webkit-user-select: none; }
+    .titlebar { display: flex; align-items: baseline; gap: 0.6rem; margin: 0 0 0.25rem; flex-wrap: wrap; }
+    h1 { font-size: 1.3rem; margin: 0; }
+    .subtitle { color: var(--vscode-descriptionForeground); font-size: 0.85rem; }
+    .copy-btn {
+      margin-left: auto;
+      align-self: center;
+      font-family: var(--vscode-font-family);
+      color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+      background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+      border: none;
+      padding: 0.2rem 0.7rem;
+      border-radius: 2px;
+      cursor: pointer;
+    }
+    .copy-btn:hover { background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground)); }
+    .error {
+      color: var(--vscode-errorForeground);
+      font-family: var(--vscode-editor-font-family, monospace);
+      white-space: pre-wrap;
+      margin-bottom: 1rem;
+    }
+    .stack { list-style: none; margin: 0; padding: 0; }
+    .frame {
+      font-family: var(--vscode-editor-font-family, monospace);
+      padding: 0.2rem 0.4rem;
+      border-bottom: 1px solid var(--vscode-panel-border, transparent);
+      cursor: context-menu;
+    }
+    .frame:hover { background: var(--vscode-list-hoverBackground); }
+    .frame.selected { background: var(--vscode-list-activeSelectionBackground); }
+    /* Custom right-click menu (the default Cut/Copy/Paste menu is suppressed). */
+    .ctx-menu {
+      position: fixed; display: none; z-index: 10; min-width: 120px; padding: 0.2rem 0;
+      background: var(--vscode-menu-background, var(--vscode-editorWidget-background));
+      color: var(--vscode-menu-foreground, var(--vscode-foreground));
+      border: 1px solid var(--vscode-menu-border, var(--vscode-editorWidget-border, transparent));
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.36);
+    }
+    .ctx-menu.show { display: block; }
+    .ctx-item { padding: 0.25rem 1rem; cursor: pointer; white-space: nowrap; }
+    .ctx-item:hover {
+      background: var(--vscode-menu-selectionBackground);
+      color: var(--vscode-menu-selectionForeground);
+    }
+    .frame .level { color: var(--vscode-descriptionForeground); margin-right: 0.6rem; }
+    .frame .pos { color: var(--vscode-descriptionForeground); margin-left: 0.6rem; }
+    .empty { color: var(--vscode-descriptionForeground); font-style: italic; }
+  </style>
+</head>
+<body>
+  <div class="titlebar">
+    <h1>Jasper Debugger</h1>
+    <span class="subtitle">${subtitle}</span>
+    <button id="copyBtn" class="copy-btn" title="Copy the whole stack to the clipboard">Copy Stack</button>
+  </div>
+  <div class="error" id="error"></div>
+  <ul class="stack" id="stack"></ul>
+  <div id="ctxmenu" class="ctx-menu" role="menu">
+    <div class="ctx-item" id="copyFrameItem" role="menuitem">Copy Frame</div>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    window.addEventListener('message', (event) => {
+      const msg = event.data;
+      if (msg.command === 'init') {
+        document.getElementById('error').textContent = msg.errorMessage || '';
+        const list = document.getElementById('stack');
+        list.innerHTML = '';
+        if (!msg.stack || msg.stack.length === 0) {
+          const li = document.createElement('li');
+          li.className = 'empty';
+          li.textContent = 'No stack frames available.';
+          list.appendChild(li);
+          return;
+        }
+        for (const frame of msg.stack) {
+          const li = document.createElement('li');
+          li.className = 'frame';
+          li.title = 'Right-click to copy this frame';
+          li.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            selectFrame(li, frame.level);
+            showMenu(e.clientX, e.clientY);
+          });
+          const lvl = document.createElement('span');
+          lvl.className = 'level';
+          lvl.textContent = frame.level;
+          const lbl = document.createElement('span');
+          lbl.textContent = frame.label;
+          li.appendChild(lvl);
+          li.appendChild(lbl);
+          if (frame.position) {
+            const pos = document.createElement('span');
+            pos.className = 'pos';
+            pos.textContent = frame.position;
+            li.appendChild(pos);
+          }
+          list.appendChild(li);
+        }
+      }
+    });
+
+    // ── Custom right-click menu (Copy Frame) ──────────────────────────
+    // The default Cut/Copy/Paste menu is suppressed, so copy lives here.
+    const menu = document.getElementById('ctxmenu');
+    let selectedLevel = null;
+    let selectedLi = null;
+
+    function selectFrame(li, level) {
+      if (selectedLi) selectedLi.classList.remove('selected');
+      selectedLi = li;
+      selectedLevel = level;
+      li.classList.add('selected');
+    }
+    function showMenu(x, y) {
+      menu.style.left = x + 'px';
+      menu.style.top = y + 'px';
+      menu.classList.add('show');
+    }
+    function hideMenu() { menu.classList.remove('show'); }
+
+    document.getElementById('copyFrameItem').addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (selectedLevel != null) vscode.postMessage({ command: 'copyFrame', level: selectedLevel });
+      hideMenu();
+    });
+
+    // Suppress the native context menu everywhere; close ours on any dismiss gesture.
+    window.addEventListener('contextmenu', (e) => { e.preventDefault(); });
+    document.addEventListener('click', hideMenu);
+    window.addEventListener('scroll', hideMenu, true);
+    window.addEventListener('blur', hideMenu);
+    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideMenu(); });
+
+    // Copy the whole stack to the clipboard (host-side write), with a brief flash.
+    const copyBtn = document.getElementById('copyBtn');
+    copyBtn.addEventListener('click', () => {
+      vscode.postMessage({ command: 'copyStack' });
+      const prev = copyBtn.textContent;
+      copyBtn.textContent = 'Copied';
+      setTimeout(() => { copyBtn.textContent = prev; }, 1200);
+    });
+    vscode.postMessage({ command: 'ready' });
+  </script>
+</body>
+</html>`;
+  }
+
+  private dispose(): void {
+    DebuggerPanel.panels.get(this.sessionId)?.delete(this);
+    for (const d of this.disposables) d.dispose();
+    this.disposables = [];
+    // Closing the panel implicitly terminates the suspended process it owned,
+    // releasing the stalled GsProcess on the server (same as dismissing the
+    // error notifier). clearStack is best-effort: the session may already be gone.
+    debug.clearStack(this.session, this.gsProcess);
+  }
+}

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -1,8 +1,19 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
+import * as path from 'path';
+import * as fs from 'fs';
 import { ActiveSession } from './sessionManager';
 import * as debug from './debugQueries';
+import * as queries from './browserQueries';
+import { unwrapTranscriptCapture } from './transcriptCapture';
 import { logError } from './gciLog';
+
+// The webview's DOM behavior lives in a standalone file (like listFilter.js /
+// methodListView.js) so it gets IDE support and can be jsdom-tested in isolation
+// instead of being trapped inside the inline <script> template literal. The
+// webview needs the raw source text to inject into a <script> tag, so we read it
+// at runtime rather than importing it as a compiled module.
+const debuggerViewJs = fs.readFileSync(path.join(__dirname, '..', 'src', 'debuggerView.js'), 'utf8');
 
 /**
  * Jasper Debugger — a roomy, Smalltalk-style debugger rendered as a VS Code
@@ -26,7 +37,28 @@ import { logError } from './gciLog';
 type DebuggerInbound =
   | { command: 'ready' }
   | { command: 'copyStack' }
-  | { command: 'copyFrame'; level: number };
+  | { command: 'copyFrame'; level: number }
+  | { command: 'selectFrame'; level: number };
+
+/**
+ * Build the `gemstone://` URI for a method's source, in the exact form the
+ * GemStoneFileSystemProvider expects — and the same one the DAP
+ * `stackTraceRequest` builds for its `Source.path`. Opening this URI gives the
+ * companion source editor all the real-editor features (syntax highlight,
+ * senders/implementors, breakpoint gutters, compile-on-save).
+ *
+ * Exported so the URI format is unit-testable independently of the panel.
+ * (Sharing this resolution with the DAP path is review #5, a later Stage 1 item.)
+ */
+export function buildMethodSourceUri(sessionId: number, uriInfo: debug.MethodUriInfo): string {
+  const side = uriInfo.isMeta ? 'class' : 'instance';
+  return `gemstone://${sessionId}`
+    + `/${encodeURIComponent(uriInfo.dictName)}`
+    + `/${encodeURIComponent(uriInfo.className)}`
+    + `/${side}`
+    + `/${encodeURIComponent(uriInfo.category)}`
+    + `/${encodeURIComponent(uriInfo.selector)}`;
+}
 
 /** Resolved pieces of a frame label, before formatting. */
 export interface FrameLabelParts {
@@ -83,11 +115,20 @@ function escapeHtml(s: string): string {
 
 /** A single stack frame summary sent to the webview. */
 interface FrameSummary {
-  /** 1-based frame number (1 = top), shown so frames are easy to refer to. */
+  /** 1-based DISPLAY number (1 = top), after filtering; shown to the user. */
   level: number;
   label: string;
   /** Pre-formatted `@<stepPoint> line <line>` annotation; '' when unavailable. */
   position: string;
+}
+
+/**
+ * Host-side cached frame: a `FrameSummary` plus the real GsProcess frame level.
+ * Display levels are renumbered 1..N after filtering, but server queries
+ * (`revealFrameSource`, etc.) must use the original level — so we keep both.
+ */
+interface DisplayFrame extends FrameSummary {
+  serverLevel: number;
 }
 
 /**
@@ -111,13 +152,152 @@ export function formatStackForClipboard(errorMessage: string, frames: FrameSumma
   return lines.join('\n');
 }
 
+/** Virtual-document scheme for read-only frame source (doits + non-symbol-list methods). */
+const READONLY_SOURCE_SCHEME = 'gemstone-debug';
+
+/**
+ * A fully-resolved stack frame, before display filtering and renumbering.
+ * Carries the classification bits the stack filter needs (which `FrameSummary`,
+ * the wire/display shape, deliberately omits).
+ */
+export interface RawFrame {
+  /** Real GsProcess frame level (1 = top); preserved for server queries. */
+  serverLevel: number;
+  methodOop: bigint;
+  /** Home (enclosing) method — equal to methodOop for non-block frames. */
+  homeMethodOop: bigint;
+  isBlock: boolean;
+  /** Defining class name WITHOUT any " class" suffix (for machinery matching). */
+  definingClassName: string;
+  selector: string;
+  /** True for doit / "Executed Code" frames (no resolvable home class). */
+  isExecutedCode: boolean;
+  label: string;
+  line?: number;
+  stepPoint?: number;
+}
+
+// Exception/halt machinery, trimmed from the TOP of the stack so the debugger
+// opens on the user's frame (e.g. `[] in Foo>>bar`) instead of `signal`/`halt`.
+// `AbstractException` covers signal/_signal/_signalToDebugger/_executeHandler:
+// (instance and class side); the selectors cover Object>>halt and friends.
+const MACHINERY_SELECTORS = new Set([
+  'halt', 'halt:', 'pause', 'error:', 'signal', 'signal:',
+]);
+// Kernel block-invocation selectors that appear as transcript-capture-wrapper
+// glue at the BOTTOM (the doit evaluates its blocks via these).
+const BLOCK_EVAL_SELECTORS = new Set([
+  'value', 'value:', 'value:value:', 'value:value:value:', 'ensure:', 'ifCurtailed:', 'on:do:',
+]);
+
+/** True when a frame is exception-signalling / halt machinery. */
+export function isExceptionMachinery(f: RawFrame): boolean {
+  return f.definingClassName === 'AbstractException'
+    || f.selector.startsWith('doesNotUnderstand')
+    || f.selector.startsWith('_doesNotUnderstand')
+    || f.selector.startsWith('_signal')
+    || MACHINERY_SELECTORS.has(f.selector);
+}
+
+/**
+ * Filter a raw stack down to what's worth showing: trim exception/halt
+ * machinery from the top, and collapse the whole transcript-capture wrapper at
+ * the bottom to the single "Executed Code" doit frame. Mid-stack frames are
+ * never removed. Always keeps ≥1 frame.
+ *
+ * The bottom collapse is *anchored on the deepest `Executed Code` frame* (the
+ * doit) rather than on the literal last frame — because GemStone leaves a
+ * `<Reenter marker>` (and sometimes other cruft) *below* the doit. We keep that
+ * one doit frame, drop everything beneath it, and drop the contiguous glue
+ * above it (the doit's own block frames, which also read as "Executed Code",
+ * plus block-eval kernel frames like `ensure:`/`value`) up to the first real
+ * user frame.
+ *
+ * Heuristic, and deliberately conservative — it only trims at the two ends, so
+ * an unrecognised stack degrades to "shows a couple extra frames", never to
+ * dropping real user frames.
+ */
+export function filterStack(raws: RawFrame[]): RawFrame[] {
+  if (raws.length <= 1) return raws;
+
+  // Top: drop a contiguous run of machinery frames (never the whole stack).
+  let top = 0;
+  while (top < raws.length - 1 && isExceptionMachinery(raws[top])) top++;
+  const kept = raws.slice(top);
+
+  // Bottom: find the deepest doit (Executed Code) frame, if any.
+  let doitIdx = -1;
+  for (let i = kept.length - 1; i >= 0; i--) {
+    if (kept[i].isExecutedCode) { doitIdx = i; break; }
+  }
+  if (doitIdx === -1) return kept; // no wrapper (e.g. a breakpoint in a method)
+
+  // Walk up over the contiguous wrapper glue (doit's block frames + block-eval
+  // kernel frames) to the first real user frame; keep [user…] + the one doit.
+  let u = doitIdx - 1;
+  while (u >= 0 && (kept[u].isExecutedCode || BLOCK_EVAL_SELECTORS.has(kept[u].selector))) u--;
+  return [...kept.slice(0, u + 1), kept[doitIdx]];
+}
+
 export class DebuggerPanel {
   private static panels = new Map<number, Set<DebuggerPanel>>();
+  /**
+   * Highlight for the selected frame's current step point in the companion
+   * source editor — the standard debugger "focused stack frame" colour, boxed
+   * and on the overview ruler. It marks just the step-point token (NOT the whole
+   * line), so a line with several sends shows exactly where execution paused.
+   * One type shared by all panels (a decoration type is a style, not per-editor).
+   */
+  private static readonly stepPointDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: new vscode.ThemeColor('editor.focusedStackFrameHighlightBackground'),
+    border: '1px solid',
+    borderColor: new vscode.ThemeColor('editor.focusedStackFrameHighlightBackground'),
+    borderRadius: '2px',
+    overviewRulerColor: new vscode.ThemeColor('editor.focusedStackFrameHighlightBackground'),
+    overviewRulerLane: vscode.OverviewRulerLane.Full,
+  });
+
+  // ── Read-only source for frames with no gemstone:// editor ──────────
+  // "Executed Code" doits (no class at all) and methods whose class isn't in the
+  // session's symbol list (so no dictName → no gemstone:// URI) are served
+  // read-only through a content provider (never dirty, no "Untitled-N" pileup)
+  // keyed by a per-session+method virtual URI.
+  private static readOnlySources = new Map<string, string>();
+  private static providerRegistered = false;
+
+  private static ensureReadOnlySourceProvider(): void {
+    if (DebuggerPanel.providerRegistered) return;
+    DebuggerPanel.providerRegistered = true;
+    vscode.workspace.registerTextDocumentContentProvider(READONLY_SOURCE_SCHEME, {
+      provideTextDocumentContent: (uri: vscode.Uri) =>
+        DebuggerPanel.readOnlySources.get(uri.toString()) ?? '',
+    });
+  }
+
+  /** Stash a frame's read-only source and return its virtual URI; `title` is the tab label. */
+  private static stashReadOnlySource(sessionId: number, methodOop: bigint, title: string, source: string): vscode.Uri {
+    DebuggerPanel.ensureReadOnlySourceProvider();
+    // Path titles the tab; query keeps each method distinct.
+    const uri = vscode.Uri.from({
+      scheme: READONLY_SOURCE_SCHEME,
+      path: title,
+      query: `session=${sessionId}&method=${methodOop}`,
+    });
+    DebuggerPanel.readOnlySources.set(uri.toString(), source);
+    return uri;
+  }
+
   private readonly panel: vscode.WebviewPanel;
   private readonly sessionId: number;
   private disposables: vscode.Disposable[] = [];
-  /** Last fetched stack, cached so 'copyStack' need not re-query the server. */
-  private frames: FrameSummary[] = [];
+  /** Last fetched (filtered) stack, cached so copy/select need not re-query. */
+  private frames: DisplayFrame[] = [];
+  /** Column the companion source editor lives in, reused across frame selects. */
+  private sourceColumn: vscode.ViewColumn | undefined;
+  /** The editor currently carrying the step-point highlight, if any. */
+  private decoratedEditor: vscode.TextEditor | undefined;
+  /** Virtual read-only source URIs this panel stashed (pruned on dispose). */
+  private stashedSourceKeys = new Set<string>();
 
   static create(session: ActiveSession, gsProcess: bigint, errorMessage: string): void {
     const panel = vscode.window.createWebviewPanel(
@@ -165,7 +345,8 @@ export class DebuggerPanel {
         this.panel.webview.postMessage({
           command: 'init',
           errorMessage: this.errorMessage,
-          stack: this.frames,
+          // Send only the display shape; serverLevel stays host-side.
+          stack: this.frames.map(f => ({ level: f.level, label: f.label, position: f.position })),
         });
         return;
       }
@@ -180,7 +361,156 @@ export class DebuggerPanel {
         if (frame) void vscode.env.clipboard.writeText(formatFrameForClipboard(frame));
         return;
       }
+      case 'selectFrame': {
+        // Map the display level the webview reported back to the server level.
+        const frame = this.frames.find(f => f.level === msg.level);
+        if (frame) void this.revealFrameSource(frame.serverLevel);
+        return;
+      }
     }
+  }
+
+  /**
+   * Open the selected frame's source in the companion editor docked *below* the
+   * panel, and highlight the step point the IP is on.
+   *
+   * Two source kinds:
+   *  - a class>>selector method → the real `gemstone://` editor (full editing,
+   *    senders/implementors, breakpoint gutters);
+   *  - an "Executed Code" / doit frame (no home dictionary) → a read-only
+   *    virtual editor showing the executed source (so these frames still show
+   *    their code rather than opening nothing).
+   *
+   * Resolution is lazy (only the selected frame, on demand) — the cheap stack
+   * listing already happened on `ready`, so the expensive URI/source resolution
+   * (review #6) is deferred to here. Everything is best-effort: a failure to
+   * open one frame's source must never tear down the debugger.
+   */
+  private async revealFrameSource(level: number): Promise<void> {
+    try {
+      const info = debug.getFrameInfo(this.session, this.gsProcess, level);
+      // Block frames share their home method's source; resolve from the home
+      // method (blocks aren't dictionary entries) but keep the frame's own
+      // method+ip for the position (matches buildFrame's naming/position split).
+      const { homeMethodOop } = debug.getMethodBlockInfo(this.session, info.methodOop);
+      // Same classification as buildFrame's label (C3): a frame the stack list
+      // shows as a method must never open as "Executed Code", and vice-versa.
+      const home = this.resolveHomeMethod(homeMethodOop);
+
+      let uri: vscode.Uri;
+      let methodForOffsets: { className: string; isMeta: boolean; selector: string } | undefined;
+      if (home.uriInfo) {
+        // In the symbol list → the real editable gemstone:// editor.
+        uri = vscode.Uri.parse(buildMethodSourceUri(this.session.id, home.uriInfo));
+        methodForOffsets = { className: home.uriInfo.className, isMeta: home.uriInfo.isMeta, selector: home.uriInfo.selector };
+      } else {
+        // No gemstone:// URI: show the source read-only. Strip the Transcript-
+        // capture glue so a doit shows just the user's code (e.g.
+        // `JasperDebugDemo new run`). Title by the method when we have one, so a
+        // non-symbol-list method isn't mislabelled "Executed Code".
+        const source = unwrapTranscriptCapture(debug.getMethodSource(this.session, info.methodOop));
+        const title = home.isExecutedCode ? 'Executed Code' : `${home.definingClassName}>>#${home.selector}`;
+        uri = DebuggerPanel.stashReadOnlySource(this.session.id, info.methodOop, title, source);
+        this.stashedSourceKeys.add(uri.toString());
+      }
+
+      const editor = await this.showSourceEditor(uri);
+
+      // Only the editable gemstone:// method gets a step-point highlight (C2):
+      // the read-only view has no reliable IP→source mapping (executed code is
+      // unwrapped; a non-symbol-list method has no step-point offsets here).
+      // TODO(Stage "Hardening"): revisit highlighting the read-only view.
+      const range = methodForOffsets
+        ? this.stepPointRange(editor.document, info, level, methodForOffsets)
+        : undefined;
+      // Clear a stale highlight if the source moved to a different editor.
+      if (this.decoratedEditor && this.decoratedEditor !== editor) {
+        this.decoratedEditor.setDecorations(DebuggerPanel.stepPointDecoration, []);
+      }
+      if (range) {
+        editor.setDecorations(DebuggerPanel.stepPointDecoration, [range]);
+        editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+      } else {
+        editor.setDecorations(DebuggerPanel.stepPointDecoration, []);
+      }
+      this.decoratedEditor = editor;
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  /**
+   * Open `uri` in the companion source editor and return it. The editor lives in
+   * a dedicated group docked *below* the panel: the first time, we focus the
+   * panel and split a new group beneath it; later selections reuse that group
+   * (remembered as `sourceColumn`). Focus stays in the panel so clicking through
+   * frames stays fluid, and the doc opens as a reused preview tab (no pile-up).
+   */
+  private async showSourceEditor(uri: vscode.Uri): Promise<vscode.TextEditor> {
+    if (this.sourceColumn === undefined) {
+      try {
+        this.panel.reveal(this.panel.viewColumn, false); // focus the panel's group…
+        await vscode.commands.executeCommand('workbench.action.newGroupBelow'); // …then split below it
+      } catch { /* best-effort layout; fall back to the active group */ }
+    }
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(doc, {
+      viewColumn: this.sourceColumn ?? vscode.ViewColumn.Active,
+      preview: true,
+      preserveFocus: true,
+    });
+    this.sourceColumn = editor.viewColumn ?? this.sourceColumn;
+    // gemstone:// docs get their language from the FS provider; the read-only
+    // executed-code scheme does not, so set it so the source is highlighted.
+    if (doc.languageId !== 'gemstone-smalltalk') {
+      await vscode.languages.setTextDocumentLanguage(doc, 'gemstone-smalltalk');
+    }
+    return editor;
+  }
+
+  /**
+   * The range to highlight for a frame's current step point — just the token at
+   * the step point, NOT the whole line. Prefers the exact step-point character
+   * offset (`getSourceOffsets`, available for class>>selector methods); falls
+   * back to the start of the IP's source line when offsets aren't available
+   * (e.g. executed-code frames). Returns undefined when there's nothing to mark.
+   */
+  private stepPointRange(
+    doc: vscode.TextDocument,
+    info: debug.FrameInfo,
+    level: number,
+    method: { className: string; isMeta: boolean; selector: string } | undefined,
+  ): vscode.Range | undefined {
+    let pos: vscode.Position | undefined;
+
+    // Exact step-point offset → the precise sub-expression start.
+    if (method) {
+      try {
+        const stepPoint = debug.getStepPoint(this.session, this.gsProcess, level);
+        if (stepPoint) {
+          // getSourceOffsets returns GemStone `_sourceOffsets`, which are
+          // 1-BASED (see getStepPointSelectorRanges.ts). doc.positionAt is
+          // 0-based, so convert — otherwise the highlight sits one char too far.
+          const offsets = queries.getSourceOffsets(this.session, method.className, method.isMeta, method.selector);
+          const offset = offsets[stepPoint - 1];
+          if (offset != null && offset >= 1 && doc.positionAt) pos = doc.positionAt(offset - 1);
+        }
+      } catch { /* best-effort; fall back to the IP line below */ }
+    }
+
+    // Fallback: the first non-whitespace token of the IP's source line.
+    if (!pos) {
+      let line = 0;
+      try { line = debug.getLineForIp(this.session, info.methodOop, info.ipOffset); } catch { /* */ }
+      if (line > 0) {
+        const col = doc.lineAt?.(line - 1)?.firstNonWhitespaceCharacterIndex ?? 0;
+        pos = new vscode.Position(line - 1, col);
+      }
+    }
+    if (!pos) return undefined;
+
+    // Mark the token at the step point (its beginning), not the whole line.
+    return doc.getWordRangeAtPosition?.(pos) ?? new vscode.Range(pos, pos.translate(0, 1));
   }
 
   /**
@@ -190,55 +520,63 @@ export class DebuggerPanel {
    * and Debug Call Stack frame-for-frame. Proves the `debugQueries` pipe works
    * from this second consumer before Stage 1 builds the real layout on top.
    */
-  private fetchStack(): FrameSummary[] {
-    const frames: FrameSummary[] = [];
+  private fetchStack(): DisplayFrame[] {
+    const raws: RawFrame[] = [];
     try {
       const depth = debug.getStackDepth(this.session, this.gsProcess);
       for (let level = 1; level <= depth; level++) {
-        frames.push(this.buildFrame(level));
+        raws.push(this.buildFrame(level));
       }
     } catch (e: unknown) {
       logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      return [];
     }
-    return frames;
+    // Trim machinery/wrapper glue, then renumber the survivors 1..N for display
+    // while keeping each one's real server level for subsequent queries.
+    return filterStack(raws).map((r, i) => ({
+      level: i + 1,
+      serverLevel: r.serverLevel,
+      label: r.label,
+      // Executed-code frames have no meaningful step point/line once unwrapped (#3).
+      position: r.isExecutedCode ? '' : formatFramePosition(r.stepPoint, r.line),
+    }));
   }
 
   /**
-   * Build a single frame summary: a `Class[ class]>>#selector` label plus the
-   * step point and source line. The label logic mirrors the DAP path exactly
-   * — only frames whose contents can't be fetched are `<frame N>`; a valid
-   * frame with no introspectable method (e.g. an executed-code or block
-   * context) is `Executed Code`, NOT "unavailable". Step point / line are
-   * best-effort and simply omitted when unavailable.
+   * Resolve a single raw frame: a `Class[ class]>>#selector` label plus the
+   * classification bits the stack filter needs. The label logic mirrors the DAP
+   * path — only frames whose contents can't be fetched are `<frame N>`; a valid
+   * frame with no introspectable method (a doit / executed-code or its blocks)
+   * is `Executed Code`. Step point / line are best-effort.
    */
-  private buildFrame(level: number): FrameSummary {
+  private buildFrame(level: number): RawFrame {
     let info: debug.FrameInfo;
     try {
       info = debug.getFrameInfo(this.session, this.gsProcess, level);
     } catch (e: unknown) {
       logError(this.sessionId, e instanceof Error ? e.message : String(e));
-      return { level, label: `<frame ${level}>`, position: '' };
+      return {
+        serverLevel: level, methodOop: 0n, homeMethodOop: 0n, isBlock: false,
+        definingClassName: '', selector: '', isExecutedCode: false, label: `<frame ${level}>`,
+      };
     }
 
-    let label: string;
+    // Block vs home method (homeMethodOop == methodOop for non-blocks).
+    let isBlock = false;
+    let homeMethodOop = info.methodOop;
     try {
-      // For a block frame, name the enclosing (home) method and prefix `[] in `,
-      // matching GsNMethod>>printOn:. homeMethodOop == methodOop for non-blocks.
-      const { isBlock, homeMethodOop } = debug.getMethodBlockInfo(this.session, info.methodOop);
+      const blockInfo = debug.getMethodBlockInfo(this.session, info.methodOop);
+      isBlock = blockInfo.isBlock;
+      homeMethodOop = blockInfo.homeMethodOop;
+    } catch { /* treat as a non-block frame */ }
 
-      // Defining class + selector come from the home method.
-      let definingClass: string;
-      let selector: string;
-      const uriInfo = debug.getMethodUriInfo(this.session, homeMethodOop);
-      if (uriInfo && uriInfo.dictName) {
-        definingClass = `${uriInfo.className}${uriInfo.isMeta ? ' class' : ''}`;
-        selector = uriInfo.selector;
-      } else {
-        const methodInfo = debug.getMethodInfo(this.session, homeMethodOop);
-        definingClass = methodInfo.className;
-        selector = methodInfo.selector;
-      }
+    // Resolve the home method's identity (the single source of truth for
+    // "is this executed code?", shared with revealFrameSource — see C3).
+    const home = this.resolveHomeMethod(homeMethodOop);
 
+    let label: string;
+    if (home.definingClassName) {
+      const definingClass = `${home.definingClassName}${home.isMeta ? ' class' : ''}`;
       // Receiver class drives the `Receiver (Defining)` disambiguation for
       // inherited methods (non-block frames only — see formatFrameLabel).
       let receiverClass: string | undefined;
@@ -247,11 +585,11 @@ export class DebuggerPanel {
           receiverClass = debug.getObjectClassName(this.session, info.receiverOop);
         } catch { /* best-effort; fall back to defining class only */ }
       }
-
-      label = formatFrameLabel({ isBlock, definingClass, selector, receiverClass });
-    } catch {
+      label = formatFrameLabel({ isBlock, definingClass, selector: home.selector, receiverClass });
+    } else {
       label = 'Executed Code';
     }
+    const isExecutedCode = home.isExecutedCode;
 
     let line: number | undefined;
     try {
@@ -263,7 +601,47 @@ export class DebuggerPanel {
       stepPoint = debug.getStepPoint(this.session, this.gsProcess, level);
     } catch { /* best-effort */ }
 
-    return { level, label, position: formatFramePosition(stepPoint, line) };
+    return {
+      serverLevel: level, methodOop: info.methodOop, homeMethodOop, isBlock,
+      definingClassName: home.definingClassName, selector: home.selector,
+      isExecutedCode, label, line, stepPoint,
+    };
+  }
+
+  /**
+   * Resolve a (home) method's display identity — the SINGLE source of truth for
+   * "is this executed code?", shared by buildFrame (labelling/classification)
+   * and revealFrameSource (source-pane routing) so the two can never disagree.
+   *
+   *  - in the session's symbol list → `uriInfo` set (editable via gemstone://);
+   *  - resolvable class but not in the symbol list → `uriInfo` undefined, but
+   *    definingClassName/selector are still set — a real method, NOT executed code;
+   *  - no resolvable class at all (a doit) → isExecutedCode true.
+   */
+  private resolveHomeMethod(homeMethodOop: bigint): {
+    uriInfo: debug.MethodUriInfo | undefined;
+    definingClassName: string;
+    selector: string;
+    isMeta: boolean;
+  } & { isExecutedCode: boolean } {
+    let uriInfo: debug.MethodUriInfo | undefined;
+    let definingClassName = '';
+    let selector = '';
+    let isMeta = false;
+    try {
+      uriInfo = debug.getMethodUriInfo(this.session, homeMethodOop);
+      if (uriInfo && uriInfo.dictName) {
+        definingClassName = uriInfo.className;
+        selector = uriInfo.selector;
+        isMeta = uriInfo.isMeta;
+      } else {
+        uriInfo = undefined; // no dictName → not usable to build a gemstone:// URI
+        const methodInfo = debug.getMethodInfo(this.session, homeMethodOop);
+        definingClassName = methodInfo.className;
+        selector = methodInfo.selector;
+      }
+    } catch { /* doit / executed code: no resolvable home class */ }
+    return { uriInfo, definingClassName, selector, isMeta, isExecutedCode: definingClassName === '' };
   }
 
   /** Dimmed "For <user> on <stone> @ <host>" subtitle from the login. */
@@ -355,89 +733,16 @@ export class DebuggerPanel {
   <div id="ctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="copyFrameItem" role="menuitem">Copy Frame</div>
   </div>
+  <script nonce="${nonce}">${debuggerViewJs}</script>
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
-    window.addEventListener('message', (event) => {
-      const msg = event.data;
-      if (msg.command === 'init') {
-        document.getElementById('error').textContent = msg.errorMessage || '';
-        const list = document.getElementById('stack');
-        list.innerHTML = '';
-        if (!msg.stack || msg.stack.length === 0) {
-          const li = document.createElement('li');
-          li.className = 'empty';
-          li.textContent = 'No stack frames available.';
-          list.appendChild(li);
-          return;
-        }
-        for (const frame of msg.stack) {
-          const li = document.createElement('li');
-          li.className = 'frame';
-          li.title = 'Right-click to copy this frame';
-          li.addEventListener('contextmenu', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            selectFrame(li, frame.level);
-            showMenu(e.clientX, e.clientY);
-          });
-          const lvl = document.createElement('span');
-          lvl.className = 'level';
-          lvl.textContent = frame.level;
-          const lbl = document.createElement('span');
-          lbl.textContent = frame.label;
-          li.appendChild(lvl);
-          li.appendChild(lbl);
-          if (frame.position) {
-            const pos = document.createElement('span');
-            pos.className = 'pos';
-            pos.textContent = frame.position;
-            li.appendChild(pos);
-          }
-          list.appendChild(li);
-        }
-      }
-    });
-
-    // ── Custom right-click menu (Copy Frame) ──────────────────────────
-    // The default Cut/Copy/Paste menu is suppressed, so copy lives here.
-    const menu = document.getElementById('ctxmenu');
-    let selectedLevel = null;
-    let selectedLi = null;
-
-    function selectFrame(li, level) {
-      if (selectedLi) selectedLi.classList.remove('selected');
-      selectedLi = li;
-      selectedLevel = level;
-      li.classList.add('selected');
-    }
-    function showMenu(x, y) {
-      menu.style.left = x + 'px';
-      menu.style.top = y + 'px';
-      menu.classList.add('show');
-    }
-    function hideMenu() { menu.classList.remove('show'); }
-
-    document.getElementById('copyFrameItem').addEventListener('click', (e) => {
-      e.stopPropagation();
-      if (selectedLevel != null) vscode.postMessage({ command: 'copyFrame', level: selectedLevel });
-      hideMenu();
-    });
-
-    // Suppress the native context menu everywhere; close ours on any dismiss gesture.
-    window.addEventListener('contextmenu', (e) => { e.preventDefault(); });
-    document.addEventListener('click', hideMenu);
-    window.addEventListener('scroll', hideMenu, true);
-    window.addEventListener('blur', hideMenu);
-    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideMenu(); });
-
-    // Copy the whole stack to the clipboard (host-side write), with a brief flash.
-    const copyBtn = document.getElementById('copyBtn');
-    copyBtn.addEventListener('click', () => {
-      vscode.postMessage({ command: 'copyStack' });
-      const prev = copyBtn.textContent;
-      copyBtn.textContent = 'Copied';
-      setTimeout(() => { copyBtn.textContent = prev; }, 1200);
-    });
+    DebuggerView.init({
+      list: document.getElementById('stack'),
+      menu: document.getElementById('ctxmenu'),
+      copyFrameItem: document.getElementById('copyFrameItem'),
+      copyBtn: document.getElementById('copyBtn'),
+      error: document.getElementById('error'),
+    }, vscode);
     vscode.postMessage({ command: 'ready' });
   </script>
 </body>
@@ -446,6 +751,13 @@ export class DebuggerPanel {
 
   private dispose(): void {
     DebuggerPanel.panels.get(this.sessionId)?.delete(this);
+    // Drop the step-point highlight from the companion editor (which outlives
+    // the panel) so a stale highlight doesn't linger after the debugger closes.
+    this.decoratedEditor?.setDecorations(DebuggerPanel.stepPointDecoration, []);
+    this.decoratedEditor = undefined;
+    // Release this panel's stashed read-only source.
+    for (const key of this.stashedSourceKeys) DebuggerPanel.readOnlySources.delete(key);
+    this.stashedSourceKeys.clear();
     for (const d of this.disposables) d.dispose();
     this.disposables = [];
     // Closing the panel implicitly terminates the suspended process it owned,

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -51,29 +51,60 @@
     }
   }
 
-  // Render the selected frame's variables (self first, then args/temps) into
-  // varsEl. Each is { name, value } where value is the host-computed printString.
-  function renderVariables(varsEl, vars) {
+  // Render the selected frame's variables into varsEl, grouped (Receiver /
+  // Instance variables / Arguments & Temps / stack temps). Each group is
+  // { title, kind, collapsed?, vars:[{name, value, oop}] }; value is the
+  // host-computed printString. onInspect(oop, name) is called when a row is
+  // clicked (opens a GT Inspector); it's optional so tests can omit it.
+  function renderVariables(varsEl, groups, onInspect) {
     varsEl.innerHTML = '';
-    if (!vars || vars.length === 0) {
+    if (!groups || groups.length === 0) {
       const d = document.createElement('div');
       d.className = 'empty';
       d.textContent = 'No variables.';
       varsEl.appendChild(d);
       return;
     }
-    for (const v of vars) {
-      const row = document.createElement('div');
-      row.className = 'var';
-      const name = document.createElement('span');
-      name.className = 'var-name' + (v.name === 'self' ? ' self' : '');
-      name.textContent = v.name;
-      const val = document.createElement('span');
-      val.className = 'var-value';
-      val.textContent = v.value;
-      row.appendChild(name);
-      row.appendChild(val);
-      varsEl.appendChild(row);
+    for (const g of groups) {
+      const group = document.createElement('div');
+      group.className = 'var-group' + (g.collapsed ? ' collapsed' : '');
+      group.dataset.kind = g.kind;
+
+      const title = document.createElement('div');
+      title.className = 'var-group-title';
+      title.textContent = g.title;
+      // Clicking a group title collapses/expands its body.
+      title.addEventListener('click', function () { group.classList.toggle('collapsed'); });
+      group.appendChild(title);
+
+      const body = document.createElement('div');
+      body.className = 'var-group-body';
+      for (const v of (g.vars || [])) {
+        const row = document.createElement('div');
+        row.className = 'var';
+        row.dataset.oop = v.oop;
+        row.title = 'GT Inspect';
+
+        const name = document.createElement('span');
+        name.className = 'var-name' + (v.name === 'self' ? ' self' : '');
+        name.textContent = v.name;
+        const val = document.createElement('span');
+        val.className = 'var-value';
+        val.textContent = v.value;
+        const oop = document.createElement('span');
+        oop.className = 'var-oop';
+        oop.textContent = v.oop;
+
+        row.appendChild(name);
+        row.appendChild(val);
+        row.appendChild(oop);
+        row.addEventListener('click', function () {
+          if (onInspect) onInspect(v.oop, v.name);
+        });
+        body.appendChild(row);
+      }
+      group.appendChild(body);
+      varsEl.appendChild(group);
     }
   }
 
@@ -113,7 +144,7 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, copyBtn, error, toolbar, variables, evalInput, evalResult, main, splitter } = refs;
+    const { list, menu, copyFrameItem, copyBtn, error, toolbar, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar } = refs;
     let selectedLevel = null;
 
     function select(level) {
@@ -180,6 +211,7 @@
       // Restore a previously saved ratio when reopening a reloaded webview.
       const saved = vscode.getState ? vscode.getState() : null;
       if (saved && saved.stackBasis) main.style.setProperty('--stack-basis', saved.stackBasis);
+      if (saved && saved.evalHeight && evalbar) evalbar.style.setProperty('--eval-height', saved.evalHeight);
 
       // The basis at mousedown, so endDrag can tell a real drag from a bare click.
       let startBasis = null;
@@ -216,6 +248,44 @@
       });
     }
 
+    // Horizontal splitter: dragging rewrites `--eval-height` (the eval bar's
+    // height). The panes flex-fill the rest, so dragging DOWN shrinks the eval bar
+    // and grows the panes (more stack frames); dragging UP grows the eval bar.
+    // Baseline is the live eval-bar height at mousedown (so the drag tracks 1:1).
+    // Persisted like the column splitter.
+    if (hsplitter && evalbar) {
+      let startY = 0;
+      let startHeight = 0;
+      function onHMove(e) {
+        // The splitter sits above the eval bar, so moving it down (clientY up)
+        // makes the eval bar smaller — hence startY - e.clientY.
+        let h = startHeight + (startY - e.clientY);
+        h = Math.max(42, Math.min(window.innerHeight * 0.75, h));
+        evalbar.style.setProperty('--eval-height', Math.round(h) + 'px');
+      }
+      function endHDrag() {
+        window.removeEventListener('mousemove', onHMove);
+        window.removeEventListener('mouseup', endHDrag);
+        hsplitter.classList.remove('dragging');
+        const height = evalbar.style.getPropertyValue('--eval-height').trim();
+        if (!height) return;
+        if (vscode.setState) {
+          const state = (vscode.getState ? vscode.getState() : null) || {};
+          state.evalHeight = height;
+          vscode.setState(state);
+        }
+        vscode.postMessage({ command: 'saveLayout', evalHeight: height });
+      }
+      hsplitter.addEventListener('mousedown', (e) => {
+        startY = e.clientY;
+        startHeight = evalbar.getBoundingClientRect().height;
+        hsplitter.classList.add('dragging');
+        e.preventDefault();
+        window.addEventListener('mousemove', onHMove);
+        window.addEventListener('mouseup', endHDrag);
+      });
+    }
+
     // Suppress the native Cut/Copy/Paste menu everywhere; close our popup on any
     // dismiss gesture (outside click, scroll, focus loss, Escape).
     window.addEventListener('contextmenu', (e) => { e.preventDefault(); });
@@ -236,7 +306,9 @@
         // Default-select the top frame so the debugger opens focused on a frame.
         if (msg.stack && msg.stack.length > 0) select(msg.stack[0].level);
       } else if (msg.command === 'variables') {
-        if (variables) renderVariables(variables, msg.vars);
+        if (variables) renderVariables(variables, msg.groups, function (oop, name) {
+          vscode.postMessage({ command: 'inspectVariable', oop: oop, name: name });
+        });
       } else if (msg.command === 'evalResult') {
         if (evalResult) {
           evalResult.textContent = msg.value != null ? msg.value : '';

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -1,0 +1,153 @@
+/**
+ * Webview-side behavior for the Jasper Debugger panel (debuggerPanel.ts).
+ *
+ * Like listFilter.js / methodListView.js, this is read at runtime via
+ * fs.readFileSync and injected into the webview as a <script> tag — it is NOT
+ * compiled into the bundle. It lives in its own file so the stack rendering,
+ * frame selection, and the custom right-click ("Copy Frame") popup can be
+ * unit-tested in jsdom (see debuggerView.test.ts) instead of being trapped
+ * inside the inline webview <script> string.
+ *
+ * Stage 1 extraction: the host (debuggerPanel.ts) keeps owning the data layer
+ * and clipboard writes; this module owns everything that happens in the DOM.
+ *
+ * Exposed as the global `DebuggerView` so both the webview (classic <script>)
+ * and tests (new Function(source)()) can reach it.
+ */
+(function () {
+  // Render the stack frames into listEl. Each frame becomes
+  //   <li class="frame" data-level="N"> <span.level> <span.label> [<span.pos>]
+  // The data-level attribute is how selection and the copy popup refer back to
+  // a frame, so the host never needs to send DOM node identities.
+  function renderStack(listEl, stack) {
+    listEl.innerHTML = '';
+    if (!stack || stack.length === 0) {
+      const li = document.createElement('li');
+      li.className = 'empty';
+      li.textContent = 'No stack frames available.';
+      listEl.appendChild(li);
+      return;
+    }
+    for (const frame of stack) {
+      const li = document.createElement('li');
+      li.className = 'frame';
+      li.dataset.level = String(frame.level);
+      li.title = 'Click to select; right-click to copy this frame';
+      const lvl = document.createElement('span');
+      lvl.className = 'level';
+      lvl.textContent = frame.level;
+      const lbl = document.createElement('span');
+      lbl.className = 'label';
+      lbl.textContent = frame.label;
+      li.appendChild(lvl);
+      li.appendChild(lbl);
+      if (frame.position) {
+        const pos = document.createElement('span');
+        pos.className = 'pos';
+        pos.textContent = frame.position;
+        li.appendChild(pos);
+      }
+      listEl.appendChild(li);
+    }
+  }
+
+  // Mark the frame with the given level selected, clearing any prior selection.
+  // Returns the selected <li>, or null when no frame carries that level.
+  function selectFrame(listEl, level) {
+    const prev = listEl.querySelector('.frame.selected');
+    if (prev) prev.classList.remove('selected');
+    const li = listEl.querySelector('.frame[data-level="' + level + '"]');
+    if (li) li.classList.add('selected');
+    return li;
+  }
+
+  // Show the custom context menu at the cursor; hide it.
+  function showMenu(menuEl, x, y) {
+    menuEl.style.left = x + 'px';
+    menuEl.style.top = y + 'px';
+    menuEl.classList.add('show');
+  }
+  function hideMenu(menuEl) { menuEl.classList.remove('show'); }
+
+  // Find the 1-based level of the frame containing an event target, or null.
+  function frameLevelOf(target) {
+    const li = target && target.closest ? target.closest('.frame') : null;
+    return li ? Number(li.dataset.level) : null;
+  }
+
+  /**
+   * Wire all webview interactions given the DOM refs + the vscode api object.
+   * Returns a tiny controller (mainly for tests):
+   *   selectedLevel() — the currently selected frame's level (or null)
+   *   select(level)   — programmatically select a frame
+   *
+   * Selecting a frame (left-click, right-click, or the default top-frame select)
+   * marks it `.selected`, tracks it so "Copy Frame" knows its target, and posts
+   * `selectFrame` to the host so it can open that frame's source in the companion
+   * editor and highlight the current line.
+   */
+  function init(refs, vscode) {
+    const { list, menu, copyFrameItem, copyBtn, error } = refs;
+    let selectedLevel = null;
+
+    function select(level) {
+      if (level == null) return;
+      selectFrame(list, level);
+      selectedLevel = level;
+      vscode.postMessage({ command: 'selectFrame', level });
+    }
+
+    // Left-click selects a frame (will drive the source pane in later Stage 1 work).
+    list.addEventListener('click', (e) => {
+      const level = frameLevelOf(e.target);
+      if (level != null) select(level);
+    });
+
+    // Right-click selects the frame AND opens the custom copy popup.
+    list.addEventListener('contextmenu', (e) => {
+      const level = frameLevelOf(e.target);
+      if (level == null) return;
+      e.preventDefault();
+      e.stopPropagation();
+      select(level);
+      showMenu(menu, e.clientX, e.clientY);
+    });
+
+    copyFrameItem.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (selectedLevel != null) vscode.postMessage({ command: 'copyFrame', level: selectedLevel });
+      hideMenu(menu);
+    });
+
+    copyBtn.addEventListener('click', () => {
+      vscode.postMessage({ command: 'copyStack' });
+      const prev = copyBtn.textContent;
+      copyBtn.textContent = 'Copied';
+      setTimeout(() => { copyBtn.textContent = prev; }, 1200);
+    });
+
+    // Suppress the native Cut/Copy/Paste menu everywhere; close our popup on any
+    // dismiss gesture (outside click, scroll, focus loss, Escape).
+    window.addEventListener('contextmenu', (e) => { e.preventDefault(); });
+    document.addEventListener('click', () => hideMenu(menu));
+    window.addEventListener('scroll', () => hideMenu(menu), true);
+    window.addEventListener('blur', () => hideMenu(menu));
+    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideMenu(menu); });
+
+    // Inbound messages from the host.
+    window.addEventListener('message', (event) => {
+      const msg = event.data;
+      if (msg.command === 'init') {
+        if (error) error.textContent = msg.errorMessage || '';
+        renderStack(list, msg.stack);
+        // Default-select the top frame so the debugger opens focused on a frame.
+        if (msg.stack && msg.stack.length > 0) select(msg.stack[0].level);
+      }
+    });
+
+    return { selectedLevel: () => selectedLevel, select };
+  }
+
+  const root = typeof globalThis !== 'undefined' ? globalThis : window;
+  root.DebuggerView = { renderStack, selectFrame, showMenu, hideMenu, frameLevelOf, init };
+})();

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -113,7 +113,7 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, copyBtn, error, toolbar, variables, evalInput, evalResult } = refs;
+    const { list, menu, copyFrameItem, copyBtn, error, toolbar, variables, evalInput, evalResult, main, splitter } = refs;
     let selectedLevel = null;
 
     function select(level) {
@@ -169,6 +169,50 @@
         if (e.key !== 'Enter') return;
         const expr = evalInput.value.trim();
         if (expr) vscode.postMessage({ command: 'evalInFrame', level: selectedLevel, expr });
+      });
+    }
+
+    // Draggable splitter: dragging re-apportions the Call Stack vs Variables
+    // panes by rewriting `--stack-basis` (the stack pane's width) on `.main`.
+    // The ratio is persisted via webview state (survives a reload) and posted to
+    // the host as `saveLayout` (so the next debugger panel opens the same way).
+    if (splitter && main) {
+      // Restore a previously saved ratio when reopening a reloaded webview.
+      const saved = vscode.getState ? vscode.getState() : null;
+      if (saved && saved.stackBasis) main.style.setProperty('--stack-basis', saved.stackBasis);
+
+      // The basis at mousedown, so endDrag can tell a real drag from a bare click.
+      let startBasis = null;
+      function onMove(e) {
+        const rect = main.getBoundingClientRect();
+        if (rect.width <= 0) return;
+        let pct = ((e.clientX - rect.left) / rect.width) * 100;
+        pct = Math.max(20, Math.min(80, pct));
+        main.style.setProperty('--stack-basis', pct.toFixed(1) + '%');
+      }
+      function endDrag() {
+        // The global listeners exist only for the duration of the drag (attached
+        // on mousedown), so idle mouse movement never runs onMove.
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', endDrag);
+        splitter.classList.remove('dragging');
+        const basis = main.style.getPropertyValue('--stack-basis').trim();
+        // Persist only when the divider actually moved — a bare click leaves the
+        // basis unchanged and must not trigger a state write / host round-trip.
+        if (!basis || basis === startBasis) return;
+        if (vscode.setState) {
+          const state = (vscode.getState ? vscode.getState() : null) || {};
+          state.stackBasis = basis;
+          vscode.setState(state);
+        }
+        vscode.postMessage({ command: 'saveLayout', stackBasis: basis });
+      }
+      splitter.addEventListener('mousedown', (e) => {
+        startBasis = main.style.getPropertyValue('--stack-basis').trim();
+        splitter.classList.add('dragging');
+        e.preventDefault();
+        window.addEventListener('mousemove', onMove);
+        window.addEventListener('mouseup', endDrag);
       });
     }
 

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -108,6 +108,22 @@
     }
   }
 
+  // Render (or clear) the "Create #selector in Class" action shown when the
+  // process is parked on a doesNotUnderstand:. `dnu` is { selector, className,
+  // isMeta } or null/undefined (nothing to create). onCreate is called when the
+  // button is clicked (posts createDnuMethod); optional so tests can omit it.
+  function renderDnu(dnuBarEl, dnu, onCreate) {
+    if (!dnuBarEl) return;
+    dnuBarEl.innerHTML = '';
+    if (!dnu) return;
+    const btn = document.createElement('button');
+    btn.className = 'dnu-btn';
+    btn.textContent = 'Create #' + dnu.selector + ' in ' + dnu.className + (dnu.isMeta ? ' class' : '');
+    btn.title = 'Create the missing method, then re-run the send into it';
+    if (onCreate) btn.addEventListener('click', onCreate);
+    dnuBarEl.appendChild(btn);
+  }
+
   // Mark the frame with the given level selected, clearing any prior selection.
   // Returns the selected <li>, or null when no frame carries that level.
   function selectFrame(listEl, level) {
@@ -144,7 +160,7 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, copyBtn, error, toolbar, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar } = refs;
+    const { list, menu, copyFrameItem, copyBtn, error, dnuBar, toolbar, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar } = refs;
     let selectedLevel = null;
 
     function select(level) {
@@ -299,6 +315,8 @@
       const msg = event.data;
       if (msg.command === 'init') {
         if (error) error.textContent = msg.errorMessage || '';
+        // Show the create-method action when parked on a doesNotUnderstand:.
+        renderDnu(dnuBar, msg.dnu, function () { vscode.postMessage({ command: 'createDnuMethod' }); });
         // Clear stale variables / eval output; the default-select below re-fetches.
         if (variables) variables.innerHTML = '';
         if (evalResult) { evalResult.textContent = ''; evalResult.classList.remove('error'); }
@@ -309,6 +327,12 @@
         if (variables) renderVariables(variables, msg.groups, function (oop, name) {
           vscode.postMessage({ command: 'inspectVariable', oop: oop, name: name });
         });
+      } else if (msg.command === 'banner') {
+        // Lightweight banner-only update (no stack re-render / frame re-select, so
+        // it won't steal focus): set the error/guidance text and clear the DNU
+        // Create button. Used while a created method is being edited.
+        if (error) error.textContent = msg.text || '';
+        if (dnuBar) dnuBar.innerHTML = '';
       } else if (msg.command === 'evalResult') {
         if (evalResult) {
           evalResult.textContent = msg.value != null ? msg.value : '';
@@ -321,5 +345,5 @@
   }
 
   const root = typeof globalThis !== 'undefined' ? globalThis : window;
-  root.DebuggerView = { renderStack, renderVariables, selectFrame, showMenu, hideMenu, frameLevelOf, init };
+  root.DebuggerView = { renderStack, renderVariables, renderDnu, selectFrame, showMenu, hideMenu, frameLevelOf, init };
 })();

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -51,6 +51,32 @@
     }
   }
 
+  // Render the selected frame's variables (self first, then args/temps) into
+  // varsEl. Each is { name, value } where value is the host-computed printString.
+  function renderVariables(varsEl, vars) {
+    varsEl.innerHTML = '';
+    if (!vars || vars.length === 0) {
+      const d = document.createElement('div');
+      d.className = 'empty';
+      d.textContent = 'No variables.';
+      varsEl.appendChild(d);
+      return;
+    }
+    for (const v of vars) {
+      const row = document.createElement('div');
+      row.className = 'var';
+      const name = document.createElement('span');
+      name.className = 'var-name' + (v.name === 'self' ? ' self' : '');
+      name.textContent = v.name;
+      const val = document.createElement('span');
+      val.className = 'var-value';
+      val.textContent = v.value;
+      row.appendChild(name);
+      row.appendChild(val);
+      varsEl.appendChild(row);
+    }
+  }
+
   // Mark the frame with the given level selected, clearing any prior selection.
   // Returns the selected <li>, or null when no frame carries that level.
   function selectFrame(listEl, level) {
@@ -87,7 +113,7 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, copyBtn, error } = refs;
+    const { list, menu, copyFrameItem, copyBtn, error, toolbar, variables, evalInput, evalResult } = refs;
     let selectedLevel = null;
 
     function select(level) {
@@ -126,6 +152,26 @@
       setTimeout(() => { copyBtn.textContent = prev; }, 1200);
     });
 
+    // Toolbar: each button posts its data-cmd. Step/restart act on the selected
+    // frame (level included); resume/terminate don't need a level.
+    if (toolbar) {
+      toolbar.addEventListener('click', (e) => {
+        const btn = e.target && e.target.closest ? e.target.closest('button[data-cmd]') : null;
+        if (!btn) return;
+        const command = btn.dataset.cmd;
+        vscode.postMessage(selectedLevel != null ? { command, level: selectedLevel } : { command });
+      });
+    }
+
+    // Eval-in-frame: Enter evaluates the expression in the selected frame.
+    if (evalInput) {
+      evalInput.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter') return;
+        const expr = evalInput.value.trim();
+        if (expr) vscode.postMessage({ command: 'evalInFrame', level: selectedLevel, expr });
+      });
+    }
+
     // Suppress the native Cut/Copy/Paste menu everywhere; close our popup on any
     // dismiss gesture (outside click, scroll, focus loss, Escape).
     window.addEventListener('contextmenu', (e) => { e.preventDefault(); });
@@ -139,9 +185,19 @@
       const msg = event.data;
       if (msg.command === 'init') {
         if (error) error.textContent = msg.errorMessage || '';
+        // Clear stale variables / eval output; the default-select below re-fetches.
+        if (variables) variables.innerHTML = '';
+        if (evalResult) { evalResult.textContent = ''; evalResult.classList.remove('error'); }
         renderStack(list, msg.stack);
         // Default-select the top frame so the debugger opens focused on a frame.
         if (msg.stack && msg.stack.length > 0) select(msg.stack[0].level);
+      } else if (msg.command === 'variables') {
+        if (variables) renderVariables(variables, msg.vars);
+      } else if (msg.command === 'evalResult') {
+        if (evalResult) {
+          evalResult.textContent = msg.value != null ? msg.value : '';
+          evalResult.classList.toggle('error', !!msg.isError);
+        }
       }
     });
 
@@ -149,5 +205,5 @@
   }
 
   const root = typeof globalThis !== 'undefined' ? globalThis : window;
-  root.DebuggerView = { renderStack, selectFrame, showMenu, hideMenu, frameLevelOf, init };
+  root.DebuggerView = { renderStack, renderVariables, selectFrame, showMenu, hideMenu, frameLevelOf, init };
 })();

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -930,6 +930,10 @@ export function activate(context: vscode.ExtensionContext) {
       codeExecutor.executeIt();
     }),
 
+    vscode.commands.registerCommand('gemstone.debugIt', () => {
+      codeExecutor.debugIt();
+    }),
+
     vscode.commands.registerCommand('gemstone.copyDisplayItResult', () => {
       codeExecutor.copyLastResult();
     }),

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,6 +25,7 @@ import { CodeExecutor } from './codeExecutor';
 import { SystemBrowser } from './systemBrowser';
 import { GlobalsBrowser } from './globalsBrowser';
 import { GtInspector } from './gtInspector';
+import { DebuggerPanel } from './debuggerPanel';
 import { GemStoneFileSystemProvider, MethodCompiledEvent } from './gemstoneFileSystemProvider';
 import { openWorkspace } from './workspace';
 import { GemStoneDebugSession } from './gemstoneDebugSession';
@@ -849,6 +850,9 @@ export function activate(context: vscode.ExtensionContext) {
       SystemBrowser.disposeForSession(session.id);
       GlobalsBrowser.disposeForSession(session.id);
       GtInspector.disposeForSession(session.id);
+      // Dispose before logout so each panel's dispose() can still release its
+      // suspended GsProcess against a live handle.
+      DebuggerPanel.disposeForSession(session.id);
       sessionManager.logout(session.id);
       treeProvider.refresh();
       inspectorProvider.removeSessionItems(session.id);

--- a/client/src/gciConstants.ts
+++ b/client/src/gciConstants.ts
@@ -20,6 +20,10 @@ export const OOP_Four = 0x22n;
 
 // Perform flags (from gcicmn.ht)
 export const GCI_PERFORM_FLAG_ENABLE_DEBUG = 1;
+// Place a single-step breakpoint at the start of the executed code and run to
+// it, so execution halts on the first statement (Pharo-style "Debug It").
+// Implies GCI_PERFORM_FLAG_INTERPRETED (native code off, required for stepping).
+export const GCI_PERFORM_FLAG_SINGLE_STEP = 4;
 
 // Class OOPs (from gcioop.ht)
 export const OOP_CLASS_BOOLEAN = 68097n;

--- a/client/src/gtInspector.ts
+++ b/client/src/gtInspector.ts
@@ -29,7 +29,7 @@ export class GtInspector {
   private currentOop: bigint;
   private currentLabel: string;
 
-  static create(session: ActiveSession, oop: bigint, label: string): void {
+  static create(session: ActiveSession, oop: bigint, label: string): GtInspector {
     const panel = vscode.window.createWebviewPanel(
       'gemstoneSuperInspector',
       'Inspector',
@@ -41,6 +41,16 @@ export class GtInspector {
       GtInspector.panels.set(session.id, new Set());
     }
     GtInspector.panels.get(session.id)!.add(inspector);
+    return inspector;
+  }
+
+  /**
+   * Close this inspector's panel. Used by an owner (e.g. the debugger that
+   * opened it) to tear it down; disposing the panel fires onDidDispose →
+   * `dispose()`, which de-registers it from the per-session set.
+   */
+  close(): void {
+    this.panel.dispose();
   }
 
   static disposeForSession(sessionId: number): void {

--- a/client/src/nbRunner.ts
+++ b/client/src/nbRunner.ts
@@ -1,0 +1,177 @@
+import * as vscode from 'vscode';
+import { ActiveSession } from './sessionManager';
+import { GciError } from './gciLibrary';
+import { pollReadable } from './socketPoll';
+
+/**
+ * Shared non-blocking GCI call runner.
+ *
+ * GemStone's blocking GCI calls (GciTsPerform / GciTsContinueWith) run
+ * synchronously on the extension-host main thread, so a slow/looping/re-halting
+ * server operation freezes the *entire* VS Code extension host — not just a
+ * webview (see the Enhanced Debugger freeze, 2026-06-22). The non-blocking GCI
+ * API (GciTsNb…) avoids that: start the call, then poll the session socket for
+ * the result on a timer, yielding to the event loop between polls.
+ *
+ * This is the single implementation of that poll loop, shared by `codeExecutor`
+ * (Execute/Display It, via `pollNbToCompletion`) and the debugger's step/trim
+ * (via `runNbCall`) so the cancel/break/backoff/progress behaviour can't drift
+ * between the two. It does NOT cover Resume: GemStone 3.7.x has no
+ * GciTsNbContinue, so a non-blocking Resume needs a worker thread (tracked).
+ */
+
+// Poll cadence: start tight (steps usually finish in a few ms), then back off so
+// a genuinely long operation doesn't busy-spin.
+const BACKOFF_INTERVALS = [10, 10, 20, 40, 80, 160, 320, 500];
+const MAX_INTERVAL = 500;
+// Only surface a progress UI once an operation is clearly slow, so the common
+// fast step never flashes a notification.
+const PROGRESS_THRESHOLD_MS = 2000;
+
+/** Thrown when the user cancels (hard-breaks) a non-blocking GemStone call. */
+export class NbCancelledError extends Error {
+  constructor(message = 'GemStone operation cancelled') {
+    super(message);
+    this.name = 'NbCancelledError';
+  }
+}
+
+/**
+ * Whether a started non-blocking call's result is ready: 1 = ready, 0 = pending,
+ * -1 = error. Uses GciTsNbPoll when available (3.7+); otherwise polls the session
+ * socket directly (GciTsSocket + native poll), exactly as the GciTsNbResult docs
+ * prescribe for older servers.
+ */
+export function pollNbResultReady(session: ActiveSession): { result: number; err: GciError } {
+  if (session.gci.isAvailable('GciTsNbPoll')) {
+    return session.gci.GciTsNbPoll(session.handle, 0);
+  }
+  const { fd, err } = session.gci.GciTsSocket(session.handle);
+  if (err.number !== 0 || fd < 0) {
+    return { result: -1, err };
+  }
+  const ready = pollReadable(fd, 0);
+  return {
+    result: ready,
+    err: ready === -1
+      ? ({ number: -1, message: 'Failed to poll the GemStone session socket' } as GciError)
+      : err,
+  };
+}
+
+export interface NbRunOptions {
+  /** Progress-notification title shown only if the call runs past ~2s. */
+  title?: string;
+}
+
+/**
+ * Poll an ALREADY-STARTED non-blocking GemStone call to completion without
+ * blocking the extension host.
+ *
+ * @param onReady reads the result once polling reports it's ready (typically
+ *                `GciTsNbResult`) and returns the caller's value; may throw to
+ *                signal failure.
+ *
+ * If the call outlives `PROGRESS_THRESHOLD_MS`, a cancellable progress
+ * notification appears: the first cancel sends a soft break and updates the
+ * notification so the user can see it registered; a second sends a hard break
+ * and rejects with `NbCancelledError`.
+ */
+export function pollNbToCompletion<T>(
+  session: ActiveSession,
+  onReady: () => T,
+  opts: NbRunOptions = {},
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let pollIndex = 0;
+    let elapsedMs = 0;
+    let progressShown = false;
+    let softBreakSent = false;
+    let progressResolve: (() => void) | null = null;
+
+    const finishProgress = (): void => {
+      if (progressResolve) {
+        progressResolve();
+        progressResolve = null;
+      }
+    };
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      finishProgress();
+      fn();
+    };
+
+    const doPoll = (): void => {
+      if (settled) return;
+      const { result: pollResult, err: pollErr } = pollNbResultReady(session);
+
+      if (pollResult === 1) {
+        settle(() => {
+          try { resolve(onReady()); } catch (e) { reject(e); }
+        });
+        return;
+      }
+      if (pollResult === -1) {
+        settle(() => reject(new Error(pollErr.message || `GemStone poll error ${pollErr.number}`)));
+        return;
+      }
+
+      const interval = pollIndex < BACKOFF_INTERVALS.length ? BACKOFF_INTERVALS[pollIndex] : MAX_INTERVAL;
+      pollIndex++;
+      elapsedMs += interval;
+
+      if (elapsedMs >= PROGRESS_THRESHOLD_MS && !progressShown) {
+        progressShown = true;
+        void vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: opts.title ?? 'GemStone: working…',
+            cancellable: true,
+          },
+          (progress, token) => {
+            token.onCancellationRequested(() => {
+              if (!softBreakSent) {
+                // First cancel: soft break — ask the gem to stop at a safe point —
+                // and acknowledge it so the user knows the click registered.
+                session.gci.GciTsBreak(session.handle, false);
+                softBreakSent = true;
+                progress.report({ message: 'Soft break sent — waiting for the gem to stop…' });
+              } else {
+                // Second cancel: hard break — interrupt now and give up on the call.
+                session.gci.GciTsBreak(session.handle, true);
+                settle(() => reject(new NbCancelledError()));
+              }
+            });
+            return new Promise<void>(res => { progressResolve = res; });
+          },
+        );
+      }
+
+      setTimeout(doPoll, interval);
+    };
+
+    doPoll();
+  });
+}
+
+/**
+ * Start a non-blocking GemStone call and poll it to completion.
+ *
+ * @param start issues the `GciTsNb…` call; returns `{ success, err }`. A failed
+ *              start rejects without polling.
+ * @param onReady see {@link pollNbToCompletion}.
+ */
+export function runNbCall<T>(
+  session: ActiveSession,
+  start: () => { success: boolean; err: GciError },
+  onReady: () => T,
+  opts: NbRunOptions = {},
+): Promise<T> {
+  const { success, err } = start();
+  if (!success) {
+    return Promise.reject(new Error(err.message || `GemStone error ${err.number}`));
+  }
+  return pollNbToCompletion(session, onReady, opts);
+}

--- a/client/src/transcriptCapture.ts
+++ b/client/src/transcriptCapture.ts
@@ -1,0 +1,58 @@
+/**
+ * The Transcript-capture wrapper for executed code.
+ *
+ * `CodeExecutor` runs user code inside this wrapper so Transcript writes can be
+ * captured into SessionTemps. The wrapped source is what GemStone compiles and
+ * stores as the doit's method source — so a debugger stopped in executed code
+ * sees the *wrapped* text, full of `__vsc…` glue.
+ *
+ * Both halves live here, sharing one prefix/suffix, so the unwrap stays in lock
+ * step with the wrap: if the glue ever changes, `unwrapTranscriptCapture` keeps
+ * working (or, failing an exact match, degrades to showing the full source
+ * rather than mangling it).
+ */
+
+/** Everything before the user code, ending at the block that holds it. */
+export const TRANSCRIPT_CAPTURE_PREFIX = `| __vscCapture __vscOriginal __vscResult |
+__vscCapture := WriteStream on: String new.
+__vscOriginal := SessionTemps current at: #Transcript ifAbsent: [nil].
+SessionTemps current at: #Transcript put: __vscCapture.
+[__vscResult := [`;
+
+/** Everything after the user code: close the block, restore Transcript, return. */
+export const TRANSCRIPT_CAPTURE_SUFFIX = `] value]
+  ensure: [
+    SessionTemps current at: #Transcript put: __vscOriginal.
+    SessionTemps current at: #'__vscTranscriptResult' put: __vscCapture contents.
+  ].
+__vscResult`;
+
+/**
+ * Wrap user code so Transcript writes are captured into SessionTemps. Returns
+ * the wrapped source and the offset at which the user code begins (used to map
+ * compile-error positions back into the user's selection).
+ *
+ * The user code is embedded directly in Smalltalk source (inside a block), NOT
+ * inside a string literal, so single quotes must NOT be escaped.
+ */
+export function wrapWithTranscriptCapture(code: string): { wrappedCode: string; codeOffset: number } {
+  return {
+    wrappedCode: TRANSCRIPT_CAPTURE_PREFIX + code + TRANSCRIPT_CAPTURE_SUFFIX,
+    codeOffset: TRANSCRIPT_CAPTURE_PREFIX.length,
+  };
+}
+
+/**
+ * Recover the user's original code from wrapped doit source. Returns the source
+ * unchanged when it isn't a Transcript-capture wrapper (a plain doit, or a
+ * future glue change), so the debugger never mangles unrecognised source.
+ */
+export function unwrapTranscriptCapture(source: string): string {
+  const trimmed = source.trim();
+  if (trimmed.startsWith(TRANSCRIPT_CAPTURE_PREFIX) && trimmed.endsWith(TRANSCRIPT_CAPTURE_SUFFIX)) {
+    return trimmed
+      .slice(TRANSCRIPT_CAPTURE_PREFIX.length, trimmed.length - TRANSCRIPT_CAPTURE_SUFFIX.length)
+      .trim();
+  }
+  return source;
+}

--- a/client/src/workspace.ts
+++ b/client/src/workspace.ts
@@ -6,11 +6,35 @@ const MOD_KEY = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
 export const WORKSPACE_TEMPLATE =
     `"Workspace\nPlace cursor anywhere on a line with code\nand press [<${MOD_KEY}>+<K> followed by <D>]\n(note that this is a two-keypress chord) to display"\n6 * 7\n`;
 
+/**
+ * Open a GemStone Workspace scratch buffer.
+ *
+ * It uses the *named* untitled URI `untitled:Workspace` rather than
+ * `openTextDocument({content})`. An anonymous untitled doc is titled
+ * "Untitled-N" and — because it carries unsaved content — VS Code's hot-exit
+ * restores it under a *fresh* number on every window reload, so the buffers
+ * pile up (Untitled-1, Untitled-2, …). The named doc keeps the stable title
+ * "Workspace" across reloads, and reopening the same URI reuses the one
+ * document instead of spawning new ones. (An editable buffer with content is
+ * still "dirty" — only a saved file is ever truly clean — but it no longer
+ * multiplies or loses its name.)
+ */
 export async function openWorkspace(): Promise<void> {
-  logInfo('[Workspace] opening new workspace document');
+  logInfo('[Workspace] opening workspace document');
   try {
-    const workspaceDocument = await vscode.workspace.openTextDocument({content: WORKSPACE_TEMPLATE, language: 'gemstone-smalltalk' });
-    await vscode.window.showTextDocument(workspaceDocument, { preview: false });
+    const uri = vscode.Uri.from({ scheme: 'untitled', path: 'Workspace' });
+    const doc = await vscode.workspace.openTextDocument(uri);
+    if (doc.languageId !== 'gemstone-smalltalk') {
+      await vscode.languages.setTextDocumentLanguage(doc, 'gemstone-smalltalk');
+    }
+    // Seed the template only into a fresh, empty buffer — never into a doc that
+    // hot-exit just restored with the user's own content.
+    if (doc.getText().length === 0) {
+      const edit = new vscode.WorkspaceEdit();
+      edit.insert(uri, new vscode.Position(0, 0), WORKSPACE_TEMPLATE);
+      await vscode.workspace.applyEdit(edit);
+    }
+    await vscode.window.showTextDocument(doc, { preview: false });
     logInfo('[Workspace] opened successfully');
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
   ],
   "main": "./client/out/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "[gemstone-smalltalk]": {
+        "editor.minimap.enabled": false
+      }
+    },
     "languages": [
       {
         "id": "gemstone-topaz",

--- a/package.json
+++ b/package.json
@@ -500,6 +500,12 @@
         "icon": "$(run)"
       },
       {
+        "command": "gemstone.debugIt",
+        "title": "Debug It",
+        "category": "GemStone",
+        "icon": "$(debug-alt)"
+      },
+      {
         "command": "gemstone.copyDisplayItResult",
         "title": "Copy Display It Result",
         "category": "GemStone"
@@ -1036,6 +1042,11 @@
           "group": "1_gemstone@3"
         },
         {
+          "command": "gemstone.debugIt",
+          "when": "editorTextFocus && resourceLangId == gemstone-smalltalk && !gemstone.executing",
+          "group": "1_gemstone@4"
+        },
+        {
           "command": "gemstone.sendersOf",
           "when": "editorTextFocus && resourceLangId == gemstone-smalltalk",
           "group": "2_navigation@0"
@@ -1122,6 +1133,12 @@
         "command": "gemstone.executeIt",
         "key": "ctrl+k e",
         "mac": "cmd+k e",
+        "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing"
+      },
+      {
+        "command": "gemstone.debugIt",
+        "key": "ctrl+k r",
+        "mac": "cmd+k r",
         "when": "editorTextFocus && gemstone.hasActiveSession && !gemstone.executing"
       },
       {


### PR DESCRIPTION
## Overview (This is a work-in-progress)

Adds an **Enhanced Debugger** — a roomy, Smalltalk-style debugger rendered as a VS Code **webview** — offered *alongside* the existing DAP debugger. When a GemStone error/halt is raised, the notifier now offers **"Enhanced Debug"** next to **"Debug"** (DAP); whichever you pick owns that suspended `gsProcess`, so the two never coexist on the same process.

> **The existing DAP debugger is unchanged and still fully available.** It remains the default "Debug" path; the Enhanced Debugger is a second, independent consumer of the shared `debugQueries.ts` data layer. Nothing about the DAP `GemStoneDebugSession` was removed.

## What's new

### Entry points
- **"Enhanced Debug"** button on the debuggable-error notifier (parallel to "Debug").
- **Debug It** command (`gemstone.debugIt`, `Ctrl+K R`, editor context menu) — breaks on the first statement of the selection (server-side single-step flag, no injected `halt`) and opens the Enhanced Debugger directly.
- Auto-reveal the **Run and Debug** view after attaching a DAP session (fixes "nothing happened" after clicking Debug).

### Enhanced Debugger panel
- **Call Stack** pane with machinery-filtered frames (`signal`/`halt`/`doesNotUnderstand:` chains trimmed so it opens on your frame), `[] in` block labels, and `Receiver (Defining)` disambiguation.
- **Companion `gemstone://` source editor** docked below the panel — a real editor (syntax highlight, senders/implementors, breakpoint gutters, compile-on-save) — with a **step-point token highlight** (not whole-line), including read-only "Executed Code" doits and light-theme contrast.
- **Variables** pane grouped into Receiver / Instance variables / Arguments & Temps / collapsed `(stack temps)`, with a dim oop column and **click → GT Inspector**.
- **Eval-in-frame** bar (binds `self`, instVars, globals, and the frame's named args/temps).
- **Toolbar**: Resume / Step Over / Into / Through / Restart Frame / Terminate 
- **Draggable splitters** (stack↔variables, panes↔eval) and panel↔source divider, all persisted for the window session; compact first-open layout.
- **Glue eliminated** (at least for some stacks) 

### Stepping & continue
- **Non-blocking step / trim** (`nbRunner.ts`) so a slow/looping step no longer freezes the extension host, and is cancellable.
- **Native-code stepping toggle** — sets a benign breakpoint to force interpreted mode (GemStone can't step native code, err 6014); ref-counted, released on close.
- **Resume / step-to-completion renders a halted Display-It's result** back in the workspace, refocusing the editor so its Backspace/Enter keybindings work.
- **Uncontinuable-halt (error 6011)** handling: a Terminate-only banner, no growing exception-chain message.
- **Resume-hang fix**: `continueExecution` passes `OOP_ILLEGAL` (not `OOP_NIL`) to `GciTsContinueWith` — correct for both a normal halt and a re-entered/trimmed frame.

### Edit-and-continue
- Saving a frame's companion source recompiles it and re-enters the frame (`trimStackToLevel:`) so execution picks up the new code. Top-frame edits are guarded (GemStone can't re-enter the absolute top frame in place).

### Create-method-from-`doesNotUnderstand:`
- On a DNU, the panel offers **"Create #&lt;selector&gt; in &lt;Class&gt;"** → opens a pre-filled `gemstone://` new-method template docked below, focused to type.
- On a clean save: a real method sender is **re-entered** (`trimStackToLevel:`) so **Resume** re-runs the send into the new method; a workspace/"Executed Code" sender (no class, can't be re-entered) is guided to **Resume** — GemStone's `MessageNotUnderstood>>defaultAction` re-performs the send. **Never auto-resumes** (auto-resume of the parked DNU machinery hung the gem).
- The created method tab closes with the debugger (URI built to match the FS provider's form).

## Architecture notes
- `debuggerPanel.ts` (webview host) + `debuggerView.js` (DOM, read at runtime) + `debugQueries.ts` (DAP-free data layer, shared with the DAP session).
- New helpers: `nbRunner.ts` (cancellable non-blocking GCI poll loop), `transcriptCapture.ts` (shared Display-It wrapper strip).

## Testing
- **Client suite: 2013 tests passing** (≈ **+241** new client test cases over `main`).
- **MCP: 95 passing**; **server** green (all three run by the pre-push hook).
- `tsc` clean across client/server/mcp.
- New test files: `debuggerPanel.test.ts`, `debuggerView.test.ts`, `nbRunner.test.ts`, `transcriptCapture.test.ts` (plus additions to `debugQueries`, `codeExecutor`, `extension`, `gemstoneFileSystemProvider` tests).

## Known limitations / follow-ups
- Resume is still **blocking** (a genuinely infinite Resume can stall the host); a worker-thread non-blocking Resume is a tracked nice-to-have.
- Workspace/"Executed Code" senders can't be re-entered in place (GemStone limitation) — handled by guiding to Resume.
-  Rigorous testing has not been done.  
