### PR TITLE
WIP: Enhanced Debugger — Implement-in features added, editable variables, step-point highlighting, and stop/step bug fixes

### DIFF
--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -329,6 +329,53 @@ describe('debugQueries', () => {
     });
   });
 
+  describe('getClassHomeInfo', () => {
+    const RECEIVER_OOP = 0x456n;
+
+    function sessionReturning(data: string): ActiveSession {
+      const session = createMockSession();
+      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
+        result: 9000n, err: { ...noErr },
+      }));
+      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
+        bytesReturned: 0, data, err: { ...noErr },
+      }));
+      return session;
+    }
+
+    it('resolves an instance receiver to its class + home dictionary', () => {
+      const session = sessionReturning('SmallInteger\tinstance\tGlobals');
+      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toEqual({
+        className: 'SmallInteger', isMeta: false, dictName: 'Globals',
+      });
+    });
+
+    it('resolves a class receiver to its class-side', () => {
+      const session = sessionReturning('JasperDebugDemo\tclass\tUserGlobals');
+      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toEqual({
+        className: 'JasperDebugDemo', isMeta: true, dictName: 'UserGlobals',
+      });
+    });
+
+    it('returns a blank dictName when the class is not in the symbol list', () => {
+      const session = sessionReturning('Loner\tinstance\t');
+      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toEqual({
+        className: 'Loner', isMeta: false, dictName: '',
+      });
+    });
+
+    it('returns undefined when the execute fails', () => {
+      const session = createMockSession();
+      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
+        result: 9000n, err: { ...noErr },
+      }));
+      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
+        bytesReturned: 0, data: '', err: { ...noErr, number: 1, message: 'boom' },
+      }));
+      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toBeUndefined();
+    });
+  });
+
   describe('getInstVarNames', () => {
     it('does not send multi-word selectors', () => {
       const session = createMockSession();

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -329,7 +329,7 @@ describe('debugQueries', () => {
     });
   });
 
-  describe('getClassHomeInfo', () => {
+  describe('getReceiverClassChain', () => {
     const RECEIVER_OOP = 0x456n;
 
     function sessionReturning(data: string): ActiveSession {
@@ -343,28 +343,41 @@ describe('debugQueries', () => {
       return session;
     }
 
-    it('resolves an instance receiver to its class + home dictionary', () => {
-      const session = sessionReturning('SmallInteger\tinstance\tGlobals');
-      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toEqual({
-        className: 'SmallInteger', isMeta: false, dictName: 'Globals',
-      });
+    it('parses the full chain (most-specific first), flagging the class that implements the selector', () => {
+      // Interval -> SequenceableCollection -> Collection (implements it) -> Object (implements it).
+      const session = sessionReturning(
+        'Interval\tinstance\tGlobals\t0\n'
+        + 'SequenceableCollection\tinstance\tKernel\t0\n'
+        + 'Collection\tinstance\tKernel\t1\n'
+        + 'Object\tinstance\tKernel\t1',
+      );
+      expect(debug.getReceiverClassChain(session, RECEIVER_OOP, 'asOrderedCollection')).toEqual([
+        { className: 'Interval', isMeta: false, dictName: 'Globals', implementsSelector: false },
+        { className: 'SequenceableCollection', isMeta: false, dictName: 'Kernel', implementsSelector: false },
+        { className: 'Collection', isMeta: false, dictName: 'Kernel', implementsSelector: true },
+        { className: 'Object', isMeta: false, dictName: 'Kernel', implementsSelector: true },
+      ]);
     });
 
-    it('resolves a class receiver to its class-side', () => {
-      const session = sessionReturning('JasperDebugDemo\tclass\tUserGlobals');
-      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toEqual({
-        className: 'JasperDebugDemo', isMeta: true, dictName: 'UserGlobals',
-      });
+    it('parses a single-class chain', () => {
+      const session = sessionReturning('SmallInteger\tinstance\tGlobals\t0');
+      expect(debug.getReceiverClassChain(session, RECEIVER_OOP, 'foo')).toEqual([
+        { className: 'SmallInteger', isMeta: false, dictName: 'Globals', implementsSelector: false },
+      ]);
     });
 
-    it('returns a blank dictName when the class is not in the symbol list', () => {
-      const session = sessionReturning('Loner\tinstance\t');
-      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toEqual({
-        className: 'Loner', isMeta: false, dictName: '',
-      });
+    it('marks a class-side chain (class receiver) and a blank dict for a non-symbol-list class', () => {
+      const session = sessionReturning('Loner\tclass\t\t1');
+      expect(debug.getReceiverClassChain(session, RECEIVER_OOP, 'foo')).toEqual([
+        { className: 'Loner', isMeta: true, dictName: '', implementsSelector: true },
+      ]);
     });
 
-    it('returns undefined when the execute fails', () => {
+    it('returns [] when the chain is empty', () => {
+      expect(debug.getReceiverClassChain(sessionReturning(''), RECEIVER_OOP, 'foo')).toEqual([]);
+    });
+
+    it('returns [] when the execute fails', () => {
       const session = createMockSession();
       (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
         result: 9000n, err: { ...noErr },
@@ -372,7 +385,7 @@ describe('debugQueries', () => {
       (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
         bytesReturned: 0, data: '', err: { ...noErr, number: 1, message: 'boom' },
       }));
-      expect(debug.getClassHomeInfo(session, RECEIVER_OOP)).toBeUndefined();
+      expect(debug.getReceiverClassChain(session, RECEIVER_OOP, 'Object')).toEqual([]);
     });
   });
 

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -1951,7 +1951,7 @@ describe('DebuggerPanel', () => {
       expect(posted(panel, 'init').length).toBe(1); // only the original ready init
     });
 
-    it('re-enters the sender frame (trim, NOT resume) on a clean compile', async () => {
+    it('on a clean save, refreshes with a "used on next send" message and does NOT trim/resume (option B)', async () => {
       const panel = openPanel();
       sendMessage(panel, { command: 'implementInReceiver', level: 2 });
       await flush();
@@ -1959,13 +1959,13 @@ describe('DebuggerPanel', () => {
 
       saveListener()({ uri } as vscode.TextDocument);
       await tick();
-      // The overridden frame is server level 2; its caller (the sender) is level 3.
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
-      expect(debug.continueExecution).not.toHaveBeenCalled(); // never auto-resume
-      expect(lastPosted(panel, 'init').errorMessage).toMatch(/resume/i);
+      // Option B: no auto-restart and never auto-resume — just refresh + explain.
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      expect(debug.continueExecution).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/used on the next/i);
     });
 
-    it('does NOT trim and keeps the template pending when the compile fails', async () => {
+    it('keeps the template pending on a failed compile, then finishes on a clean re-save', async () => {
       const panel = openPanel();
       sendMessage(panel, { command: 'implementInReceiver', level: 2 });
       await flush();
@@ -1976,11 +1976,12 @@ describe('DebuggerPanel', () => {
       );
       saveListener()({ uri } as vscode.TextDocument);
       await tick();
-      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      // Bad compile → finish not run yet (no "saved" message).
+      expect(posted(panel, 'init').some((m: { errorMessage?: string }) => /used on the next/i.test(m.errorMessage ?? ''))).toBe(false);
 
-      saveListener()({ uri } as vscode.TextDocument); // re-save after fixing
+      saveListener()({ uri } as vscode.TextDocument); // re-save after fixing → pending survived
       await tick();
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/used on the next/i);
     });
 
     it('refuses to implement when the receiver class has no home dictionary', async () => {
@@ -2055,36 +2056,11 @@ describe('DebuggerPanel', () => {
       const panel = openPanel();
       sendMessage(panel, { command: 'implementInReceiver', level: 2 });
       await flush();
-      // Save → the banner/init message explains Interval still shadows it.
+      // Save → the message explains Interval still shadows it (no trim — option B).
       saveListener()({ uri: vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] } as vscode.TextDocument);
       await tick();
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/Interval already implements/i);
-    });
-
-    it('explains "used on the next send" (no in-place trim) when the caller is a non-re-enterable doit', async () => {
-      // Stack where the overridden frame's only caller is Executed Code: make the
-      // frame BELOW the inherited one a doit so the sender isn't re-enterable.
-      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
-        if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
-        if (oop === 2n) return { className: 'Object', selector: 'halt' };
-        if (oop === 3n) throw new Error('doit: no class'); // sender of frame 2 → Executed Code
-        return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
-      });
-      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce([
-        { className: 'Interval', isMeta: false, dictName: 'Globals', implementsSelector: false },
-        { className: 'SequenceableCollection', isMeta: false, dictName: 'Kernel', implementsSelector: false },
-      ]);
-      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
-        async (items: unknown) => (items as { index: number }[])[1] as never);
-      const panel = openPanel();
-      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
-      await flush();
-      saveListener()({ uri: vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] } as vscode.TextDocument);
-      await tick();
-
-      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();          // can't re-enter a doit
-      expect(lastPosted(panel, 'init').errorMessage).toMatch(/used on the next/i);
-      expect(lastPosted(panel, 'init').errorMessage).toMatch(/re-run the expression/i);
     });
 
     it('opens nothing when the inheritance-chain QuickPick is cancelled', async () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -74,7 +74,7 @@ import {
   filterStack, isExceptionMachinery, RawFrame,
   flattenLayoutLeaves, sourceRatioFromLayout, setSourceRatioInLayout, EditorGroupLayout,
 } from '../debuggerPanel';
-import { wrapWithTranscriptCapture } from '../transcriptCapture';
+import { wrapWithTranscriptCapture, TRANSCRIPT_CAPTURE_PREFIX } from '../transcriptCapture';
 import { GtInspector } from '../gtInspector';
 import { ActiveSession } from '../sessionManager';
 import { GemStoneLogin } from '../loginTypes';
@@ -667,21 +667,124 @@ describe('DebuggerPanel', () => {
       expect(debug.getSourceOffsetsForMethod).toHaveBeenCalledWith(session, 999n);
     });
 
-    it('does NOT highlight a read-only frame whose source was unwrapped', async () => {
-      // A true doit whose stored source is the transcript-capture-wrapped form:
-      // the panel unwraps it for display, so the server's offsets refer to the
-      // wrapped source and no longer line up — highlighting stays off.
+    it('highlights an unwrapped read-only frame, shifting offsets into the displayed source (T0)', async () => {
+      // A doit whose stored source is the Transcript-capture-wrapped form
+      // (Display It / Execute It / Inspect It). The panel unwraps it for display,
+      // so the server's offsets — in WRAPPED coordinates — must be shifted back
+      // by the stripped prefix to land on the displayed user code.
       const panel = openPanelWithStack();
       vi.mocked(debug.getMethodInfo).mockImplementationOnce(() => { throw new Error('doit: nil inClass'); });
       vi.mocked(debug.getMethodSource).mockReturnValueOnce(
         wrapWithTranscriptCapture('JasperDebugDemo new run').wrappedCode,
       );
+      // Same 1-based offsets as the 1:1 case, but pushed into wrapped coordinates
+      // by the prefix length — so after the shift they reproduce the column-7 hit.
+      vi.mocked(debug.getSourceOffsetsForMethod).mockReturnValueOnce(
+        [1, 8, 26].map(o => o + TRANSCRIPT_CAPTURE_PREFIX.length),
+      );
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const editor = await shownEditor();
+      // step point 2 → (8 + prefix) - 1 - prefix → positionAt(7) → (0, 7).
+      const range = vi.mocked(editor.setDecorations).mock.calls[0][1][0] as vscode.Range;
+      expect(range.start.line).toBe(0);
+      expect(range.start.character).toBe(7);
+      expect(editor.revealRange).toHaveBeenCalled();
+    });
+
+    it('does NOT highlight when the shifted offset falls in the stripped prefix', async () => {
+      // Guard for the shift: if a step point's offset lands inside the stripped
+      // Transcript-capture prefix, the shifted offset goes negative — skip the
+      // highlight rather than let positionAt clamp it to the document start.
+      const panel = openPanelWithStack();
+      vi.mocked(debug.getMethodInfo).mockImplementationOnce(() => { throw new Error('doit: nil inClass'); });
+      vi.mocked(debug.getMethodSource).mockReturnValueOnce(
+        wrapWithTranscriptCapture('JasperDebugDemo new run').wrappedCode,
+      );
+      // Small offsets (< prefix length) → shifted offset < 0.
+      vi.mocked(debug.getSourceOffsetsForMethod).mockReturnValueOnce([1, 8, 26]);
       sendMessage(panel, { command: 'selectFrame', level: 3 });
       await flush();
 
       const editor = await shownEditor();
       expect(vi.mocked(editor.setDecorations).mock.calls[0][1]).toEqual([]); // cleared, not set
       expect(editor.revealRange).not.toHaveBeenCalled();
+    });
+
+    // A collapsed Executed Code frame: Display It / Execute It / Inspect It run
+    // user code inside the Transcript-capture wrapper's nested blocks, and
+    // filterStack collapses those frames into the single DEEPEST doit frame —
+    // but execution stopped in the TOP block (the user's halt). The highlight
+    // must use that top frame's step point, not the collapsed doit frame's
+    // (which sits out in the wrapper glue, after the user code).
+    describe('collapsed executed-code highlight (T0 stop frame)', () => {
+      // These overrides leak past clearAllMocks — restore the factory defaults.
+      afterEach(() => {
+        vi.mocked(debug.getStackDepth).mockImplementation(() => 5);
+        vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) => ({
+          methodOop: BigInt(level), ipOffset: 5, receiverOop: BigInt(level * 100),
+          argAndTempNames: [], argAndTempOops: [],
+        }));
+        vi.mocked(debug.getMethodBlockInfo).mockImplementation((_s: unknown, methodOop: bigint) => ({
+          isBlock: methodOop === 1n, homeMethodOop: methodOop,
+        }));
+        vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+          if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
+          if (oop === 2n) return { className: 'Object', selector: 'halt' };
+          return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+        });
+        vi.mocked(debug.getMethodSource).mockImplementation(() => '| t | t := 6 * 7. t halt');
+        vi.mocked(debug.getStepPoint).mockImplementation(() => 2);
+        vi.mocked(debug.getSourceOffsetsForMethod).mockImplementation(() => [1, 8, 26]);
+      });
+
+      it('highlights the true stop frame, not the collapsed doit frame', async () => {
+        // 3 frames, all sharing the doit's home method (oop 30n):
+        //   level 1 — inner wrapper block, stopped at the user halt (step point 2)
+        //   level 2 — outer wrapper block
+        //   level 3 — the doit home (step point 5, out in the wrapper glue)
+        vi.mocked(debug.getStackDepth).mockImplementation(() => 3);
+        vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) => ({
+          methodOop: BigInt(level), ipOffset: 5, receiverOop: 100n,
+          argAndTempNames: [], argAndTempOops: [],
+        }));
+        // All three resolve to the same doit home (30n) → collapse to one frame.
+        vi.mocked(debug.getMethodBlockInfo).mockImplementation((_s: unknown, methodOop: bigint) => ({
+          isBlock: methodOop !== 3n, homeMethodOop: 30n,
+        }));
+        // No symbol-list entry and no resolvable class → executed code (a doit).
+        vi.mocked(debug.getMethodInfo).mockImplementation(() => { throw new Error('doit'); });
+        vi.mocked(debug.getMethodSource).mockImplementation(
+          () => wrapWithTranscriptCapture('Array new add: 1; halt; add: 2').wrappedCode,
+        );
+        // Step point differs by frame: the stop frame (level 1) is at the halt;
+        // the collapsed doit (level 3) is out in the glue.
+        vi.mocked(debug.getStepPoint).mockImplementation((_s: unknown, _p: unknown, level: number) =>
+          level === 1 ? 2 : 5);
+        // Home-method offsets in WRAPPED coordinates; the shift maps them back:
+        // sp 2 → 8 → col 7 (the halt); sp 5 → 40 → col 39 (the glue).
+        const shift = TRANSCRIPT_CAPTURE_PREFIX.length;
+        vi.mocked(debug.getSourceOffsetsForMethod).mockImplementation(
+          () => [1, 8, 15, 22, 40].map(o => o + shift),
+        );
+
+        DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+        const panel = lastPanel();
+        sendReady(panel);
+        // filterStack collapses all three frames into one Executed Code frame.
+        expect(initPayload(panel).stack).toHaveLength(1);
+
+        sendMessage(panel, { command: 'selectFrame', level: 1 });
+        await flush();
+
+        // Highlight uses the STOP frame (level 1 → sp 2 → col 7), NOT the
+        // collapsed doit frame (level 3 → sp 5 → col 39).
+        const editor = await shownEditor();
+        const range = vi.mocked(editor.setDecorations).mock.calls[0][1][0] as vscode.Range;
+        expect(range.start.character).toBe(7);
+        expect(editor.revealRange).toHaveBeenCalled();
+      });
     });
 
     it('clears the highlight (no reveal) when there is no step point and no source line', async () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -60,8 +60,9 @@ vi.mock('../debugQueries', () => ({
   releaseStepping: vi.fn(),
   // Create-method-from-DNU detection — defaults to "not a DNU" (no Create button).
   getDoesNotUnderstandInfo: vi.fn(() => undefined),
-  // Implement-in-receiver (override): resolve the receiver's class + home dict.
-  getClassHomeInfo: vi.fn(() => ({ className: 'SmallInteger', isMeta: false, dictName: 'Globals' })),
+  // Implement-in-receiver (override): the receiver's inheritance chain (default
+  // is a single class → no QuickPick; tests override it for the multi-class case).
+  getReceiverClassChain: vi.fn(() => [{ className: 'SmallInteger', isMeta: false, dictName: 'Globals' }]),
 }));
 
 // Clicking a variable row opens a GT Inspector — stub the static entry point.
@@ -1973,8 +1974,8 @@ describe('DebuggerPanel', () => {
     });
 
     it('refuses to implement when the receiver class has no home dictionary', async () => {
-      vi.mocked(debug.getClassHomeInfo).mockReturnValueOnce(
-        { className: 'SmallInteger', isMeta: false, dictName: '' },
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(
+        [{ className: 'SmallInteger', isMeta: false, dictName: '' }],
       );
       const panel = openPanel();
       vi.mocked(vscode.workspace.openTextDocument).mockClear();
@@ -1983,6 +1984,90 @@ describe('DebuggerPanel', () => {
 
       expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/symbol list/i);
+    });
+
+    // The receiver (Interval) chain for #asOrderedCollection: two override targets
+    // then the class that already implements it (Collection) and Object.
+    const CHAIN = [
+      { className: 'Interval', isMeta: false, dictName: 'Globals', implementsSelector: false },
+      { className: 'SequenceableCollection', isMeta: false, dictName: 'Kernel', implementsSelector: false },
+      { className: 'Collection', isMeta: false, dictName: 'Kernel', implementsSelector: true },
+      { className: 'Object', isMeta: false, dictName: 'Kernel', implementsSelector: true },
+    ];
+
+    it('QuickPicks the full chain (override vs already-implements) and opens the chosen class', async () => {
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(CHAIN);
+      // Choose SequenceableCollection (index 1) — a superclass override target.
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[1] as never);
+      const panel = openPanel();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+
+      // The picker offered the whole chain, receiver first; classes that already
+      // implement the selector are marked as edit (not override) targets.
+      const items = vi.mocked(vscode.window.showQuickPick).mock.calls.at(-1)![0] as
+        { label: string; description: string }[];
+      expect(items.map(i => i.label)).toEqual(['Interval', 'SequenceableCollection', 'Collection', 'Object']);
+      expect(items[0].description).toMatch(/override here/i);
+      expect(items[2].description).toMatch(/already implements/i);
+      // A stub template for the chosen (non-implementing) superclass.
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      expect(uri.toString()).toContain('/Kernel/SequenceableCollection/instance/');
+      expect(uri.toString()).toContain('new-method');
+    });
+
+    it('opens the EXISTING source (no stub) when the chosen class already implements it', async () => {
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(CHAIN);
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[2] as never); // Collection (implements it)
+      const panel = openPanel();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+
+      // The real method URI (not a new-method template), and NOT clobbered by a stub.
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      expect(uri.toString()).toContain('/Kernel/Collection/instance/');
+      expect(uri.toString()).not.toContain('new-method');
+      const editor = await vi.mocked(vscode.window.showTextDocument).mock.results.at(-1)!.value;
+      expect(editor.edit).not.toHaveBeenCalled(); // existing source left intact
+    });
+
+    it('warns that a subclass implementation shadows an override placed higher up', async () => {
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce([
+        { className: 'Interval', isMeta: false, dictName: 'Globals', implementsSelector: true },  // active impl
+        { className: 'SequenceableCollection', isMeta: false, dictName: 'Kernel', implementsSelector: false },
+      ]);
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[1] as never); // implement in the superclass
+      const panel = openPanel();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+      // Save → the banner/init message explains Interval still shadows it.
+      saveListener()({ uri: vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] } as vscode.TextDocument);
+      await tick();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/Interval already implements/i);
+    });
+
+    it('opens nothing when the inheritance-chain QuickPick is cancelled', async () => {
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(CHAIN);
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValueOnce(undefined as never);
+      const panel = openPanel();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+
+      expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
+    });
+
+    it('skips the QuickPick when the chain has a single class', async () => {
+      // Default mock chain is single-element → straight to the template, no prompt.
+      const panel = openPanel();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+      expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
     });
   });
 

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -38,6 +38,13 @@ vi.mock('../debugQueries', () => ({
   getInstVarNames: vi.fn(() => [] as string[]),
   getNamedInstVarOops: vi.fn(() => [] as bigint[]),
   evaluateInFrame: vi.fn(() => '42'),
+  evaluateInFrameToOop: vi.fn(() => 999n),
+  setFrameTemp: vi.fn(),
+  setInstVar: vi.fn(),
+  getInstVarOop: vi.fn(() => 700n),
+  isSpecialOop: vi.fn(() => false),
+  saveObjs: vi.fn(),
+  releaseObjs: vi.fn(),
   continueExecution: vi.fn(() => ({ completed: true })),
   stepOver: vi.fn(() => ({ completed: false })),
   stepInto: vi.fn(() => ({ completed: false })),
@@ -298,6 +305,28 @@ describe('DebuggerPanel', () => {
     expect(html).toContain('For DataCurator on gs64stone @ devhost');
     // The subtitle uses the dimmed description color.
     expect(html).toMatch(/\.subtitle\s*\{[^}]*--vscode-descriptionForeground/);
+  });
+
+  it('styles editable variable rows with a pointer cursor (the editable affordance)', () => {
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const html = lastPanel().webview.html;
+
+    // Editable rows get a pointer cursor; the base row stays a plain default
+    // (so `self` and other non-editable rows don't look clickable).
+    expect(html).toMatch(/\.var\.editable\s*\{[^}]*cursor:\s*pointer/);
+    expect(html).toMatch(/\.vars \.var\s*\{[^}]*cursor:\s*default/);
+  });
+
+  it('styles a rejected variable expression with an error border + visible message line', () => {
+    DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+    const html = lastPanel().webview.html;
+
+    // The editor's .error state recolors the border to the validation-error color…
+    expect(html).toMatch(/\.var-edit\.error\s*\{[^}]*--vscode-inputValidation-errorBorder/);
+    // …and the message line below it uses the error foreground color…
+    expect(html).toMatch(/\.var-edit-error\s*\{[^}]*--vscode-errorForeground/);
+    // …and is text-selectable so the real error can be copied out.
+    expect(html).toMatch(/\.var-edit-error\s*\{[^}]*user-select:\s*text/);
   });
 
   it('HTML-escapes session text so it cannot inject markup into the page', () => {
@@ -990,8 +1019,8 @@ describe('DebuggerPanel', () => {
       expect(receiver.vars[0]).toEqual({ name: 'self', value: '<print 300>', oop: '300' });
       const argtemps = groups.find((g: { kind: string }) => g.kind === 'argtemps');
       expect(argtemps.vars).toEqual([
-        { name: 'amount', value: '<print 11>', oop: '11' },
-        { name: 'total', value: '<print 22>', oop: '22' },
+        { name: 'amount', value: '<print 11>', oop: '11', edit: { kind: 'temp', index: 1 } },
+        { name: 'total', value: '<print 22>', oop: '22', edit: { kind: 'temp', index: 2 } },
       ]);
     });
 
@@ -1004,11 +1033,16 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'selectFrame', level: 2 });
 
       const groups = lastPosted(panel, 'variables').groups;
+      // A named temp carries its 1-based write index into the unfiltered
+      // argAndTempNames (`amount` is #1). The `.tN` eval-stack temps are NOT
+      // editable — they sit past the method's argsAndTemps offsets, so the write
+      // primitive can't address them — so they carry NO edit metadata.
       expect(groups.find((g: { kind: string }) => g.kind === 'argtemps').vars)
-        .toEqual([{ name: 'amount', value: '<print 11>', oop: '11' }]);
+        .toEqual([{ name: 'amount', value: '<print 11>', oop: '11', edit: { kind: 'temp', index: 1 } }]);
       const stack = groups.find((g: { kind: string }) => g.kind === 'stacktemps');
       expect(stack.collapsed).toBe(true);
       expect(stack.vars).toEqual([{ name: '.t1', value: '<print 99>', oop: '99' }]);
+      expect(stack.vars[0].edit).toBeUndefined();
     });
 
     it('hides the __vsc transcript-capture glue temps from an executed-code frame', () => {
@@ -1022,7 +1056,9 @@ describe('DebuggerPanel', () => {
 
       const groups = lastPosted(panel, 'variables').groups;
       const argtemps = groups.find((g: { kind: string }) => g.kind === 'argtemps');
-      expect(argtemps.vars).toEqual([{ name: 'amount', value: '<print 11>', oop: '11' }]);
+      // `amount` sits at unfiltered index 3 (after the two __vsc glue temps),
+      // so its 1-based write index is 3 even though the glue rows are hidden.
+      expect(argtemps.vars).toEqual([{ name: 'amount', value: '<print 11>', oop: '11', edit: { kind: 'temp', index: 3 } }]);
       // None of the glue names leak into any group.
       const allNames = groups.flatMap((g: { vars: { name: string }[] }) => g.vars.map(v => v.name));
       expect(allNames.some((n: string) => n.startsWith('__vsc'))).toBe(false);
@@ -1036,8 +1072,8 @@ describe('DebuggerPanel', () => {
 
       const groups = lastPosted(panel, 'variables').groups;
       expect(groups.find((g: { kind: string }) => g.kind === 'instvars').vars).toEqual([
-        { name: 'count', value: '<print 7>', oop: '7' },
-        { name: 'sum', value: '<print 8>', oop: '8' },
+        { name: 'count', value: '<print 7>', oop: '7', edit: { kind: 'instvar', index: 1 } },
+        { name: 'sum', value: '<print 8>', oop: '8', edit: { kind: 'instvar', index: 2 } },
       ]);
     });
 
@@ -1045,6 +1081,171 @@ describe('DebuggerPanel', () => {
       const panel = openPanel();
       sendMessage(panel, { command: 'inspectVariable', oop: '300', name: 'self' });
       expect(GtInspector.create).toHaveBeenCalledWith(session, 300n, 'self');
+    });
+
+    it('setVariable (instvar) evaluates the expr, writes via instVarAt:put:, refreshes, and reports ok', () => {
+      vi.mocked(debug.evaluateInFrameToOop).mockReturnValueOnce(777n);
+      const panel = openPanel();
+      const before = posted(panel, 'variables').length;
+      sendMessage(panel, { command: 'setVariable', level: 3, kind: 'instvar', index: 2, expr: '99' });
+
+      expect(debug.evaluateInFrameToOop).toHaveBeenCalledWith(session, GS_PROCESS, '99', expect.any(Number));
+      expect(debug.setInstVar).toHaveBeenCalledWith(session, expect.any(BigInt), 2, 777n);
+      // Re-fetched variables so every row's printString + OOP reflect the new object.
+      expect(posted(panel, 'variables').length).toBe(before + 1);
+      expect(lastPosted(panel, 'setVariableResult')).toEqual({ command: 'setVariableResult', ok: true });
+    });
+
+    it('setVariable (temp) writes via _frameAt:tempAt:put:, refreshes, and reports ok', () => {
+      vi.mocked(debug.evaluateInFrameToOop).mockReturnValueOnce(555n);
+      const panel = openPanel();
+      const before = posted(panel, 'variables').length;
+      sendMessage(panel, { command: 'setVariable', level: 3, kind: 'temp', index: 4, expr: 'self' });
+
+      expect(debug.setFrameTemp).toHaveBeenCalledWith(session, GS_PROCESS, expect.any(Number), 4, 555n);
+      expect(debug.setInstVar).not.toHaveBeenCalled(); // a temp write must NOT touch instVars
+      expect(posted(panel, 'variables').length).toBe(before + 1);
+      expect(lastPosted(panel, 'setVariableResult')).toEqual({ command: 'setVariableResult', ok: true });
+    });
+
+    it('setVariable refuses (and reports !ok) while a non-blocking step is in flight', async () => {
+      let release: (r: debug.StepResult) => void = () => {};
+      vi.mocked(debug.stepOverNb).mockReturnValueOnce(new Promise<debug.StepResult>(res => { release = res; }));
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 3 }); // holds the session's single GCI call
+      await tick();
+
+      sendMessage(panel, { command: 'setVariable', level: 3, kind: 'instvar', index: 1, expr: '99' });
+      // A blocking frame write can't share the session with an in-flight step.
+      expect(debug.evaluateInFrameToOop).not.toHaveBeenCalled();
+      expect(debug.setInstVar).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'setVariableResult').ok).toBe(false);
+
+      release({ completed: false }); // let the step settle
+      await tick();
+    });
+
+    it('setVariable reports a compile/runtime error (and does NOT refresh) so the editor stays open', () => {
+      vi.mocked(debug.evaluateInFrameToOop).mockImplementationOnce(() => { throw new Error('a parse error'); });
+      const panel = openPanel();
+      const before = posted(panel, 'variables').length;
+      sendMessage(panel, { command: 'setVariable', level: 3, kind: 'instvar', index: 1, expr: 'bogus +' });
+
+      expect(debug.setInstVar).not.toHaveBeenCalled();
+      expect(posted(panel, 'variables').length).toBe(before); // no refresh on failure
+      const res = lastPosted(panel, 'setVariableResult');
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain('a parse error');
+    });
+
+    describe('variable revert (single-level undo)', () => {
+      // A frame (level 2) with one named temp `amount` (#1, value oop 11) and a
+      // receiver (300) with one instVar `count` (#1). getInstVarOop returns the
+      // instVar's *original* oop (700) when captured before the first edit.
+      beforeEach(() => {
+        vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) =>
+          level === 2
+            ? { methodOop: 2n, ipOffset: 5, receiverOop: 300n, argAndTempNames: ['amount'], argAndTempOops: [11n] }
+            : { methodOop: BigInt(level), ipOffset: 5, receiverOop: BigInt(level * 100), argAndTempNames: [], argAndTempOops: [] });
+        vi.mocked(debug.getInstVarNames).mockReturnValue(['count']);
+        vi.mocked(debug.getNamedInstVarOops).mockReturnValue([700n]);
+        vi.mocked(debug.getInstVarOop).mockReturnValue(700n);
+      });
+
+      // mockReturnValue is sticky past clearAllMocks; restore factory defaults so
+      // these don't bleed into sibling tests (getFrameInfo is reset by the outer
+      // beforeEach, so it's not listed here).
+      afterEach(() => {
+        vi.mocked(debug.getInstVarNames).mockReturnValue([]);
+        vi.mocked(debug.getNamedInstVarOops).mockReturnValue([]);
+        vi.mocked(debug.getInstVarOop).mockReturnValue(700n);
+        vi.mocked(debug.isSpecialOop).mockReturnValue(false);
+        vi.mocked(debug.evaluateInFrameToOop).mockReturnValue(999n);
+        vi.mocked(debug.continueExecution).mockReturnValue({ completed: true });
+      });
+
+      const editInstVar = (panel: ReturnType<typeof lastPanel>, expr = '99') =>
+        sendMessage(panel, { command: 'setVariable', level: 2, kind: 'instvar', index: 1, expr });
+
+      it('captures + pins the original on the FIRST edit only (not on the second)', () => {
+        vi.mocked(debug.evaluateInFrameToOop).mockReturnValue(999n);
+        const panel = openPanel();
+        editInstVar(panel, '99');
+        editInstVar(panel, '123');
+
+        expect(debug.getInstVarOop).toHaveBeenCalledTimes(1);          // captured once
+        expect(debug.saveObjs).toHaveBeenCalledTimes(1);               // pinned once
+        expect(debug.saveObjs).toHaveBeenCalledWith(session, [700n]);  // the original oop
+      });
+
+      it('does NOT pin an immediate (special) original', () => {
+        vi.mocked(debug.isSpecialOop).mockReturnValue(true);
+        const panel = openPanel();
+        editInstVar(panel);
+        expect(debug.saveObjs).not.toHaveBeenCalled();
+      });
+
+      it('marks the edited row revertible (and only that row)', () => {
+        const panel = openPanel();
+        editInstVar(panel);
+        const groups = lastPosted(panel, 'variables').groups;
+        const count = groups.find((g: { kind: string }) => g.kind === 'instvars').vars[0];
+        expect(count).toMatchObject({ name: 'count', revertible: true });
+        // `self` (read-only) never becomes revertible.
+        const self = groups.find((g: { kind: string }) => g.kind === 'receiver').vars[0];
+        expect(self.revertible).toBeUndefined();
+      });
+
+      it('revertVariable writes the stored original back and clears the dirty flag', () => {
+        const panel = openPanel();
+        editInstVar(panel);
+        sendMessage(panel, { command: 'revertVariable', level: 2, kind: 'instvar', index: 1 });
+
+        // The LAST instVar write restores the original (700), not the edit (999).
+        expect(debug.setInstVar).toHaveBeenLastCalledWith(session, 300n, 1, 700n);
+        const count = lastPosted(panel, 'variables').groups
+          .find((g: { kind: string }) => g.kind === 'instvars').vars[0];
+        expect(count.revertible).toBeUndefined(); // icon gone after revert
+      });
+
+      it('revertVariable on a slot with no recorded original is a no-op', () => {
+        const panel = openPanel();
+        sendMessage(panel, { command: 'revertVariable', level: 2, kind: 'instvar', index: 1 });
+        expect(debug.setInstVar).not.toHaveBeenCalled();
+      });
+
+      it('reverts a frame temp via the original oop', () => {
+        vi.mocked(debug.evaluateInFrameToOop).mockReturnValue(999n);
+        const panel = openPanel();
+        sendMessage(panel, { command: 'setVariable', level: 2, kind: 'temp', index: 1, expr: '99' });
+        sendMessage(panel, { command: 'revertVariable', level: 2, kind: 'temp', index: 1 });
+
+        // Original temp value (oop 11, from argAndTempOops[0]) written back.
+        expect(debug.setFrameTemp).toHaveBeenLastCalledWith(session, GS_PROCESS, expect.any(Number), 1, 11n);
+      });
+
+      it('releases pinned originals on Resume (leaving the halt)', () => {
+        vi.mocked(debug.continueExecution).mockReturnValue({ completed: false, errorMessage: 'next halt' });
+        const panel = openPanel();
+        editInstVar(panel); // pins 700
+        sendMessage(panel, { command: 'resume' });
+        expect(debug.releaseObjs).toHaveBeenCalledWith(session, [700n]);
+      });
+
+      it('releases pinned originals when the debugger is CLOSED (no export-set leak)', () => {
+        const panel = openPanel();
+        editInstVar(panel); // pins 700
+        closePanel(panel);  // user closes the debugger window
+        expect(debug.releaseObjs).toHaveBeenCalledWith(session, [700n]);
+      });
+
+      it('releases pinned originals on Step (stack moved)', async () => {
+        const panel = openPanel();
+        editInstVar(panel); // pins 700
+        sendMessage(panel, { command: 'stepOver', level: 2 });
+        await tick();
+        expect(debug.releaseObjs).toHaveBeenCalledWith(session, [700n]);
+      });
     });
 
     it('evaluates an expression in the selected frame and posts the result', () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -2061,7 +2061,7 @@ describe('DebuggerPanel', () => {
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/Interval already implements/i);
     });
 
-    it('tells the user to re-run (not Resume) when the caller is a non-re-enterable doit', async () => {
+    it('explains "used on the next send" (no in-place trim) when the caller is a non-re-enterable doit', async () => {
       // Stack where the overridden frame's only caller is Executed Code: make the
       // frame BELOW the inherited one a doit so the sender isn't re-enterable.
       vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
@@ -2083,8 +2083,8 @@ describe('DebuggerPanel', () => {
       await tick();
 
       expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();          // can't re-enter a doit
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/used on the next/i);
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/re-run the expression/i);
-      expect(lastPosted(panel, 'init').errorMessage).not.toMatch(/dispatch into it, or step/i);
     });
 
     it('opens nothing when the inheritance-chain QuickPick is cancelled', async () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -60,6 +60,8 @@ vi.mock('../debugQueries', () => ({
   releaseStepping: vi.fn(),
   // Create-method-from-DNU detection — defaults to "not a DNU" (no Create button).
   getDoesNotUnderstandInfo: vi.fn(() => undefined),
+  // Implement-in-receiver (override): resolve the receiver's class + home dict.
+  getClassHomeInfo: vi.fn(() => ({ className: 'SmallInteger', isMeta: false, dictName: 'Globals' })),
 }));
 
 // Clicking a variable row opens a GT Inspector — stub the static entry point.
@@ -474,7 +476,7 @@ describe('DebuggerPanel', () => {
       const panel = lastPanel();
       sendReady(panel);
 
-      expect(initPayload(panel).stack).toEqual([
+      expect(initPayload(panel).stack).toMatchObject([
         { level: 1, label: '[] in JasperDebugDemo>>#finish', position: '@2 line 12' },
         { level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12' },
         { level: 3, label: 'JasperDebugDemo>>#accumulateFrom:to:', position: '@2 line 12' },
@@ -510,7 +512,7 @@ describe('DebuggerPanel', () => {
       const panel = lastPanel();
       sendReady(panel);
 
-      expect(initPayload(panel).stack[0]).toEqual({ level: 1, label: '<frame 1>', position: '' });
+      expect(initPayload(panel).stack[0]).toMatchObject({ level: 1, label: '<frame 1>', position: '' });
     });
 
     // An "unprintable" / unresolvable receiver: getObjectClassName throws. The
@@ -527,9 +529,10 @@ describe('DebuggerPanel', () => {
       sendReady(panel);
 
       // Without the receiver class there is no `Receiver (Defining)` form —
-      // just the plain defining-class label.
-      expect(initPayload(panel).stack[1]).toEqual({
-        level: 2, label: 'Object>>#halt', position: '@2 line 12',
+      // just the plain defining-class label, and the frame isn't overridable
+      // (we can't tell the receiver inherited the method).
+      expect(initPayload(panel).stack[1]).toMatchObject({
+        level: 2, label: 'Object>>#halt', position: '@2 line 12', overridable: false,
       });
     });
 
@@ -1885,6 +1888,101 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'stepOver', level: 1 });
       await tick();
       expect(lastPosted(panel, 'init').dnu).toBeUndefined();
+    });
+  });
+
+  describe('implement in receiver (override)', () => {
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    // The base stack's level-2 frame is an inherited method: receiver is a
+    // SmallInteger (oop 200) while the method (#halt) is defined in Object.
+    function openPanel() {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      return panel;
+    }
+
+    function saveListener(): (doc: vscode.TextDocument) => void {
+      return vi.mocked(vscode.workspace.onDidSaveTextDocument).mock.calls[0][0];
+    }
+
+    it('marks an inherited-method frame overridable, carrying the receiver class', () => {
+      const overridable = initPayload(openPanel()).stack.find((f: { overridable?: boolean }) => f.overridable);
+      expect(overridable.receiverClass).toBe('SmallInteger');   // the receiver's class…
+      expect(overridable.label).toContain('Object');            // …while the method lives in Object
+    });
+
+    it('does NOT mark a frame overridable when the receiver IS the defining class', () => {
+      const selfFrames = initPayload(openPanel()).stack
+        .filter((f: { receiverClass?: string }) => f.receiverClass === 'JasperDebugDemo');
+      expect(selfFrames.length).toBeGreaterThan(0);
+      for (const f of selfFrames) expect(f.overridable).toBeFalsy();
+    });
+
+    it('opens a new-method template for the receiver class + frame selector, with banner help (no init)', async () => {
+      const panel = openPanel();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      // gemstone:// new-method URI targeting the RECEIVER's class + home dict.
+      expect(uri.toString()).toContain('/Globals/SmallInteger/instance/');
+      expect(uri.toString()).toContain('new-method');
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith('workbench.action.newGroupBelow');
+      const editor = await vi.mocked(vscode.window.showTextDocument).mock.results.at(-1)!.value;
+      expect(editor.edit).toHaveBeenCalled(); // generic template replaced with the #halt stub
+      // Banner help (NOT a full init that would re-select the top frame + steal focus).
+      const banner = lastPosted(panel, 'banner');
+      expect(banner.text).toContain('#halt');
+      expect(banner.text).toContain('SmallInteger');
+      expect(posted(panel, 'init').length).toBe(1); // only the original ready init
+    });
+
+    it('re-enters the sender frame (trim, NOT resume) on a clean compile', async () => {
+      const panel = openPanel();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] as vscode.Uri;
+
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      // The overridden frame is server level 2; its caller (the sender) is level 3.
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(debug.continueExecution).not.toHaveBeenCalled(); // never auto-resume
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/resume/i);
+    });
+
+    it('does NOT trim and keeps the template pending when the compile fails', async () => {
+      const panel = openPanel();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] as vscode.Uri;
+
+      vi.mocked(vscode.languages.getDiagnostics).mockReturnValueOnce(
+        [{ severity: vscode.DiagnosticSeverity.Error }] as never,
+      );
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+
+      saveListener()({ uri } as vscode.TextDocument); // re-save after fixing
+      await tick();
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+    });
+
+    it('refuses to implement when the receiver class has no home dictionary', async () => {
+      vi.mocked(debug.getClassHomeInfo).mockReturnValueOnce(
+        { className: 'SmallInteger', isMeta: false, dictName: '' },
+      );
+      const panel = openPanel();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+
+      expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/symbol list/i);
     });
   });
 

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -966,6 +966,73 @@ describe('DebuggerPanel', () => {
         vi.mocked(vscode.commands.executeCommand).mockReset();
       }
     });
+
+    // ── Orphaned companion source tabs across a VS Code window close ──────
+    // The webview panel is NOT restored across a window close (no serializer),
+    // but its companion source editor is a real text-editor tab, which VS Code
+    // always restores — orphaned and broken (no live session to resolve
+    // gemstone://). We persist the open source URIs to workspaceState and reap
+    // the leftovers on the next activation.
+    const ORPHAN_KEY = 'jasper.debugger.orphanSourceUris';
+    function fakeMemento(initial: Record<string, unknown> = {}): vscode.Memento {
+      const store = new Map<string, unknown>(Object.entries(initial));
+      return {
+        get: (key: string, def?: unknown) => (store.has(key) ? store.get(key) : def),
+        update: (key: string, val: unknown) => {
+          if (val === undefined) store.delete(key); else store.set(key, val);
+          return Promise.resolve();
+        },
+        keys: () => Array.from(store.keys()),
+      } as unknown as vscode.Memento;
+    }
+
+    it('reaps a debugger source tab a prior session left open, then re-arms the set', () => {
+      const orphan = 'gemstone://1/UserGlobals/JasperDebugDemo/instance/accessing/finish';
+      const memento = fakeMemento({ [ORPHAN_KEY]: [orphan] });
+      const orphanTab = { input: new vscode.TabInputText(vscode.Uri.parse(orphan)) };
+      // An unrelated tab the user opened independently (e.g. System Browser) — never ours.
+      const otherTab = { input: new vscode.TabInputText(vscode.Uri.parse('gemstone://1/UserGlobals/Foo/instance/x/bar')) };
+      const groups = vscode.window.tabGroups.all as unknown as { viewColumn: number; tabs: unknown[] }[];
+      groups.push({ viewColumn: 1, tabs: [orphanTab, otherTab] });
+
+      DebuggerPanel.initSourceTabCleanup(memento);
+
+      expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(vscode.window.tabGroups.close)).toHaveBeenCalledWith(orphanTab);
+      // The set is re-armed (emptied) so this session starts tracking fresh.
+      expect(memento.get(ORPHAN_KEY)).toBeUndefined();
+    });
+
+    it('persists an opened source URI so an abrupt window close can reap it next launch', async () => {
+      const memento = fakeMemento();
+      DebuggerPanel.initSourceTabCleanup(memento);
+      const panel = openPanelWithStack();
+      vi.mocked(vscode.window.showTextDocument).mockResolvedValueOnce(columnedEditor(9) as never);
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce({ ...URI_INFO, selector: 'orphanProbeA' });
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+
+      const uri = (vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri).toString();
+      expect(uri).toContain('orphanProbeA');                       // our just-opened source…
+      expect(memento.get(ORPHAN_KEY) as string[]).toContain(uri);  // …is now tracked for reaping.
+    });
+
+    it('drops the URI from the tracked set on a clean panel close (nothing to reap)', async () => {
+      const memento = fakeMemento();
+      DebuggerPanel.initSourceTabCleanup(memento);
+      const panel = openPanelWithStack();
+      vi.mocked(vscode.window.showTextDocument).mockResolvedValueOnce(columnedEditor(9) as never);
+      vi.mocked(debug.getMethodUriInfo).mockReturnValueOnce({ ...URI_INFO, selector: 'orphanProbeB' });
+      sendMessage(panel, { command: 'selectFrame', level: 3 });
+      await flush();
+      const uri = (vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri).toString();
+      expect(memento.get(ORPHAN_KEY) as string[]).toContain(uri); // tracked while open…
+
+      closePanel(panel);
+
+      // …and dropped on a clean dispose, so the next launch has nothing to reap.
+      expect((memento.get(ORPHAN_KEY) as string[] | undefined) ?? []).not.toContain(uri);
+    });
   });
 
   it('terminates the suspended gsProcess (via clearStack) when the panel window is closed', () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -1369,6 +1369,59 @@ describe('DebuggerPanel', () => {
       expect(panel.dispose).not.toHaveBeenCalled();
     });
 
+    // The step-at-halt fix: a Step on a collapsed "Executed Code" doit frame must
+    // step from the TRUE stop frame (the nested wrapper block where the halt is),
+    // not the collapsed doit-home level — else a single Step at a halt steps over
+    // the whole user block and runs the process to completion (the reported bug).
+    describe('step at a halt steps the stop frame, not the collapsed doit', () => {
+      // These overrides leak past clearAllMocks — restore the factory defaults.
+      afterEach(() => {
+        vi.mocked(debug.getStackDepth).mockImplementation(() => 5);
+        vi.mocked(debug.getMethodBlockInfo).mockImplementation((_s: unknown, methodOop: bigint) => ({
+          isBlock: methodOop === 1n, homeMethodOop: methodOop,
+        }));
+        vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+          if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
+          if (oop === 2n) return { className: 'Object', selector: 'halt' };
+          return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+        });
+      });
+
+      // 3 frames all sharing the doit home (30n) → filterStack collapses them into
+      // ONE Executed Code frame (serverLevel 3, the deepest). Execution actually
+      // stopped in the top wrapper block (serverLevel 1, the user's halt).
+      function setUpWrappedDoit() {
+        vi.mocked(debug.getStackDepth).mockImplementation(() => 3);
+        vi.mocked(debug.getFrameInfo).mockImplementation((_s: unknown, _p: unknown, level: number) => ({
+          methodOop: BigInt(level), ipOffset: 5, receiverOop: 100n,
+          argAndTempNames: [], argAndTempOops: [],
+        }));
+        vi.mocked(debug.getMethodBlockInfo).mockImplementation((_s: unknown, methodOop: bigint) => ({
+          isBlock: methodOop !== 3n, homeMethodOop: 30n,
+        }));
+        vi.mocked(debug.getMethodInfo).mockImplementation(() => { throw new Error('doit'); });
+      }
+
+      it('Step Over redirects from the collapsed doit (server level 3) to the stop frame (level 1)', async () => {
+        setUpWrappedDoit();
+        const panel = openPanel();
+        expect(initPayload(panel).stack).toHaveLength(1); // collapsed to one frame
+        sendMessage(panel, { command: 'stepOver', level: 1 }); // the single displayed frame
+        await tick();
+        // Without the fix this would step from the doit-home server level (3),
+        // running the whole user block to completion; the stop frame is level 1.
+        expect(debug.stepOverNb).toHaveBeenCalledWith(session, GS_PROCESS, 1);
+      });
+
+      it('Step Into likewise steps the stop frame, not the doit home', async () => {
+        setUpWrappedDoit();
+        const panel = openPanel();
+        sendMessage(panel, { command: 'stepInto', level: 1 });
+        await tick();
+        expect(debug.stepIntoNb).toHaveBeenCalledWith(session, GS_PROCESS, 1);
+      });
+    });
+
     it('surfaces a clear message when a step hits native-code (error 6014), without disposing', async () => {
       vi.mocked(debug.stepOverNb).mockResolvedValueOnce({
         completed: false,

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -79,7 +79,7 @@ vi.mock('../browserQueries', () => ({
 import * as vscode from 'vscode';
 import * as debug from '../debugQueries';
 import {
-  DebuggerPanel, formatFrameLabel, formatFramePosition, buildMethodStub,
+  DebuggerPanel, formatFrameLabel, formatFramePosition, buildMethodStub, selectorArgCount,
   formatFrameForClipboard, formatStackForClipboard, buildMethodSourceUri,
   filterStack, isExceptionMachinery, RawFrame,
   flattenLayoutLeaves, sourceRatioFromLayout, setSourceRatioInLayout, EditorGroupLayout,
@@ -243,6 +243,25 @@ describe('buildMethodStub', () => {
 
   it('includes a placeholder body so the method compiles as-is', () => {
     expect(buildMethodStub('foo', 0)).toContain('^nil');
+  });
+});
+
+describe('selectorArgCount', () => {
+  it('counts the colons of a keyword selector', () => {
+    expect(selectorArgCount('fourtyTwo:bar:')).toBe(2);
+    expect(selectorArgCount('at:put:')).toBe(2);
+    expect(selectorArgCount('foo:')).toBe(1);
+  });
+
+  it('treats a binary selector as one argument', () => {
+    expect(selectorArgCount('+')).toBe(1);
+    expect(selectorArgCount('>=')).toBe(1);
+    expect(selectorArgCount(',')).toBe(1);
+  });
+
+  it('treats a unary selector as zero arguments', () => {
+    expect(selectorArgCount('makeWidget')).toBe(0);
+    expect(selectorArgCount('foo')).toBe(0);
   });
 });
 
@@ -1420,6 +1439,14 @@ describe('DebuggerPanel', () => {
         await tick();
         expect(debug.stepIntoNb).toHaveBeenCalledWith(session, GS_PROCESS, 1);
       });
+
+      it('Step Through likewise steps the stop frame, not the doit home', async () => {
+        setUpWrappedDoit();
+        const panel = openPanel();
+        sendMessage(panel, { command: 'stepThrough', level: 1 });
+        await tick();
+        expect(debug.stepThruNb).toHaveBeenCalledWith(session, GS_PROCESS, 1);
+      });
     });
 
     it('surfaces a clear message when a step hits native-code (error 6014), without disposing', async () => {
@@ -2074,7 +2101,7 @@ describe('DebuggerPanel', () => {
       const items = vi.mocked(vscode.window.showQuickPick).mock.calls.at(-1)![0] as
         { label: string; description: string }[];
       expect(items.map(i => i.label)).toEqual(['Interval', 'SequenceableCollection', 'Collection', 'Object']);
-      expect(items[0].description).toMatch(/override here/i);
+      expect(items[0].description).toMatch(/implement here/i);
       expect(items[2].description).toMatch(/already implements/i);
       // A stub template for the chosen (non-implementing) superclass.
       const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
@@ -2133,6 +2160,162 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'implementInReceiver', level: 2 });
       await flush();
       expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('implement subclassResponsibility (T4)', () => {
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    // A subclassResponsibility stop: the `subclassResponsibility` marker frame on
+    // top, the abstract method (`Integer>>foo`, receiver LargeNegativeInteger)
+    // below it, then a re-enterable caller, then a deeper frame. getMethodInfo
+    // overrides leak past clearAllMocks — restore the base shape in afterEach.
+    afterEach(() => {
+      vi.mocked(debug.getStackDepth).mockImplementation(() => 5);
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
+        if (oop === 2n) return { className: 'Object', selector: 'halt' };
+        return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+      });
+      vi.mocked(debug.getDoesNotUnderstandInfo).mockReturnValue(undefined);
+    });
+
+    // serverLevel → method identity. Level 1 is the marker, level 2 the abstract
+    // method, level 3 a re-enterable caller, level 4 a deeper user method.
+    function setUpSubclassRespStack(senderIsExecutedCode = false) {
+      vi.mocked(debug.getStackDepth).mockImplementation(() => 4);
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'Object', selector: 'subclassResponsibility' };
+        if (oop === 2n) return { className: 'Integer', selector: 'foo' };
+        if (oop === 3n) {
+          if (senderIsExecutedCode) throw new Error('doit'); // no class → Executed Code
+          return { className: 'SomeClass', selector: 'bar' };
+        }
+        return { className: 'JasperDebugDemo', selector: 'run' };
+      });
+    }
+
+    // Receiver chain for #foo: the concrete class, an intermediate, the abstract
+    // definer (which "implements" #foo only as the subclassResponsibility stub),
+    // then classes ABOVE the definer — which T4 must trim away.
+    const SR_CHAIN = [
+      { className: 'LargeNegativeInteger', isMeta: false, dictName: 'Globals', implementsSelector: false },
+      { className: 'LargeInteger', isMeta: false, dictName: 'Globals', implementsSelector: false },
+      { className: 'Integer', isMeta: false, dictName: 'Globals', implementsSelector: true },
+      { className: 'Number', isMeta: false, dictName: 'Kernel', implementsSelector: false },
+      { className: 'Object', isMeta: false, dictName: 'Kernel', implementsSelector: true },
+    ];
+
+    function openPanel() {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+      return panel;
+    }
+
+    function saveListener(): (doc: vscode.TextDocument) => void {
+      return vi.mocked(vscode.workspace.onDidSaveTextDocument).mock.calls[0][0];
+    }
+
+    it('opens the debugger on the abstract method (subclassResponsibility frame trimmed)', () => {
+      setUpSubclassRespStack();
+      const stack = initPayload(openPanel()).stack;
+      // The marker frame is trimmed; the abstract method `Integer>>foo` is the top.
+      expect(stack[0].label).toContain('foo');
+      expect(stack.some((f: { label: string }) => /subclassResponsibility/.test(f.label))).toBe(false);
+    });
+
+    it('offers the "Implement #sel" action when parked on a subclassResponsibility', () => {
+      setUpSubclassRespStack();
+      expect(initPayload(openPanel()).subclassResp).toEqual({ selector: 'foo' });
+    });
+
+    it('does NOT offer the implement action when a doesNotUnderstand: is also parked (DNU wins)', () => {
+      setUpSubclassRespStack();
+      vi.mocked(debug.getDoesNotUnderstandInfo).mockReturnValue(
+        { className: 'Foo', isMeta: false, dictName: 'Globals', selector: 'bar', argCount: 0 });
+      const payload = initPayload(openPanel());
+      expect(payload.subclassResp).toBeUndefined();
+      expect(payload.dnu).toBeTruthy();
+    });
+
+    it('QuickPicks the chain BOUNDED at the abstract definer, then opens a stub', async () => {
+      setUpSubclassRespStack();
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(SR_CHAIN);
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[0] as never); // LargeNegativeInteger
+      const panel = openPanel();
+      vi.mocked(vscode.workspace.openTextDocument).mockClear();
+      sendMessage(panel, { command: 'implementSubclassResponsibility' });
+      await flush();
+
+      // Bounded at Integer (the definer) — Number/Object above it are dropped.
+      const items = vi.mocked(vscode.window.showQuickPick).mock.calls.at(-1)![0] as { label: string }[];
+      expect(items.map(i => i.label)).toEqual(['LargeNegativeInteger', 'LargeInteger', 'Integer']);
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls[0][0] as vscode.Uri;
+      expect(uri.toString()).toContain('/Globals/LargeNegativeInteger/instance/');
+      expect(uri.toString()).toContain('new-method');
+    });
+
+    it('on a clean save, re-enters the caller so Resume re-dispatches into the new method', async () => {
+      setUpSubclassRespStack(); // caller (level 3) is a re-enterable method frame
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(SR_CHAIN);
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[0] as never);
+      const panel = openPanel();
+      sendMessage(panel, { command: 'implementSubclassResponsibility' });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] as vscode.Uri;
+
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3); // the caller's level
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/re-entered the caller/i);
+    });
+
+    it('tells the user to re-run when the caller is workspace/Executed Code (no trim)', async () => {
+      setUpSubclassRespStack(true); // caller is a doit → not re-enterable
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(SR_CHAIN);
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[0] as never);
+      const panel = openPanel();
+      sendMessage(panel, { command: 'implementSubclassResponsibility' });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] as vscode.Uri;
+
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/re-run the expression/i);
+    });
+
+    it('stops offering Implement after a re-run save (srSuppressed) — the method now exists', async () => {
+      setUpSubclassRespStack(true);
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(SR_CHAIN);
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[0] as never);
+      const panel = openPanel();
+      expect(initPayload(panel).subclassResp).toEqual({ selector: 'foo' }); // offered at first
+      sendMessage(panel, { command: 'implementSubclassResponsibility' });
+      await flush();
+      const uri = vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] as vscode.Uri;
+
+      saveListener()({ uri } as vscode.TextDocument);
+      await tick();
+      // The same subclassResponsibility is still parked, but the button must NOT
+      // re-appear (the method exists now) — like dnuSuppressed.
+      expect(lastPosted(panel, 'init').subclassResp).toBeUndefined();
+    });
+
+    it('does NOT offer Implement when the frame below the marker is not a real method', () => {
+      // Defensive guard: an Executed-Code / block frame can't be implemented in.
+      vi.mocked(debug.getStackDepth).mockImplementation(() => 3);
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'Object', selector: 'subclassResponsibility' };
+        if (oop === 2n) throw new Error('doit'); // frame below the marker → Executed Code
+        return { className: 'JasperDebugDemo', selector: 'run' };
+      });
+      expect(initPayload(openPanel()).subclassResp).toBeUndefined();
     });
   });
 
