### PR TITLE
Welcome: replace auto-opened workspace with a Getting Started walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Changed
+
+- **Logging in no longer auto-opens a "Workspace" scratch buffer.** The old behavior opened an untitled `Workspace` document on every connect; because an untitled doc carrying content is permanently dirty, VS Code nagged to save it on exit and hot-exit kept restoring it. Instead, the **first** successful connect now opens a native **"Get Started with GemStone"** walkthrough — a dismissible Welcome-tab card with steps (connect → open a workspace → Display It → Inspect It), each of which checks itself off as you do it. The scratch workspace is still one click away on demand: a new **`GemStone: Open Getting Started Workspace`** command (also surfaced as a button in the empty **Logins & Sessions** view and as a walkthrough step) opens the same untitled buffer as before. The walkthrough shows once per machine; reopen it anytime from **Help → Welcome** or the Command Palette, and a **`GemStone: Reset Getting Started`** command makes it auto-open again on your next connect. A "Reopen this walkthrough later" step documents both inside the walkthrough itself.
+
 ## [1.7.1] - 2026-06-24
 
 ### Fixed

--- a/client/src/__tests__/walkthroughMedia.test.ts
+++ b/client/src/__tests__/walkthroughMedia.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// The Getting Started walkthrough (contributes.walkthroughs) points each step at a
+// markdown file under resources/. Those paths are resolved by VS Code at runtime, so
+// a typo or a deleted/unshipped file yields a broken, blank walkthrough step rather
+// than a build error. This guard asserts every declared media path exists on disk.
+//
+// __dirname is client/src/__tests__, so the repo root (where package.json lives) is
+// three levels up.
+describe('walkthrough media files are present', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const walkthroughs: Array<{ id: string; steps: Array<{ id: string; media?: Record<string, string> }> }> =
+    pkg.contributes?.walkthroughs ?? [];
+
+  const mediaPaths: string[] = [];
+  for (const wt of walkthroughs) {
+    for (const step of wt.steps ?? []) {
+      const media = step.media ?? {};
+      for (const key of ['markdown', 'image', 'svg']) {
+        if (typeof media[key] === 'string') mediaPaths.push(media[key]);
+      }
+    }
+  }
+
+  it('declares the Getting Started walkthrough with steps (guards a broken scan)', () => {
+    const gettingStarted = walkthroughs.find((w) => w.id === 'gemstoneGettingStarted');
+    expect(gettingStarted).toBeDefined();
+    expect(gettingStarted!.steps.length).toBeGreaterThan(0);
+  });
+
+  it.each(mediaPaths)('ships walkthrough media %s (exists on disk)', (rel) => {
+    expect(fs.existsSync(path.join(repoRoot, rel))).toBe(true);
+  });
+});

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -120,6 +120,13 @@ export async function handleClassDefinitionCompiled(event: ClassDefinitionCompil
   }
 }
 
+// Getting Started onboarding. The walkthrough auto-opens once per machine on the
+// first successful connect; this globalState key records that it has been shown.
+// Clear it via the `gemstone.resetGettingStarted` command to make it auto-open
+// again on the next connect.
+const GETTING_STARTED_SEEN_KEY = 'gemstone.hasSeenGettingStarted';
+const GETTING_STARTED_WALKTHROUGH_ID = 'gemtalksystems.gemstone-ide#gemstoneGettingStarted';
+
 export function activate(context: vscode.ExtensionContext) {
   jasperChannel = vscode.window.createOutputChannel('Jasper');
   context.subscriptions.push(jasperChannel);
@@ -602,6 +609,34 @@ export function activate(context: vscode.ExtensionContext) {
       LoginEditorPanel.show(storage, context.secrets, treeProvider, copy, sysadminStorage);
     }),
 