@@ -2269,6 +2452,26 @@ describe('filterStack', () => {
     const kept = filterStack(DNU_STACK);
     expect(kept.map(f => f.serverLevel)).toEqual([7]); // just the Executed Code sender
     expect(kept[0].label).toBe('Executed Code');
+  });
+
+  // A subclassResponsibility stop (T4): `subclassResponsibility` → `self error:` →
+  // signal machinery. All of it is trimmed (incl. the marker) so the debugger opens
+  // on the abstract method itself — the method T4 offers to implement.
+  const SUBCLASS_RESP_STACK: RawFrame[] = [
+    raw({ serverLevel: 1, label: 'AbstractException class>>#signal', definingClassName: 'AbstractException', selector: 'signal' }),
+    raw({ serverLevel: 2, label: 'LargeNegativeInteger (Object)>>#error:', definingClassName: 'Object', selector: 'error:' }),
+    raw({ serverLevel: 3, label: 'LargeNegativeInteger (Object)>>#subclassResponsibility', definingClassName: 'Object', selector: 'subclassResponsibility' }),
+    raw({ serverLevel: 4, label: 'LargeNegativeInteger (Integer)>>#foo', definingClassName: 'Integer', selector: 'foo' }),
+    raw({ serverLevel: 5, label: 'Executed Code', methodOop: DOIT, homeMethodOop: DOIT, isExecutedCode: true }),
+  ];
+
+  it('trims the subclassResponsibility machinery down to the abstract method', () => {
+    const kept = filterStack(SUBCLASS_RESP_STACK);
+    // The signal/error:/subclassResponsibility marker frames are gone; the abstract
+    // method `foo` (level 4) is the top frame, the doit sender below it.
+    expect(kept.map(f => f.serverLevel)).toEqual([4, 5]);
+    expect(kept[0].label).toContain('foo');
+    expect(kept.some(f => /subclassResponsibility/.test(f.selector))).toBe(false);
   });
 });
 

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -1895,6 +1895,16 @@ describe('DebuggerPanel', () => {
   describe('implement in receiver (override)', () => {
     const flush = () => new Promise(resolve => setTimeout(resolve, 0));
 
+    // getMethodInfo overrides (in the doit-sender test) leak past clearAllMocks —
+    // restore the base so later tests see the standard 5-frame stack.
+    afterEach(() => {
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
+        if (oop === 2n) return { className: 'Object', selector: 'halt' };
+        return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+      });
+    });
+
     // The base stack's level-2 frame is an inherited method: receiver is a
     // SmallInteger (oop 200) while the method (#halt) is defined in Object.
     function openPanel() {
@@ -2049,6 +2059,32 @@ describe('DebuggerPanel', () => {
       saveListener()({ uri: vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] } as vscode.TextDocument);
       await tick();
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/Interval already implements/i);
+    });
+
+    it('tells the user to re-run (not Resume) when the caller is a non-re-enterable doit', async () => {
+      // Stack where the overridden frame's only caller is Executed Code: make the
+      // frame BELOW the inherited one a doit so the sender isn't re-enterable.
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'finish' };
+        if (oop === 2n) return { className: 'Object', selector: 'halt' };
+        if (oop === 3n) throw new Error('doit: no class'); // sender of frame 2 → Executed Code
+        return { className: 'JasperDebugDemo', selector: 'accumulateFrom:to:' };
+      });
+      vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce([
+        { className: 'Interval', isMeta: false, dictName: 'Globals', implementsSelector: false },
+        { className: 'SequenceableCollection', isMeta: false, dictName: 'Kernel', implementsSelector: false },
+      ]);
+      vi.mocked(vscode.window.showQuickPick).mockImplementationOnce(
+        async (items: unknown) => (items as { index: number }[])[1] as never);
+      const panel = openPanel();
+      sendMessage(panel, { command: 'implementInReceiver', level: 2 });
+      await flush();
+      saveListener()({ uri: vi.mocked(vscode.workspace.openTextDocument).mock.calls.at(-1)![0] } as vscode.TextDocument);
+      await tick();
+
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();          // can't re-enter a doit
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/re-run the expression/i);
+      expect(lastPosted(panel, 'init').errorMessage).not.toMatch(/dispatch into it, or step/i);
     });
 
     it('opens nothing when the inheritance-chain QuickPick is cancelled', async () => {

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -32,6 +32,11 @@ interface DebuggerViewApi {
     dnu: { selector: string; className: string; isMeta: boolean } | null | undefined,
     onCreate?: () => void,
   ): void;
+  renderSubclassResp(
+    dnuBarEl: HTMLElement,
+    sr: { selector: string } | null | undefined,
+    onImplement?: () => void,
+  ): void;
   selectFrame(listEl: HTMLElement, level: number): HTMLElement | null;
   showMenu(menuEl: HTMLElement, x: number, y: number): void;
   hideMenu(menuEl: HTMLElement): void;
@@ -78,7 +83,11 @@ const STACK: FrameSummary[] = [
 
 // Build the panel's DOM (the elements debuggerPanel.ts's getHtml renders) and
 // wire DebuggerView to a fake vscode whose postMessage we can assert on.
-function setup(stack: FrameSummary[] = STACK, dnu?: { selector: string; className: string; isMeta: boolean }) {
+function setup(
+  stack: FrameSummary[] = STACK,
+  dnu?: { selector: string; className: string; isMeta: boolean },
+  subclassResp?: { selector: string },
+) {
   document.body.innerHTML = `
     <button id="copyBtn">Copy Stack</button>
     <div id="toolbar">
@@ -114,7 +123,7 @@ function setup(stack: FrameSummary[] = STACK, dnu?: { selector: string; classNam
   const ctrl = api().init(refs, vscode);
   // Deliver the host's init payload, as the webview does on load.
   window.dispatchEvent(new MessageEvent('message', {
-    data: { command: 'init', errorMessage: 'boom', stack, dnu },
+    data: { command: 'init', errorMessage: 'boom', stack, dnu, subclassResp },
   }));
   return { refs, vscode, ctrl };
 }
@@ -798,6 +807,33 @@ describe('DebuggerView.renderDnu (create-method-from-DNU)', () => {
 
 });
 
+describe('DebuggerView.renderSubclassResp (T4)', () => {
+  beforeEach(() => { document.body.innerHTML = '<div id="dnuBar"></div>'; });
+
+  it('renders an "Implement #selector" button (no class — chosen via picker)', () => {
+    const bar = document.getElementById('dnuBar')!;
+    api().renderSubclassResp(bar, { selector: 'foo' });
+    const btn = bar.querySelector('button.dnu-btn') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toBe('Implement #foo');
+  });
+
+  it('clears the bar (no button) when there is no subclassResponsibility', () => {
+    const bar = document.getElementById('dnuBar')!;
+    api().renderSubclassResp(bar, { selector: 'foo' });
+    api().renderSubclassResp(bar, null);
+    expect(bar.querySelector('button.dnu-btn')).toBeNull();
+  });
+
+  it('invokes onImplement when the button is clicked', () => {
+    const bar = document.getElementById('dnuBar')!;
+    const onImplement = vi.fn();
+    api().renderSubclassResp(bar, { selector: 'foo' }, onImplement);
+    (bar.querySelector('button.dnu-btn') as HTMLButtonElement).click();
+    expect(onImplement).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('DebuggerView init — DNU button wiring', () => {
   it('renders the Create button from the init payload and posts createDnuMethod on click', () => {
     const { refs, vscode } = setup(STACK, { selector: 'foo:', className: 'Array', isMeta: false });
@@ -820,5 +856,19 @@ describe('DebuggerView init — DNU button wiring', () => {
     }));
     expect(refs.error.textContent).toBe('Fill in the body, then save (Ctrl+S).');
     expect(refs.dnuBar!.querySelector('button.dnu-btn')).toBeNull(); // button cleared
+  });
+
+  it('renders the Implement button from the init payload and posts implementSubclassResponsibility', () => {
+    const { refs, vscode } = setup(STACK, undefined, { selector: 'foo' });
+    const btn = refs.dnuBar!.querySelector('button.dnu-btn') as HTMLButtonElement;
+    expect(btn.textContent).toBe('Implement #foo');
+    btn.click();
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'implementSubclassResponsibility' });
+  });
+
+  it('shows the DNU Create button (not the Implement button) when both are present', () => {
+    const { refs } = setup(STACK, { selector: 'foo:', className: 'Array', isMeta: false }, { selector: 'foo' });
+    const btn = refs.dnuBar!.querySelector('button.dnu-btn') as HTMLButtonElement;
+    expect(btn.textContent).toContain('Create #foo:'); // DNU wins; Implement not rendered
   });
 });

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -243,12 +243,13 @@ describe('DebuggerView.init — right-click copy popup', () => {
     expect(refs.menu.classList.contains('show')).toBe(false);
   });
 
-  it('shows "Implement in <receiverClass>" only on an overridable frame', () => {
+  it('shows "Implement in…" (a picker follows) only on an overridable frame', () => {
     const { refs } = setup();
-    // Frame 2 is an inherited method (overridable) → item shown + labelled.
+    // Frame 2 is an inherited method (overridable) → item shown; the ellipsis
+    // signals the class picker (an overridable frame always has several targets).
     frame(refs, 2).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
     expect(refs.frameImplItem!.style.display).not.toBe('none');
-    expect(refs.frameImplItem!.textContent).toBe('Implement in SmallInteger');
+    expect(refs.frameImplItem!.textContent).toBe('Implement in…');
 
     // Frame 1 is NOT overridable → item hidden.
     frame(refs, 1).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -11,7 +11,7 @@ beforeAll(() => {
   new Function(source)();
 });
 
-interface FrameSummary { level: number; label: string; position: string; }
+interface FrameSummary { level: number; label: string; position: string; overridable?: boolean; receiverClass?: string; }
 
 interface DebuggerViewApi {
   renderStack(listEl: HTMLElement, stack: FrameSummary[]): void;
@@ -50,6 +50,7 @@ interface Refs {
   list: HTMLElement;
   menu: HTMLElement;
   copyFrameItem: HTMLElement;
+  frameImplItem?: HTMLElement;
   copyBtn: HTMLElement;
   error: HTMLElement;
   dnuBar?: HTMLElement;
@@ -71,7 +72,7 @@ function api(): DebuggerViewApi {
 
 const STACK: FrameSummary[] = [
   { level: 1, label: '[] in JasperDebugDemo>>#finish', position: '@2 line 12' },
-  { level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12' },
+  { level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12', overridable: true, receiverClass: 'SmallInteger' },
   { level: 3, label: 'JasperDebugDemo>>#accumulateFrom:to:', position: '' },
 ];
 
@@ -92,12 +93,13 @@ function setup(stack: FrameSummary[] = STACK, dnu?: { selector: string; classNam
     <div id="dnuBar"></div>
     <div class="main"><ul id="stack"></ul><div id="variables"></div></div>
     <input id="evalInput"><div id="evalResult"></div>
-    <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div></div>
+    <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div><div id="frameImplItem" style="display:none;">Implement in receiver</div></div>
     <div id="varctxmenu"><div id="varInspectItem">GT Inspect</div></div>`;
   const refs: Refs = {
     list: document.getElementById('stack')!,
     menu: document.getElementById('ctxmenu')!,
     copyFrameItem: document.getElementById('copyFrameItem')!,
+    frameImplItem: document.getElementById('frameImplItem')!,
     copyBtn: document.getElementById('copyBtn')!,
     error: document.getElementById('error')!,
     dnuBar: document.getElementById('dnuBar')!,
@@ -238,6 +240,27 @@ describe('DebuggerView.init — right-click copy popup', () => {
   it('a right-click outside any frame does not open the menu', () => {
     const { refs } = setup();
     refs.list.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    expect(refs.menu.classList.contains('show')).toBe(false);
+  });
+
+  it('shows "Implement in <receiverClass>" only on an overridable frame', () => {
+    const { refs } = setup();
+    // Frame 2 is an inherited method (overridable) → item shown + labelled.
+    frame(refs, 2).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    expect(refs.frameImplItem!.style.display).not.toBe('none');
+    expect(refs.frameImplItem!.textContent).toBe('Implement in SmallInteger');
+
+    // Frame 1 is NOT overridable → item hidden.
+    frame(refs, 1).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    expect(refs.frameImplItem!.style.display).toBe('none');
+  });
+
+  it('clicking Implement posts implementInReceiver for the selected level and hides the menu', () => {
+    const { refs, vscode } = setup();
+    frame(refs, 2).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    refs.frameImplItem!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'implementInReceiver', level: 2 });
     expect(refs.menu.classList.contains('show')).toBe(false);
   });
 });

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -18,8 +18,14 @@ interface DebuggerViewApi {
   renderVariables(
     varsEl: HTMLElement,
     groups: { title: string; kind: string; collapsed?: boolean;
-      vars: { name: string; value: string; oop: string }[] }[],
-    onInspect?: (oop: string, name: string) => void,
+      vars: { name: string; value: string; oop: string;
+        edit?: { kind: string; index: number }; revertible?: boolean }[] }[],
+    handlers?: {
+      contextMenu?: (e: Event, oop: string, name: string) => void;
+      commit?: (edit: { kind: string; index: number }, expr: string) => void;
+      revert?: (edit: { kind: string; index: number }) => void;
+      setActiveEditor?: (ctrl: unknown) => void;
+    },
   ): void;
   renderDnu(
     dnuBarEl: HTMLElement,
@@ -55,6 +61,8 @@ interface Refs {
   main?: HTMLElement;
   splitter?: HTMLElement;
   hsplitter?: HTMLElement;
+  varMenu?: HTMLElement;
+  varInspectItem?: HTMLElement;
 }
 
 function api(): DebuggerViewApi {
@@ -84,7 +92,8 @@ function setup(stack: FrameSummary[] = STACK, dnu?: { selector: string; classNam
     <div id="dnuBar"></div>
     <div class="main"><ul id="stack"></ul><div id="variables"></div></div>
     <input id="evalInput"><div id="evalResult"></div>
-    <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div></div>`;
+    <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div></div>
+    <div id="varctxmenu"><div id="varInspectItem">GT Inspect</div></div>`;
   const refs: Refs = {
     list: document.getElementById('stack')!,
     menu: document.getElementById('ctxmenu')!,
@@ -96,6 +105,8 @@ function setup(stack: FrameSummary[] = STACK, dnu?: { selector: string; classNam
     variables: document.getElementById('variables')!,
     evalInput: document.getElementById('evalInput') as HTMLInputElement,
     evalResult: document.getElementById('evalResult')!,
+    varMenu: document.getElementById('varctxmenu')!,
+    varInspectItem: document.getElementById('varInspectItem')!,
   };
   const vscode = { postMessage: vi.fn() };
   const ctrl = api().init(refs, vscode);
@@ -283,14 +294,124 @@ describe('DebuggerView.renderVariables', () => {
     expect(group.classList.contains('collapsed')).toBe(false);
   });
 
-  it('clicking a variable row calls onInspect with the row oop + name', () => {
+  it('right-clicking a row invokes the contextMenu handler with the row oop + name (GT Inspect)', () => {
     const el = document.getElementById('variables')!;
-    const onInspect = vi.fn();
+    const contextMenu = vi.fn();
     api().renderVariables(el, [
       { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'x', oop: '100' }] },
-    ], onInspect);
+    ], { contextMenu });
+    (el.querySelector('.var') as HTMLElement)
+      .dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
+    expect(contextMenu).toHaveBeenCalled();
+    expect(contextMenu.mock.calls[0].slice(1)).toEqual(['100', 'self']);
+  });
+
+  it('marks editable rows (with edit metadata) and leaves self read-only', () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, [
+      { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'x', oop: '100' }] },
+      { title: 'Instance variables', kind: 'instvars',
+        vars: [{ name: 'total', value: '0', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+    ]);
+    const rows = el.querySelectorAll('.var');
+    expect(rows[0].classList.contains('editable')).toBe(false); // self
+    expect(rows[1].classList.contains('editable')).toBe(true);  // total
+  });
+
+  it('left-clicking an editable row opens an inline editor prefilled with the printString', () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, [
+      { title: 'Instance variables', kind: 'instvars',
+        vars: [{ name: 'total', value: '42', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+    ]);
     (el.querySelector('.var') as HTMLElement).click();
-    expect(onInspect).toHaveBeenCalledWith('100', 'self');
+    const input = el.querySelector('.var-edit') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe('42');
+  });
+
+  it('left-clicking a read-only stack temp (no edit metadata) does NOT open an editor', () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, [
+      { title: '(stack temps)', kind: 'stacktemps', vars: [{ name: '.t1', value: '7', oop: '36' }] },
+    ]);
+    const row = el.querySelector('.var') as HTMLElement;
+    expect(row.classList.contains('editable')).toBe(false);
+    row.click();
+    expect(el.querySelector('.var-edit')).toBeNull();
+  });
+
+  it('shows the revert icon only on revertible rows; clicking it calls revert (not the editor)', () => {
+    const el = document.getElementById('variables')!;
+    const revert = vi.fn();
+    api().renderVariables(el, [
+      { title: 'Instance variables', kind: 'instvars', vars: [
+        { name: 'count', value: '9', oop: '200', edit: { kind: 'instvar', index: 1 }, revertible: true },
+        { name: 'sum', value: '0', oop: '201', edit: { kind: 'instvar', index: 2 } },
+      ] },
+    ], { revert });
+    const rows = el.querySelectorAll('.var');
+    const revIcon = rows[0].querySelector('.var-revert') as HTMLElement;
+    expect(revIcon).not.toBeNull();
+    expect(rows[1].querySelector('.var-revert')).toBeNull(); // not revertible → no icon
+
+    revIcon.click();
+    expect(revert).toHaveBeenCalledWith({ kind: 'instvar', index: 1 });
+    // The click must NOT open the inline editor on that row.
+    expect(rows[0].querySelector('.var-edit')).toBeNull();
+  });
+
+  it('left-clicking the read-only self row does NOT open an editor', () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, [
+      { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'x', oop: '100' }] },
+    ]);
+    (el.querySelector('.var') as HTMLElement).click();
+    expect(el.querySelector('.var-edit')).toBeNull();
+  });
+
+  it('Enter in the inline editor calls commit with the edit target + trimmed expression', () => {
+    const el = document.getElementById('variables')!;
+    const commit = vi.fn();
+    api().renderVariables(el, [
+      { title: 'Instance variables', kind: 'instvars',
+        vars: [{ name: 'total', value: '42', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+    ], { commit });
+    (el.querySelector('.var') as HTMLElement).click();
+    const input = el.querySelector('.var-edit') as HTMLInputElement;
+    input.value = '  99  ';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(commit).toHaveBeenCalledWith({ kind: 'instvar', index: 1 }, '99');
+    // Stays open (so an error can be fixed); not removed on commit.
+    expect(el.querySelector('.var-edit')).not.toBeNull();
+  });
+
+  it('blurring the inline editor cancels it (when there is no error)', async () => {
+    const el = document.getElementById('variables')!;
+    api().renderVariables(el, [
+      { title: 'Instance variables', kind: 'instvars',
+        vars: [{ name: 'total', value: '42', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+    ]);
+    (el.querySelector('.var') as HTMLElement).click();
+    (el.querySelector('.var-edit') as HTMLInputElement).dispatchEvent(new FocusEvent('blur'));
+    await new Promise(r => setTimeout(r, 0)); // blur-close is deferred a tick
+    expect(el.querySelector('.var-edit')).toBeNull();
+  });
+
+  it('Esc cancels the inline editor and restores the displayed value', () => {
+    const el = document.getElementById('variables')!;
+    const commit = vi.fn();
+    api().renderVariables(el, [
+      { title: 'Instance variables', kind: 'instvars',
+        vars: [{ name: 'total', value: '42', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+    ], { commit });
+    (el.querySelector('.var') as HTMLElement).click();
+    const input = el.querySelector('.var-edit') as HTMLInputElement;
+    input.value = '99';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(el.querySelector('.var-edit')).toBeNull();
+    expect(commit).not.toHaveBeenCalled();
+    expect((el.querySelector('.var-value') as HTMLElement).style.display).toBe('');
   });
 
   it('shows an empty-state message when there are no groups', () => {
@@ -356,7 +477,7 @@ describe('DebuggerView.init — inbound variables / evalResult', () => {
     expect(refs.variables.querySelectorAll('.var')).toHaveLength(2);
   });
 
-  it('clicking a pushed variable row posts inspectVariable to the host', () => {
+  it('right-clicking a pushed variable row then GT Inspect posts inspectVariable to the host', () => {
     const { refs, vscode } = setup();
     vi.mocked(vscode.postMessage).mockClear();
     window.dispatchEvent(new MessageEvent('message', {
@@ -364,8 +485,91 @@ describe('DebuggerView.init — inbound variables / evalResult', () => {
         { title: 'Receiver', kind: 'receiver', vars: [{ name: 'self', value: 'x', oop: '100' }] },
       ] },
     }));
-    (refs.variables.querySelector('.var') as HTMLElement).click();
+    (refs.variables.querySelector('.var') as HTMLElement)
+      .dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
+    expect(refs.varMenu!.classList.contains('show')).toBe(true);
+    (refs.varInspectItem as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'inspectVariable', oop: '100', name: 'self' });
+  });
+
+  it('Enter in an editable pushed row posts setVariable with the selected frame level', () => {
+    const { refs, vscode } = setup(); // top frame (level 1) selected by default
+    vi.mocked(vscode.postMessage).mockClear();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'variables', groups: [
+        { title: 'Instance variables', kind: 'instvars',
+          vars: [{ name: 'total', value: '0', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+      ] },
+    }));
+    (refs.variables.querySelector('.var') as HTMLElement).click();
+    const input = refs.variables.querySelector('.var-edit') as HTMLInputElement;
+    input.value = '99';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(vscode.postMessage).toHaveBeenCalledWith(
+      { command: 'setVariable', level: 1, kind: 'instvar', index: 1, expr: '99' });
+  });
+
+  it('setVariableResult failure flags the open editor (keeps it open) instead of closing it', () => {
+    const { refs } = setup();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'variables', groups: [
+        { title: 'Instance variables', kind: 'instvars',
+          vars: [{ name: 'total', value: '0', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+      ] },
+    }));
+    (refs.variables.querySelector('.var') as HTMLElement).click();
+    const input = refs.variables.querySelector('.var-edit') as HTMLInputElement;
+    input.value = 'bogus +';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'setVariableResult', ok: false, error: 'a parse error' },
+    }));
+    const stillOpen = refs.variables.querySelector('.var-edit') as HTMLInputElement;
+    expect(stillOpen).not.toBeNull();
+    expect(stillOpen.classList.contains('error')).toBe(true);
+    expect(stillOpen.title).toBe('a parse error');
+    // A visible message line (not just a hover tooltip) names the failure.
+    const errLine = refs.variables.querySelector('.var-edit-error') as HTMLElement;
+    expect(errLine).not.toBeNull();
+    expect(errLine.textContent).toBe('a parse error');
+  });
+
+  it('clicking the revert icon on a pushed row posts revertVariable with the frame level', () => {
+    const { refs, vscode } = setup(); // top frame (level 1) selected by default
+    vi.mocked(vscode.postMessage).mockClear();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'variables', groups: [
+        { title: 'Instance variables', kind: 'instvars', vars: [
+          { name: 'count', value: '9', oop: '200', edit: { kind: 'instvar', index: 1 }, revertible: true },
+        ] },
+      ] },
+    }));
+    (refs.variables.querySelector('.var-revert') as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(vscode.postMessage).toHaveBeenCalledWith(
+      { command: 'revertVariable', level: 1, kind: 'instvar', index: 1 });
+  });
+
+  it('keeps an errored editor open when the input is blurred (so the message stays copyable)', async () => {
+    const { refs } = setup();
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'variables', groups: [
+        { title: 'Instance variables', kind: 'instvars',
+          vars: [{ name: 'total', value: '0', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+      ] },
+    }));
+    (refs.variables.querySelector('.var') as HTMLElement).click();
+    const input = refs.variables.querySelector('.var-edit') as HTMLInputElement;
+    input.value = 'bogus +';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { command: 'setVariableResult', ok: false, error: 'a parse error' },
+    }));
+    // Click on the message line to copy it → the input blurs; the editor must NOT
+    // vanish (it would before the fix), so the text remains selectable.
+    input.dispatchEvent(new FocusEvent('blur'));
+    await new Promise(r => setTimeout(r, 0));
+    expect(refs.variables.querySelector('.var-edit')).not.toBeNull();
+    expect(refs.variables.querySelector('.var-edit-error')!.textContent).toBe('a parse error');
   });
 
   it('shows an eval result, flagging errors', () => {

--- a/client/src/__tests__/transcriptCapture.test.ts
+++ b/client/src/__tests__/transcriptCapture.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
-  wrapWithTranscriptCapture, unwrapTranscriptCapture, TRANSCRIPT_CAPTURE_PREFIX,
+  wrapWithTranscriptCapture, unwrapTranscriptCapture, transcriptCaptureUserCodeOffset,
+  TRANSCRIPT_CAPTURE_PREFIX,
 } from '../transcriptCapture';
 
 describe('transcriptCapture', () => {
@@ -35,5 +36,38 @@ describe('transcriptCapture', () => {
   it('leaves source that only has the prefix (no matching suffix) unchanged', () => {
     const partial = `${TRANSCRIPT_CAPTURE_PREFIX}JasperDebugDemo new run`;
     expect(unwrapTranscriptCapture(partial)).toBe(partial);
+  });
+
+  describe('transcriptCaptureUserCodeOffset', () => {
+    it('is the prefix length for wrapped source with no leading whitespace', () => {
+      const wrapped = wrapWithTranscriptCapture('JasperDebugDemo new run').wrappedCode;
+      expect(transcriptCaptureUserCodeOffset(wrapped)).toBe(TRANSCRIPT_CAPTURE_PREFIX.length);
+    });
+
+    it('shifts a wrapped-coordinate offset onto the displayed (unwrapped) source', () => {
+      // The contract the debugger relies on: a server offset minus this shift
+      // indexes the unwrapped source at the same character.
+      const code = 'JasperDebugDemo new run';
+      const wrapped = wrapWithTranscriptCapture(code).wrappedCode;
+      const shift = transcriptCaptureUserCodeOffset(wrapped);
+      const displayed = unwrapTranscriptCapture(wrapped);
+      const wrappedOffset = wrapped.indexOf('run');         // a step point in user code
+      expect(displayed[wrappedOffset - shift]).toBe('r');    // lands on the same char
+      expect(displayed.slice(wrappedOffset - shift)).toBe('run');
+    });
+
+    it('accounts for whitespace trimmed from both the whole source and the inner code', () => {
+      const inner = '  6 * 7';   // leading whitespace inside the block, trimmed on display
+      const wrapped = `\n${wrapWithTranscriptCapture(inner).wrappedCode}\n`;
+      const shift = transcriptCaptureUserCodeOffset(wrapped);
+      const displayed = unwrapTranscriptCapture(wrapped);    // '6 * 7'
+      const wrappedOffset = wrapped.indexOf('* 7');
+      expect(displayed.slice(wrappedOffset - shift)).toBe('* 7');
+    });
+
+    it('is 0 for non-wrapped source (raw Debug It / 1:1 method shown unmodified)', () => {
+      expect(transcriptCaptureUserCodeOffset('JasperDebugDemo new run')).toBe(0);
+      expect(transcriptCaptureUserCodeOffset(`${TRANSCRIPT_CAPTURE_PREFIX}no suffix`)).toBe(0);
+    });
   });
 });

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -862,6 +862,19 @@ export function trimStackToLevelNb(
 export function evaluateInFrame(
   session: ActiveSession, gsProcess: bigint, expression: string, level: number,
 ): string {
+  return getObjectPrintString(session, evaluateInFrameToOop(session, gsProcess, expression, level));
+}
+
+/**
+ * Like {@link evaluateInFrame} but returns the result *OOP* rather than its
+ * printString. Used by the Variables-pane editor (T1) to evaluate the typed
+ * expression in the frame, then write the resulting object back into the frame
+ * temp / instVar. A compile or runtime error surfaces as a thrown GCI error
+ * (same as the eval bar), so the caller can keep the editor open on failure.
+ */
+export function evaluateInFrameToOop(
+  session: ActiveSession, gsProcess: bigint, expression: string, level: number,
+): bigint {
   // The frame's receiver becomes `self` for the evaluation.
   const { receiverOop, argAndTempNames, argAndTempOops } = getFrameInfo(session, gsProcess, level);
 
@@ -875,10 +888,68 @@ export function evaluateInFrame(
   // Bind the frame's named args/temps when present; otherwise keep the lean
   // single-arg path (self + instVars + globals via the session's symbol list).
   const symbolListOop = buildFrameSymbolList(session, argAndTempNames, argAndTempOops);
-  const resultOop = symbolListOop === null
+  return symbolListOop === null
     ? gciPerform(session, exprOop, 'evaluateInContext:', [receiverOop])
     : gciPerform(session, exprOop, 'evaluateInContext:symbolList:', [receiverOop, symbolListOop]);
-  return getObjectPrintString(session, resultOop);
+}
+
+/**
+ * Writes `valueOop` into a method argument / temporary of the suspended frame,
+ * via the kernel `GsProcess>>_frameAt:tempAt:put:` primitive (the same one GBS
+ * and GT use). `offset` is the 1-based index into the frame's `argAndTempNames`
+ * (so it matches the index `getFrameInfo` reads). Handles method temps,
+ * VariableContext temps, copying-block args, and the eval-stack `.tN` temps.
+ */
+export function setFrameTemp(
+  session: ActiveSession, gsProcess: bigint, level: number, offset: number, valueOop: bigint,
+): void {
+  gciPerform(session, gsProcess, '_frameAt:tempAt:put:', [
+    intToOop(session, level), intToOop(session, offset), valueOop,
+  ]);
+}
+
+/**
+ * Writes `valueOop` into the `index`-th (1-based) named instance variable of
+ * `receiverOop`, via `instVarAt:put:`.
+ */
+export function setInstVar(
+  session: ActiveSession, receiverOop: bigint, index: number, valueOop: bigint,
+): void {
+  gciPerform(session, receiverOop, 'instVarAt:put:', [intToOop(session, index), valueOop]);
+}
+
+/** Reads the OOP of the `index`-th (1-based) named instance variable. Used by
+ *  variable-revert to capture the original value before it's overwritten. */
+export function getInstVarOop(
+  session: ActiveSession, receiverOop: bigint, index: number,
+): bigint {
+  return gciPerform(session, receiverOop, 'instVarAt:', [intToOop(session, index)]);
+}
+
+/**
+ * Pins objects against garbage collection by adding them to the session's export
+ * set (`GciTsSaveObjs`). Variable-revert uses this to keep a slot's original
+ * value alive after the slot is overwritten — otherwise it could be scavenged
+ * and its OOP number reused for a different object, so revert would restore the
+ * wrong object. No-op for an empty list; immediates need not be saved.
+ */
+export function saveObjs(session: ActiveSession, oops: bigint[]): void {
+  if (oops.length === 0) return;
+  const { success, err } = session.gci.GciTsSaveObjs(session.handle, oops);
+  if (!success || err.number !== 0) {
+    throw new Error(err.message || 'GciTsSaveObjs failed');
+  }
+}
+
+/** Releases objects previously pinned with {@link saveObjs} (`GciTsReleaseObjs`).
+ *  Targeted release only — never ReleaseAllObjs, since a session may host more
+ *  than one debugger panel. No-op for an empty list. */
+export function releaseObjs(session: ActiveSession, oops: bigint[]): void {
+  if (oops.length === 0) return;
+  const { success, err } = session.gci.GciTsReleaseObjs(session.handle, oops);
+  if (!success || err.number !== 0) {
+    throw new Error(err.message || 'GciTsReleaseObjs failed');
+  }
 }
 
 /** Resolve a global (e.g. a class name) to its OOP; null if it doesn't resolve. */

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -230,6 +230,59 @@ export function getMethodSource(session: ActiveSession, methodOop: bigint): stri
 }
 
 /**
+ * Where to add a method on a given object's class. `className` is the (non-meta)
+ * class name; `isMeta` is true when the object IS a class (so a class-side
+ * method is wanted). `dictName` is the dictionary that class lives in (for the
+ * gemstone:// new-method URI); '' when the class isn't in the user's symbol
+ * list. Mirrors the class-resolution tail of DnuInfo, but for an arbitrary
+ * object (a debugger frame's receiver) rather than a doesNotUnderstand: send.
+ */
+export interface ClassHomeInfo {
+  className: string;
+  isMeta: boolean;
+  dictName: string;
+}
+
+/**
+ * Resolve where a method would be added on `receiverOop`'s class — used to
+ * implement (override) an inherited method in the receiver's OWN class from the
+ * debugger. A class receiver resolves to its class-side; the home dictionary is
+ * found by NAME key in the user's symbol list (see the symbol-list home-dict
+ * gotcha). Returns undefined on any failure so callers degrade gracefully.
+ */
+export function getClassHomeInfo(session: ActiveSession, receiverOop: bigint): ClassHomeInfo | undefined {
+  try {
+    const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
+      session.handle, 'Utf8', OOP_NIL,
+    );
+    if (resErr.number !== 0) return undefined;
+
+    const code = `| rcvr base meta dn |
+rcvr := Object _objectForOop: ${receiverOop}.
+(rcvr isKindOf: Class)
+  ifTrue: [ base := rcvr. meta := true ]
+  ifFalse: [ base := rcvr class. meta := false ].
+dn := ''.
+System myUserProfile symbolList do: [:d |
+  (d includesKey: base name asSymbol) ifTrue: [ dn := d name ]].
+base name asString, String tab,
+  (meta ifTrue: ['class'] ifFalse: ['instance']), String tab,
+  dn`;
+
+    const { data, err } = session.gci.GciTsExecuteFetchBytes(
+      session.handle, code, -1, classUtf8, OOP_ILLEGAL, OOP_NIL, 64 * 1024,
+    );
+    if (err.number !== 0) return undefined;
+
+    const parts = data.split('\t');
+    if (parts.length < 3) return undefined;
+    return { className: parts[0], isMeta: parts[1] === 'class', dictName: parts[2] };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * The pieces needed to create the method a `doesNotUnderstand:` is asking for.
  * `className` is the (non-meta) name of the class the method should be added to;
  * `isMeta` is true when the unknown message was sent to a *class* (so a

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -241,44 +241,66 @@ export interface ClassHomeInfo {
   className: string;
   isMeta: boolean;
   dictName: string;
+  /** True when this class ALREADY implements the selector (it's an edit target,
+   *  and — if more specific than the chosen target — a shadowing implementation). */
+  implementsSelector?: boolean;
 }
 
 /**
- * Resolve where a method would be added on `receiverOop`'s class — used to
- * implement (override) an inherited method in the receiver's OWN class from the
- * debugger. A class receiver resolves to its class-side; the home dictionary is
- * found by NAME key in the user's symbol list (see the symbol-list home-dict
- * gotcha). Returns undefined on any failure so callers degrade gracefully.
+ * The receiver's full class chain — its class and every superclass up to Object
+ * — as candidate places to implement (override) `selector`. Ordered
+ * most-specific first (the receiver's class), so callers can pre-select it. A
+ * class receiver walks its class-side chain (isMeta true throughout). For each
+ * class: its home dictionary (found by NAME key in the user's symbol list — see
+ * the symbol-list home-dict gotcha; '' when not in the symbol list, so not an
+ * editable target) and whether it ALREADY implements `selector` (so the caller
+ * can open the existing source instead of clobbering it with a stub, and warn
+ * about a subclass implementation shadowing a superclass override). Returns []
+ * on any failure so callers degrade gracefully.
  */
-export function getClassHomeInfo(session: ActiveSession, receiverOop: bigint): ClassHomeInfo | undefined {
+export function getReceiverClassChain(
+  session: ActiveSession, receiverOop: bigint, selector: string,
+): ClassHomeInfo[] {
   try {
     const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
       session.handle, 'Utf8', OOP_NIL,
     );
-    if (resErr.number !== 0) return undefined;
+    if (resErr.number !== 0) return [];
 
-    const code = `| rcvr base meta dn |
+    // selector is a method selector (no quotes), but guard the quote anyway.
+    const sel = selector.replace(/'/g, "''");
+    const code = `| rcvr meta cls sel rows nm dn impl |
 rcvr := Object _objectForOop: ${receiverOop}.
 (rcvr isKindOf: Class)
-  ifTrue: [ base := rcvr. meta := true ]
-  ifFalse: [ base := rcvr class. meta := false ].
-dn := ''.
-System myUserProfile symbolList do: [:d |
-  (d includesKey: base name asSymbol) ifTrue: [ dn := d name ]].
-base name asString, String tab,
-  (meta ifTrue: ['class'] ifFalse: ['instance']), String tab,
-  dn`;
+  ifTrue: [ cls := rcvr. meta := true ]
+  ifFalse: [ cls := rcvr class. meta := false ].
+sel := '${sel}' asSymbol.
+rows := OrderedCollection new.
+[ cls notNil ] whileTrue: [
+  nm := cls theNonMetaClass name asString.
+  dn := ''.
+  System myUserProfile symbolList do: [:d |
+    (d includesKey: nm asSymbol) ifTrue: [ dn := d name ]].
+  impl := cls includesSelector: sel.
+  rows add: nm, String tab, (meta ifTrue: ['class'] ifFalse: ['instance']), String tab, dn,
+    String tab, (impl ifTrue: ['1'] ifFalse: ['0']).
+  cls := cls superclass ].
+rows inject: '' into: [:acc :r | acc isEmpty ifTrue: [r] ifFalse: [acc, (String with: Character lf), r]]`;
 
     const { data, err } = session.gci.GciTsExecuteFetchBytes(
       session.handle, code, -1, classUtf8, OOP_ILLEGAL, OOP_NIL, 64 * 1024,
     );
-    if (err.number !== 0) return undefined;
+    if (err.number !== 0) return [];
 
-    const parts = data.split('\t');
-    if (parts.length < 3) return undefined;
-    return { className: parts[0], isMeta: parts[1] === 'class', dictName: parts[2] };
+    return data.split('\n').filter(line => line.length > 0).map(line => {
+      const parts = line.split('\t');
+      return {
+        className: parts[0], isMeta: parts[1] === 'class', dictName: parts[2] ?? '',
+        implementsSelector: parts[3] === '1',
+      };
+    });
   } catch {
-    return undefined;
+    return [];
   }
 }
 

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -677,6 +677,8 @@ export class DebuggerPanel {
   private pendingOverrideUri: string | undefined;
   private pendingOverrideSelector: string | undefined;
   private pendingOverrideSenderLevel: number | undefined;
+  /** The class the pending override is being implemented in (for the save message). */
+  private pendingOverrideTargetClass: string | undefined;
   /** Set when the chosen target is shadowed by a more-specific subclass impl;
    *  surfaced after save so the user understands why the re-entered frame still
    *  shows the subclass method, not the one they just implemented. */
@@ -1103,6 +1105,7 @@ export class DebuggerPanel {
       this.pendingOverrideSenderLevel =
         sender && !sender.isExecutedCode && sender.serverLevel > 1 ? sender.serverLevel : undefined;
       this.pendingOverrideShadowedBy = shadowedBy;
+      this.pendingOverrideTargetClass = target.className;
       this.dnuMethodUris.add(openUri.toString());  // closed with the panel
       this.dnuMethodUris.add(compiledUri.toString());
       DebuggerPanel.persistLiveSourceUris();
@@ -1132,16 +1135,24 @@ export class DebuggerPanel {
    * the method still exists; tell the user to re-run. Mirrors finishDnuMethod.
    */
   private async finishOverrideMethod(
-    selector: string, senderLevel: number | undefined, shadowedBy: string | undefined,
+    selector: string, senderLevel: number | undefined,
+    shadowedBy: string | undefined, targetClass: string,
   ): Promise<void> {
     const sel = selector ? `#${selector}` : 'the method';
+    const inTarget = targetClass ? ` in ${targetClass}` : '';
     // When a more-specific subclass already implements the selector, the receiver
     // keeps using THAT method — explain why the frame won't show the new one.
     const shadowNote = shadowedBy
-      ? ` (NOTE: ${shadowedBy} already implements ${sel}, so the frame still shows ${shadowedBy}>>${sel}.)`
+      ? ` NOTE: ${shadowedBy} already implements ${sel}, so the frame still shows ${shadowedBy}>>${sel}.`
       : '';
     if (senderLevel === undefined) {
-      this.errorMessage = `Saved ${sel} — press Resume (▶) or re-run the send to dispatch into it.${shadowNote}`;
+      // No re-enterable caller (the send came straight from a workspace doit, or
+      // the only caller is the top frame) — we CAN'T re-dispatch in place. Resume
+      // would just finish the inherited version that's already running, NOT the
+      // new override. The honest next step is to re-run the expression.
+      this.errorMessage = `Saved ${sel}${inTarget}. The current frame is still running the inherited `
+        + 'version it already entered — re-run the expression to dispatch into the new method. '
+        + `(Resume here just finishes the old one.)${shadowNote}`;
       this.postInit();
       return;
     }
@@ -1153,8 +1164,8 @@ export class DebuggerPanel {
       this.dnuSuppressed = false;
       this.frames = this.fetchStack();
       this.dnuInfo = this.detectDnu();
-      this.errorMessage = `Saved ${sel} — re-entered the calling frame. Press Resume (▶) to `
-        + `dispatch into it, or step into it.${shadowNote}`;
+      this.errorMessage = `Saved ${sel}${inTarget} — re-entered the calling frame. Press Resume (▶) `
+        + `to re-send and dispatch into it, or step into it.${shadowNote}`;
       this.postInit();
     });
   }
@@ -1716,11 +1727,13 @@ export class DebuggerPanel {
       const selector = this.pendingOverrideSelector ?? '';
       const senderLevel = this.pendingOverrideSenderLevel;
       const shadowedBy = this.pendingOverrideShadowedBy;
+      const targetClass = this.pendingOverrideTargetClass ?? '';
       this.pendingOverrideUri = undefined;
       this.pendingOverrideSelector = undefined;
       this.pendingOverrideSenderLevel = undefined;
       this.pendingOverrideShadowedBy = undefined;
-      void this.finishOverrideMethod(selector, senderLevel, shadowedBy);
+      this.pendingOverrideTargetClass = undefined;
+      void this.finishOverrideMethod(selector, senderLevel, shadowedBy, targetClass);
       return;
     }
 

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -1543,6 +1543,15 @@ export class DebuggerPanel {
    * user expects from one Step Over. Stepping from level 1 would instead crawl
    * one step point at a time through the hidden machinery.
    *
+   * For a collapsed "Executed Code" doit frame, the displayed level is the
+   * DEEPEST doit frame (the doit home), but for wrapped code (Display It /
+   * Execute It / Inspect It) the halt is in a nested wrapper block ABOVE it.
+   * Stepping from the doit-home level would step OVER the whole user block —
+   * running every remaining statement to completion in one Step (the step-at-
+   * halt bug: a single Step ran the process to the end). So we step from the
+   * TRUE stop frame (the same `stopFrameLevel` the highlight uses) — one Step
+   * then advances one user statement, never auto-completing past a halt.
+   *
    * Requires native code OFF (codeExecutor toggles it before a debuggable run;
    * the panel holds it off while open) — GemStone can't step native code (error
    * 6014). If a step still hits that, we surface a clear message rather than
@@ -1555,7 +1564,14 @@ export class DebuggerPanel {
       : command === 'stepInto' ? debug.stepIntoNb
         : debug.stepThruNb; // "Through" == gciStepThru
     const frame = this.frames.find(f => f.level === displayLevel) ?? this.frames[0];
-    const level = frame?.serverLevel ?? 1;
+    let level = frame?.serverLevel ?? 1;
+    // Redirect a step on a collapsed doit frame to its true stop frame (the
+    // nested wrapper block where the halt actually is), or one Step at a halt
+    // steps over the entire user block to completion. Mirrors revealFrameSource.
+    if (frame?.isExecutedCode) {
+      const raw = this.rawFrames.find(r => r.serverLevel === frame.serverLevel);
+      if (raw) level = this.stopFrameLevel(raw.homeMethodOop, frame.serverLevel);
+    }
     await this.runNb('Step', async () => {
       // Stepping moves the stack → the prior halt's revert slots are now invalid.
       this.clearUndoState();

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -69,6 +69,8 @@ type DebuggerInbound =
   | { command: 'stepThrough'; level: number }
   | { command: 'restartFrame'; level: number }
   | { command: 'inspectVariable'; oop: string; name: string }
+  | { command: 'setVariable'; level: number; kind: 'instvar' | 'temp'; index: number; expr: string }
+  | { command: 'revertVariable'; level: number; kind: 'instvar' | 'temp'; index: number }
   | { command: 'createDnuMethod' }
   | { command: 'saveLayout'; stackBasis?: string; evalHeight?: string };
 
@@ -78,6 +80,19 @@ interface VarRow {
   value: string;
   /** The variable's OOP as a decimal string (drives the dim column + GT Inspect). */
   oop: string;
+  /**
+   * When present, this row is editable via the variable evaluator (T1). Carries
+   * the server-side write target: `instvar` → `instVarAt:put:` on the receiver,
+   * `temp` → `_frameAt:tempAt:put:` on the frame. `index` is 1-based. Absent for
+   * the (non-editable) `self` receiver row.
+   */
+  edit?: { kind: 'instvar' | 'temp'; index: number };
+  /**
+   * True when this slot has been edited away from its original value this halt,
+   * so the webview shows a revert (↺) icon. Set only when true (so unchanged
+   * rows stay lean); see the per-panel undo state in DebuggerPanel.
+   */
+  revertible?: boolean;
 }
 
 /**
@@ -608,6 +623,19 @@ export class DebuggerPanel {
   private disposed = false;
 
   /**
+   * Variable-revert (single-level undo) state, scoped to the current halt.
+   * `undoOriginals` maps a slot key (`level:kind:index`) → the OOP the slot held
+   * before its FIRST edit this halt; `undoDirty` is the subset whose value still
+   * differs from that original (drives the ↺ revert icon). `undoPinned` is the
+   * non-immediate originals saved against GC via `saveObjs` — released together
+   * (never per-slot, since the export set isn't ref-counted) by clearUndoState()
+   * on any stack-mutating op and on dispose. See setVariable / revertVariable.
+   */
+  private undoOriginals = new Map<string, bigint>();
+  private undoDirty = new Set<string>();
+  private undoPinned: bigint[] = [];
+
+  /**
    * @param onComplete called with the process's result oop when execution
    *   completes via Resume or step-to-completion (e.g. so a halted Display It
    *   can render its result back in the workspace). Omitted when there's no
@@ -725,6 +753,16 @@ export class DebuggerPanel {
         return;
       }
       case 'createDnuMethod': { void this.createDnuMethod(); return; }
+      case 'setVariable': {
+        const frame = this.frames.find(f => f.level === msg.level);
+        this.setVariable(frame?.serverLevel, msg.kind, msg.index, msg.expr);
+        return;
+      }
+      case 'revertVariable': {
+        const frame = this.frames.find(f => f.level === msg.level);
+        this.revertVariable(frame?.serverLevel, msg.kind, msg.index);
+        return;
+      }
       case 'inspectVariable': {
         // Open the clicked variable in a GT Inspector (beside), like GT Inspect.
         // Track it so it closes with the debugger (it's an artifact of it).
@@ -963,20 +1001,28 @@ export class DebuggerPanel {
       try { return debug.getObjectPrintString(this.session, oop); }
       catch { return '<unprintable>'; }
     };
-    const row = (name: string, oop: bigint): VarRow =>
-      ({ name, value: safePrint(oop), oop: oop.toString() });
+    const row = (name: string, oop: bigint, edit?: VarRow['edit']): VarRow => {
+      // Stamp `revertible` only when this slot has been edited away from its
+      // original this halt (the webview then shows the ↺ icon). Left undefined
+      // otherwise so unchanged rows stay lean.
+      const revertible = edit && this.undoDirty.has(this.undoKey(serverLevel, edit.kind, edit.index))
+        ? true : undefined;
+      return { name, value: safePrint(oop), oop: oop.toString(), edit, revertible };
+    };
 
     const groups: VarGroup[] = [];
 
-    // 1. Receiver — `self`.
+    // 1. Receiver — `self`. Not editable (you can't reassign a frame's receiver),
+    // so no `edit` metadata: the webview renders it read-only.
     groups.push({ title: 'Receiver', kind: 'receiver', vars: [row('self', info.receiverOop)] });
 
     // 2. Instance variables — the receiver's named instVars (none for immediates).
+    // Editable via `instVarAt:put:` (1-based index).
     try {
       const ivNames = debug.getInstVarNames(this.session, info.receiverOop);
       if (ivNames.length > 0) {
         const ivOops = debug.getNamedInstVarOops(this.session, info.receiverOop, ivNames.length);
-        const ivVars = ivNames.map((n, i) => row(n, ivOops[i]));
+        const ivVars = ivNames.map((n, i) => row(n, ivOops[i], { kind: 'instvar', index: i + 1 }));
         groups.push({ title: 'Instance variables', kind: 'instvars', vars: ivVars });
       }
     } catch (e: unknown) {
@@ -987,12 +1033,20 @@ export class DebuggerPanel {
     // `__vsc…` temps are the Transcript-capture wrapper's glue (see
     // transcriptCapture.ts); they're hidden, just like the glue is stripped from
     // an executed-code frame's source.
+    // The write primitive `_frameAt:tempAt:put:` indexes the *unfiltered*
+    // argAndTempNames array (1-based), so a NAMED temp's editable index is `i + 1`
+    // even though we drop `__vsc` glue. The synthetic `.tN` eval-stack temps are
+    // left read-only: they appear in the names array but sit past the method's
+    // declared argsAndTemps offsets, so the primitive can't address them ("method
+    // temp or arg not found"). (They stay viewable + GT-Inspectable, like `self`.)
     const named: VarRow[] = [];
     const stackTemps: VarRow[] = [];
     for (let i = 0; i < info.argAndTempNames.length; i++) {
       const name = info.argAndTempNames[i];
       if (name.startsWith('__vsc')) continue;
-      (name.startsWith('.') ? stackTemps : named).push(row(name, info.argAndTempOops[i]));
+      const isStackTemp = name.startsWith('.');
+      const r = row(name, info.argAndTempOops[i], isStackTemp ? undefined : { kind: 'temp', index: i + 1 });
+      (isStackTemp ? stackTemps : named).push(r);
     }
     if (named.length > 0) {
       groups.push({ title: 'Arguments & Temps', kind: 'argtemps', vars: named });
@@ -1017,6 +1071,120 @@ export class DebuggerPanel {
     this.panel.webview.postMessage({ command: 'evalResult', expr, value, isError });
   }
 
+  /**
+   * Assign a variable from the variable evaluator (T1): evaluate `expr` in the
+   * frame, then write the resulting object into the receiver's instVar or the
+   * frame's temp. On success, re-fetch ALL variables so every row's printString,
+   * OOP (dim column) and GT-Inspect target reflect the new object — the old OOP
+   * is stale once the slot points at a different object. On a compile/runtime
+   * error nothing is written and the error is sent back so the webview keeps the
+   * editor open.
+   */
+  private setVariable(
+    serverLevel: number | undefined, kind: 'instvar' | 'temp', index: number, expr: string,
+  ): void {
+    if (serverLevel == null) return;
+    // Writing is a blocking GCI perform; refuse while a non-blocking step/trim
+    // owns the session's single in-flight call.
+    if (this.nbBusy) {
+      this.notifyBusy('Set variable');
+      this.panel.webview.postMessage({ command: 'setVariableResult', ok: false, error: 'Busy — try again' });
+      return;
+    }
+    try {
+      const valueOop = debug.evaluateInFrameToOop(this.session, this.gsProcess, expr, serverLevel);
+      const info = debug.getFrameInfo(this.session, this.gsProcess, serverLevel);
+      // Capture + pin the slot's pre-edit value BEFORE overwriting it (first edit
+      // only), so revert can restore the exact original object.
+      this.captureUndoOriginal(serverLevel, kind, index, info);
+      if (kind === 'instvar') {
+        debug.setInstVar(this.session, info.receiverOop, index, valueOop);
+      } else {
+        debug.setFrameTemp(this.session, this.gsProcess, serverLevel, index, valueOop);
+      }
+      this.undoDirty.add(this.undoKey(serverLevel, kind, index));
+      this.panel.webview.postMessage({ command: 'setVariableResult', ok: true });
+      this.postVariables(serverLevel);
+    } catch (e: unknown) {
+      const error = e instanceof Error ? e.message : String(e);
+      logError(this.sessionId, error);
+      this.panel.webview.postMessage({ command: 'setVariableResult', ok: false, error });
+    }
+  }
+
+  private undoKey(level: number, kind: 'instvar' | 'temp', index: number): string {
+    return `${level}:${kind}:${index}`;
+  }
+
+  /**
+   * Record (once per slot, this halt) the value a slot holds before its first
+   * edit, and pin it against GC so revert can write the exact original object
+   * back. Immediates aren't pinned (they can't be collected). `info` is the
+   * already-fetched frame contents for `level`.
+   */
+  private captureUndoOriginal(
+    level: number, kind: 'instvar' | 'temp', index: number, info: debug.FrameInfo,
+  ): void {
+    const key = this.undoKey(level, kind, index);
+    if (this.undoOriginals.has(key)) return; // keep the FIRST original
+    const originalOop = kind === 'instvar'
+      ? debug.getInstVarOop(this.session, info.receiverOop, index)
+      : info.argAndTempOops[index - 1];
+    if (originalOop === undefined) return; // defensive: nothing to remember
+    this.undoOriginals.set(key, originalOop);
+    if (!debug.isSpecialOop(this.session, originalOop)) {
+      debug.saveObjs(this.session, [originalOop]);
+      this.undoPinned.push(originalOop);
+    }
+  }
+
+  /**
+   * Revert a slot to the value it held before its first edit this halt (the ↺
+   * icon). Writes the stored original OOP straight back (no re-evaluation), then
+   * refreshes — the row is no longer dirty, so the icon disappears. The pin is
+   * NOT released here (the slot re-references the object anyway); pins are freed
+   * en masse by clearUndoState(). No-op if the slot has no stored original.
+   */
+  private revertVariable(
+    serverLevel: number | undefined, kind: 'instvar' | 'temp', index: number,
+  ): void {
+    if (serverLevel == null) return;
+    const key = this.undoKey(serverLevel, kind, index);
+    const originalOop = this.undoOriginals.get(key);
+    if (originalOop === undefined) return; // nothing recorded for this slot
+    // A blocking write can't share the session with an in-flight non-blocking op.
+    if (this.nbBusy) { this.notifyBusy('Revert variable'); return; }
+    try {
+      if (kind === 'instvar') {
+        const receiverOop = debug.getFrameInfo(this.session, this.gsProcess, serverLevel).receiverOop;
+        debug.setInstVar(this.session, receiverOop, index, originalOop);
+      } else {
+        debug.setFrameTemp(this.session, this.gsProcess, serverLevel, index, originalOop);
+      }
+      this.undoDirty.delete(key);
+      this.postVariables(serverLevel);
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  /**
+   * Drop all variable-revert state and release every pinned original. Called on
+   * any stack-mutating op (step / resume / restart) and on dispose — once the
+   * stack moves, the stored `{level,index}` slots are no longer valid, and we
+   * must not leak the session's export set. Best-effort release (a failure here
+   * must not break dispose).
+   */
+  private clearUndoState(): void {
+    if (this.undoPinned.length > 0) {
+      try { debug.releaseObjs(this.session, this.undoPinned); }
+      catch (e: unknown) { logError(this.sessionId, e instanceof Error ? e.message : String(e)); }
+    }
+    this.undoPinned = [];
+    this.undoOriginals.clear();
+    this.undoDirty.clear();
+  }
+
   /** Resume execution: closes the panel if the process completes, else refreshes on the new error. */
   private resume(): void {
     if (this.guardStaleTopActivation('Resume')) return;
@@ -1029,6 +1197,8 @@ export class DebuggerPanel {
       this.notifyBusy('Resume');
       return;
     }
+    // Leaving this halt: drop revert state + release pinned originals.
+    this.clearUndoState();
     const result = debug.continueExecution(this.session, this.gsProcess);
     if (result.completed) {
       this.onCompleted(result);
@@ -1117,6 +1287,8 @@ export class DebuggerPanel {
     const frame = this.frames.find(f => f.level === displayLevel) ?? this.frames[0];
     const level = frame?.serverLevel ?? 1;
     await this.runNb('Step', async () => {
+      // Stepping moves the stack → the prior halt's revert slots are now invalid.
+      this.clearUndoState();
       // Non-blocking + cancellable: a step that crawls hidden machinery or steps
       // a looping method no longer freezes the extension host (see nbRunner.ts).
       const result = await fn(this.session, this.gsProcess, level);
@@ -1217,6 +1389,8 @@ export class DebuggerPanel {
       return;
     }
     await this.runNb('Restart frame', async () => {
+      // The trim rebuilds the stack → revert slots no longer apply.
+      this.clearUndoState();
       await debug.trimStackToLevelNb(this.session, this.gsProcess, serverLevel);
       if (this.disposed) return;
       this.staleTopActivation = false; // the trim discarded any stale top activation
@@ -1893,12 +2067,48 @@ export class DebuggerPanel {
     .var-group.collapsed .var-group-body { display: none; }
     .vars .var {
       padding: 0.15rem 0.2rem; display: flex; gap: 0.5rem; align-items: baseline;
-      cursor: pointer; border-radius: 3px;
+      cursor: default; border-radius: 3px;
     }
+    /* Only editable rows invite a click (left-click opens the variable evaluator);
+       the pointer cursor signals they're interactive. */
+    .vars .var.editable { cursor: pointer; }
+    /* While editing, let the error message wrap onto its own line under the input. */
+    .vars .var.editing { flex-wrap: wrap; }
     .vars .var:hover { background: var(--vscode-list-hoverBackground); }
+    /* Inline variable evaluator: replaces the value cell in place, prefilled with
+       the printString. .error flags a rejected (compile/runtime) expression. */
+    .vars .var-edit {
+      flex: 1 1 auto; min-width: 0; box-sizing: border-box; user-select: text; -webkit-user-select: text;
+      font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85em;
+      color: var(--vscode-input-foreground); background: var(--vscode-input-background);
+      border: 1px solid var(--vscode-focusBorder, var(--vscode-input-border, transparent));
+      padding: 0.05rem 0.25rem; border-radius: 2px;
+    }
+    .vars .var-edit.error {
+      border-color: var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+      background: var(--vscode-inputValidation-errorBackground, var(--vscode-input-background));
+      outline: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+    }
+    /* The rejected-expression message, on its own line below the input.
+       Selectable so the user can copy the real error text. */
+    .vars .var-edit-error {
+      flex: 1 0 100%; margin-top: 0.15rem; padding-left: 0.1rem;
+      color: var(--vscode-errorForeground); font-size: 0.78em; white-space: pre-wrap; word-break: break-word;
+      user-select: text; -webkit-user-select: text; cursor: text;
+    }
     .vars .var-name { color: var(--vscode-symbolIcon-variableForeground, var(--vscode-foreground)); white-space: nowrap; flex: 0 0 auto; }
     .vars .var-name.self { font-style: italic; }
-    .vars .var-value { color: var(--vscode-descriptionForeground); white-space: pre; overflow: hidden; text-overflow: ellipsis; flex: 1 1 auto; }
+    /* The value hugs its content (shrink-and-ellipsize, not grow) so the revert
+       icon can sit right after it; min-width:0 lets the ellipsis kick in. */
+    .vars .var-value { color: var(--vscode-descriptionForeground); white-space: pre; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }
+    /* Revert (↺) icon on an edited row — immediately to the right of the value.
+       A long printString ellipsizes (the value shrinks), so the icon stays glued
+       to the value and never scrolls off; the dim OOP stays pinned far right. */
+    .vars .var-revert {
+      flex: 0 0 auto; cursor: pointer; user-select: none;
+      color: var(--vscode-descriptionForeground); opacity: 0.8;
+    }
+    .vars .var-revert:hover { opacity: 1; color: var(--vscode-foreground); }
     /* OOP shown dim at the row end, matching the GT Inspector header convention. */
     .vars .var-oop {
       flex: 0 0 auto; margin-left: auto; white-space: nowrap;
@@ -1961,6 +2171,9 @@ export class DebuggerPanel {
   <div id="ctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="copyFrameItem" role="menuitem">Copy Frame</div>
   </div>
+  <div id="varctxmenu" class="ctx-menu" role="menu">
+    <div class="ctx-item" id="varInspectItem" role="menuitem">GT Inspect</div>
+  </div>
   <script nonce="${nonce}">${debuggerViewJs}</script>
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
@@ -1979,6 +2192,8 @@ export class DebuggerPanel {
       main: document.getElementById('main'),
       splitter: document.getElementById('splitter'),
       hsplitter: document.getElementById('hsplitter'),
+      varMenu: document.getElementById('varctxmenu'),
+      varInspectItem: document.getElementById('varInspectItem'),
     }, vscode);
     vscode.postMessage({ command: 'ready' });
   </script>
@@ -1990,6 +2205,9 @@ export class DebuggerPanel {
     this.disposed = true; // an in-flight Nb step/trim continuation must skip the dead panel
     if (this.layoutSampler) { clearInterval(this.layoutSampler); this.layoutSampler = undefined; }
     DebuggerPanel.panels.get(this.sessionId)?.delete(this);
+    // Release any pinned revert originals so closing the debugger never leaks the
+    // session's export set.
+    this.clearUndoState();
     // Restore native code once the last debugger for this session closes
     // (paired with acquireStepping in create).
     debug.releaseStepping(this.session);

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -73,7 +73,26 @@ type DebuggerInbound =
   | { command: 'revertVariable'; level: number; kind: 'instvar' | 'temp'; index: number }
   | { command: 'createDnuMethod' }
   | { command: 'implementInReceiver'; level: number }
+  | { command: 'implementSubclassResponsibility' }
   | { command: 'saveLayout'; stackBasis?: string; evalHeight?: string };
+
+/**
+ * What's needed to offer "Implement #<selector>" when the process is parked on a
+ * `subclassResponsibility` (T4). Detected client-side from the raw stack: the
+ * abstract method is the frame just below the `subclassResponsibility[:]` marker,
+ * so `selector`/`definingClassName` come from that frame and `senderServerLevel`
+ * is the frame below it (the caller, for re-dispatch on save). `definingClassName`
+ * bounds the implement target — you implement at-or-below the abstract class.
+ */
+interface SubclassRespInfo {
+  selector: string;
+  /** Server level of the abstract-method frame (its receiver → the implement target). */
+  abstractServerLevel: number;
+  /** Server level of the frame that called the abstract method (-1 if none). */
+  senderServerLevel: number;
+  /** The abstract method's defining class — the upper bound for the class picker. */
+  definingClassName: string;
+}
 
 /** A single variable row (name / printString / oop) sent to the webview. */
 interface VarRow {
@@ -309,8 +328,13 @@ export interface RawFrame {
 // parks in under GCI debug (MessageNotUnderstood>>defaultAction → _defaultAction →
 // _signal → signal → doesNotUnderstand: → _doesNotUnderstand:…); trimming them opens
 // the debugger on the user's frame (e.g. Executed Code) rather than this machinery.
+// `subclassResponsibility`/`subclassResponsibility:` are the abstract-method markers
+// (`subclassResponsibility` → `self error:`; the `:` form signals Error 2008 directly).
+// Trimming them opens the debugger on the abstract method itself (the frame just below,
+// e.g. `LargeNegativeInteger(Integer)>>foo`) — the method T4 offers to implement.
 const MACHINERY_SELECTORS = new Set([
   'halt', 'halt:', 'pause', 'error:', 'signal', 'signal:', 'defaultAction', '_defaultAction',
+  'subclassResponsibility', 'subclassResponsibility:',
 ]);
 // Kernel block-invocation selectors that appear as transcript-capture-wrapper
 // glue at the BOTTOM (the doit evaluates its blocks via these).
@@ -682,6 +706,28 @@ export class DebuggerPanel {
    *  the method they just implemented higher up the chain. */
   private pendingOverrideShadowedBy: string | undefined;
   /**
+   * Set for a T4 (subclassResponsibility) implement: the server level of the
+   * frame that SENT the abstract method (the caller). Unlike a plain override
+   * (option B), an abstract method that's on the stack won't dispatch into the
+   * new method on a bare Resume — its activation already returned to the abstract
+   * stub — so on a clean save we re-enter this sender (when re-enterable) so the
+   * send re-dispatches into the concrete method. Undefined for a normal override.
+   */
+  private pendingOverrideReEnterSenderLevel: number | undefined;
+  /**
+   * When the suspended process is parked on a `subclassResponsibility` (an abstract
+   * method that should have been overridden in a concrete subclass), the info
+   * needed to offer "Implement #<selector>" (T4). Re-detected whenever the stack is
+   * (re)fetched, undefined otherwise. Drives the webview's Implement button.
+   */
+  private subclassRespInfo: SubclassRespInfo | undefined;
+  /**
+   * Suppresses the "Implement #sel" button once a T4 implement is underway/resolved
+   * for the SAME parked subclassResponsibility (mirrors `dnuSuppressed`). Reset when
+   * a trim rebuilds the stack (a genuinely new abstract-method stop may then appear).
+   */
+  private srSuppressed = false;
+  /**
    * Suppresses the "Create #sel" button once a create is underway or resolved, so
    * it never reappears for the SAME parked doesNotUnderstand: (the method now
    * exists, but the suspended process still has the DNU frame on its stack). Reset
@@ -811,6 +857,7 @@ export class DebuggerPanel {
       case 'ready': {
         this.frames = this.fetchStack();
         this.dnuInfo = this.detectDnu();
+        this.subclassRespInfo = this.detectSubclassResp();
         this.postInit();
         return;
       }
@@ -856,6 +903,7 @@ export class DebuggerPanel {
       }
       case 'createDnuMethod': { void this.createDnuMethod(); return; }
       case 'implementInReceiver': { void this.implementInReceiver(msg.level); return; }
+      case 'implementSubclassResponsibility': { void this.implementSubclassResponsibility(); return; }
       case 'setVariable': {
         const frame = this.frames.find(f => f.level === msg.level);
         this.setVariable(frame?.serverLevel, msg.kind, msg.index, msg.expr);
@@ -900,6 +948,9 @@ export class DebuggerPanel {
       dnu: this.dnuInfo
         ? { selector: this.dnuInfo.selector, className: this.dnuInfo.className, isMeta: this.dnuInfo.isMeta }
         : undefined,
+      // When parked on a subclassResponsibility, drive the "Implement #sel" button (T4).
+      // The target class is chosen via picker, so only the selector is sent.
+      subclassResp: this.subclassRespInfo ? { selector: this.subclassRespInfo.selector } : undefined,
     });
   }
 
@@ -907,6 +958,7 @@ export class DebuggerPanel {
   private refresh(): void {
     this.frames = this.fetchStack();
     this.dnuInfo = this.detectDnu();
+    this.subclassRespInfo = this.detectSubclassResp();
     this.postInit();
   }
 
@@ -927,6 +979,35 @@ export class DebuggerPanel {
       logError(this.sessionId, e instanceof Error ? e.message : String(e));
       return undefined;
     }
+  }
+
+  /**
+   * Detect whether the process is parked on a `subclassResponsibility` (T4): scan
+   * the RAW stack (pre-trim) for the `subclassResponsibility[:]` marker frame — the
+   * frame just below it is the abstract method whose selector should be implemented
+   * concretely. Client-side only (no GCI round-trip): the marker, the abstract
+   * method's selector + defining class, and the caller's level all come from frames
+   * the panel already built. Suppressed while a DNU is offered (DNU takes
+   * precedence), while a T4 template is being edited, or once resolved (srSuppressed).
+   */
+  private detectSubclassResp(): SubclassRespInfo | undefined {
+    if (this.dnuInfo || this.srSuppressed || this.pendingOverrideUri !== undefined) return undefined;
+    const raws = this.rawFrames;
+    const srIdx = raws.findIndex(
+      r => r.selector === 'subclassResponsibility' || r.selector === 'subclassResponsibility:');
+    // Need the abstract method frame just below the marker. (srIdx+1 must exist.)
+    if (srIdx === -1 || srIdx + 1 >= raws.length) return undefined;
+    const abstractFrame = raws[srIdx + 1];
+    // Only a real method can be implemented/overridden — never a block or doit.
+    if (!abstractFrame.selector || abstractFrame.isBlock || abstractFrame.isExecutedCode) return undefined;
+    if (!abstractFrame.definingClassName) return undefined;
+    const sender = raws[srIdx + 2];
+    return {
+      selector: abstractFrame.selector,
+      abstractServerLevel: abstractFrame.serverLevel,
+      senderServerLevel: sender ? sender.serverLevel : -1,
+      definingClassName: abstractFrame.definingClassName,
+    };
   }
 
   /**
@@ -1038,10 +1119,71 @@ export class DebuggerPanel {
       this.postInit();
       return;
     }
+    await this.pickAndOpenImplementTemplate({
+      selector, chain, contextLabel: `${frame.label}@sv${frame.serverLevel}`,
+    });
+  }
 
+  /**
+   * "Implement #<selector>" for a `subclassResponsibility` stop (T4): the process
+   * is parked because an abstract method (a `^self subclassResponsibility` stub)
+   * was invoked on a concrete subclass that didn't override it. Offer to implement
+   * that selector concretely. Reuses the override harness (chain QuickPick + stub),
+   * with two differences from T3:
+   *  - the candidate chain is BOUNDED at the abstract method's defining class
+   *    (you implement at-or-below the abstract class, never above it — a concrete
+   *    Object/Number method would defeat the abstract contract for OTHER subclasses);
+   *  - on a clean save we re-enter the CALLER (the sender of the abstract method),
+   *    because the abstract activation already returned its stub — a bare Resume
+   *    wouldn't dispatch into the new method (see finishOverrideMethod / DNU).
+   */
+  private async implementSubclassResponsibility(): Promise<void> {
+    const info = this.subclassRespInfo;
+    if (!info) return;
+    let receiverOop: bigint;
+    try {
+      receiverOop = debug.getFrameInfo(this.session, this.gsProcess, info.abstractServerLevel).receiverOop;
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      this.errorMessage = `Could not resolve the receiver of #${info.selector}.`;
+      this.postInit();
+      return;
+    }
+    let chain = debug.getReceiverClassChain(this.session, receiverOop, info.selector);
+    // Bound the chain at the abstract method's defining class (inclusive).
+    const boundIdx = chain.findIndex(c => c.className === info.definingClassName);
+    if (boundIdx >= 0) chain = chain.slice(0, boundIdx + 1);
+    if (chain.length === 0) {
+      this.errorMessage = `Could not resolve the receiver's class to implement #${info.selector}.`;
+      this.postInit();
+      return;
+    }
+    await this.pickAndOpenImplementTemplate({
+      selector: info.selector, chain,
+      contextLabel: `subclassResponsibility #${info.selector}`,
+      reEnterSenderLevel: info.senderServerLevel,
+    });
+  }
+
+  /**
+   * Shared tail for T3 (implementInReceiver) and T4 (implementSubclassResponsibility):
+   * pick a target class from `chain` (QuickPick when >1; receiver's class
+   * pre-selected), then open an editor — a pre-filled stub for a class that doesn't
+   * implement the selector, or the EXISTING source for one that does (never
+   * clobbered). Records the pending-override state so the next clean save runs
+   * `finishOverrideMethod`. `reEnterSenderLevel` (T4 only) makes that save re-enter
+   * the caller so the send re-dispatches into the new method.
+   */
+  private async pickAndOpenImplementTemplate(opts: {
+    selector: string;
+    chain: debug.ClassHomeInfo[];
+    contextLabel: string;
+    reEnterSenderLevel?: number;
+  }): Promise<void> {
+    const { selector, chain, reEnterSenderLevel } = opts;
     // One candidate → go straight in. Several → let the user pick where in the
     // chain to implement (receiver's class first; each marked override vs edit).
-    logInfo(`[Jasper Debugger] implementInReceiver #${selector}: chain = `
+    logInfo(`[Jasper Debugger] implement #${selector}: chain = `
       + chain.map(c => `${c.className}${c.implementsSelector ? '(impl)' : ''}`).join(' → '));
     let targetIndex = 0;
     if (chain.length > 1) {
@@ -1050,12 +1192,12 @@ export class DebuggerPanel {
           label: c.className,
           description: !c.dictName ? '(not in your symbol list)'
             : c.implementsSelector ? `already implements #${selector} — opens it to edit (in ${c.dictName})`
-            : `override here (in ${c.dictName})`,
+            : `implement here (in ${c.dictName})`,
           index: i,
         })),
         {
           placeHolder: `Implement #${selector} in which class? (receiver is ${chain[0].className})`,
-          // The right-click happens IN the webview, which keeps/regains focus —
+          // The pick is triggered from the webview, which keeps/regains focus —
           // without this the QuickPick loses focus and auto-dismisses before the
           // user can see it (it just flashes). Keep it open until an explicit pick.
           ignoreFocusOut: true,
@@ -1091,8 +1233,9 @@ export class DebuggerPanel {
       ? compiledUri
       : this.gemstoneMethodUri(target.dictName, target.className, target.isMeta, 'new-method');
     logInfo(`[Jasper Debugger] implement #${selector} in ${target.className} `
-      + `(${editingExisting ? 'edit existing' : 'new override'}); overridden frame = `
-      + `${frame.label}@sv${frame.serverLevel}${shadowedBy ? `; shadowed by ${shadowedBy}` : ''}`);
+      + `(${editingExisting ? 'edit existing' : 'new method'}); from `
+      + `${opts.contextLabel}${shadowedBy ? `; shadowed by ${shadowedBy}` : ''}`
+      + `${reEnterSenderLevel !== undefined ? `; re-enter sender sv${reEnterSenderLevel}` : ''}`);
     try {
       await this.openTemplateEditor(
         openUri, editingExisting ? undefined : buildMethodStub(selector, selectorArgCount(selector)));
@@ -1100,14 +1243,19 @@ export class DebuggerPanel {
       this.pendingOverrideSelector = selector;
       this.pendingOverrideShadowedBy = shadowedBy;
       this.pendingOverrideTargetClass = target.className;
+      this.pendingOverrideReEnterSenderLevel = reEnterSenderLevel;
       this.dnuMethodUris.add(openUri.toString());  // closed with the panel
       this.dnuMethodUris.add(compiledUri.toString());
       DebuggerPanel.persistLiveSourceUris();
       // Banner-only guidance (NOT postInit — that re-selects the top frame and
       // steals focus from the editor we just opened; see createDnuMethod).
       const verb = editingExisting ? `Editing existing #${selector} in` : `Editing new method #${selector} in`;
-      let text = `${verb} ${target.className} below — edit the body, then save it (Ctrl+S / Cmd+S). `
-        + `It's then used on the next #${selector} send.`;
+      // T4 (re-enter sender): the abstract method is on the stack, so the new method
+      // is reached by re-dispatching the send — not "the next send" (T3 / option B).
+      const usage = reEnterSenderLevel !== undefined
+        ? `On a clean save the call to #${selector} is re-dispatched into it (or re-run the expression).`
+        : `It's then used on the next #${selector} send.`;
+      let text = `${verb} ${target.className} below — edit the body, then save it (Ctrl+S / Cmd+S). ${usage}`;
       if (shadowedBy) {
         text += ` NOTE: ${shadowedBy} already implements #${selector}, so a ${chain[0].className} still `
           + `uses ${shadowedBy}>>#${selector}, not ${target.className}'s.`;
@@ -1122,16 +1270,24 @@ export class DebuggerPanel {
   }
 
   /**
-   * After an override method is saved (clean compile), DON'T auto-restart anything
-   * (option B — predictable, no surprising stack jumps): the method now exists and
-   * is used on the NEXT send of the selector. The call already on the stack keeps
-   * running the method it dispatched to; the user Resumes (later sends — e.g. the
-   * next loop iteration — use the new one) or re-runs. We just refresh + explain.
-   * (Unlike DNU, where the send is parked unhandled and MUST be re-dispatched, an
-   * override's send already succeeded into the inherited method.)
+   * After an implement/override method is saved (clean compile).
+   *
+   * For a plain T3 override (`reEnterSenderLevel` undefined) DON'T auto-restart
+   * anything (option B — predictable, no surprising stack jumps): the method now
+   * exists and is used on the NEXT send of the selector. The call already on the
+   * stack keeps running the method it dispatched to; the user Resumes (later sends
+   * use the new one) or re-runs. (An override's send already succeeded into the
+   * inherited method, so the current activation is legitimate.)
+   *
+   * For a T4 subclassResponsibility implement (`reEnterSenderLevel` set) the abstract
+   * activation already returned its stub, so a bare Resume would NOT dispatch into
+   * the new method — re-enter the CALLER (when it's a re-enterable method frame, like
+   * the DNU path) so a Resume re-sends the selector and finds the concrete method;
+   * for a workspace/"Executed Code" caller, tell the user to re-run the expression.
    */
   private async finishOverrideMethod(
     selector: string, shadowedBy: string | undefined, targetClass: string,
+    reEnterSenderLevel?: number,
   ): Promise<void> {
     const sel = selector ? `#${selector}` : 'the method';
     const inTarget = targetClass ? ` in ${targetClass}` : '';
@@ -1140,9 +1296,46 @@ export class DebuggerPanel {
     const shadowNote = shadowedBy
       ? ` NOTE: ${shadowedBy} already implements ${sel}, so ${shadowedBy}>>${sel} still wins for this receiver.`
       : '';
+
+    // T4: re-dispatch from the caller of the abstract method.
+    if (reEnterSenderLevel !== undefined) {
+      const senderRaw = reEnterSenderLevel >= 0
+        ? this.rawFrames.find(r => r.serverLevel === reEnterSenderLevel)
+        : undefined;
+      if (!senderRaw || senderRaw.isExecutedCode || reEnterSenderLevel <= 1) {
+        // Workspace/"Executed Code" (or top) caller — can't be re-entered in place
+        // (the kernel trim sends compiledMethodAt: to its nil class), so don't trim.
+        this.srSuppressed = true; // the method exists now; don't re-offer Implement
+        this.frames = this.fetchStack();
+        this.dnuInfo = this.detectDnu();
+        this.subclassRespInfo = this.detectSubclassResp();
+        this.errorMessage = `Saved ${sel}${inTarget} — re-run the expression to dispatch into the new `
+          + `method. (Resume just finishes the abstract stub, which returns the receiver.)${shadowNote}`;
+        this.postInit();
+        return;
+      }
+      // A real method caller — re-enter it (non-blocking trim) so the user's Resume
+      // re-sends the selector from a clean frame, dispatching into the new method.
+      await this.runNb('Implement method', async () => {
+        await debug.trimStackToLevelNb(this.session, this.gsProcess, reEnterSenderLevel);
+        if (this.disposed) return;
+        this.staleTopActivation = false; // the trim rebuilt the stack from a fresh activation
+        this.uncontinuable = false;
+        this.srSuppressed = false;        // fresh stack — a new abstract stop may legitimately appear
+        this.frames = this.fetchStack();
+        this.dnuInfo = this.detectDnu();
+        this.subclassRespInfo = this.detectSubclassResp();
+        this.errorMessage = `Saved ${sel}${inTarget} — re-entered the caller. Press Resume (▶) to `
+          + `re-send ${sel} into the new method, or step into it.${shadowNote}`;
+        this.postInit();
+      });
+      return;
+    }
+
     this.dnuSuppressed = false;
     this.frames = this.fetchStack();   // labels/source may have shifted; no trim
     this.dnuInfo = this.detectDnu();
+    this.subclassRespInfo = this.detectSubclassResp();
     this.errorMessage = `Saved ${sel}${inTarget} — used on the next ${sel} send. Resume (▶) to continue `
       + '(the call now on the stack finishes with the previously-found version), or re-run the '
       + `expression.${shadowNote}`;
@@ -1722,11 +1915,13 @@ export class DebuggerPanel {
       const selector = this.pendingOverrideSelector ?? '';
       const shadowedBy = this.pendingOverrideShadowedBy;
       const targetClass = this.pendingOverrideTargetClass ?? '';
+      const reEnterSenderLevel = this.pendingOverrideReEnterSenderLevel;
       this.pendingOverrideUri = undefined;
       this.pendingOverrideSelector = undefined;
       this.pendingOverrideShadowedBy = undefined;
       this.pendingOverrideTargetClass = undefined;
-      void this.finishOverrideMethod(selector, shadowedBy, targetClass);
+      this.pendingOverrideReEnterSenderLevel = undefined;
+      void this.finishOverrideMethod(selector, shadowedBy, targetClass, reEnterSenderLevel);
       return;
     }
 

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -72,6 +72,7 @@ type DebuggerInbound =
   | { command: 'setVariable'; level: number; kind: 'instvar' | 'temp'; index: number; expr: string }
   | { command: 'revertVariable'; level: number; kind: 'instvar' | 'temp'; index: number }
   | { command: 'createDnuMethod' }
+  | { command: 'implementInReceiver'; level: number }
   | { command: 'saveLayout'; stackBasis?: string; evalHeight?: string };
 
 /** A single variable row (name / printString / oop) sent to the webview. */
@@ -200,6 +201,17 @@ export function buildMethodStub(selector: string, argCount: number): string {
     + '\t^nil\n';
 }
 
+/**
+ * Argument count implied by a selector: the number of colons for a keyword
+ * selector, 1 for a binary selector (an operator like `+` / `<=`), else 0
+ * (unary). Used to stub an override whose selector comes from the frame (the
+ * DNU path instead reads the arg count off the failed send's descriptor).
+ */
+export function selectorArgCount(selector: string): number {
+  if (selector.includes(':')) return (selector.match(/:/g) ?? []).length;
+  return /^[A-Za-z_]/.test(selector) ? 0 : 1;
+}
+
 /** Minimal HTML-escape for interpolating session text into the page. */
 function escapeHtml(s: string): string {
   return s
@@ -216,6 +228,10 @@ interface FrameSummary {
   label: string;
   /** Pre-formatted `@<stepPoint> line <line>` annotation; '' when unavailable. */
   position: string;
+  /** True when the running method was inherited → offer "Implement in <receiverClass>". */
+  overridable?: boolean;
+  /** Receiver's class name, for the override menu item's label. */
+  receiverClass?: string;
 }
 
 /**
@@ -270,6 +286,16 @@ export interface RawFrame {
   selector: string;
   /** True for doit / "Executed Code" frames (no resolvable home class). */
   isExecutedCode: boolean;
+  /** Receiver's actual class name (non-block frames only); drives override detection. */
+  receiverClassName?: string;
+  /**
+   * True when the running method was INHERITED — the receiver's class differs
+   * from the method's defining class (a real, non-doit method frame). This is
+   * exactly when "Implement <selector> in <ReceiverClass>" is offered (override).
+   * The home-dictionary check (is the receiver class editable?) is deferred to
+   * click time, to keep buildFrame off the extra per-frame server round-trip.
+   */
+  overridable?: boolean;
   label: string;
   line?: number;
   stepPoint?: number;
@@ -641,6 +667,17 @@ export class DebuggerPanel {
   private pendingDnuMethodUri: string | undefined;
   private pendingDnuSelector: string | undefined;
   /**
+   * While an "Implement in <receiverClass>" override template is being edited:
+   * the `gemstone://` new-method URI, the selector being implemented, and the
+   * server level of the SENDER frame (the caller of the overridden method).
+   * Saving the template (a clean compile) re-enters that sender so a Resume
+   * re-dispatches the send into the freshly-created override (so the frame is
+   * "reset to that method"). Undefined sender → can't re-enter; just refresh.
+   */
+  private pendingOverrideUri: string | undefined;
+  private pendingOverrideSelector: string | undefined;
+  private pendingOverrideSenderLevel: number | undefined;
+  /**
    * Suppresses the "Create #sel" button once a create is underway or resolved, so
    * it never reappears for the SAME parked doesNotUnderstand: (the method now
    * exists, but the suspended process still has the DNU frame on its stack). Reset
@@ -814,6 +851,7 @@ export class DebuggerPanel {
         return;
       }
       case 'createDnuMethod': { void this.createDnuMethod(); return; }
+      case 'implementInReceiver': { void this.implementInReceiver(msg.level); return; }
       case 'setVariable': {
         const frame = this.frames.find(f => f.level === msg.level);
         this.setVariable(frame?.serverLevel, msg.kind, msg.index, msg.expr);
@@ -850,7 +888,10 @@ export class DebuggerPanel {
       command: 'init',
       errorMessage: this.errorMessage,
       // Send only the display shape; serverLevel stays host-side.
-      stack: this.frames.map(f => ({ level: f.level, label: f.label, position: f.position })),
+      stack: this.frames.map(f => ({
+        level: f.level, label: f.label, position: f.position,
+        overridable: f.overridable, receiverClass: f.receiverClass,
+      })),
       // When parked on a doesNotUnderstand:, drive the "Create #sel in Class" button.
       dnu: this.dnuInfo
         ? { selector: this.dnuInfo.selector, className: this.dnuInfo.className, isMeta: this.dnuInfo.isMeta }
@@ -945,6 +986,105 @@ export class DebuggerPanel {
       this.errorMessage = `Could not open a method template: ${e instanceof Error ? e.message : String(e)}`;
       this.postInit();
     }
+  }
+
+  /**
+   * "Implement <selector> in <ReceiverClass>" (T2/T3 override): the selected
+   * frame is running a method the receiver INHERITED; open a template to create
+   * that selector in the receiver's OWN class. Reuses the create-method-from-DNU
+   * machinery (template editor + buildMethodStub), but the target class comes
+   * from the receiver (getClassHomeInfo) and the selector/arg-count from the
+   * frame. On a clean save, `finishOverrideMethod` re-enters the SENDER so a
+   * Resume re-dispatches the send into the new override (the frame is "reset to
+   * that method"). Degrades with the same in-band error help as the DNU path.
+   */
+  private async implementInReceiver(displayLevel: number): Promise<void> {
+    const frame = this.frames.find(f => f.level === displayLevel);
+    if (!frame || !frame.overridable) return;
+    const raw = this.rawFrames.find(r => r.serverLevel === frame.serverLevel);
+    const selector = raw?.selector;
+    if (!selector) return;
+
+    let receiverOop: bigint;
+    try {
+      receiverOop = debug.getFrameInfo(this.session, this.gsProcess, frame.serverLevel).receiverOop;
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      this.errorMessage = `Could not resolve the receiver of ${frame.label}.`;
+      this.postInit();
+      return;
+    }
+    const target = debug.getClassHomeInfo(this.session, receiverOop);
+    if (!target) {
+      this.errorMessage = `Could not resolve the receiver's class to implement #${selector}.`;
+      this.postInit();
+      return;
+    }
+    if (!target.dictName) {
+      // No home dictionary → no editable gemstone:// URI (same guard as the DNU path).
+      this.errorMessage = `Can't implement #${selector}: ${target.className} isn't in your symbol `
+        + 'list, so its source has no home dictionary. Add the class to a dictionary first.';
+      this.postInit();
+      return;
+    }
+
+    const uri = this.gemstoneMethodUri(target.dictName, target.className, target.isMeta, 'new-method');
+    // On a clean save the FS provider swaps the template tab to the real method
+    // URI — built EXACTLY as the provider builds it (see createDnuMethod) so the
+    // close-on-dispose match works.
+    const compiledUri = this.gemstoneMethodUri(target.dictName, target.className, target.isMeta, selector);
+    // The caller of the overridden frame — re-entered on save so the send
+    // re-dispatches into the new override. The displayed stack is ordered
+    // top(1)→base(N), so the sender is the NEXT-deeper displayed frame.
+    const idx = this.frames.indexOf(frame);
+    const sender = idx >= 0 ? this.frames[idx + 1] : undefined;
+    try {
+      await this.openTemplateEditor(uri, buildMethodStub(selector, selectorArgCount(selector)));
+      this.pendingOverrideUri = uri.toString();
+      this.pendingOverrideSelector = selector;
+      this.pendingOverrideSenderLevel =
+        sender && !sender.isExecutedCode && sender.serverLevel > 1 ? sender.serverLevel : undefined;
+      this.dnuMethodUris.add(uri.toString());      // closed with the panel
+      this.dnuMethodUris.add(compiledUri.toString());
+      DebuggerPanel.persistLiveSourceUris();
+      // Banner-only guidance (NOT postInit — that re-selects the top frame and
+      // steals focus from the template we just opened; see createDnuMethod).
+      this.errorMessage = `Editing new method #${selector} in ${target.className} below — fill in the `
+        + 'body, then save it (Ctrl+S / Cmd+S) to create it. The frame will then re-enter the new method.';
+      this.panel.webview.postMessage({ command: 'banner', text: this.errorMessage });
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      this.errorMessage = `Could not open a method template: ${e instanceof Error ? e.message : String(e)}`;
+      this.postInit();
+    }
+  }
+
+  /**
+   * After an override method is created (clean compile), re-enter the sender of
+   * the overridden frame (non-blocking trim) so the user's next Resume re-runs
+   * the send and method lookup finds the new override — the frame is reset to
+   * the new method. When there's no re-enterable sender (a workspace/top caller),
+   * the method still exists; tell the user to re-run. Mirrors finishDnuMethod.
+   */
+  private async finishOverrideMethod(selector: string, senderLevel: number | undefined): Promise<void> {
+    const sel = selector ? `#${selector}` : 'the method';
+    if (senderLevel === undefined) {
+      this.errorMessage = `Created ${sel} — press Resume (▶) or re-run the send to dispatch into the new method.`;
+      this.postInit();
+      return;
+    }
+    await this.runNb('Implement in receiver', async () => {
+      await debug.trimStackToLevelNb(this.session, this.gsProcess, senderLevel);
+      if (this.disposed) return;
+      this.staleTopActivation = false; // the trim rebuilt the stack from a fresh activation
+      this.uncontinuable = false;
+      this.dnuSuppressed = false;
+      this.frames = this.fetchStack();
+      this.dnuInfo = this.detectDnu();
+      this.errorMessage = `Created ${sel} — re-entered the calling frame. Press Resume (▶) to `
+        + 'dispatch into the new method, or step into it.';
+      this.postInit();
+    });
   }
 
   /**
@@ -1491,6 +1631,20 @@ export class DebuggerPanel {
       return;
     }
 
+    // Implement-in-receiver (override): saving the template creates the method in
+    // the receiver's class; on a clean compile, re-enter the sender so Resume
+    // re-dispatches into it. A bad compile keeps the pending state for a re-save.
+    if (this.pendingOverrideUri !== undefined && doc.uri.toString() === this.pendingOverrideUri) {
+      if (this.recompileFailed(doc.uri)) return;
+      const selector = this.pendingOverrideSelector ?? '';
+      const senderLevel = this.pendingOverrideSenderLevel;
+      this.pendingOverrideUri = undefined;
+      this.pendingOverrideSelector = undefined;
+      this.pendingOverrideSenderLevel = undefined;
+      void this.finishOverrideMethod(selector, senderLevel);
+      return;
+    }
+
     if (this.editableSourceUri === undefined || this.selectedServerLevel === undefined) return;
     if (doc.uri.toString() !== this.editableSourceUri) return;
     // The recompile failed if the FS provider left an error diagnostic on the URI
@@ -1842,6 +1996,8 @@ export class DebuggerPanel {
       serverLevel: r.serverLevel,
       label: r.label,
       isExecutedCode: r.isExecutedCode,
+      overridable: r.overridable,
+      receiverClass: r.receiverClassName,
       // Executed-code frames have no meaningful step point/line once unwrapped (#3).
       position: r.isExecutedCode ? '' : formatFramePosition(r.stepPoint, r.line),
     }));
@@ -1880,11 +2036,11 @@ export class DebuggerPanel {
     const home = this.resolveHomeMethod(homeMethodOop);
 
     let label: string;
+    let receiverClass: string | undefined;
     if (home.definingClassName) {
       const definingClass = `${home.definingClassName}${home.isMeta ? ' class' : ''}`;
       // Receiver class drives the `Receiver (Defining)` disambiguation for
       // inherited methods (non-block frames only — see formatFrameLabel).
-      let receiverClass: string | undefined;
       if (!isBlock) {
         try {
           receiverClass = debug.getObjectClassName(this.session, info.receiverOop);
@@ -1895,6 +2051,13 @@ export class DebuggerPanel {
       label = 'Executed Code';
     }
     const isExecutedCode = home.isExecutedCode;
+    // The running method was inherited iff the receiver's class differs from the
+    // method's defining class — the precise condition for offering "Implement in
+    // <ReceiverClass>" (override). (getObjectClassName returns "Foo class" for a
+    // class receiver, so a class-side inherited method qualifies too.)
+    const overridable = !isBlock && !isExecutedCode && !!receiverClass
+      && receiverClass !== home.definingClassName
+      && receiverClass !== `${home.definingClassName} class`;
 
     let line: number | undefined;
     try {
@@ -1909,7 +2072,7 @@ export class DebuggerPanel {
     return {
       serverLevel: level, methodOop: info.methodOop, homeMethodOop, isBlock,
       definingClassName: home.definingClassName, selector: home.selector,
-      isExecutedCode, label, line, stepPoint,
+      isExecutedCode, receiverClassName: receiverClass, overridable, label, line, stepPoint,
     };
   }
 
@@ -2234,6 +2397,7 @@ export class DebuggerPanel {
   </div>
   <div id="ctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="copyFrameItem" role="menuitem">Copy Frame</div>
+    <div class="ctx-item" id="frameImplItem" role="menuitem" style="display:none;">Implement in receiver</div>
   </div>
   <div id="varctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="varInspectItem" role="menuitem">GT Inspect</div>
@@ -2245,6 +2409,7 @@ export class DebuggerPanel {
       list: document.getElementById('stack'),
       menu: document.getElementById('ctxmenu'),
       copyFrameItem: document.getElementById('copyFrameItem'),
+      frameImplItem: document.getElementById('frameImplItem'),
       copyBtn: document.getElementById('copyBtn'),
       error: document.getElementById('error'),
       dnuBar: document.getElementById('dnuBar'),

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -1149,13 +1149,15 @@ export class DebuggerPanel {
       ? ` NOTE: ${shadowedBy} already implements ${sel}, so the frame still shows ${shadowedBy}>>${sel}.`
       : '';
     if (senderLevel === undefined) {
-      // No re-enterable caller (the send came straight from a workspace doit, or
-      // the only caller is the top frame) — we CAN'T re-dispatch in place. Resume
-      // would just finish the inherited version that's already running, NOT the
-      // new override. The honest next step is to re-run the expression.
-      this.errorMessage = `Saved ${sel}${inTarget}. The current frame is still running the inherited `
-        + 'version it already entered — re-run the expression to dispatch into the new method. '
-        + `(Resume here just finishes the old one.)${shadowNote}`;
+      // No re-enterable caller (the send came from a workspace doit/block, or the
+      // only caller is the top frame), so we can't re-dispatch THIS in-flight call
+      // in place. But the method now exists: the next time the selector is sent it
+      // dispatches into the new version — so Resume (which finishes the in-flight
+      // call with the old method, then continues — e.g. the next loop iteration)
+      // or a fresh re-run will use it.
+      this.errorMessage = `Saved ${sel}${inTarget} — used on the next ${sel} send. Resume (▶) to `
+        + 'continue (the call now on the stack finishes with the previously-found version), or '
+        + `re-run the expression.${shadowNote}`;
       this.postInit();
       return;
     }

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -7,7 +7,7 @@ import * as debug from './debugQueries';
 import * as queries from './browserQueries';
 import { unwrapTranscriptCapture, transcriptCaptureUserCodeOffset } from './transcriptCapture';
 import { GtInspector } from './gtInspector';
-import { logError } from './gciLog';
+import { logError, logInfo } from './gciLog';
 import { NbCancelledError } from './nbRunner';
 
 // The webview's DOM behavior lives in a standalone file (like listFilter.js /
@@ -1041,6 +1041,8 @@ export class DebuggerPanel {
 
     // One candidate → go straight in. Several → let the user pick where in the
     // chain to implement (receiver's class first; each marked override vs edit).
+    logInfo(`[Jasper Debugger] implementInReceiver #${selector}: chain = `
+      + chain.map(c => `${c.className}${c.implementsSelector ? '(impl)' : ''}`).join(' → '));
     let targetIndex = 0;
     if (chain.length > 1) {
       const pick = await vscode.window.showQuickPick(
@@ -1051,7 +1053,13 @@ export class DebuggerPanel {
             : `override here (in ${c.dictName})`,
           index: i,
         })),
-        { placeHolder: `Implement #${selector} in which class? (receiver is ${chain[0].className})` },
+        {
+          placeHolder: `Implement #${selector} in which class? (receiver is ${chain[0].className})`,
+          // The right-click happens IN the webview, which keeps/regains focus —
+          // without this the QuickPick loses focus and auto-dismisses before the
+          // user can see it (it just flashes). Keep it open until an explicit pick.
+          ignoreFocusOut: true,
+        },
       );
       if (this.disposed) return;          // panel closed while the pick was open
       if (!pick) return;                  // user cancelled — open nothing

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -677,6 +677,10 @@ export class DebuggerPanel {
   private pendingOverrideUri: string | undefined;
   private pendingOverrideSelector: string | undefined;
   private pendingOverrideSenderLevel: number | undefined;
+  /** Set when the chosen target is shadowed by a more-specific subclass impl;
+   *  surfaced after save so the user understands why the re-entered frame still
+   *  shows the subclass method, not the one they just implemented. */
+  private pendingOverrideShadowedBy: string | undefined;
   /**
    * Suppresses the "Create #sel" button once a create is underway or resolved, so
    * it never reappears for the SAME parked doesNotUnderstand: (the method now
@@ -990,13 +994,25 @@ export class DebuggerPanel {
 
   /**
    * "Implement <selector> in <ReceiverClass>" (T2/T3 override): the selected
-   * frame is running a method the receiver INHERITED; open a template to create
-   * that selector in the receiver's OWN class. Reuses the create-method-from-DNU
-   * machinery (template editor + buildMethodStub), but the target class comes
-   * from the receiver (getClassHomeInfo) and the selector/arg-count from the
-   * frame. On a clean save, `finishOverrideMethod` re-enters the SENDER so a
-   * Resume re-dispatches the send into the new override (the frame is "reset to
-   * that method"). Degrades with the same in-band error help as the DNU path.
+   * frame is running a method the receiver INHERITED; open an editor to implement
+   * that selector somewhere along the receiver's inheritance chain. The candidate
+   * classes (getReceiverClassChain — the receiver's class up through Object) and
+   * the selector/arg-count come from the frame. With more than one candidate, a
+   * QuickPick lets the user choose where in the hierarchy to implement (the
+   * receiver's class is pre-selected); each entry notes its home dictionary and
+   * whether it ALREADY implements the selector.
+   *
+   * For a class that does NOT yet implement it → a pre-filled stub (reuses the
+   * create-method-from-DNU template machinery). For one that ALREADY does → its
+   * EXISTING source opens (never clobbered with a stub). Either way, on a clean
+   * save `finishOverrideMethod` re-enters the SENDER so a Resume re-dispatches the
+   * send into the new code (the frame is "reset to that method").
+   *
+   * SHADOWING: if a SUBCLASS between the receiver and the chosen target already
+   * implements the selector, method lookup for this receiver still finds that
+   * subclass method, so the re-entered frame shows the subclass — not the new
+   * one. We detect that and tell the user why. Degrades with the same in-band
+   * error help as the DNU path.
    */
   private async implementInReceiver(displayLevel: number): Promise<void> {
     const frame = this.frames.find(f => f.level === displayLevel);
@@ -1014,12 +1030,34 @@ export class DebuggerPanel {
       this.postInit();
       return;
     }
-    const target = debug.getClassHomeInfo(this.session, receiverOop);
-    if (!target) {
+    // The receiver's class and every superclass up to Object — each a place the
+    // selector could be implemented, flagged with whether it already is.
+    const chain = debug.getReceiverClassChain(this.session, receiverOop, selector);
+    if (chain.length === 0) {
       this.errorMessage = `Could not resolve the receiver's class to implement #${selector}.`;
       this.postInit();
       return;
     }
+
+    // One candidate → go straight in. Several → let the user pick where in the
+    // chain to implement (receiver's class first; each marked override vs edit).
+    let targetIndex = 0;
+    if (chain.length > 1) {
+      const pick = await vscode.window.showQuickPick(
+        chain.map((c, i) => ({
+          label: c.className,
+          description: !c.dictName ? '(not in your symbol list)'
+            : c.implementsSelector ? `already implements #${selector} — opens it to edit (in ${c.dictName})`
+            : `override here (in ${c.dictName})`,
+          index: i,
+        })),
+        { placeHolder: `Implement #${selector} in which class? (receiver is ${chain[0].className})` },
+      );
+      if (this.disposed) return;          // panel closed while the pick was open
+      if (!pick) return;                  // user cancelled — open nothing
+      targetIndex = pick.index;
+    }
+    const target = chain[targetIndex];
     if (!target.dictName) {
       // No home dictionary → no editable gemstone:// URI (same guard as the DNU path).
       this.errorMessage = `Can't implement #${selector}: ${target.className} isn't in your symbol `
@@ -1028,30 +1066,49 @@ export class DebuggerPanel {
       return;
     }
 
-    const uri = this.gemstoneMethodUri(target.dictName, target.className, target.isMeta, 'new-method');
-    // On a clean save the FS provider swaps the template tab to the real method
-    // URI — built EXACTLY as the provider builds it (see createDnuMethod) so the
-    // close-on-dispose match works.
+    // Shadowing: the method actually used by this receiver is the FIRST class in
+    // the chain (most specific) that implements the selector. If that class is
+    // strictly below the chosen target, the new/edited target method is shadowed.
+    const activeIndex = chain.findIndex(c => c.implementsSelector);
+    const shadowedBy = activeIndex >= 0 && activeIndex < targetIndex ? chain[activeIndex].className : undefined;
+
+    // For a class that already implements the selector, open its EXISTING source
+    // (no stub → never clobber a real method). Otherwise open a pre-filled stub.
+    const editingExisting = target.implementsSelector === true;
     const compiledUri = this.gemstoneMethodUri(target.dictName, target.className, target.isMeta, selector);
+    // selector 'new-method' is the FS provider's template URI; for an edit we open
+    // the real method URI directly. Built EXACTLY as the provider builds it (see
+    // createDnuMethod) so the close-on-dispose match works.
+    const openUri = editingExisting
+      ? compiledUri
+      : this.gemstoneMethodUri(target.dictName, target.className, target.isMeta, 'new-method');
     // The caller of the overridden frame — re-entered on save so the send
-    // re-dispatches into the new override. The displayed stack is ordered
+    // re-dispatches into the new code. The displayed stack is ordered
     // top(1)→base(N), so the sender is the NEXT-deeper displayed frame.
     const idx = this.frames.indexOf(frame);
     const sender = idx >= 0 ? this.frames[idx + 1] : undefined;
     try {
-      await this.openTemplateEditor(uri, buildMethodStub(selector, selectorArgCount(selector)));
-      this.pendingOverrideUri = uri.toString();
+      await this.openTemplateEditor(
+        openUri, editingExisting ? undefined : buildMethodStub(selector, selectorArgCount(selector)));
+      this.pendingOverrideUri = openUri.toString();
       this.pendingOverrideSelector = selector;
       this.pendingOverrideSenderLevel =
         sender && !sender.isExecutedCode && sender.serverLevel > 1 ? sender.serverLevel : undefined;
-      this.dnuMethodUris.add(uri.toString());      // closed with the panel
+      this.pendingOverrideShadowedBy = shadowedBy;
+      this.dnuMethodUris.add(openUri.toString());  // closed with the panel
       this.dnuMethodUris.add(compiledUri.toString());
       DebuggerPanel.persistLiveSourceUris();
       // Banner-only guidance (NOT postInit — that re-selects the top frame and
-      // steals focus from the template we just opened; see createDnuMethod).
-      this.errorMessage = `Editing new method #${selector} in ${target.className} below — fill in the `
-        + 'body, then save it (Ctrl+S / Cmd+S) to create it. The frame will then re-enter the new method.';
-      this.panel.webview.postMessage({ command: 'banner', text: this.errorMessage });
+      // steals focus from the editor we just opened; see createDnuMethod).
+      const verb = editingExisting ? `Editing existing #${selector} in` : `Editing new method #${selector} in`;
+      let text = `${verb} ${target.className} below — edit the body, then save it (Ctrl+S / Cmd+S). `
+        + 'The frame will then re-enter it.';
+      if (shadowedBy) {
+        text += ` NOTE: ${shadowedBy} already implements #${selector}, so a ${chain[0].className} still `
+          + `uses ${shadowedBy}>>#${selector} — the frame will show that, not ${target.className}'s.`;
+      }
+      this.errorMessage = text;
+      this.panel.webview.postMessage({ command: 'banner', text });
     } catch (e: unknown) {
       logError(this.sessionId, e instanceof Error ? e.message : String(e));
       this.errorMessage = `Could not open a method template: ${e instanceof Error ? e.message : String(e)}`;
@@ -1066,10 +1123,17 @@ export class DebuggerPanel {
    * the new method. When there's no re-enterable sender (a workspace/top caller),
    * the method still exists; tell the user to re-run. Mirrors finishDnuMethod.
    */
-  private async finishOverrideMethod(selector: string, senderLevel: number | undefined): Promise<void> {
+  private async finishOverrideMethod(
+    selector: string, senderLevel: number | undefined, shadowedBy: string | undefined,
+  ): Promise<void> {
     const sel = selector ? `#${selector}` : 'the method';
+    // When a more-specific subclass already implements the selector, the receiver
+    // keeps using THAT method — explain why the frame won't show the new one.
+    const shadowNote = shadowedBy
+      ? ` (NOTE: ${shadowedBy} already implements ${sel}, so the frame still shows ${shadowedBy}>>${sel}.)`
+      : '';
     if (senderLevel === undefined) {
-      this.errorMessage = `Created ${sel} — press Resume (▶) or re-run the send to dispatch into the new method.`;
+      this.errorMessage = `Saved ${sel} — press Resume (▶) or re-run the send to dispatch into it.${shadowNote}`;
       this.postInit();
       return;
     }
@@ -1081,8 +1145,8 @@ export class DebuggerPanel {
       this.dnuSuppressed = false;
       this.frames = this.fetchStack();
       this.dnuInfo = this.detectDnu();
-      this.errorMessage = `Created ${sel} — re-entered the calling frame. Press Resume (▶) to `
-        + 'dispatch into the new method, or step into it.';
+      this.errorMessage = `Saved ${sel} — re-entered the calling frame. Press Resume (▶) to `
+        + `dispatch into it, or step into it.${shadowNote}`;
       this.postInit();
     });
   }
@@ -1095,7 +1159,7 @@ export class DebuggerPanel {
    * body). Mirrors showSourceEditor's docking so the first open splits a group
    * beneath the panel; later opens reuse that group.
    */
-  private async openTemplateEditor(uri: vscode.Uri, stub: string): Promise<vscode.TextEditor> {
+  private async openTemplateEditor(uri: vscode.Uri, stub?: string): Promise<vscode.TextEditor> {
     const firstOpen = this.sourceColumn === undefined;
     if (firstOpen) {
       try {
@@ -1111,10 +1175,15 @@ export class DebuggerPanel {
     });
     this.sourceColumn = editor.viewColumn ?? this.sourceColumn;
     this.sourceEditor = editor;
-    // Replace the whole document with the pre-filled stub.
-    const lastLine = Math.max(0, editor.document.lineCount - 1);
-    const end = editor.document.lineAt(lastLine).range.end;
-    await editor.edit(b => b.replace(new vscode.Range(new vscode.Position(0, 0), end), stub));
+    // Replace the whole document with the pre-filled stub — but ONLY for a fresh
+    // template. When `stub` is omitted (implementing in a class that ALREADY has
+    // the selector), leave the FS provider's existing source so we never clobber
+    // a real method with a placeholder body.
+    if (stub !== undefined) {
+      const lastLine = Math.max(0, editor.document.lineCount - 1);
+      const end = editor.document.lineAt(lastLine).range.end;
+      await editor.edit(b => b.replace(new vscode.Range(new vscode.Position(0, 0), end), stub));
+    }
     this.shownSourceUris.add(uri.toString()); // closed with the panel
     DebuggerPanel.persistLiveSourceUris();
     if (firstOpen) await this.applySourcePaneRatio();
@@ -1638,10 +1707,12 @@ export class DebuggerPanel {
       if (this.recompileFailed(doc.uri)) return;
       const selector = this.pendingOverrideSelector ?? '';
       const senderLevel = this.pendingOverrideSenderLevel;
+      const shadowedBy = this.pendingOverrideShadowedBy;
       this.pendingOverrideUri = undefined;
       this.pendingOverrideSelector = undefined;
       this.pendingOverrideSenderLevel = undefined;
-      void this.finishOverrideMethod(selector, senderLevel);
+      this.pendingOverrideShadowedBy = undefined;
+      void this.finishOverrideMethod(selector, senderLevel, shadowedBy);
       return;
     }
 

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -1097,6 +1097,9 @@ export class DebuggerPanel {
     // top(1)→base(N), so the sender is the NEXT-deeper displayed frame.
     const idx = this.frames.indexOf(frame);
     const sender = idx >= 0 ? this.frames[idx + 1] : undefined;
+    logInfo(`[Jasper Debugger] implement #${selector} in ${target.className}: `
+      + `overridden frame = ${frame.label}@sv${frame.serverLevel} (display ${frame.level}); `
+      + `sender = ${sender ? `${sender.label}@sv${sender.serverLevel} executedCode=${sender.isExecutedCode}` : 'none'}`);
     try {
       await this.openTemplateEditor(
         openUri, editingExisting ? undefined : buildMethodStub(selector, selectorArgCount(selector)));
@@ -1671,6 +1674,8 @@ export class DebuggerPanel {
    * re-enters the same method one level up).
    */
   private async restartFrame(serverLevel: number): Promise<void> {
+    logInfo(`[Jasper Debugger] restartFrame: trimming to serverLevel ${serverLevel} `
+      + `(stack tops: ${this.frames.slice(0, 4).map(f => `${f.level}=${f.label}@sv${f.serverLevel}`).join(', ')})`);
     if (serverLevel <= 1) {
       // Show the notice IN the panel (the banner) — a toast is easy to miss while
       // the webview has focus. It clears on the next step/resume/restart.

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -500,6 +500,67 @@ export class DebuggerPanel {
    */
   private static savedSourceRatio: number | undefined;
 
+  /**
+   * Workspace-state key + handle for reaping orphaned companion source tabs.
+   *
+   * The companion source editor is a real text-editor tab (a `gemstone://`
+   * method or our `gemstone-debug:` doc), which VS Code persists and restores
+   * across a window close — unlike the webview panel, which is dropped (we
+   * register no serializer). So if the window is closed while a debugger is
+   * open, `dispose()` → `closeSourceEditors()` can't win the shutdown race (the
+   * async tab close isn't persisted), and the source tab comes back next launch
+   * orphaned — and broken, since there's no live session to resolve `gemstone://`.
+   *
+   * Fix: keep the set of currently-open debugger source URIs in `workspaceState`
+   * (rewritten as the union of all live panels whenever it changes; emptied on
+   * clean dispose). On the next activation `initSourceTabCleanup` closes whatever
+   * is left over — exactly the tabs a window-close-with-debugger-open orphaned —
+   * then re-arms a fresh set. Tracking only our own URIs means a System Browser
+   * tab the user opened independently is never touched.
+   */
+  private static orphanState: vscode.Memento | undefined;
+  private static readonly ORPHAN_SOURCE_KEY = 'jasper.debugger.orphanSourceUris';
+
+  /**
+   * Arm orphan-source-tab cleanup for this window: close any source tab a prior
+   * session left open at window close, then re-arm a fresh (empty) set. Call once
+   * from `activate()` with `context.workspaceState`.
+   */
+  static initSourceTabCleanup(state: vscode.Memento): void {
+    DebuggerPanel.orphanState = state;
+    const orphans = state.get<string[]>(DebuggerPanel.ORPHAN_SOURCE_KEY, []);
+    // Re-arm immediately; live panels re-populate as they open source editors.
+    void state.update(DebuggerPanel.ORPHAN_SOURCE_KEY, undefined);
+    if (orphans.length === 0) return;
+    const wanted = new Set(orphans);
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        if (tab.input instanceof vscode.TabInputText && wanted.has(tab.input.uri.toString())) {
+          void vscode.window.tabGroups.close(tab);
+        }
+      }
+    }
+  }
+
+  /**
+   * Rewrite the persisted orphan set as the union of every live panel's open
+   * source URIs. Called after any panel opens/closes a source tab so the set
+   * always reflects what's currently open — if the window dies abruptly, the
+   * leftover set is exactly what needs reaping next launch. No-op until armed.
+   */
+  private static persistLiveSourceUris(): void {
+    const state = DebuggerPanel.orphanState;
+    if (!state) return;
+    const uris = new Set<string>();
+    for (const set of DebuggerPanel.panels.values()) {
+      for (const dbg of set) {
+        for (const u of dbg.shownSourceUris) uris.add(u);
+        for (const u of dbg.dnuMethodUris) uris.add(u);
+      }
+    }
+    void state.update(DebuggerPanel.ORPHAN_SOURCE_KEY, uris.size ? Array.from(uris) : undefined);
+  }
+
   private static ensureReadOnlySourceProvider(): void {
     if (DebuggerPanel.providerRegistered) return;
     DebuggerPanel.providerRegistered = true;
@@ -867,6 +928,7 @@ export class DebuggerPanel {
       this.pendingDnuMethodUri = uri.toString();
       this.dnuMethodUris.add(uri.toString());
       this.dnuMethodUris.add(compiledUri.toString());
+      DebuggerPanel.persistLiveSourceUris();
       this.pendingDnuSelector = dnu.selector;
       // Replace the DNU error with what-to-do guidance — the most visible spot, and
       // the next step is the user's (the original complaint was that nothing said to
@@ -914,6 +976,7 @@ export class DebuggerPanel {
     const end = editor.document.lineAt(lastLine).range.end;
     await editor.edit(b => b.replace(new vscode.Range(new vscode.Position(0, 0), end), stub));
     this.shownSourceUris.add(uri.toString()); // closed with the panel
+    DebuggerPanel.persistLiveSourceUris();
     if (firstOpen) await this.applySourcePaneRatio();
     return editor;
   }
@@ -1604,6 +1667,7 @@ export class DebuggerPanel {
       preserveFocus: true,
     });
     this.shownSourceUris.add(uri.toString()); // closed with the panel (see dispose)
+    DebuggerPanel.persistLiveSourceUris();
     this.sourceColumn = editor.viewColumn ?? this.sourceColumn;
     this.sourceEditor = editor; // live .viewColumn used at close time (see field doc)
     // Size the brand-new source group: re-apply the user's remembered ratio (or
@@ -2218,6 +2282,10 @@ export class DebuggerPanel {
     // Close the companion source editor and any GT Inspectors this debugger
     // opened — they're artifacts of this debugger and shouldn't outlive it.
     this.closeSourceEditors();
+    // Drop this panel's source tabs from the persisted orphan set (it was already
+    // removed from `panels` above, so the union now excludes it). A clean dispose
+    // thus leaves nothing to reap; only a window-close-with-debugger-open does.
+    DebuggerPanel.persistLiveSourceUris();
     for (const inspector of this.openedInspectors) inspector.close();
     this.openedInspectors.clear();
     // Release this panel's stashed read-only source.

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import { ActiveSession } from './sessionManager';
 import * as debug from './debugQueries';
 import * as queries from './browserQueries';
-import { unwrapTranscriptCapture } from './transcriptCapture';
+import { unwrapTranscriptCapture, transcriptCaptureUserCodeOffset } from './transcriptCapture';
 import { GtInspector } from './gtInspector';
 import { logError } from './gciLog';
 import { NbCancelledError } from './nbRunner';
@@ -512,6 +512,13 @@ export class DebuggerPanel {
   private disposables: vscode.Disposable[] = [];
   /** Last fetched (filtered) stack, cached so copy/select need not re-query. */
   private frames: DisplayFrame[] = [];
+  /**
+   * The UN-filtered raw stack from the same fetch. `filterStack` collapses a
+   * doit's wrapper/block frames into a single "Executed Code" frame, discarding
+   * the frame execution actually stopped in — so the highlight path consults
+   * these to find the true stop frame (see `stopFrameLevel`).
+   */
+  private rawFrames: RawFrame[] = [];
   /** Column the companion source editor lives in, reused across frame selects. */
   private sourceColumn: vscode.ViewColumn | undefined;
   /**
@@ -1319,11 +1326,14 @@ export class DebuggerPanel {
 
       let uri: vscode.Uri;
       let methodForOffsets: { className: string; isMeta: boolean; selector: string } | undefined;
-      // For a read-only view we can still highlight the step point IF the
-      // displayed source matches the server's method source 1:1 (a raw Debug It
-      // doit). Set to the frame's method OOP in that case; left undefined when
-      // the source was unwrapped (offsets would point into the wrapped source).
+      // For a read-only view we still highlight the step point from the frame's
+      // method OOP. The server's step-point offsets are in the stored source's
+      // coordinates; when the displayed source was unwrapped from the Transcript-
+      // capture glue (Display It / Execute It / Inspect It), shift them by the
+      // stripped prefix so they land in the user code. `readOnlyOffsetShift` is 0
+      // for a raw Debug It / non-symbol-list method shown 1:1.
       let readOnlyOffsetMethodOop: bigint | undefined;
+      let readOnlyOffsetShift = 0;
       if (home.uriInfo) {
         // In the symbol list → the real editable gemstone:// editor.
         uri = vscode.Uri.parse(buildMethodSourceUri(this.session.id, home.uriInfo));
@@ -1347,11 +1357,12 @@ export class DebuggerPanel {
         // line up. (This mirrors the editable path, which uses home offsets.)
         const rawSource = debug.getMethodSource(this.session, homeMethodOop);
         const source = unwrapTranscriptCapture(rawSource);
-        // If unwrapping was a no-op the displayed source is the server source,
-        // so the server's step-point offsets map onto it directly (Debug It).
-        // If it stripped a wrapper, the offsets refer to the wrapped source and
-        // would mis-highlight, so leave highlighting off (as before).
-        if (source === rawSource) readOnlyOffsetMethodOop = homeMethodOop;
+        // Highlight from the home method's offsets, shifted into the displayed
+        // source's coordinates. The shift is 0 when nothing was unwrapped (the
+        // displayed source IS the server source — a raw Debug It), and the
+        // stripped-prefix length when the Transcript-capture glue was removed.
+        readOnlyOffsetMethodOop = homeMethodOop;
+        readOnlyOffsetShift = transcriptCaptureUserCodeOffset(rawSource);
         const title = home.isExecutedCode ? 'Executed Code' : `${home.definingClassName}>>#${home.selector}`;
         uri = DebuggerPanel.stashReadOnlySource(this.session.id, homeMethodOop, title, source);
         this.stashedSourceKeys.add(uri.toString());
@@ -1359,14 +1370,27 @@ export class DebuggerPanel {
 
       const editor = await this.showSourceEditor(uri);
 
+      // For a collapsed "Executed Code" doit frame, the displayed level is the
+      // deepest doit frame, but execution actually stopped in a nested wrapper
+      // block above it (Display It / Execute It / Inspect It). Query the step
+      // point from the true stop frame so the marker lands on the user's halt
+      // rather than the wrapper glue. Other frames show un-collapsed, so they
+      // stop where they display (highlightLevel === level).
+      const highlightLevel = home.isExecutedCode ? this.stopFrameLevel(homeMethodOop, level) : level;
+      let highlightInfo = info;
+      if (highlightLevel !== level) {
+        try { highlightInfo = debug.getFrameInfo(this.session, this.gsProcess, highlightLevel); }
+        catch { /* keep the displayed frame's info for the line fallback */ }
+      }
+
       // Highlight the current step point: from class>>selector offsets for an
-      // editable method, or from the method OOP for an un-wrapped read-only doit
-      // (Debug It). A wrapped/unwrappable read-only view stays un-highlighted —
-      // its offsets wouldn't line up with the displayed source.
+      // editable method, or from the method OOP for a read-only doit — shifting
+      // the offsets into the displayed source when the Transcript-capture glue
+      // was stripped (Display It / Execute It / Inspect It).
       const range = methodForOffsets
-        ? this.stepPointRange(editor.document, info, level, methodForOffsets)
+        ? this.stepPointRange(editor.document, highlightInfo, highlightLevel, methodForOffsets)
         : readOnlyOffsetMethodOop !== undefined
-          ? this.stepPointRange(editor.document, info, level, undefined, readOnlyOffsetMethodOop)
+          ? this.stepPointRange(editor.document, highlightInfo, highlightLevel, undefined, readOnlyOffsetMethodOop, readOnlyOffsetShift)
           : undefined;
       // Clear a stale highlight if the source moved to a different editor.
       if (this.decoratedEditor && this.decoratedEditor !== editor) {
@@ -1473,6 +1497,27 @@ export class DebuggerPanel {
   }
 
   /**
+   * The server level of the frame execution actually stopped in, for a collapsed
+   * "Executed Code" doit frame. `filterStack` keeps only the DEEPEST executed-code
+   * frame (the doit home), but for wrapped code (Display It / Execute It / Inspect
+   * It) the halt is in a nested wrapper block ABOVE it. All of the doit's frames —
+   * the wrapper blocks and the doit home — share its `homeMethodOop`, while
+   * machinery and unrelated user-method frames do not, so the stop frame is the
+   * TOPMOST raw frame (lowest server level) with that home method.
+   *
+   * Resolves to the doit home itself when nothing nests above it (a raw Debug It,
+   * or a doit that just called into a user method), and to `fallbackLevel` if the
+   * raws are unavailable — so the caller can use it unconditionally.
+   */
+  private stopFrameLevel(homeMethodOop: bigint, fallbackLevel: number): number {
+    // rawFrames is in server order (top first), so the first match is the topmost.
+    for (const r of this.rawFrames) {
+      if (r.homeMethodOop === homeMethodOop) return r.serverLevel;
+    }
+    return fallbackLevel;
+  }
+
+  /**
    * The range to highlight for a frame's current step point — just the token at
    * the step point, NOT the whole line. Prefers the exact step-point character
    * offset (`getSourceOffsets`, available for class>>selector methods); falls
@@ -1485,13 +1530,15 @@ export class DebuggerPanel {
     level: number,
     method: { className: string; isMeta: boolean; selector: string } | undefined,
     readOnlyMethodOop?: bigint,
+    readOnlyOffsetShift = 0,
   ): vscode.Range | undefined {
     let pos: vscode.Position | undefined;
 
     // Exact step-point offset → the precise sub-expression start. The offsets
     // come from class>>selector for an editable method, or straight from the
-    // method OOP for a raw doit (Debug It), whose displayed source matches the
-    // server source 1:1 so the offsets line up.
+    // method OOP for a read-only doit. For a doit shown with its Transcript-
+    // capture glue stripped, the offsets are in the stored (wrapped) source's
+    // coordinates, so shift them into the displayed source.
     if (method || readOnlyMethodOop !== undefined) {
       try {
         const stepPoint = debug.getStepPoint(this.session, this.gsProcess, level);
@@ -1503,13 +1550,20 @@ export class DebuggerPanel {
             ? queries.getSourceOffsets(this.session, method.className, method.isMeta, method.selector)
             : debug.getSourceOffsetsForMethod(this.session, readOnlyMethodOop!);
           const offset = offsets[stepPoint - 1];
-          if (offset != null && offset >= 1 && doc.positionAt) pos = doc.positionAt(offset - 1);
+          const displayOffset = offset != null ? offset - 1 - readOnlyOffsetShift : -1;
+          // A negative offset means the step point sits before the displayed
+          // source (in the stripped Transcript-capture prefix) — skip it rather
+          // than let positionAt clamp the highlight to the document start.
+          if (displayOffset >= 0 && doc.positionAt) pos = doc.positionAt(displayOffset);
         }
       } catch { /* best-effort; fall back to the IP line below */ }
     }
 
-    // Fallback: the first non-whitespace token of the IP's source line.
-    if (!pos) {
+    // Fallback: the first non-whitespace token of the IP's source line. Only
+    // valid when the displayed source's line numbering matches the server's —
+    // i.e. an editable method or a 1:1 read-only doit. A stripped wrapper shifts
+    // every line, so skip the fallback there (the offset path above is exact).
+    if (!pos && readOnlyOffsetShift === 0) {
       let line = 0;
       try { line = debug.getLineForIp(this.session, info.methodOop, info.ipOffset); } catch { /* */ }
       if (line > 0) {
@@ -1539,8 +1593,10 @@ export class DebuggerPanel {
       }
     } catch (e: unknown) {
       logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      this.rawFrames = [];
       return [];
     }
+    this.rawFrames = raws; // retained for stopFrameLevel (pre-collapse lookup)
     // Trim machinery/wrapper glue, then renumber the survivors 1..N for display
     // while keeping each one's real server level for subsequent queries.
     return filterStack(raws).map((r, i) => ({

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -667,21 +667,19 @@ export class DebuggerPanel {
   private pendingDnuMethodUri: string | undefined;
   private pendingDnuSelector: string | undefined;
   /**
-   * While an "Implement in <receiverClass>" override template is being edited:
-   * the `gemstone://` new-method URI, the selector being implemented, and the
-   * server level of the SENDER frame (the caller of the overridden method).
-   * Saving the template (a clean compile) re-enters that sender so a Resume
-   * re-dispatches the send into the freshly-created override (so the frame is
-   * "reset to that method"). Undefined sender → can't re-enter; just refresh.
+   * While an "Implement in <class>" template is being edited: the `gemstone://`
+   * URI being edited (a new-method template, or the real method when editing an
+   * existing one), the selector, and the target class (for the save message).
+   * Saving (a clean compile) just refreshes + explains — option B, no auto-trim;
+   * the new method is used on the NEXT send of the selector.
    */
   private pendingOverrideUri: string | undefined;
   private pendingOverrideSelector: string | undefined;
-  private pendingOverrideSenderLevel: number | undefined;
   /** The class the pending override is being implemented in (for the save message). */
   private pendingOverrideTargetClass: string | undefined;
   /** Set when the chosen target is shadowed by a more-specific subclass impl;
-   *  surfaced after save so the user understands why the re-entered frame still
-   *  shows the subclass method, not the one they just implemented. */
+   *  surfaced after save so the user understands why a new send still won't reach
+   *  the method they just implemented higher up the chain. */
   private pendingOverrideShadowedBy: string | undefined;
   /**
    * Suppresses the "Create #sel" button once a create is underway or resolved, so
@@ -1092,21 +1090,14 @@ export class DebuggerPanel {
     const openUri = editingExisting
       ? compiledUri
       : this.gemstoneMethodUri(target.dictName, target.className, target.isMeta, 'new-method');
-    // The caller of the overridden frame — re-entered on save so the send
-    // re-dispatches into the new code. The displayed stack is ordered
-    // top(1)→base(N), so the sender is the NEXT-deeper displayed frame.
-    const idx = this.frames.indexOf(frame);
-    const sender = idx >= 0 ? this.frames[idx + 1] : undefined;
-    logInfo(`[Jasper Debugger] implement #${selector} in ${target.className}: `
-      + `overridden frame = ${frame.label}@sv${frame.serverLevel} (display ${frame.level}); `
-      + `sender = ${sender ? `${sender.label}@sv${sender.serverLevel} executedCode=${sender.isExecutedCode}` : 'none'}`);
+    logInfo(`[Jasper Debugger] implement #${selector} in ${target.className} `
+      + `(${editingExisting ? 'edit existing' : 'new override'}); overridden frame = `
+      + `${frame.label}@sv${frame.serverLevel}${shadowedBy ? `; shadowed by ${shadowedBy}` : ''}`);
     try {
       await this.openTemplateEditor(
         openUri, editingExisting ? undefined : buildMethodStub(selector, selectorArgCount(selector)));
       this.pendingOverrideUri = openUri.toString();
       this.pendingOverrideSelector = selector;
-      this.pendingOverrideSenderLevel =
-        sender && !sender.isExecutedCode && sender.serverLevel > 1 ? sender.serverLevel : undefined;
       this.pendingOverrideShadowedBy = shadowedBy;
       this.pendingOverrideTargetClass = target.className;
       this.dnuMethodUris.add(openUri.toString());  // closed with the panel
@@ -1116,10 +1107,10 @@ export class DebuggerPanel {
       // steals focus from the editor we just opened; see createDnuMethod).
       const verb = editingExisting ? `Editing existing #${selector} in` : `Editing new method #${selector} in`;
       let text = `${verb} ${target.className} below — edit the body, then save it (Ctrl+S / Cmd+S). `
-        + 'The frame will then re-enter it.';
+        + `It's then used on the next #${selector} send.`;
       if (shadowedBy) {
         text += ` NOTE: ${shadowedBy} already implements #${selector}, so a ${chain[0].className} still `
-          + `uses ${shadowedBy}>>#${selector} — the frame will show that, not ${target.className}'s.`;
+          + `uses ${shadowedBy}>>#${selector}, not ${target.className}'s.`;
       }
       this.errorMessage = text;
       this.panel.webview.postMessage({ command: 'banner', text });
@@ -1131,48 +1122,31 @@ export class DebuggerPanel {
   }
 
   /**
-   * After an override method is created (clean compile), re-enter the sender of
-   * the overridden frame (non-blocking trim) so the user's next Resume re-runs
-   * the send and method lookup finds the new override — the frame is reset to
-   * the new method. When there's no re-enterable sender (a workspace/top caller),
-   * the method still exists; tell the user to re-run. Mirrors finishDnuMethod.
+   * After an override method is saved (clean compile), DON'T auto-restart anything
+   * (option B — predictable, no surprising stack jumps): the method now exists and
+   * is used on the NEXT send of the selector. The call already on the stack keeps
+   * running the method it dispatched to; the user Resumes (later sends — e.g. the
+   * next loop iteration — use the new one) or re-runs. We just refresh + explain.
+   * (Unlike DNU, where the send is parked unhandled and MUST be re-dispatched, an
+   * override's send already succeeded into the inherited method.)
    */
   private async finishOverrideMethod(
-    selector: string, senderLevel: number | undefined,
-    shadowedBy: string | undefined, targetClass: string,
+    selector: string, shadowedBy: string | undefined, targetClass: string,
   ): Promise<void> {
     const sel = selector ? `#${selector}` : 'the method';
     const inTarget = targetClass ? ` in ${targetClass}` : '';
     // When a more-specific subclass already implements the selector, the receiver
-    // keeps using THAT method — explain why the frame won't show the new one.
+    // keeps using THAT method — explain why a new send still won't reach this one.
     const shadowNote = shadowedBy
-      ? ` NOTE: ${shadowedBy} already implements ${sel}, so the frame still shows ${shadowedBy}>>${sel}.`
+      ? ` NOTE: ${shadowedBy} already implements ${sel}, so ${shadowedBy}>>${sel} still wins for this receiver.`
       : '';
-    if (senderLevel === undefined) {
-      // No re-enterable caller (the send came from a workspace doit/block, or the
-      // only caller is the top frame), so we can't re-dispatch THIS in-flight call
-      // in place. But the method now exists: the next time the selector is sent it
-      // dispatches into the new version — so Resume (which finishes the in-flight
-      // call with the old method, then continues — e.g. the next loop iteration)
-      // or a fresh re-run will use it.
-      this.errorMessage = `Saved ${sel}${inTarget} — used on the next ${sel} send. Resume (▶) to `
-        + 'continue (the call now on the stack finishes with the previously-found version), or '
-        + `re-run the expression.${shadowNote}`;
-      this.postInit();
-      return;
-    }
-    await this.runNb('Implement in receiver', async () => {
-      await debug.trimStackToLevelNb(this.session, this.gsProcess, senderLevel);
-      if (this.disposed) return;
-      this.staleTopActivation = false; // the trim rebuilt the stack from a fresh activation
-      this.uncontinuable = false;
-      this.dnuSuppressed = false;
-      this.frames = this.fetchStack();
-      this.dnuInfo = this.detectDnu();
-      this.errorMessage = `Saved ${sel}${inTarget} — re-entered the calling frame. Press Resume (▶) `
-        + `to re-send and dispatch into it, or step into it.${shadowNote}`;
-      this.postInit();
-    });
+    this.dnuSuppressed = false;
+    this.frames = this.fetchStack();   // labels/source may have shifted; no trim
+    this.dnuInfo = this.detectDnu();
+    this.errorMessage = `Saved ${sel}${inTarget} — used on the next ${sel} send. Resume (▶) to continue `
+      + '(the call now on the stack finishes with the previously-found version), or re-run the '
+      + `expression.${shadowNote}`;
+    this.postInit();
   }
 
   /**
@@ -1676,8 +1650,6 @@ export class DebuggerPanel {
    * re-enters the same method one level up).
    */
   private async restartFrame(serverLevel: number): Promise<void> {
-    logInfo(`[Jasper Debugger] restartFrame: trimming to serverLevel ${serverLevel} `
-      + `(stack tops: ${this.frames.slice(0, 4).map(f => `${f.level}=${f.label}@sv${f.serverLevel}`).join(', ')})`);
     if (serverLevel <= 1) {
       // Show the notice IN the panel (the banner) — a toast is easy to miss while
       // the webview has focus. It clears on the next step/resume/restart.
@@ -1727,20 +1699,18 @@ export class DebuggerPanel {
     }
 
     // Implement-in-receiver (override): saving the template creates the method in
-    // the receiver's class; on a clean compile, re-enter the sender so Resume
-    // re-dispatches into it. A bad compile keeps the pending state for a re-save.
+    // the chosen class; on a clean compile we just refresh + explain (no trim —
+    // option B). A bad compile keeps the pending state for a re-save.
     if (this.pendingOverrideUri !== undefined && doc.uri.toString() === this.pendingOverrideUri) {
       if (this.recompileFailed(doc.uri)) return;
       const selector = this.pendingOverrideSelector ?? '';
-      const senderLevel = this.pendingOverrideSenderLevel;
       const shadowedBy = this.pendingOverrideShadowedBy;
       const targetClass = this.pendingOverrideTargetClass ?? '';
       this.pendingOverrideUri = undefined;
       this.pendingOverrideSelector = undefined;
-      this.pendingOverrideSenderLevel = undefined;
       this.pendingOverrideShadowedBy = undefined;
       this.pendingOverrideTargetClass = undefined;
-      void this.finishOverrideMethod(selector, senderLevel, shadowedBy, targetClass);
+      void this.finishOverrideMethod(selector, shadowedBy, targetClass);
       return;
     }
 

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -2476,7 +2476,7 @@ export class DebuggerPanel {
   </div>
   <div id="ctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="copyFrameItem" role="menuitem">Copy Frame</div>
-    <div class="ctx-item" id="frameImplItem" role="menuitem" style="display:none;">Implement in receiver</div>
+    <div class="ctx-item" id="frameImplItem" role="menuitem" style="display:none;">Implement in…</div>
   </div>
   <div id="varctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="varInspectItem" role="menuitem">GT Inspect</div>

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -241,6 +241,24 @@
     dnuBarEl.appendChild(btn);
   }
 
+  // Render (or clear) the "Implement #selector" action shown when the process is
+  // parked on a subclassResponsibility (T4) — an abstract method invoked on a
+  // concrete subclass that didn't override it. The target class is chosen via a
+  // picker (like the override flow), so only the selector is shown on the button.
+  // `sr` is { selector } or null/undefined (nothing to implement). Shares the
+  // dnuBar; DNU and subclassResponsibility are mutually-exclusive parked states.
+  function renderSubclassResp(dnuBarEl, sr, onImplement) {
+    if (!dnuBarEl) return;
+    dnuBarEl.innerHTML = '';
+    if (!sr) return;
+    const btn = document.createElement('button');
+    btn.className = 'dnu-btn';
+    btn.textContent = 'Implement #' + sr.selector;
+    btn.title = 'Implement this abstract (subclassResponsibility) method in a concrete class';
+    if (onImplement) btn.addEventListener('click', onImplement);
+    dnuBarEl.appendChild(btn);
+  }
+
   // Mark the frame with the given level selected, clearing any prior selection.
   // Returns the selected <li>, or null when no frame carries that level.
   function selectFrame(listEl, level) {
@@ -496,8 +514,14 @@
       const msg = event.data;
       if (msg.command === 'init') {
         if (error) error.textContent = msg.errorMessage || '';
-        // Show the create-method action when parked on a doesNotUnderstand:.
+        // Show the create-method action when parked on a doesNotUnderstand:, or the
+        // implement action when parked on a subclassResponsibility (T4). Mutually
+        // exclusive; renderDnu(undefined) clears the bar before the SR button renders.
         renderDnu(dnuBar, msg.dnu, function () { vscode.postMessage({ command: 'createDnuMethod' }); });
+        if (!msg.dnu) {
+          renderSubclassResp(dnuBar, msg.subclassResp,
+            function () { vscode.postMessage({ command: 'implementSubclassResponsibility' }); });
+        }
         // Clear stale variables / eval output; the default-select below re-fetches.
         if (variables) variables.innerHTML = '';
         if (evalResult) { evalResult.textContent = ''; evalResult.classList.remove('error'); }
@@ -530,5 +554,5 @@
   }
 
   const root = typeof globalThis !== 'undefined' ? globalThis : window;
-  root.DebuggerView = { renderStack, renderVariables, renderDnu, selectFrame, showMenu, hideMenu, frameLevelOf, init };
+  root.DebuggerView = { renderStack, renderVariables, renderDnu, renderSubclassResp, selectFrame, showMenu, hideMenu, frameLevelOf, init };
 })();

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -56,7 +56,18 @@
   // { title, kind, collapsed?, vars:[{name, value, oop}] }; value is the
   // host-computed printString. onInspect(oop, name) is called when a row is
   // clicked (opens a GT Inspector); it's optional so tests can omit it.
-  function renderVariables(varsEl, groups, onInspect) {
+  // Render the grouped variables. `handlers` (all optional) wires the T1
+  // variable evaluator + GT Inspect:
+  //   contextMenu(e, oop, name) — right-click a row (GT Inspect lives here now).
+  //   commit(edit, expr)        — Enter in an editable row's inline editor;
+  //                               posts the new expression to the host.
+  //   setActiveEditor(ctrl|null)— register the open inline editor so the host's
+  //                               setVariableResult can flag an error on it (and
+  //                               so opening another editor closes the prior one).
+  // A row carries `edit` ({kind,index}) when it's editable (instVars + named/
+  // stack temps); `self` has none and stays read-only.
+  function renderVariables(varsEl, groups, handlers) {
+    handlers = handlers || {};
     varsEl.innerHTML = '';
     if (!groups || groups.length === 0) {
       const d = document.createElement('div');
@@ -81,9 +92,9 @@
       body.className = 'var-group-body';
       for (const v of (g.vars || [])) {
         const row = document.createElement('div');
-        row.className = 'var';
+        row.className = 'var' + (v.edit ? ' editable' : '');
         row.dataset.oop = v.oop;
-        row.title = 'GT Inspect';
+        row.title = v.edit ? 'Click to edit • right-click to Inspect' : 'Right-click to Inspect';
 
         const name = document.createElement('span');
         name.className = 'var-name' + (v.name === 'self' ? ' self' : '');
@@ -97,15 +108,121 @@
 
         row.appendChild(name);
         row.appendChild(val);
+        // Revert (↺) icon — only on slots edited away from their original this
+        // halt. Clicking restores the original; it must not open the editor.
+        if (v.revertible && v.edit) {
+          const rev = document.createElement('span');
+          rev.className = 'var-revert';
+          rev.textContent = '↺';
+          rev.title = 'Revert to original value';
+          rev.addEventListener('click', function (e) {
+            e.stopPropagation();
+            if (handlers.revert) handlers.revert(v.edit);
+          });
+          row.appendChild(rev);
+        }
         row.appendChild(oop);
-        row.addEventListener('click', function () {
-          if (onInspect) onInspect(v.oop, v.name);
+
+        // Right-click → GT Inspect (moved off left-click).
+        row.addEventListener('contextmenu', function (e) {
+          if (handlers.contextMenu) handlers.contextMenu(e, v.oop, v.name);
         });
+        // Left-click → open the variable evaluator (editable rows only). The
+        // guard stops a click on the row padding from stacking a 2nd editor.
+        if (v.edit) {
+          row.addEventListener('click', function () {
+            if (!row.querySelector('.var-edit')) openVarEditor(row, val, v, handlers);
+          });
+        }
         body.appendChild(row);
       }
       group.appendChild(body);
       varsEl.appendChild(group);
     }
+  }
+
+  // Open the inline "variable evaluator" on a row: an input prefilled with the
+  // value's printString (selected). Enter commits the typed expression (the host
+  // evaluates it in the frame and assigns the result); Esc cancels and restores
+  // the displayed value; blur cancels too (unless a commit is in flight). On a
+  // compile/runtime error the host calls ctrl.showError and the editor STAYS so
+  // the expression can be fixed.
+  function openVarEditor(row, valEl, v, handlers) {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'var-edit';
+    input.value = v.value;
+    valEl.style.display = 'none';
+    row.classList.add('editing'); // wraps the error message onto its own line
+    row.insertBefore(input, valEl);
+    input.focus();
+    input.select();
+
+    let pending = false;
+    let closed = false;
+    let errored = false; // an error is on screen → don't auto-close on blur
+    let errEl = null; // the visible error message line (created lazily)
+    function clearError() {
+      errored = false;
+      input.classList.remove('error');
+      input.removeAttribute('title');
+      if (errEl) { if (errEl.parentNode) errEl.parentNode.removeChild(errEl); errEl = null; }
+    }
+    function close() {
+      if (closed) return;
+      closed = true;
+      clearError();
+      if (input.parentNode) input.parentNode.removeChild(input);
+      row.classList.remove('editing');
+      valEl.style.display = '';
+      if (handlers.setActiveEditor) handlers.setActiveEditor(null);
+    }
+    const ctrl = {
+      // Surface a rejected expression unmistakably: red border on the input AND a
+      // visible message line (a hover-only tooltip is too easy to miss). The
+      // editor STAYS open so the expression can be fixed.
+      showError: function (m) {
+        pending = false;
+        errored = true;
+        const text = m || 'Error';
+        input.classList.add('error');
+        input.title = text;
+        if (!errEl) {
+          errEl = document.createElement('div');
+          errEl.className = 'var-edit-error';
+          row.appendChild(errEl);
+        }
+        errEl.textContent = text;
+        input.focus();
+        input.select();
+      },
+      close: close,
+    };
+    if (handlers.setActiveEditor) handlers.setActiveEditor(ctrl);
+
+    input.addEventListener('click', function (e) { e.stopPropagation(); });
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const expr = input.value.trim();
+        if (!expr) { close(); return; }
+        clearError();
+        pending = true;
+        if (handlers.commit) handlers.commit(v.edit, expr);
+        // Stays open: success → the host re-renders variables (removing this
+        // editor); error → ctrl.showError flags it and keeps it open.
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        close();
+      }
+    });
+    input.addEventListener('blur', function () {
+      // Defer so a click that moved focus to (e.g.) the context menu still runs.
+      // While an error is showing, DON'T auto-close — the user may be clicking the
+      // message to select/copy it (blurring the input). Esc still dismisses it.
+      setTimeout(function () { if (!pending && !errored) close(); }, 0);
+    });
   }
 
   // Render (or clear) the "Create #selector in Class" action shown when the
@@ -160,8 +277,35 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, copyBtn, error, dnuBar, toolbar, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar } = refs;
+    const { list, menu, copyFrameItem, copyBtn, error, dnuBar, toolbar, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar, varMenu, varInspectItem } = refs;
     let selectedLevel = null;
+    // The currently-open variable evaluator (so setVariableResult can flag an
+    // error on it, and opening another closes it) + the row a right-click menu
+    // targets.
+    let activeVarEditor = null;
+    let varMenuTarget = null;
+    function setActiveVarEditor(ctrl) {
+      if (ctrl == null) { activeVarEditor = null; return; }
+      if (activeVarEditor && activeVarEditor !== ctrl) activeVarEditor.close();
+      activeVarEditor = ctrl;
+    }
+    // Handlers handed to renderVariables on every refresh.
+    const varHandlers = {
+      contextMenu: function (e, oop, name) {
+        if (!varMenu) return;
+        e.preventDefault();
+        e.stopPropagation();
+        varMenuTarget = { oop: oop, name: name };
+        showMenu(varMenu, e.clientX, e.clientY);
+      },
+      commit: function (edit, expr) {
+        vscode.postMessage({ command: 'setVariable', level: selectedLevel, kind: edit.kind, index: edit.index, expr: expr });
+      },
+      revert: function (edit) {
+        vscode.postMessage({ command: 'revertVariable', level: selectedLevel, kind: edit.kind, index: edit.index });
+      },
+      setActiveEditor: setActiveVarEditor,
+    };
 
     function select(level) {
       if (level == null) return;
@@ -191,6 +335,15 @@
       if (selectedLevel != null) vscode.postMessage({ command: 'copyFrame', level: selectedLevel });
       hideMenu(menu);
     });
+
+    // Variable context menu: GT Inspect the right-clicked variable.
+    if (varInspectItem) {
+      varInspectItem.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (varMenuTarget) vscode.postMessage({ command: 'inspectVariable', oop: varMenuTarget.oop, name: varMenuTarget.name });
+        if (varMenu) hideMenu(varMenu);
+      });
+    }
 
     copyBtn.addEventListener('click', () => {
       vscode.postMessage({ command: 'copyStack' });
@@ -304,11 +457,12 @@
 
     // Suppress the native Cut/Copy/Paste menu everywhere; close our popup on any
     // dismiss gesture (outside click, scroll, focus loss, Escape).
+    function hideMenus() { hideMenu(menu); if (varMenu) hideMenu(varMenu); }
     window.addEventListener('contextmenu', (e) => { e.preventDefault(); });
-    document.addEventListener('click', () => hideMenu(menu));
-    window.addEventListener('scroll', () => hideMenu(menu), true);
-    window.addEventListener('blur', () => hideMenu(menu));
-    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideMenu(menu); });
+    document.addEventListener('click', hideMenus);
+    window.addEventListener('scroll', hideMenus, true);
+    window.addEventListener('blur', hideMenus);
+    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideMenus(); });
 
     // Inbound messages from the host.
     window.addEventListener('message', (event) => {
@@ -324,9 +478,12 @@
         // Default-select the top frame so the debugger opens focused on a frame.
         if (msg.stack && msg.stack.length > 0) select(msg.stack[0].level);
       } else if (msg.command === 'variables') {
-        if (variables) renderVariables(variables, msg.groups, function (oop, name) {
-          vscode.postMessage({ command: 'inspectVariable', oop: oop, name: name });
-        });
+        if (variables) renderVariables(variables, msg.groups, varHandlers);
+      } else if (msg.command === 'setVariableResult') {
+        // Failure → keep the editor open and flag the error so it can be fixed.
+        // Success → the host also posts 'variables', which re-renders (and so
+        // removes the editor) with fresh printStrings + OOPs.
+        if (!msg.ok && activeVarEditor) activeVarEditor.showError(msg.error);
       } else if (msg.command === 'banner') {
         // Lightweight banner-only update (no stack re-render / frame re-select, so
         // it won't steal focus): set the error/guidance text and clear the DNU

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -277,8 +277,12 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, copyBtn, error, dnuBar, toolbar, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar, varMenu, varInspectItem } = refs;
+    const { list, menu, copyFrameItem, frameImplItem, copyBtn, error, dnuBar, toolbar, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar, varMenu, varInspectItem } = refs;
     let selectedLevel = null;
+    // The last-rendered stack (frame summaries), so the right-click menu can read
+    // a frame's `overridable` / `receiverClass` to decide whether to offer the
+    // "Implement in <receiverClass>" override action.
+    let currentStack = [];
     // The currently-open variable evaluator (so setVariableResult can flag an
     // error on it, and opening another closes it) + the row a right-click menu
     // targets.
@@ -320,13 +324,24 @@
       if (level != null) select(level);
     });
 
-    // Right-click selects the frame AND opens the custom copy popup.
+    // Right-click selects the frame AND opens the custom popup. The "Implement in
+    // <receiverClass>" item is shown only for an overridable frame (an inherited
+    // method — see buildFrame), labelled with the receiver's class.
     list.addEventListener('contextmenu', (e) => {
       const level = frameLevelOf(e.target);
       if (level == null) return;
       e.preventDefault();
       e.stopPropagation();
       select(level);
+      if (frameImplItem) {
+        const frame = currentStack.find((f) => f.level === level);
+        if (frame && frame.overridable) {
+          frameImplItem.textContent = 'Implement in ' + (frame.receiverClass || 'receiver');
+          frameImplItem.style.display = '';
+        } else {
+          frameImplItem.style.display = 'none';
+        }
+      }
       showMenu(menu, e.clientX, e.clientY);
     });
 
@@ -335,6 +350,14 @@
       if (selectedLevel != null) vscode.postMessage({ command: 'copyFrame', level: selectedLevel });
       hideMenu(menu);
     });
+
+    if (frameImplItem) {
+      frameImplItem.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (selectedLevel != null) vscode.postMessage({ command: 'implementInReceiver', level: selectedLevel });
+        hideMenu(menu);
+      });
+    }
 
     // Variable context menu: GT Inspect the right-clicked variable.
     if (varInspectItem) {
@@ -474,6 +497,7 @@
         // Clear stale variables / eval output; the default-select below re-fetches.
         if (variables) variables.innerHTML = '';
         if (evalResult) { evalResult.textContent = ''; evalResult.classList.remove('error'); }
+        currentStack = msg.stack || [];
         renderStack(list, msg.stack);
         // Default-select the top frame so the debugger opens focused on a frame.
         if (msg.stack && msg.stack.length > 0) select(msg.stack[0].level);

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -336,7 +336,11 @@
       if (frameImplItem) {
         const frame = currentStack.find((f) => f.level === level);
         if (frame && frame.overridable) {
-          frameImplItem.textContent = 'Implement in ' + (frame.receiverClass || 'receiver');
+          // Ellipsis signals that clicking opens a class picker (an overridable
+          // frame always has several candidates: the receiver's class up through
+          // the class that defines the method). The frame label already names the
+          // receiver, so the menu item doesn't repeat it.
+          frameImplItem.textContent = 'Implement in…';
           frameImplItem.style.display = '';
         } else {
           frameImplItem.style.display = 'none';

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -126,6 +126,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   initializeBundledGci(context.extensionPath);
 
+  // Reap any companion debugger source tab a prior session left open when its
+  // window was closed with the Enhanced Debugger still up (it restores orphaned
+  // and broken — no session to resolve gemstone://). See DebuggerPanel.
+  DebuggerPanel.initSourceTabCleanup(context.workspaceState);
+
   try {
     initializeExtensionFolder();
   } catch (error) {

--- a/client/src/transcriptCapture.ts
+++ b/client/src/transcriptCapture.ts
@@ -56,3 +56,23 @@ export function unwrapTranscriptCapture(source: string): string {
   }
   return source;
 }
+
+/**
+ * How far `unwrapTranscriptCapture` shifts the source: the character offset, in
+ * the server's stored (wrapped) source, at which the displayed user code begins.
+ *
+ * The displayed source is a contiguous substring of the stored source, so the
+ * server's `_sourceOffsets` map onto the displayed source by subtracting this
+ * shift. Returns 0 when `source` isn't a recognised wrapper (a raw Debug It /
+ * non-symbol-list method, shown 1:1) so callers can treat both cases uniformly.
+ */
+export function transcriptCaptureUserCodeOffset(source: string): number {
+  const leadingWs = source.length - source.trimStart().length;
+  const trimmed = source.trim();
+  if (!(trimmed.startsWith(TRANSCRIPT_CAPTURE_PREFIX) && trimmed.endsWith(TRANSCRIPT_CAPTURE_SUFFIX))) {
+    return 0;
+  }
+  const inner = trimmed.slice(TRANSCRIPT_CAPTURE_PREFIX.length, trimmed.length - TRANSCRIPT_CAPTURE_SUFFIX.length);
+  const innerLeadingWs = inner.length - inner.trimStart().length;
+  return leadingWs + TRANSCRIPT_CAPTURE_PREFIX.length + innerLeadingWs;
+}


### PR DESCRIPTION
> ⚠️ **Work in progress** — opening for review/visibility of the work so far. All
> changes are scoped to the **Enhanced Debugger**; the DAP debugger
> (`gemstoneDebugSession.ts`) is untouched.

## Summary

Adds the "implement a method from the debugger" family the Jasper team requested,
makes the Variables pane editable, highlights the step point for wrapped doits,
and fixes several stop/step bugs found along the way.

- **13 commits**, ~1,220 lines of `client/src` (non-test) changed
- **~1,190 lines of new test code**, +74 net tests (full client suite green: 2091)
- `tsc` + `compile` clean

## New features

### Implement-a-method family
- **"Implement in…" (T2/T3).** Right-click an inherited-method frame → pick where
  along the receiver's inheritance chain to implement/override it (QuickPick, full
  chain to `Object`, each entry marked *implement here* vs *already implements →
  edit*). Shadowing by a more-specific subclass is detected and explained. Saving
  creates/edits the method; it's used on the next send of the selector.
- **`subclassResponsibility` (T4).** When parked on an abstract method invoked on
  a concrete subclass that didn't override it, an **"Implement #sel"** button
  offers to implement it concretely. The class picker is **bounded at the abstract
  definer** (you implement at-or-below the abstract class, never up toward
  `Object`). On a clean save it **re-enters the caller** so Resume re-dispatches
  into the new method (a bare Resume would return the abstract stub's `self`); a
  workspace caller is told to re-run the expression.

### Editable Variables pane (T1)
- Left-click an instVar or named arg/temp → an inline evaluator edits the value
  **in the frame**; a single-level revert (↺) restores the original (GC-pinned).
  GT Inspect moves to right-click. Stack temps and `self` stay read-only.

### Step-point highlighting (T0)
- Display It / Execute It / Inspect It now highlight the step-point token, mapping
  the server offset through the stripped Transcript-capture wrapper and resolving
  the true stop frame (the nested wrapper block, not the collapsed doit home).

## Bug fixes

- **Step at a `halt` no longer runs to completion.** A Step on a collapsed doit
  frame was issued from the doit-home level, stepping over the entire user block;
  it now steps from the true stop frame, advancing one statement at a time.
- **Orphaned companion source tab** left after closing a window with the debugger
  still open is now reaped on next startup.
- **`continueExecution`** passes `OOP_ILLEGAL` (not `OOP_NIL`) so a re-entered/
  trimmed frame isn't corrupted; an uncontinuable process (error 6011) is surfaced
  rather than retried.

## Tests
~1,190 lines / +74 net tests across `debuggerPanel` (+46), `debuggerView` (+19),
`debugQueries` (+5), and `transcriptCapture` (+4), including a coverage audit of
the new symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