+    vscode.commands.registerCommand('gemstone.openWalkthrough', () => {
+      void vscode.commands.executeCommand(
+        'workbench.action.openWalkthrough',
+        GETTING_STARTED_WALKTHROUGH_ID,
+        false,
+      );
+    }),
+
+    vscode.commands.registerCommand('gemstone.openWorkspace', async () => {
+      await openWorkspace();
+    }),
+
+    vscode.commands.registerCommand('gemstone.resetGettingStarted', async () => {
+      await context.globalState.update(GETTING_STARTED_SEEN_KEY, undefined);
+      const openNow = 'Open Walkthrough Now';
+      const choice = await vscode.window.showInformationMessage(
+        'Getting Started reset — the walkthrough will open automatically on your next connect.',
+        openNow,
+      );
+      if (choice === openNow) {
+        void vscode.commands.executeCommand(
+          'workbench.action.openWalkthrough',
+          GETTING_STARTED_WALKTHROUGH_ID,
+          false,
+        );
+      }
+    }),
+
     vscode.commands.registerCommand('gemstone.login', async (item: GemStoneLoginItem) => {
       if (!vscode.workspace.workspaceFolders?.length) {
         vscode.window.showErrorMessage(
@@ -781,7 +816,20 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage(`Login failed: ${msg}`);
         return;
       }
-      await openWorkspace();
+      // We no longer auto-open a workspace on every connect (it left a dirty,
+      // hot-exit-restored buffer behind). Instead, on the *first* successful
+      // connect, open the Getting Started walkthrough once — a richer, native,
+      // dismissible onboarding card that links to the on-demand workspace. The
+      // workspace stays available afterward via the gemstone.openWorkspace
+      // command and the Logins & Sessions welcome view.
+      if (!context.globalState.get<boolean>(GETTING_STARTED_SEEN_KEY)) {
+        void context.globalState.update(GETTING_STARTED_SEEN_KEY, true);
+        void vscode.commands.executeCommand(
+          'workbench.action.openWalkthrough',
+          GETTING_STARTED_WALKTHROUGH_ID,
+          false,
+        );
+      }
     }),
 
     vscode.commands.registerCommand('gemstone.sessionCommit', async (item: GemStoneSessionItem) => {

--- a/client/src/workspace.ts
+++ b/client/src/workspace.ts
@@ -4,7 +4,19 @@ import { logInfo } from './gciLog';
 const MOD_KEY = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
 
 export const WORKSPACE_TEMPLATE =
-    `"Workspace\nPlace cursor anywhere on a line with code\nand press [<${MOD_KEY}>+<K> followed by <D>]\n(note that this is a two-keypress chord) to display"\n6 * 7\n`;
+`"Workspace — a scratch pad for GemStone Smalltalk.
+ Put the cursor on a line (or select an expression), then evaluate it:
+   Display It   <${MOD_KEY}>+<K> then <D>   evaluate and insert the result inline
+   Inspect It   <${MOD_KEY}>+<K> then <I>   open the result in the Inspector
+ (each is a two-keypress chord). Display It auto-selects the result it inserts,
+ so a single Backspace removes it again."
+
+"Display It on the next line — it becomes:  6 * 7 42"
+6 * 7
+
+"Inspect It on the next line — opens your user profile in the Inspector"
+System myUserProfile
+`;
 
 /**
  * Open a GemStone Workspace scratch buffer.

--- a/package.json
+++ b/package.json
@@ -341,6 +341,10 @@
     },
     "viewsWelcome": [
       {
+        "view": "gemstoneLogins",
+        "contents": "New to GemStone? Start with the guided walkthrough.\n[Get Started with GemStone](command:gemstone.openWalkthrough)\nOr jump straight into a scratch workspace.\n[Open Getting Started Workspace](command:gemstone.openWorkspace)\nThen add a login to connect to a stone.\n[Add a Login](command:gemstone.login)"
+      },
+      {
         "view": "gemstoneInspector",
         "contents": "No objects inspected yet.\nSelect code and press Cmd+K I to inspect.",
         "when": "isMac"
@@ -373,6 +377,67 @@
         "view": "gemstoneProcesses",
         "contents": "No running GemStone processes.\n[Refresh](command:gemstone.refreshProcesses)",
         "when": "!gemstone.isWindows || gemstone.wslAvailable"
+      }
+    ],
+    "walkthroughs": [
+      {
+        "id": "gemstoneGettingStarted",
+        "title": "Get Started with GemStone",
+        "description": "Connect to a stone and explore Smalltalk expressions in Jasper.",
+        "steps": [
+          {
+            "id": "connect",
+            "title": "Connect to a stone",
+            "description": "Add a login in the Logins & Sessions view and click it to connect.\n[Add a Login](command:gemstone.login)",
+            "media": {
+              "markdown": "resources/walkthrough/connect.md"
+            },
+            "completionEvents": [
+              "onCommand:gemstone.login"
+            ]
+          },
+          {
+            "id": "openWorkspace",
+            "title": "Open a workspace",
+            "description": "Open a scratch buffer to try out Smalltalk expressions.\n[Open Workspace](command:gemstone.openWorkspace)",
+            "media": {
+              "markdown": "resources/walkthrough/workspace.md"
+            },
+            "completionEvents": [
+              "onCommand:gemstone.openWorkspace"
+            ]
+          },
+          {
+            "id": "displayIt",
+            "title": "Run your first expression",
+            "description": "Select an expression and Display It to evaluate it inline.\n[Display It](command:gemstone.displayIt)",
+            "media": {
+              "markdown": "resources/walkthrough/displayIt.md"
+            },
+            "completionEvents": [
+              "onCommand:gemstone.displayIt"
+            ]
+          },
+          {
+            "id": "inspectIt",
+            "title": "Inspect an object",
+            "description": "Inspect It opens the result in the Inspector to drill into its fields.\n[Inspect It](command:gemstone.inspectIt)",
+            "media": {
+              "markdown": "resources/walkthrough/inspectIt.md"
+            },
+            "completionEvents": [
+              "onCommand:gemstone.inspectIt"
+            ]
+          },
+          {
+            "id": "reopen",
+            "title": "Reopen this walkthrough later",
+            "description": "Closed this? Reopen it anytime from Help → Welcome, or the Command Palette.\n[Open Walkthrough...](command:welcome.showAllWalkthroughs)",
+            "media": {
+              "markdown": "resources/walkthrough/reopen.md"
+            }
+          }
+        ]
       }
     ],
     "commands": [
@@ -486,6 +551,23 @@
         "title": "Export Classes to Files",
         "category": "GemStone",
         "icon": "$(cloud-download)"
+      },
+      {
+        "command": "gemstone.openWorkspace",
+        "title": "Open Getting Started Workspace",
+        "category": "GemStone",
+        "icon": "$(notebook)"
+      },
+      {
+        "command": "gemstone.openWalkthrough",
+        "title": "Get Started with GemStone",
+        "category": "GemStone",
+        "icon": "$(mortar-board)"
+      },
+      {
+        "command": "gemstone.resetGettingStarted",
+        "title": "Reset Getting Started (Show Walkthrough on Next Connect)",
+        "category": "GemStone"
       },
       {
         "command": "gemstone.displayIt",
@@ -826,9 +908,14 @@
       ],
       "view/title": [
         {
+          "command": "gemstone.openWalkthrough",
+          "when": "view == gemstoneVersions",
+          "group": "navigation@0"
+        },
+        {
           "command": "gemstone.addLogin",
           "when": "view == gemstoneLogins",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "gemstone.clearInspector",

--- a/resources/walkthrough/connect.md
+++ b/resources/walkthrough/connect.md
@@ -1,0 +1,11 @@
+# Connect to a stone
+
+Jasper talks to a running GemStone/S 64 stone through the GCI client library.
+
+1. Open the **GemStone** view in the Activity Bar (the GemStone icon on the left).
+2. In **Logins & Sessions**, add a login with your stone's host, name, and credentials.
+3. Click the login to connect.
+
+Once connected, the session appears under its login row, and the editor commands
+(Display It, Execute It, Inspect It) become available in any `gemstone-smalltalk`
+document.

--- a/resources/walkthrough/displayIt.md
+++ b/resources/walkthrough/displayIt.md
@@ -1,0 +1,11 @@
+# Run your first expression
+
+In a workspace, place the cursor on a line of code (or select an expression) and
+evaluate it:
+
+- **Display It** — `Cmd/Ctrl + K` then `D` — evaluates and inserts the result's
+  `printString` inline, right after the expression.
+
+The workspace you opened comes preloaded with sample lines to try. Put the cursor
+on the `6 * 7` line and Display It — it turns into `6 * 7 42`. The inserted result
+is auto-selected, so a single Backspace removes it.

--- a/resources/walkthrough/inspectIt.md
+++ b/resources/walkthrough/inspectIt.md
@@ -1,0 +1,12 @@
+# Inspect an object
+
+**Inspect It** — `Cmd/Ctrl + K` then `I` — evaluates the expression and opens the
+result in the **Inspector**, where you can drill into its instance variables and
+follow references object by object.
+
+In the workspace you opened, put the cursor on the `System myUserProfile` line and
+Inspect It. The Inspector view (the eye icon in the GemStone sidebar) shows the
+object's fields; expand any field to inspect that object in turn.
+
+From here, explore the **System Browser** to read and edit classes and methods,
+and the rest of the GemStone views for sessions, processes, and databases.

--- a/resources/walkthrough/reopen.md
+++ b/resources/walkthrough/reopen.md
@@ -1,0 +1,29 @@
+# Reopen this walkthrough later
+
+Closing the Welcome tab doesn't lose anything — you can bring this walkthrough
+back at any time.
+
+## Reopen it
+
+- Click the $(mortar-board) button at the top of the **GemStone** sidebar
+  (in the **Versions** view header — the easiest way back), or
+- **Help → Welcome** (the Welcome tab lists all walkthroughs), or
+- **Command Palette** (`Cmd/Ctrl + Shift + P`) → **"Welcome: Open Walkthrough..."**
+  → **Get Started with GemStone**.
+
+## Make it auto-open again on connect
+
+This walkthrough opens automatically **once per machine**, on your first
+successful connect. After that it stays out of your way.
+
+To make it auto-open again on your next connect, run:
+
+> **Command Palette → "GemStone: Reset Getting Started"**
+
+## Where that setting lives
+
+The "already shown" flag is stored in VS Code's **global state** (the
+`state.vscdb` global storage database) under the key
+`gemstone.hasSeenGettingStarted`, owned by the `gemtalksystems.gemstone-ide`
+extension. The **Reset Getting Started** command above is the supported way to
+clear it — clearing it by hand isn't necessary.

--- a/resources/walkthrough/workspace.md
+++ b/resources/walkthrough/workspace.md
@@ -1,0 +1,12 @@
+# Open a workspace
+
+A **workspace** is a scratch buffer for trying out Smalltalk expressions — the
+GemStone equivalent of a REPL. Type any expression, select it, and evaluate.
+
+Click **Open Workspace** below to open one. It comes preloaded with sample
+expressions to try with Display It and Inspect It, plus a reminder of the chords,
+so you have something to run right away.
+
+A workspace is an ordinary `gemstone-smalltalk` document: every editor command
+and language feature (hover, go-to-definition, completion) works in it, and you
+can save it to disk (`.gst`) to keep it around.


### PR DESCRIPTION
## Summary

No longer auto-opens an untitled **Workspace** buffer on every connect. That buffer carried content, so it was permanently *dirty* — VS Code nagged to save it on exit, and hot-exit kept restoring it. This replaces that with a native onboarding flow.

## What changed

- **Getting Started walkthrough.** A native `contributes.walkthroughs` ("Get Started with GemStone") with steps: Connect → Open a workspace → Display It → Inspect It, plus a "Reopen this walkthrough later" step. Each step self-completes via `completionEvents`. It opens **once per machine** on the first successful connect (gated by `globalState`), instead of auto-opening a buffer every time.
- **On-demand workspace.** New `gemstone.openWorkspace` command opens the same untitled scratch buffer as before, now only when asked. It comes preloaded with **Display It** and **Inspect It** examples (Execute It omitted until the Transcript is wired up).
- **Discoverability.** A mortar-board (🎓) button in the **Versions** view header, a `gemstone.openWalkthrough` command, and empty-state welcome links in **Logins & Sessions**.
- **Reset path.** `gemstone.resetGettingStarted` clears the once-per-machine flag so the walkthrough opens again on the next connect (documented inside the walkthrough's reopen step, including where the `gemstone.hasSeenGettingStarted` global-state key lives).

## Tests

- New `walkthroughMedia.test.ts` guard asserts every walkthrough media file declared in `package.json` exists on disk.
- Full suite green: server 320, client 2023, mcp-server 95. Clean `tsc` compile across all three packages.

## Notes

- The `viewsWelcome` link on Logins & Sessions only shows when that view is empty (no logins configured); the header button and command cover the connected case.
- There's no VS Code API to add a button to the activity-bar icon or the container title row, so the entry-point button lives on the topmost expanded view (Versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
