### PR TITLE
Enhanced Debugger: progress + cancel, stack-frame Browse, and editable inline values

### DIFF
--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -115,6 +115,12 @@ export const TextEditorRevealType = {
   AtTop: 3,
 };
 
+export const TextEditorSelectionChangeKind = {
+  Keyboard: 1,
+  Mouse: 2,
+  Command: 3,
+};
+
 // ── OverviewRulerLane mock ────────────────────────────────
 
 export const OverviewRulerLane = {

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -642,6 +642,137 @@ describe('debugQueries', () => {
     });
   });
 
+  // Non-blocking sibling of evaluateInFrame (#9 cancel): same frame-setup +
+  // evaluateInContext: dispatch, but issued via GciTsNbPerform and polled, so a
+  // runaway expression can be cancelled. We can't run real Smalltalk, so the mock
+  // supplies the result + printString and we assert the right (non-blocking) calls.
+  describe('evaluateInFrameNb (non-blocking eval)', () => {
+    const GS_PROCESS = 9000n;
+    const FRAME_ARRAY = 0xF0n;
+    const FRAME_RECEIVER = 0x77n;
+    const EXPR_STRING = 0xE0n;
+    const EVAL_RESULT = 0x07n;
+
+    // Self-only frame (no named temps → evaluateInContext:), with the non-blocking
+    // calls wired to report "ready immediately" and hand back EVAL_RESULT.
+    function nbEvalSession() {
+      const gci = {
+        GciTsI64ToOop: vi.fn(() => ({ result: 0xAAn, err: { ...noErr } })),
+        GciTsOopToI64: vi.fn(() => ({ value: 5n, err: { ...noErr } })),
+        GciTsNewString: vi.fn(() => ({ result: EXPR_STRING, err: { ...noErr } })),
+        GciTsFetchSize: vi.fn(() => ({ result: 10n, err: { ...noErr } })),
+        GciTsFetchOops: vi.fn(() => ({
+          oops: [1n, 2n, 0n, 0n, 0n, 0n, 0n, 0n, 0x14n /* OOP_NIL names */, FRAME_RECEIVER],
+          err: { ...noErr },
+        })),
+        GciTsPerform: vi.fn((_h: unknown, _r: bigint, _s: bigint, sel: string | null) =>
+          sel === '_frameContentsAt:' ? { result: FRAME_ARRAY, err: { ...noErr } }
+            : { result: 0n, err: { ...noErr } }),
+        // printString of the evaluation result is "7".
+        GciTsPerformFetchBytes: vi.fn((_h: unknown, oop: bigint) =>
+          oop === EVAL_RESULT
+            ? { bytesReturned: 1, data: '7', err: { ...noErr } }
+            : { bytesReturned: 0, data: '', err: { ...noErr } }),
+        isAvailable: (n: string) => n === 'GciTsNbPoll',
+        GciTsNbPerform: vi.fn(() => ({ success: true, err: { ...noErr } })),
+        GciTsNbPoll: vi.fn(() => ({ result: 1, err: { ...noErr } })), // ready on first poll
+        GciTsNbResult: vi.fn(() => ({ result: EVAL_RESULT, err: { ...noErr } })),
+      };
+      return {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: gci as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+    }
+
+    it('resolves with the result printString once the non-blocking call is ready', async () => {
+      const session = nbEvalSession();
+      await expect(debug.evaluateInFrameNb(session, GS_PROCESS, '3 + 4', 3)).resolves.toBe('7');
+    });
+
+    it('issues the evaluation via GciTsNbPerform (evaluateInContext:) on the expression string', async () => {
+      const session = nbEvalSession();
+      await debug.evaluateInFrameNb(session, GS_PROCESS, '3 + 4', 3);
+
+      const nbCalls = (session.gci.GciTsNbPerform as ReturnType<typeof vi.fn>).mock.calls;
+      expect(nbCalls).toHaveLength(1);
+      expect(nbCalls[0][1]).toBe(EXPR_STRING);            // receiver = the expression String
+      expect(nbCalls[0][3]).toBe('evaluateInContext:');   // self-only selector (no named temps)
+      expect(nbCalls[0][4]).toEqual([FRAME_RECEIVER]);    // arg = the frame's receiver (self)
+    });
+
+    it('rejects when the expression string cannot be created', async () => {
+      const session = nbEvalSession();
+      (session.gci.GciTsNewString as ReturnType<typeof vi.fn>).mockReturnValue(
+        { result: 0n, err: { ...noErr, number: 2101, message: 'bad string' } });
+
+      await expect(debug.evaluateInFrameNb(session, GS_PROCESS, '3 + 4', 3))
+        .rejects.toThrow(/bad string|Cannot create expression string/);
+    });
+
+    it('rejects with the GCI error when the non-blocking result reports a failure (e.g. an interrupt)', async () => {
+      const session = nbEvalSession();
+      (session.gci.GciTsNbResult as ReturnType<typeof vi.fn>).mockReturnValue(
+        { result: 0n, err: { ...noErr, number: 6004, message: 'the operation was interrupted' } });
+
+      await expect(debug.evaluateInFrameNb(session, GS_PROCESS, '[true] whileTrue', 3))
+        .rejects.toThrow(/the operation was interrupted/);
+    });
+
+    // When the frame has named temps, the nb eval must bind them via a symbol list
+    // (evaluateInContext:symbolList:), exactly like the blocking evaluateInFrame.
+    it('binds named temps via evaluateInContext:symbolList: (not the self-only path)', async () => {
+      const NAMES_ARRAY = 0xA1n;
+      const AMOUNT_NAME = 0xB1n;
+      const AMOUNT_VALUE = 0x96n;
+      const AMOUNT_SYMBOL = 0xC1n;
+      const gci = {
+        GciTsI64ToOop: vi.fn(() => ({ result: 0xAAn, err: { ...noErr } })),
+        GciTsOopToI64: vi.fn(() => ({ value: 5n, err: { ...noErr } })),
+        GciTsNewString: vi.fn(() => ({ result: EXPR_STRING, err: { ...noErr } })),
+        GciTsNewSymbol: vi.fn(() => ({ result: AMOUNT_SYMBOL, err: { ...noErr } })),
+        GciTsResolveSymbol: vi.fn((_h: unknown, name: string) => ({
+          result: name === 'SymbolDictionary' ? 0xD1n : name === 'SymbolList' ? 0xD2n : 0xD3n,
+          err: { ...noErr },
+        })),
+        GciTsFetchSize: vi.fn((_h: unknown, oop: bigint) =>
+          ({ result: oop === NAMES_ARRAY ? 1n : 11n, err: { ...noErr } })),
+        GciTsFetchOops: vi.fn((_h: unknown, oop: bigint) =>
+          oop === NAMES_ARRAY
+            ? { oops: [AMOUNT_NAME], err: { ...noErr } }
+            : { oops: [1n, 2n, 0n, 0n, 0n, 0n, 0n, 0n, NAMES_ARRAY, FRAME_RECEIVER, AMOUNT_VALUE], err: { ...noErr } }),
+        GciTsPerform: vi.fn((_h: unknown, _r: bigint, _s: bigint, sel: string | null) => {
+          if (sel === '_frameContentsAt:') return { result: FRAME_ARRAY, err: { ...noErr } };
+          if (sel === 'new') return { result: 0xDD0n, err: { ...noErr } };
+          if (sel === 'at:put:') return { result: 0n, err: { ...noErr } };
+          if (sel === 'myUserProfile') return { result: 0xDDdn, err: { ...noErr } };
+          if (sel === 'symbolList') return { result: 0xDDan, err: { ...noErr } };
+          if (sel === 'with:') return { result: 0xDDfn, err: { ...noErr } };
+          if (sel === ',') return { result: 0xDDcn, err: { ...noErr } };
+          return { result: 0n, err: { ...noErr } };
+        }),
+        GciTsPerformFetchBytes: vi.fn((_h: unknown, oop: bigint) =>
+          oop === AMOUNT_NAME ? { bytesReturned: 6, data: 'amount', err: { ...noErr } }
+            : oop === EVAL_RESULT ? { bytesReturned: 3, data: '150', err: { ...noErr } }
+              : { bytesReturned: 0, data: '', err: { ...noErr } }),
+        isAvailable: (n: string) => n === 'GciTsNbPoll',
+        GciTsNbPerform: vi.fn(() => ({ success: true, err: { ...noErr } })),
+        GciTsNbPoll: vi.fn(() => ({ result: 1, err: { ...noErr } })),
+        GciTsNbResult: vi.fn(() => ({ result: EVAL_RESULT, err: { ...noErr } })),
+      };
+      const session = {
+        id: 1, handle: {}, login: { label: 'T' } as GemStoneLogin, stoneVersion: '3.7.2',
+        gci: gci as unknown as ActiveSession['gci'],
+      } as ActiveSession;
+
+      await expect(debug.evaluateInFrameNb(session, GS_PROCESS, 'amount * 2', 3)).resolves.toBe('150');
+
+      const nbCalls = (session.gci.GciTsNbPerform as ReturnType<typeof vi.fn>).mock.calls;
+      expect(nbCalls[0][3]).toBe('evaluateInContext:symbolList:'); // symbol-list selector
+      expect(nbCalls[0][4][0]).toBe(FRAME_RECEIVER);               // self
+      expect(nbCalls[0][4]).toHaveLength(2);                       // [receiver, symbolList]
+    });
+  });
+
   describe('completion result oop', () => {
     const GS_PROCESS = 9000n;
     const RESULT = 0x99n;

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -389,6 +389,65 @@ describe('debugQueries', () => {
     });
   });
 
+  describe('getBrowseTarget', () => {
+    const RECEIVER_OOP = 0x456n;
+
+    function sessionReturning(data: string): ActiveSession {
+      const session = createMockSession();
+      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
+        result: 9000n, err: { ...noErr },
+      }));
+      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
+        bytesReturned: 0, data, err: { ...noErr },
+      }));
+      return session;
+    }
+
+    it('parses the defining class, dictionary, and category for an instance-side method', () => {
+      const session = sessionReturning('Collection\tinstance\tKernel\taccessing');
+      expect(debug.getBrowseTarget(session, RECEIVER_OOP, 'asOrderedCollection')).toEqual({
+        className: 'Collection', isMeta: false, dictName: 'Kernel', category: 'accessing',
+      });
+    });
+
+    it('parses a class-side method', () => {
+      const session = sessionReturning('Array\tclass\tGlobals\tinstance creation');
+      expect(debug.getBrowseTarget(session, RECEIVER_OOP, 'new')).toEqual({
+        className: 'Array', isMeta: true, dictName: 'Globals', category: 'instance creation',
+      });
+    });
+
+    it('reports a blank dictionary and category when the class is outside the symbol list and the method is uncategorized', () => {
+      const session = sessionReturning('Loner\tinstance\t\t');
+      expect(debug.getBrowseTarget(session, RECEIVER_OOP, 'foo')).toEqual({
+        className: 'Loner', isMeta: false, dictName: '', category: '',
+      });
+    });
+
+    it('returns undefined when the selector is not found in the chain', () => {
+      expect(debug.getBrowseTarget(sessionReturning(''), RECEIVER_OOP, 'foo')).toBeUndefined();
+    });
+
+    it('returns undefined when symbol resolution fails', () => {
+      const session = createMockSession();
+      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
+        result: 0n, err: { ...noErr, number: 2010, message: 'not found' },
+      }));
+      expect(debug.getBrowseTarget(session, RECEIVER_OOP, 'foo')).toBeUndefined();
+    });
+
+    it('returns undefined when the execute fails', () => {
+      const session = createMockSession();
+      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
+        result: 9000n, err: { ...noErr },
+      }));
+      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
+        bytesReturned: 0, data: '', err: { ...noErr, number: 1, message: 'boom' },
+      }));
+      expect(debug.getBrowseTarget(session, RECEIVER_OOP, 'foo')).toBeUndefined();
+    });
+  });
+
   describe('getInstVarNames', () => {
     it('does not send multi-word selectors', () => {
       const session = createMockSession();

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -77,6 +77,11 @@ vi.mock('../debugQueries', () => ({
   // Implement-in-receiver (override): the receiver's inheritance chain (default
   // is a single class → no QuickPick; tests override it for the multi-class case).
   getReceiverClassChain: vi.fn(() => [{ className: 'SmallInteger', isMeta: false, dictName: 'Globals' }]),
+  // "Browse" frame: where the running selector is defined (defining class + home
+  // dict + category). Default = a resolvable, symbol-list target.
+  getBrowseTarget: vi.fn(() => ({
+    className: 'JasperDebugDemo', isMeta: false, dictName: 'UserGlobals', category: 'running',
+  })),
   // Whole-stack dump (#10/#11): one batched call. Default = a Receiver row per
   // frame whose printString/oop mirror the per-frame receiverOop (level * 100).
   fetchStackDump: vi.fn(() => [1, 2, 3, 4, 5].map(l => ({
@@ -96,6 +101,10 @@ vi.mock('../debugQueries', () => ({
 // Clicking a variable row opens a GT Inspector — stub the static entry point.
 // create() returns a closable handle so the debugger can close it on dispose.
 vi.mock('../gtInspector', () => ({ GtInspector: { create: vi.fn(() => ({ close: vi.fn() })) } }));
+
+// "Browse" a frame opens a System Browser — stub the static entry point so the
+// test doesn't pull in the whole browser module (and its many dependencies).
+vi.mock('../systemBrowser', () => ({ SystemBrowser: { openAndNavigate: vi.fn() } }));
 
 // Source offsets for the step-point highlight. These are GemStone `_sourceOffsets`,
 // which are 1-BASED (index i = offset of step point i+1); the panel must convert
@@ -123,6 +132,7 @@ import {
 import { InlineValuesCodeLensProvider } from '../inlineValuesCodeLens';
 import { wrapWithTranscriptCapture, TRANSCRIPT_CAPTURE_PREFIX } from '../transcriptCapture';
 import { GtInspector } from '../gtInspector';
+import { SystemBrowser } from '../systemBrowser';
 import { ActiveSession } from '../sessionManager';
 import { GemStoneLogin } from '../loginTypes';
 
@@ -550,6 +560,7 @@ describe('DebuggerPanel', () => {
       expect(html).toContain('id="copyFrameItem"');              // Copy Frame popup item
       expect(html).toContain('Copy Frame');
       expect(html).toContain('copyFrame');                       // per-frame copy wiring
+      expect(html).toContain('id="browseFrameItem"');            // Browse popup item
       expect(html).toMatch(/addEventListener\(\s*'contextmenu'/); // default menu suppressed + custom menu
       expect(html).toContain('preventDefault');
     });
@@ -616,6 +627,68 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'copyFrame', level: 999 });
 
       expect(vscode.env.clipboard.writeText).not.toHaveBeenCalled();
+    });
+
+    it('marks real method frames as browsable in the init payload', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      const stack = initPayload(panel).stack as Array<{ browsable?: boolean }>;
+      expect(stack.every(f => f.browsable === true)).toBe(true);
+    });
+
+    it('opens a browser on the running method’s defining class beside the debugger', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      sendMessage(panel, { command: 'browseFrame', level: 2 });
+
+      expect(SystemBrowser.openAndNavigate).toHaveBeenCalledWith(
+        session,
+        {
+          dictName: 'UserGlobals', className: 'JasperDebugDemo', isMeta: false,
+          selector: 'halt', category: 'running',
+        },
+        vscode.ViewColumn.Beside,
+      );
+    });
+
+    it('does not open a browser for an unknown frame level', () => {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      sendMessage(panel, { command: 'browseFrame', level: 999 });
+
+      expect(SystemBrowser.openAndNavigate).not.toHaveBeenCalled();
+    });
+
+    it('shows a message instead of opening a browser when the selector cannot be located', () => {
+      vi.mocked(debug.getBrowseTarget).mockReturnValueOnce(undefined);
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      sendMessage(panel, { command: 'browseFrame', level: 2 });
+
+      expect(SystemBrowser.openAndNavigate).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toContain('Could not locate #halt');
+    });
+
+    it('shows a message instead of opening a browser when the class is outside the symbol list', () => {
+      vi.mocked(debug.getBrowseTarget).mockReturnValueOnce({
+        className: 'Loner', isMeta: false, dictName: '', category: '',
+      });
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const panel = lastPanel();
+      sendReady(panel);
+
+      sendMessage(panel, { command: 'browseFrame', level: 2 });
+
+      expect(SystemBrowser.openAndNavigate).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toContain("isn't in your symbol list");
     });
 
     it('#10 copyStack: assembles the batched dump rows into per-frame groups', () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -51,6 +51,7 @@ vi.mock('../debugQueries', () => ({
   getInstVarNames: vi.fn(() => [] as string[]),
   getNamedInstVarOops: vi.fn(() => [] as bigint[]),
   evaluateInFrame: vi.fn(() => '42'),
+  evaluateInFrameNb: vi.fn(async () => '42'),
   evaluateInFrameToOop: vi.fn(() => 999n),
   setFrameTemp: vi.fn(),
   setInstVar: vi.fn(),
@@ -1646,22 +1647,164 @@ describe('DebuggerPanel', () => {
       });
     });
 
-    it('evaluates an expression in the selected frame and posts the result', () => {
-      vi.mocked(debug.evaluateInFrame).mockReturnValueOnce('1764');
+    it('evaluates an expression in the selected frame and posts the result', async () => {
+      vi.mocked(debug.evaluateInFrameNb).mockResolvedValueOnce('1764');
       const panel = openPanel();
       sendMessage(panel, { command: 'evalInFrame', level: 3, expr: '42 * 42' });
+      await tick();
 
-      expect(debug.evaluateInFrame).toHaveBeenCalledWith(session, GS_PROCESS, '42 * 42', 3);
+      expect(debug.evaluateInFrameNb).toHaveBeenCalledWith(
+        session, GS_PROCESS, '42 * 42', 3, expect.objectContaining({ onStart: expect.any(Function) }),
+      );
       expect(lastPosted(panel, 'evalResult')).toMatchObject({ value: '1764', isError: false });
     });
 
-    it('reports an eval error without throwing', () => {
-      vi.mocked(debug.evaluateInFrame).mockImplementationOnce(() => { throw new Error('doesNotUnderstand'); });
+    it('reports an eval error without throwing', async () => {
+      vi.mocked(debug.evaluateInFrameNb).mockRejectedValueOnce(new Error('doesNotUnderstand'));
       const panel = openPanel();
       sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'foo bar' });
+      await tick();
 
       expect(lastPosted(panel, 'evalResult')).toMatchObject({ isError: true });
       expect(lastPosted(panel, 'evalResult').value).toContain('doesNotUnderstand');
+    });
+
+    it('signals cancellable while a frame eval runs, then clears it', async () => {
+      let release: (v: string) => void = () => {};
+      vi.mocked(debug.evaluateInFrameNb).mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[4] as { onStart?: (c: () => void) => void };
+        opts.onStart?.(() => {});                       // the nb call begins → cancellable
+        return new Promise<string>(res => { release = res; });
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: '(1 to: 9e9) size' });
+      await tick();
+
+      expect(lastPosted(panel, 'cancellable')).toMatchObject({ on: true });
+
+      release('done');
+      await tick();
+      expect(lastPosted(panel, 'cancellable')).toMatchObject({ on: false });
+    });
+
+    it('Cancel hits the running eval’s cancel handle', async () => {
+      const cancelSpy = vi.fn();
+      vi.mocked(debug.evaluateInFrameNb).mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[4] as { onStart?: (c: () => void) => void };
+        opts.onStart?.(cancelSpy);            // the nb runner hands the panel its cancel fn
+        return new Promise<string>(() => {}); // never settles — the op stays "running"
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: '[true] whileTrue' });
+      await tick();
+
+      sendMessage(panel, { command: 'cancelOp' });
+
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('a cancelled eval shows "Evaluation Cancelled", the break kind, and the raw error', async () => {
+      let rejectEval: (e: Error) => void = () => {};
+      vi.mocked(debug.evaluateInFrameNb).mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[4] as { onStart?: (c: () => void) => void };
+        opts.onStart?.(() => {});
+        return new Promise<string>((_res, rej) => { rejectEval = rej; });
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: '[true] whileTrue' });
+      await tick();
+
+      sendMessage(panel, { command: 'cancelOp' });                    // one click → soft break
+      rejectEval(new Error('the operation was interrupted'));         // gem stops with an interrupt
+      await tick();
+
+      const res = lastPosted(panel, 'evalResult');
+      expect(res.value).toContain('Evaluation Cancelled');
+      expect(res.value).toContain('soft break');
+      expect(res.value).toContain('the operation was interrupted'); // raw error kept
+      expect(res.isError).toBe(true);
+    });
+
+    it('labels a two-click eval cancel "(hard break)"', async () => {
+      let rejectEval: (e: Error) => void = () => {};
+      vi.mocked(debug.evaluateInFrameNb).mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[4] as { onStart?: (c: () => void) => void };
+        opts.onStart?.(() => {});
+        return new Promise<string>((_res, rej) => { rejectEval = rej; });
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: '[true] whileTrue' });
+      await tick();
+
+      sendMessage(panel, { command: 'cancelOp' }); // soft
+      sendMessage(panel, { command: 'cancelOp' }); // hard
+      rejectEval(new Error('forced'));
+      await tick();
+
+      expect(lastPosted(panel, 'evalResult').value).toContain('hard break');
+    });
+
+    it('ignores a second eval while one is already running (busy)', async () => {
+      vi.mocked(debug.evaluateInFrameNb).mockReturnValueOnce(new Promise<string>(() => {})); // first hangs
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'first' });
+      await tick();
+
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'second' });
+      await tick();
+
+      expect(debug.evaluateInFrameNb).toHaveBeenCalledTimes(1); // the second was refused while busy
+    });
+
+    it('refuses a step while an eval is still running (shared nbBusy guard)', async () => {
+      vi.mocked(debug.evaluateInFrameNb).mockReturnValueOnce(new Promise<string>(() => {})); // eval hangs
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'hang' });
+      await tick();
+
+      sendMessage(panel, { command: 'stepOver', level: 3 });
+      await tick();
+
+      expect(debug.stepOverNb).not.toHaveBeenCalled();
+    });
+
+    it('refuses an eval while a step is still running (shared nbBusy guard)', async () => {
+      vi.mocked(debug.stepOverNb).mockReturnValueOnce(new Promise(() => {})); // step hangs
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 3 });
+      await tick();
+
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'x' });
+      await tick();
+
+      expect(debug.evaluateInFrameNb).not.toHaveBeenCalled();
+    });
+
+    it('does not mislabel a later eval setup error as cancelled after a prior cancel', async () => {
+      // First eval: cancelled, so cancelClicks is bumped to 1.
+      let rejectFirst: (e: Error) => void = () => {};
+      vi.mocked(debug.evaluateInFrameNb).mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[4] as { onStart?: (c: () => void) => void };
+        opts.onStart?.(() => {});
+        return new Promise<string>((_res, rej) => { rejectFirst = rej; });
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'first' });
+      await tick();
+      sendMessage(panel, { command: 'cancelOp' });          // cancelClicks → 1
+      rejectFirst(new Error('interrupted'));
+      await tick();
+
+      // Second eval whose blocking SETUP fails before polling starts → onStart never
+      // fires, so cancelClicks isn't reset there. The reset-at-entry guard must keep
+      // the stale 1 from mislabeling this real error as a cancellation.
+      vi.mocked(debug.evaluateInFrameNb).mockRejectedValueOnce(new Error('cannot create expression string'));
+      sendMessage(panel, { command: 'evalInFrame', level: 3, expr: 'second' });
+      await tick();
+
+      const res = lastPosted(panel, 'evalResult');
+      expect(res.value).toContain('Error: cannot create expression string');
+      expect(res.value).not.toContain('Cancelled');
     });
 
     it('Resume disposes the panel when execution completes', () => {
@@ -1920,7 +2063,7 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'stepOver', level: 3 }); // display 3 → server level 3
       await tick();
 
-      expect(debug.stepOverNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(debug.stepOverNb).toHaveBeenCalledWith(session, GS_PROCESS, 3, expect.anything());
       expect(posted(panel, 'init').length).toBe(before + 1);
       expect(lastPosted(panel, 'init').errorMessage).toBe('');
       expect(panel.dispose).not.toHaveBeenCalled();
@@ -1967,7 +2110,7 @@ describe('DebuggerPanel', () => {
         await tick();
         // Without the fix this would step from the doit-home server level (3),
         // running the whole user block to completion; the stop frame is level 1.
-        expect(debug.stepOverNb).toHaveBeenCalledWith(session, GS_PROCESS, 1);
+        expect(debug.stepOverNb).toHaveBeenCalledWith(session, GS_PROCESS, 1, expect.anything());
       });
 
       it('Step Into likewise steps the stop frame, not the doit home', async () => {
@@ -1975,7 +2118,7 @@ describe('DebuggerPanel', () => {
         const panel = openPanel();
         sendMessage(panel, { command: 'stepInto', level: 1 });
         await tick();
-        expect(debug.stepIntoNb).toHaveBeenCalledWith(session, GS_PROCESS, 1);
+        expect(debug.stepIntoNb).toHaveBeenCalledWith(session, GS_PROCESS, 1, expect.anything());
       });
 
       it('Step Through likewise steps the stop frame, not the doit home', async () => {
@@ -1983,7 +2126,7 @@ describe('DebuggerPanel', () => {
         const panel = openPanel();
         sendMessage(panel, { command: 'stepThrough', level: 1 });
         await tick();
-        expect(debug.stepThruNb).toHaveBeenCalledWith(session, GS_PROCESS, 1);
+        expect(debug.stepThruNb).toHaveBeenCalledWith(session, GS_PROCESS, 1, expect.anything());
       });
     });
 
@@ -2067,7 +2210,7 @@ describe('DebuggerPanel', () => {
       vi.mocked(debug.continueExecution).mockClear();
       sendMessage(panel, { command: 'resume' });
 
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2, expect.anything());
       expect(debug.continueExecution).toHaveBeenCalled(); // no longer guarded
     });
 
@@ -2085,7 +2228,7 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'stepInto', level: 3 }); // display 3 → server level 3
       await tick();
 
-      expect(debug.stepIntoNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(debug.stepIntoNb).toHaveBeenCalledWith(session, GS_PROCESS, 3, expect.anything());
     });
 
     it('"Through" maps to gciStepThru (debugQueries.stepThruNb), from the selected user frame', async () => {
@@ -2093,7 +2236,7 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'stepThrough', level: 4 }); // display 4 → server level 4
       await tick();
 
-      expect(debug.stepThruNb).toHaveBeenCalledWith(session, GS_PROCESS, 4);
+      expect(debug.stepThruNb).toHaveBeenCalledWith(session, GS_PROCESS, 4, expect.anything());
     });
 
     it('Restart Frame trims the stack (non-blocking) to the selected (deeper) frame and refreshes', async () => {
@@ -2102,8 +2245,40 @@ describe('DebuggerPanel', () => {
       sendMessage(panel, { command: 'restartFrame', level: 2 });
       await tick();
 
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2, expect.anything());
       expect(posted(panel, 'init').length).toBe(before + 1);
+    });
+
+    it('debugger nb ops suppress the 2s toast (the in-panel overlay owns cancel)', async () => {
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 3 });
+      await tick();
+
+      expect(debug.stepOverNb).toHaveBeenCalledWith(
+        session, GS_PROCESS, 3, expect.objectContaining({ suppressNotification: true }),
+      );
+    });
+
+    it('a step marks the op cancellable, and Cancel breaks it', async () => {
+      const cancelSpy = vi.fn();
+      vi.mocked(debug.stepOverNb).mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[3] as { onStart?: (c: () => void) => void };
+        opts.onStart?.(cancelSpy);             // the nb step begins polling → cancellable
+        return new Promise(() => {});          // never settles — the step "runs"
+      });
+      const panel = openPanel();
+      sendMessage(panel, { command: 'stepOver', level: 3 });
+      await tick();
+
+      expect(lastPosted(panel, 'cancellable')).toMatchObject({ on: true });
+
+      sendMessage(panel, { command: 'cancelOp' });
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+      expect(lastPosted(panel, 'flash').text).toMatch(/break sent/i); // click acknowledged
+
+      sendMessage(panel, { command: 'cancelOp' });
+      expect(cancelSpy).toHaveBeenCalledTimes(2);
+      expect(lastPosted(panel, 'flash').text).toMatch(/forc/i); // second click → force
     });
 
     it('Restart Frame on the top frame shows an in-panel notice and does not trim (GemStone cannot reset the TOS IP)', async () => {
@@ -2114,6 +2289,27 @@ describe('DebuggerPanel', () => {
 
       expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
       expect(lastPosted(panel, 'init').errorMessage).toMatch(/top frame/i);
+    });
+
+    it('Restart Frame on an Executed Code (doit) frame shows a notice and does not trim (kernel cannot reset a classless frame)', async () => {
+      vi.mocked(debug.getStackDepth).mockImplementation(() => 2);
+      vi.mocked(debug.getMethodBlockInfo).mockImplementation((_s: unknown, methodOop: bigint) => ({
+        isBlock: false, homeMethodOop: methodOop,
+      }));
+      // Top frame is a real method; the deeper frame is a doit (its method can't be
+      // resolved → Executed Code), like `<expr> halt` stepped into a real method.
+      vi.mocked(debug.getMethodInfo).mockImplementation((_s: unknown, oop: bigint) => {
+        if (oop === 1n) return { className: 'JasperDebugDemo', selector: 'initialize' };
+        throw new Error('doit');
+      });
+      const panel = openPanel();
+      vi.mocked(debug.trimStackToLevelNb).mockClear();
+
+      sendMessage(panel, { command: 'restartFrame', level: 2 }); // the Executed Code frame
+      await tick();
+
+      expect(debug.trimStackToLevelNb).not.toHaveBeenCalled();
+      expect(lastPosted(panel, 'init').errorMessage).toMatch(/Executed Code/i);
     });
 
     it('Terminate disposes the panel', () => {
@@ -2321,7 +2517,7 @@ describe('DebuggerPanel', () => {
       vi.mocked(debug.continueExecution).mockClear();
       sendMessage(panel, { command: 'resume' });
 
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 2, expect.anything());
       expect(debug.continueExecution).toHaveBeenCalled(); // no longer blocked
     });
   });
@@ -2410,7 +2606,7 @@ describe('DebuggerPanel', () => {
 
       // Retargeted from the block (server 1) to its home method (server 3) — so it
       // trims there, NOT refusing as it would for a genuine top frame.
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3, expect.anything());
       expect(lastPosted(panel, 'init').errorMessage).not.toMatch(/top frame/i);
     });
 
@@ -2495,7 +2691,7 @@ describe('DebuggerPanel', () => {
 
       // The whole home method re-runs from the top — the inner AND outer blocks
       // above the home frame are all discarded by the trim.
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 7);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 7, expect.anything());
       expect(lastPosted(panel, 'init').errorMessage).not.toMatch(/top frame/i);
     });
 
@@ -2506,7 +2702,7 @@ describe('DebuggerPanel', () => {
 
       // homeMethodFrameLevel skips the deeper kernel frame and lands on `foo` (7),
       // never on the still-deeper nothing — there's exactly one home activation.
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 7);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 7, expect.anything());
     });
 
     it('Saving from a nested block re-enters the shared home method (trims to 7)', async () => {
@@ -2558,7 +2754,7 @@ describe('DebuggerPanel', () => {
       // Retargets DOWN to the home method (server 4) — NOT a trim to the block's
       // own level (2), which would merely restart the block in place (the old
       // behaviour, before block frames retargeted to their home method).
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 4);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 4, expect.anything());
       expect(debug.trimStackToLevelNb).not.toHaveBeenCalledWith(session, GS_PROCESS, 2);
     });
 
@@ -2609,7 +2805,7 @@ describe('DebuggerPanel', () => {
 
       // Trims to the inner foo (server 3), NOT the deeper outer foo (server 6) —
       // restarting the inner recursion level, not unwinding an extra one.
-      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3);
+      expect(debug.trimStackToLevelNb).toHaveBeenCalledWith(session, GS_PROCESS, 3, expect.anything());
       expect(debug.trimStackToLevelNb).not.toHaveBeenCalledWith(session, GS_PROCESS, 6);
     });
   });

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -128,6 +128,7 @@ import {
   flattenLayoutLeaves, sourceRatioFromLayout, setSourceRatioInLayout, EditorGroupLayout,
   formatDetailedStack, stackDumpFileName, stackDumpTimestamp, DetailedStackFrame,
   computeInlineValueLines, shortenInlineValue, maskCommentsAndStrings, InlineVar,
+  inlineHoverMarkdown,
 } from '../debuggerPanel';
 import { InlineValuesCodeLensProvider } from '../inlineValuesCodeLens';
 import { wrapWithTranscriptCapture, TRANSCRIPT_CAPTURE_PREFIX } from '../transcriptCapture';
@@ -1389,6 +1390,289 @@ describe('DebuggerPanel', () => {
 
       // …and dropped on a clean dispose, so the next launch has nothing to reap.
       expect((memento.get(ORPHAN_KEY) as string[] | undefined) ?? []).not.toContain(uri);
+    });
+
+    // ── Double-click-to-edit inline values (#5 Phase 2) ───────────────────
+    // Double-clicking an editable variable's name in the source (overlay on) opens
+    // its set-value prompt — a direct selection handler, since hover command-links
+    // don't fire in all hosts. A double-click selects the word; a single click
+    // leaves an empty selection (the cursor, kept for Run to Cursor). These poke the
+    // live panel's overlay state and fire the constructor-registered handler.
+    describe('inline-value double-click-to-edit (#5 Phase 2)', () => {
+      function liveInstance(): {
+        sourceEditor: unknown;
+        inlineValuesEnabled: boolean;
+        inlineHoverLevel: number | undefined;
+        inlineEditableByName: Map<string, { kind: 'instvar' | 'temp'; index: number }>;
+      } {
+        const panels = (DebuggerPanel as unknown as { panels: Map<number, Set<unknown>> }).panels;
+        const all = [...panels.values()].flatMap(s => [...s]);
+        return all[all.length - 1] as never;
+      }
+
+      // The selection-change handler the panel registered in its constructor.
+      function lastSelectionHandler(): (e: unknown) => void {
+        const calls = vi.mocked(vscode.window.onDidChangeTextEditorSelection).mock.calls;
+        return calls[calls.length - 1][0] as (e: unknown) => void;
+      }
+
+      // A source editor whose selected text is `word`, shown at `uri`.
+      function editorWithWord(word: string, uri = 'gemstone-debug://1/Acct/instance/x/readFrom') {
+        return { document: { uri: vscode.Uri.parse(uri), getText: vi.fn(() => word) } };
+      }
+
+      // Wire a panel for click-to-edit: `year` is an editable temp (write index 2).
+      function setup(opts: { word?: string; enabled?: boolean; busy?: boolean } = {}) {
+        DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+        const handler = lastSelectionHandler();
+        const editor = editorWithWord(opts.word ?? 'year');
+        const inst = liveInstance();
+        inst.sourceEditor = editor;
+        inst.inlineValuesEnabled = opts.enabled ?? true;
+        inst.inlineHoverLevel = 3;
+        inst.inlineEditableByName = new Map([['year', { kind: 'temp', index: 2 }]]);
+        if (opts.busy) (inst as unknown as { nbBusy: boolean }).nbBusy = true;
+        return { handler, editor };
+      }
+
+      // A mouse selection event. empty:false (default) = a double-click word
+      // selection; empty:true = a single-click cursor.
+      function select(editor: unknown, over: { kind?: number; empty?: boolean; editor?: unknown } = {}) {
+        return {
+          kind: over.kind ?? vscode.TextEditorSelectionChangeKind.Mouse,
+          textEditor: 'editor' in over ? over.editor : editor,
+          selections: [{ isEmpty: over.empty ?? false }],
+        };
+      }
+
+      it('opens the prompt and writes when an editable variable is double-clicked', async () => {
+        const { handler, editor } = setup();
+        vi.mocked(vscode.window.showInputBox).mockResolvedValueOnce('99');
+        vi.mocked(debug.evaluateInFrameToOop).mockReturnValueOnce(990n);
+
+        handler(select(editor));
+        await tick();
+
+        expect(vscode.window.showInputBox).toHaveBeenCalled();
+        expect(debug.setFrameTemp).toHaveBeenCalledWith(session, GS_PROCESS, 3, 2, 990n);
+      });
+
+      it('writes nothing when the prompt is cancelled', async () => {
+        const { handler, editor } = setup();
+        vi.mocked(vscode.window.showInputBox).mockResolvedValueOnce(undefined); // Esc
+
+        handler(select(editor));
+        await tick();
+
+        expect(debug.evaluateInFrameToOop).not.toHaveBeenCalled();
+        expect(debug.setFrameTemp).not.toHaveBeenCalled();
+      });
+
+      it('writes nothing when the entered expression is blank', async () => {
+        const { handler, editor } = setup();
+        vi.mocked(vscode.window.showInputBox).mockResolvedValueOnce('   ');
+
+        handler(select(editor));
+        await tick();
+
+        expect(debug.evaluateInFrameToOop).not.toHaveBeenCalled();
+        expect(debug.setFrameTemp).not.toHaveBeenCalled();
+      });
+
+      it('surfaces a rejected expression as an error message', async () => {
+        const { handler, editor } = setup();
+        vi.mocked(vscode.window.showInputBox).mockResolvedValueOnce('bogus +');
+        vi.mocked(debug.evaluateInFrameToOop).mockImplementationOnce(() => { throw new Error('a parse error'); });
+
+        handler(select(editor));
+        await tick();
+
+        expect(debug.setFrameTemp).not.toHaveBeenCalled();
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('a parse error'));
+      });
+
+      it('refuses (no prompt) while a non-blocking step holds the session', async () => {
+        const { handler, editor } = setup({ busy: true });
+
+        handler(select(editor));
+        await tick();
+
+        expect(vscode.window.showInputBox).not.toHaveBeenCalled();
+        expect(debug.setFrameTemp).not.toHaveBeenCalled();
+      });
+
+      it('does nothing when the double-clicked word is not an editable variable', async () => {
+        const { handler, editor } = setup({ word: 'asInteger' });
+
+        handler(select(editor));
+        await tick();
+
+        expect(vscode.window.showInputBox).not.toHaveBeenCalled();
+      });
+
+      it('leaves a single click alone (empty selection = the cursor for Run to Cursor)', async () => {
+        const { handler, editor } = setup();
+
+        handler(select(editor, { empty: true }));
+        await tick();
+
+        expect(vscode.window.showInputBox).not.toHaveBeenCalled();
+      });
+
+      it('ignores a keyboard selection (only a mouse double-click edits)', async () => {
+        const { handler, editor } = setup();
+
+        handler(select(editor, { kind: vscode.TextEditorSelectionChangeKind.Keyboard }));
+        await tick();
+
+        expect(vscode.window.showInputBox).not.toHaveBeenCalled();
+      });
+
+      it('does nothing while the inline overlay is off', async () => {
+        const { handler, editor } = setup({ enabled: false });
+
+        handler(select(editor));
+        await tick();
+
+        expect(vscode.window.showInputBox).not.toHaveBeenCalled();
+      });
+
+      it('ignores selections in an editor other than the source pane', async () => {
+        const { handler } = setup();
+
+        handler(select(undefined,
+          { editor: editorWithWord('year', 'gemstone-debug://1/Acct/instance/x/somethingElse') }));
+        await tick();
+
+        expect(vscode.window.showInputBox).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // The inline value+pencil is served by a registered HoverProvider (via the
+  // static `provideInlineHover`), NOT the decoration's `hoverMessage` — command
+  // links only fire from provider hovers. These poke the live panel's overlay
+  // state directly (the map is normally filled by updateInlineValues from a real
+  // source editor, which the headless editor mock can't supply).
+  describe('inline-value hover provider (#5 Phase 2)', () => {
+    // The most-recently-created live DebuggerPanel instance (held in the static
+    // registry), so a test can seed its inline-overlay state.
+    function liveInstance(): {
+      shownSourceUris: Set<string>;
+      sourceEditor: unknown;
+      inlineValuesEnabled: boolean;
+      inlineHoverByLine: Map<number, InlineVar[]>;
+      inlineHoverLevel: number | undefined;
+    } {
+      const panels = (DebuggerPanel as unknown as { panels: Map<number, Set<unknown>> }).panels;
+      const all = [...panels.values()].flatMap(s => [...s]);
+      return all[all.length - 1] as never;
+    }
+
+    // Seed a fresh panel's overlay for a UNIQUE source URI (so `panelForSourceUri`
+    // resolves to this test's panel, not an undisposed one another test left in the
+    // static registry). Returns the URI to hover. `sourceTag` overrides the panel's
+    // CURRENT source (to exercise the stale-document guard).
+    function seedOverlay(
+      tag: string, vars: InlineVar[], opts: { enabled?: boolean; sourceTag?: string } = {},
+    ): string {
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const uri = `gemstone-debug://1/Acct/instance/accessing/${tag}`;
+      const inst = liveInstance();
+      inst.shownSourceUris.add(uri);
+      const sourceUri = opts.sourceTag ? `gemstone-debug://1/Acct/instance/accessing/${opts.sourceTag}` : uri;
+      inst.sourceEditor = { document: { uri: vscode.Uri.parse(sourceUri) } };
+      inst.inlineValuesEnabled = opts.enabled ?? true;
+      inst.inlineHoverLevel = 3;
+      inst.inlineHoverByLine = new Map([[7, vars]]);
+      return uri;
+    }
+
+    it('serves the value and a double-click-to-edit hint for an annotated line of the live source', () => {
+      const uri = seedOverlay('serve',
+        [{ name: 'year', value: '2021', full: '2021', edit: { kind: 'temp', index: 2 } }]);
+
+      const md = DebuggerPanel.provideInlineHover(uri, 7);
+
+      expect(md?.value).toContain('**year** = 2021');
+      expect(md?.value).toContain('Double-click the variable name'); // edit hint, not a (dead) command-link
+    });
+
+    it('omits the edit hint for a read-only variable (self)', () => {
+      const uri = seedOverlay('selfRo', [{ name: 'self', value: 'an Acct', full: 'an Acct' }]);
+
+      const md = DebuggerPanel.provideInlineHover(uri, 7);
+
+      expect(md?.value).toBe('**self** = an Acct');
+      expect(md?.value).not.toContain('command:');
+    });
+
+    it('returns nothing when the inline overlay is off', () => {
+      const uri = seedOverlay('off',
+        [{ name: 'year', value: '2021', full: '2021', edit: { kind: 'temp', index: 2 } }],
+        { enabled: false });
+
+      expect(DebuggerPanel.provideInlineHover(uri, 7)).toBeUndefined();
+    });
+
+    it('returns nothing for a line with no annotated variable', () => {
+      const uri = seedOverlay('noVar',
+        [{ name: 'year', value: '2021', full: '2021', edit: { kind: 'temp', index: 2 } }]);
+
+      expect(DebuggerPanel.provideInlineHover(uri, 99)).toBeUndefined();
+    });
+
+    it('returns nothing when the hovered document is not the panel’s live source', () => {
+      // The overlay was computed for this URI, but the panel now shows a different
+      // source — a stale map must not mislabel the other document.
+      const uri = seedOverlay('hovered',
+        [{ name: 'year', value: '2021', full: '2021', edit: { kind: 'temp', index: 2 } }],
+        { sourceTag: 'nowShowingOther' });
+
+      expect(DebuggerPanel.provideInlineHover(uri, 7)).toBeUndefined();
+    });
+
+    // The white-box tests above seed the overlay maps by hand; this one drives the
+    // REAL updateInlineValues against a source editor so the population path itself
+    // (frame vars → editable-by-name + per-line hover + decoration) is covered.
+    it('updateInlineValues fills the editable + hover maps from the frame’s variables', () => {
+      vi.mocked(debug.fetchFrameVariables).mockImplementation((_s: unknown, _p: unknown, level: number) =>
+        level === 3
+          ? [
+            { group: 'receiver', name: 'self', value: '<print 300>', oop: '300', index: 0 },
+            { group: 'argtemps', name: 'year', value: '<print 2021>', oop: '2021', index: 1 },
+          ]
+          : [{ group: 'receiver', name: 'self', value: `<print ${level * 100}>`, oop: `${level * 100}`, index: 0 }]);
+      DebuggerPanel.create(session, GS_PROCESS, ERROR_MSG);
+      const inst = liveInstance() as never as {
+        shownSourceUris: Set<string>; sourceEditor: unknown; inlineValuesEnabled: boolean;
+        inlineEditableByName: Map<string, { kind: string; index: number }>;
+        updateInlineValues(editor: unknown, level: number): void;
+      };
+      const uri = 'gemstone-debug://1/Acct/instance/x/popMap';
+      const src = '^year + 1';
+      const editor = {
+        document: {
+          uri: vscode.Uri.parse(uri),
+          getText: () => src,
+          lineAt: (n: number) => ({ range: new vscode.Range(n, 0, n, src.length) }),
+        },
+        setDecorations: vi.fn(),
+      };
+      inst.shownSourceUris.add(uri);
+      inst.sourceEditor = editor;
+      inst.inlineValuesEnabled = true;
+
+      inst.updateInlineValues(editor, 3);
+
+      // The editable temp `year` (server write index 1) is indexed by name…
+      expect(inst.inlineEditableByName.get('year')).toEqual({ kind: 'temp', index: 1 });
+      // …a decoration was rendered…
+      expect(editor.setDecorations).toHaveBeenCalled();
+      // …and the hover provider now serves `year`'s value on its line.
+      const hover = DebuggerPanel.provideInlineHover(uri, 0)?.value ?? '';
+      expect(hover).toContain('**year**');
+      expect(hover).toContain('2021');
     });
   });
 
@@ -4014,6 +4298,44 @@ describe('computeInlineValueLines', () => {
     const v: InlineVar[] = [{ name: 'amount', value: '9', full: '9' }];
     const overlay = computeInlineValueLines(lines, v, { perLine: true });
     expect(overlay.map(o => o.line)).toEqual([1]);
+  });
+});
+
+describe('inlineHoverMarkdown (#5 Phase 2 — the inline-value hover)', () => {
+  it('shows each variable as a bold name and its full (un-truncated) value', () => {
+    const md = inlineHoverMarkdown(
+      [{ name: 'balance', value: 'an Ord…', full: 'an OrderedCollection(1 2 3)' }],
+    );
+    expect(md).toContain('**balance**');
+    expect(md).toContain('= an OrderedCollection(1 2 3)'); // the full value, not the truncated one
+  });
+
+  it('hints that an editable variable is set by double-clicking its name', () => {
+    const md = inlineHoverMarkdown(
+      [{ name: 'amount', value: '75', full: '75', edit: { kind: 'temp', index: 2 } }],
+    );
+    expect(md).toContain('**amount** = 75');
+    expect(md).toContain('Double-click the variable name'); // the double-click-to-edit hint
+  });
+
+  it('escapes markdown-significant characters in the value so it renders verbatim', () => {
+    const md = inlineHoverMarkdown([{ name: 'x', value: 'evil', full: '`[a]`*b*' }]);
+    expect(md).toContain('\\`\\[a\\]\\`\\*b\\*'); // backticks/brackets/asterisks escaped
+  });
+
+  it('omits the click hint for a read-only-only hover (no editable variable)', () => {
+    const md = inlineHoverMarkdown([{ name: 'self', value: 'an Account', full: 'an Account' }]);
+    expect(md).toBe('**self** = an Account'); // no hint, no affordance
+  });
+
+  it('shows the hint once when a line mixes an editable and a read-only variable', () => {
+    const md = inlineHoverMarkdown([
+      { name: 'self', value: 'an Account', full: 'an Account' },
+      { name: 'count', value: '7', full: '7', edit: { kind: 'instvar', index: 1 } },
+    ]);
+    expect(md).toContain('**self** = an Account');
+    expect(md).toContain('**count** = 7');
+    expect(md.match(/Double-click the variable name/g)).toHaveLength(1); // hint appears exactly once
   });
 });
 

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -76,6 +76,8 @@ interface Refs {
   hsplitter?: HTMLElement;
   varMenu?: HTMLElement;
   varInspectItem?: HTMLElement;
+  busyOverlay?: HTMLElement;
+  busyCancel?: HTMLElement;
 }
 
 function api(): DebuggerViewApi {
@@ -114,7 +116,9 @@ function setup(
     <div class="main"><ul id="stack"></ul><div id="variables"></div></div>
     <input id="evalInput"><div id="evalResult"></div>
     <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div><div id="homeFrameItem" style="display:none;">Go to home method</div><div id="frameImplItem" style="display:none;">Implement in receiver</div></div>
-    <div id="varctxmenu"><div id="varInspectItem">GT Inspect</div></div>`;
+    <div id="varctxmenu"><div id="varInspectItem">GT Inspect</div></div>
+    <div id="busyOverlay" class="busy-overlay" style="display:none;"><div class="busy-box"><div class="busy-spinner"></div><button id="busyCancel" style="display:none;">Cancel</button></div></div>`;
+  document.body.classList.remove('busy');
   const refs: Refs = {
     list: document.getElementById('stack')!,
     menu: document.getElementById('ctxmenu')!,
@@ -136,6 +140,8 @@ function setup(
     evalResult: document.getElementById('evalResult')!,
     varMenu: document.getElementById('varctxmenu')!,
     varInspectItem: document.getElementById('varInspectItem')!,
+    busyOverlay: document.getElementById('busyOverlay')!,
+    busyCancel: document.getElementById('busyCancel')!,
   };
   const vscode = { postMessage: vi.fn() };
   const ctrl = api().init(refs, vscode);
@@ -350,6 +356,313 @@ describe('DebuggerView.init — right-click copy popup', () => {
 
     expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'selectFrame', level: 5 });
     expect(frame(refs, 5).classList.contains('selected')).toBe(true);
+  });
+});
+
+describe('DebuggerView.init — progress indicator (#9)', () => {
+  // setup()'s default frame-select fires one server request; deliver its reply so
+  // every test starts idle, then exercise its own action from that clean baseline.
+  function setupIdle() {
+    const ctx = setup();
+    window.dispatchEvent(new MessageEvent('message', { data: { command: 'variables', groups: [] } }));
+    return ctx;
+  }
+
+  // Selecting a frame is a server round-trip (it fetches that frame's variables).
+  function selectAFrame(refs: Refs) {
+    frame(refs, 3).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  }
+
+  function respond() {
+    window.dispatchEvent(new MessageEvent('message', { data: { command: 'variables', groups: [] } }));
+  }
+
+  it('shows nothing while a server request finishes within the reveal delay', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      selectAFrame(refs);
+      vi.advanceTimersByTime(499);
+
+      expect(refs.busyOverlay!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reveals the spinner once a server request outlives the reveal delay', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      selectAFrame(refs);
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('');
+      expect(document.body.classList.contains('busy')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides the spinner when the host sends its response', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      selectAFrame(refs);
+      vi.advanceTimersByTime(500);
+      respond();
+
+      expect(refs.busyOverlay!.style.display).toBe('none');
+      expect(document.body.classList.contains('busy')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('never flashes when the host responds before the reveal delay', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      selectAFrame(refs);
+      respond();
+      vi.advanceTimersByTime(1000);
+
+      expect(refs.busyOverlay!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not show a spinner for local-only commands like Copy Stack', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      refs.copyBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      vi.advanceTimersByTime(1000);
+
+      expect(refs.busyOverlay!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  function markCancellable() {
+    window.dispatchEvent(new MessageEvent('message', { data: { command: 'cancellable', on: true } }));
+  }
+
+  it('offers a Cancel button when the running op is cancellable', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      markCancellable();
+      selectAFrame(refs);
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('');
+      expect(refs.busyCancel!.style.display).toBe('');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows the spinner but no Cancel button for a non-cancellable op', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      selectAFrame(refs);
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('');
+      expect(refs.busyCancel!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('requests cancellation when the Cancel button is clicked', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs, vscode } = setupIdle();
+
+      markCancellable();
+      selectAFrame(refs);
+      vi.advanceTimersByTime(500);
+      refs.busyCancel!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'cancelOp' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides the Cancel button when the op completes', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      markCancellable();
+      selectAFrame(refs);
+      vi.advanceTimersByTime(500);
+      respond();
+
+      expect(refs.busyCancel!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the spinner and Cancel up when the host posts a transient flash (e.g. Break sent)', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      markCancellable();
+      selectAFrame(refs);
+      vi.advanceTimersByTime(500);
+      // The Cancel-click acknowledgement is a 'flash' posted mid-op; it must NOT end
+      // the span — otherwise the spinner vanishes and a 2nd Cancel (hard break) is impossible.
+      window.dispatchEvent(new MessageEvent('message', { data: { command: 'flash', text: 'Break sent…' } }));
+
+      expect(refs.busyOverlay!.style.display).toBe('');
+      expect(refs.busyCancel!.style.display).toBe('');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Each server-bound command must start the busy span (otherwise a slow op of that
+  // kind would show no spinner). Drive each through its real toolbar/eval trigger.
+  for (const cmd of ['stepOver', 'stepInto', 'stepThrough', 'restartFrame', 'resume']) {
+    it(`shows the spinner for a ${cmd} request`, () => {
+      vi.useFakeTimers();
+      try {
+        const { refs } = setupIdle();
+
+        refs.toolbar.querySelector(`[data-cmd="${cmd}"]`)!
+          .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        vi.advanceTimersByTime(500);
+
+        expect(refs.busyOverlay!.style.display).toBe('');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  }
+
+  it('shows the spinner for an evalInFrame request', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      (refs.evalInput as HTMLInputElement).value = '3 + 4';
+      refs.evalInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT show the spinner for a local-only command (Terminate)', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      refs.toolbar.querySelector('[data-cmd="terminate"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reveals then hides the spinner from a host-pushed busy message', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+
+      window.dispatchEvent(new MessageEvent('message', { data: { command: 'busy', on: true } }));
+      vi.advanceTimersByTime(500);
+      expect(refs.busyOverlay!.style.display).toBe('');
+
+      window.dispatchEvent(new MessageEvent('message', { data: { command: 'busy', on: false } }));
+      expect(refs.busyOverlay!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Render one editable variable through the host's 'variables' message, so the
+  // init-wired var handlers (commit/revert/contextMenu → post(...)) are exercised.
+  function renderEditableVar(refs: Refs) {
+    window.dispatchEvent(new MessageEvent('message', { data: { command: 'variables', groups: [
+      { title: 'Instance variables', kind: 'instvar',
+        vars: [{ name: 'count', value: '5', oop: '200', edit: { kind: 'instvar', index: 1 } }] },
+    ] } }));
+    return refs.variables.querySelector('.var') as HTMLElement;
+  }
+
+  it('shows the spinner for a setVariable request (commit from the variable editor)', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+      const row = renderEditableVar(refs);
+
+      row.click(); // open the inline editor
+      const input = refs.variables.querySelector('.var-edit') as HTMLInputElement;
+      input.value = '42';
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })); // commit → post(setVariable)
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows the spinner for a revertVariable request', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+      window.dispatchEvent(new MessageEvent('message', { data: { command: 'variables', groups: [
+        { title: 'Instance variables', kind: 'instvar',
+          vars: [{ name: 'count', value: '9', oop: '201', edit: { kind: 'instvar', index: 1 }, revertible: true }] },
+      ] } }));
+
+      (refs.variables.querySelector('.var-revert') as HTMLElement)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true })); // → post(revertVariable)
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT show the spinner for inspectVariable (deliberately excluded — opens a separate inspector)', () => {
+    vi.useFakeTimers();
+    try {
+      const { refs } = setupIdle();
+      const row = renderEditableVar(refs);
+
+      row.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true })); // sets varMenuTarget
+      refs.varInspectItem!.dispatchEvent(new MouseEvent('click', { bubbles: true })); // → post(inspectVariable)
+      vi.advanceTimersByTime(500);
+
+      expect(refs.busyOverlay!.style.display).toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -11,7 +11,7 @@ beforeAll(() => {
   new Function(source)();
 });
 
-interface FrameSummary { level: number; label: string; position: string; overridable?: boolean; receiverClass?: string; breakable?: boolean; homeDisplayLevel?: number; }
+interface FrameSummary { level: number; label: string; position: string; overridable?: boolean; receiverClass?: string; breakable?: boolean; browsable?: boolean; homeDisplayLevel?: number; }
 
 interface DebuggerViewApi {
   renderStack(listEl: HTMLElement, stack: FrameSummary[]): void;
@@ -55,6 +55,7 @@ interface Refs {
   list: HTMLElement;
   menu: HTMLElement;
   copyFrameItem: HTMLElement;
+  browseFrameItem?: HTMLElement;
   homeFrameItem?: HTMLElement;
   frameImplItem?: HTMLElement;
   copyBtn: HTMLElement;
@@ -86,7 +87,7 @@ function api(): DebuggerViewApi {
 
 const STACK: FrameSummary[] = [
   { level: 1, label: '[] in JasperDebugDemo>>#finish', position: '@2 line 12' },
-  { level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12', overridable: true, receiverClass: 'SmallInteger' },
+  { level: 2, label: 'SmallInteger (Object)>>#halt', position: '@2 line 12', overridable: true, receiverClass: 'SmallInteger', browsable: true },
   { level: 3, label: 'JasperDebugDemo>>#accumulateFrom:to:', position: '' },
 ];
 
@@ -115,7 +116,7 @@ function setup(
     <div id="dnuBar"></div>
     <div class="main"><ul id="stack"></ul><div id="variables"></div></div>
     <input id="evalInput"><div id="evalResult"></div>
-    <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div><div id="homeFrameItem" style="display:none;">Go to home method</div><div id="frameImplItem" style="display:none;">Implement in receiver</div></div>
+    <div id="ctxmenu"><div id="copyFrameItem">Copy Frame</div><div id="browseFrameItem" style="display:none;">Browse</div><div id="homeFrameItem" style="display:none;">Go to home method</div><div id="frameImplItem" style="display:none;">Implement in receiver</div></div>
     <div id="varctxmenu"><div id="varInspectItem">GT Inspect</div></div>
     <div id="busyOverlay" class="busy-overlay" style="display:none;"><div class="busy-box"><div class="busy-spinner"></div><button id="busyCancel" style="display:none;">Cancel</button></div></div>`;
   document.body.classList.remove('busy');
@@ -123,6 +124,7 @@ function setup(
     list: document.getElementById('stack')!,
     menu: document.getElementById('ctxmenu')!,
     copyFrameItem: document.getElementById('copyFrameItem')!,
+    browseFrameItem: document.getElementById('browseFrameItem')!,
     homeFrameItem: document.getElementById('homeFrameItem')!,
     frameImplItem: document.getElementById('frameImplItem')!,
     copyBtn: document.getElementById('copyBtn')!,
@@ -295,6 +297,24 @@ describe('DebuggerView.init — right-click copy popup', () => {
     refs.frameImplItem!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'implementInReceiver', level: 2 });
+  });
+
+  it('shows "Browse" only on a frame that runs a real class method', () => {
+    const { refs } = setup();
+
+    frame(refs, 2).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    expect(refs.browseFrameItem!.style.display).not.toBe('none');
+
+    frame(refs, 1).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    expect(refs.browseFrameItem!.style.display).toBe('none');
+  });
+
+  it('clicking Browse posts browseFrame for the selected level and hides the menu', () => {
+    const { refs, vscode } = setup();
+    frame(refs, 2).dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    refs.browseFrameItem!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({ command: 'browseFrame', level: 2 });
     expect(refs.menu.classList.contains('show')).toBe(false);
   });
 

--- a/client/src/__tests__/gemstoneCodeLensProvider.test.ts
+++ b/client/src/__tests__/gemstoneCodeLensProvider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 
@@ -50,9 +50,22 @@ describe('GemStoneCodeLensProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
     sessionManager = new SessionManager();
     provider = new GemStoneCodeLensProvider(sessionManager);
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The count is computed off the resolve path (so a spinner can paint first),
+  // so resolving twice with the deferred work flushed in between yields the count.
+  function resolveCount(lens: any): any {
+    provider.resolveCodeLens(lens);   // first resolve → spinner + schedules the lookup
+    vi.runAllTimers();                // run the deferred sendersOf/implementorsOf
+    return provider.resolveCodeLens(lens); // re-resolve → cache hit → the count
+  }
 
   describe('provideCodeLenses', () => {
     // Each method gets two lenses on the same line: one for senders, one
@@ -96,6 +109,39 @@ true
   });
 
   describe('resolveCodeLens', () => {
+    it('shows a non-clickable spinner placeholder while the count is still loading', () => {
+      const session = createMockSession();
+      sessionManager.getSelectedSession = () => session;
+      (queries.sendersOf as ReturnType<typeof vi.fn>).mockReturnValue([{}, {}]);
+
+      const doc = createMockDocument(`method: MyClass
+foo
+  ^ 42
+%`);
+      const lenses = provider.provideCodeLenses(doc as any);
+      const loading = provider.resolveCodeLens(lenses[0]); // before the deferred lookup runs
+
+      expect(loading.command?.title).toContain('$(loading~spin)');
+      expect(loading.command?.command).toBe(''); // not clickable while counting
+      expect(queries.sendersOf).not.toHaveBeenCalled(); // the lookup is deferred, not run inline
+    });
+
+    it('replaces the spinner with the real count once the lookup completes', () => {
+      const session = createMockSession();
+      sessionManager.getSelectedSession = () => session;
+      (queries.sendersOf as ReturnType<typeof vi.fn>).mockReturnValue([{}, {}]);
+
+      const doc = createMockDocument(`method: MyClass
+foo
+  ^ 42
+%`);
+      const lens = provider.provideCodeLenses(doc as any)[0];
+
+      expect(provider.resolveCodeLens(lens).command?.title).toContain('$(loading~spin)');
+      vi.runAllTimers(); // the deferred lookup runs and caches the count
+      expect(provider.resolveCodeLens(lens).command?.title).toBe('2 senders');
+    });
+
     it('returns "No session" when no session is selected', () => {
       const doc = createMockDocument(`method: MyClass
 foo
@@ -129,7 +175,7 @@ foo
   ^ 42
 %`);
       const lenses = provider.provideCodeLenses(doc as any);
-      const sendersLens = provider.resolveCodeLens(lenses[0]);
+      const sendersLens = resolveCount(lenses[0]);
 
       expect(sendersLens.command?.title).toBe('2 senders');
       expect(sendersLens.command?.command).toBe('gemstone.sendersOfSelector');
@@ -155,7 +201,7 @@ foo
   ^ 42
 %`);
       const lenses = provider.provideCodeLenses(doc as any);
-      const implementorsLens = provider.resolveCodeLens(lenses[1]);
+      const implementorsLens = resolveCount(lenses[1]);
 
       expect(implementorsLens.command?.title).toBe('1 implementor');
       expect(implementorsLens.command?.command).toBe('gemstone.implementorsOfSelector');
@@ -179,7 +225,7 @@ foo
   ^ 42
 %`);
       const lenses = provider.provideCodeLenses(doc as any);
-      provider.resolveCodeLens(lenses[0]); // senders lens
+      resolveCount(lenses[0]); // senders lens
 
       expect(queries.sendersOf).toHaveBeenCalled();
       expect(queries.implementorsOf).not.toHaveBeenCalled();
@@ -196,7 +242,7 @@ foo
   ^ 42
 %`);
       const lenses = provider.provideCodeLenses(doc as any);
-      provider.resolveCodeLens(lenses[1]); // implementors lens
+      resolveCount(lenses[1]); // implementors lens
 
       expect(queries.implementorsOf).toHaveBeenCalled();
       expect(queries.sendersOf).not.toHaveBeenCalled();
@@ -218,8 +264,8 @@ foo
   ^ 42
 %`);
       const lenses = provider.provideCodeLenses(doc as any);
-      expect(provider.resolveCodeLens(lenses[0]).command?.title).toBe('1 sender');
-      expect(provider.resolveCodeLens(lenses[1]).command?.title).toBe('1 implementor');
+      expect(resolveCount(lenses[0]).command?.title).toBe('1 sender');
+      expect(resolveCount(lenses[1]).command?.title).toBe('1 implementor');
     });
 
     it('caches counts so a re-resolve does not re-run the server lookup', () => {
@@ -235,11 +281,28 @@ foo
   ^ 42
 %`);
       const lenses = provider.provideCodeLenses(doc as any);
-      expect(provider.resolveCodeLens(lenses[0]).command?.title).toBe('3 senders');
-      // Re-provide + re-resolve (fresh lens objects, as VS Code does on a refresh).
+      expect(resolveCount(lenses[0]).command?.title).toBe('3 senders');
+      // Re-provide + re-resolve (fresh lens objects, as VS Code does on a refresh):
+      // the count comes from cache, so no second server lookup.
       const again = provider.provideCodeLenses(doc as any);
       expect(provider.resolveCodeLens(again[0]).command?.title).toBe('3 senders');
       expect(queries.sendersOf as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispose() cancels a pending count lookup (no blocking GCI after teardown)', () => {
+      const session = createMockSession();
+      sessionManager.getSelectedSession = () => session;
+
+      const doc = createMockDocument(`method: MyClass
+foo
+  ^ 42
+%`);
+      provider.resolveCodeLens(provider.provideCodeLenses(doc as any)[0]); // schedules the lookup
+
+      provider.dispose();
+      vi.runAllTimers();              // a still-pending timer would fire here
+
+      expect(queries.sendersOf).not.toHaveBeenCalled();
     });
 
     it('refresh() clears the count cache (so a recompile can recount)', () => {
@@ -251,9 +314,9 @@ foo
 foo
   ^ 42
 %`);
-      provider.resolveCodeLens(provider.provideCodeLenses(doc as any)[0]);
+      resolveCount(provider.provideCodeLenses(doc as any)[0]);
       provider.refresh();
-      provider.resolveCodeLens(provider.provideCodeLenses(doc as any)[0]);
+      resolveCount(provider.provideCodeLenses(doc as any)[0]);
       expect(queries.sendersOf as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(2);
     });
   });

--- a/client/src/__tests__/nbRunner.test.ts
+++ b/client/src/__tests__/nbRunner.test.ts
@@ -126,4 +126,77 @@ describe('runNbCall — cancellation', () => {
       vi.mocked(vscode.window.withProgress).mockReset();
     }
   });
+
+  // The in-panel Cancel button drives cancellation through opts.onStart, which
+  // works even before the ~2s notification would appear (no toast involved).
+  it('hands out an external cancel via onStart that soft- then hard-breaks', async () => {
+    vi.useFakeTimers();
+    try {
+      const session = makeSession([{ result: 0 }]); // always pending → never settles on its own
+      let cancel: (() => void) | undefined;
+      const p = runNbCall(
+        session,
+        () => ({ success: true, err: noErr as never }),
+        () => 'unused',
+        { onStart: (c) => { cancel = c; } },
+      );
+
+      expect(cancel).toBeTypeOf('function');
+
+      cancel!(); // first → soft break
+      expect(session.gci.GciTsBreak).toHaveBeenCalledWith(session.handle, false);
+
+      cancel!(); // second → hard break + reject
+      expect(session.gci.GciTsBreak).toHaveBeenCalledWith(session.handle, true);
+      await expect(p).rejects.toBeInstanceOf(NbCancelledError);
+
+      vi.clearAllTimers();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('runNbCall — notification suppression', () => {
+  it('does NOT show the 2s notification when suppressNotification is set', async () => {
+    vi.useFakeTimers();
+    vi.mocked(vscode.window.withProgress).mockClear();
+    try {
+      const session = makeSession([{ result: 0 }]); // pending forever
+      const p = runNbCall(
+        session, () => ({ success: true, err: noErr as never }), () => 'x',
+        { suppressNotification: true },
+      );
+      p.catch(() => {}); // we abandon the call; swallow the (never-fired) rejection
+
+      await vi.advanceTimersByTimeAsync(3000); // well past the 2s threshold
+
+      expect(vscode.window.withProgress).not.toHaveBeenCalled();
+      vi.clearAllTimers();
+    } finally {
+      vi.useRealTimers();
+      vi.mocked(vscode.window.withProgress).mockReset();
+    }
+  });
+
+  it('shows the 2s notification when suppressNotification is not set', async () => {
+    vi.useFakeTimers();
+    vi.mocked(vscode.window.withProgress).mockImplementation(() => new Promise<never>(() => {}));
+    try {
+      const session = makeSession([{ result: 0 }]);
+      const p = runNbCall(
+        session, () => ({ success: true, err: noErr as never }), () => 'x',
+        { title: 'GemStone: working…' },
+      );
+      p.catch(() => {});
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(vscode.window.withProgress).toHaveBeenCalled();
+      vi.clearAllTimers();
+    } finally {
+      vi.useRealTimers();
+      vi.mocked(vscode.window.withProgress).mockReset();
+    }
+  });
 });

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -1055,27 +1055,27 @@ function performStepNb(
 }
 
 export function stepOverNb(
-  session: ActiveSession, gsProcess: bigint, level: number,
+  session: ActiveSession, gsProcess: bigint, level: number, opts: NbRunOptions = {},
 ): Promise<StepResult> {
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: stepOver (nb) from level ${level}`);
-  return performStepNb(session, gsProcess, 'gciStepOverFromLevel:', [levelOop], { title: 'GemStone: stepping over…' });
+  return performStepNb(session, gsProcess, 'gciStepOverFromLevel:', [levelOop], { title: 'GemStone: stepping over…', ...opts });
 }
 
 export function stepIntoNb(
-  session: ActiveSession, gsProcess: bigint, level: number,
+  session: ActiveSession, gsProcess: bigint, level: number, opts: NbRunOptions = {},
 ): Promise<StepResult> {
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: stepInto (nb) from level ${level}`);
-  return performStepNb(session, gsProcess, 'gciStepIntoFromLevel:', [levelOop], { title: 'GemStone: stepping into…' });
+  return performStepNb(session, gsProcess, 'gciStepIntoFromLevel:', [levelOop], { title: 'GemStone: stepping into…', ...opts });
 }
 
 export function stepThruNb(
-  session: ActiveSession, gsProcess: bigint, level: number,
+  session: ActiveSession, gsProcess: bigint, level: number, opts: NbRunOptions = {},
 ): Promise<StepResult> {
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: stepThru (nb) from level ${level}`);
-  return performStepNb(session, gsProcess, 'gciStepThruFromLevel:', [levelOop], { title: 'GemStone: stepping through…' });
+  return performStepNb(session, gsProcess, 'gciStepThruFromLevel:', [levelOop], { title: 'GemStone: stepping through…', ...opts });
 }
 
 // ── Continue / Terminate ────────────────────────────────
@@ -1147,7 +1147,7 @@ export function trimStackToLevel(
  * variant (no debug-stop during the trim's unwind).
  */
 export function trimStackToLevelNb(
-  session: ActiveSession, gsProcess: bigint, level: number,
+  session: ActiveSession, gsProcess: bigint, level: number, opts: NbRunOptions = {},
 ): Promise<void> {
   const levelOop = intToOop(session, level);
   logInfo(`[Session ${session.id}] Debug: trimStackToLevel (nb) ${level}`);
@@ -1162,7 +1162,7 @@ export function trimStackToLevelNb(
         throw new Error(err.message || `GemStone error ${err.number} in trimStackToLevel:`);
       }
     },
-    { title: 'GemStone: restarting frame…' },
+    { title: 'GemStone: restarting frame…', ...opts },
   );
 }
 
@@ -1200,6 +1200,44 @@ export function evaluateInFrame(
  * temp / instVar. A compile or runtime error surfaces as a thrown GCI error
  * (same as the eval bar), so the caller can keep the editor open on failure.
  */
+/**
+ * Non-blocking sibling of {@link evaluateInFrame}: evaluate `expression` in the
+ * frame and resolve with the result's printString, issued via GciTsNbPerform and
+ * polled off the main thread. The eval-bar uses this so a long/looping/runaway
+ * expression neither freezes the panel nor blocks the host — and can be cancelled
+ * (see {@link NbRunOptions.onStart}). The frame setup (receiver, symbol list,
+ * expression string) is still blocking, but cheap; only the evaluation itself —
+ * the part that can run away — is non-blocking.
+ */
+export function evaluateInFrameNb(
+  session: ActiveSession, gsProcess: bigint, expression: string, level: number,
+  opts: NbRunOptions = {},
+): Promise<string> {
+  const { receiverOop, argAndTempNames, argAndTempOops } = getFrameInfo(session, gsProcess, level);
+
+  const { result: exprOop, err: strErr } = session.gci.GciTsNewString(session.handle, expression);
+  if (strErr.number !== 0) {
+    return Promise.reject(new Error(strErr.message || 'Cannot create expression string'));
+  }
+
+  const symbolListOop = buildFrameSymbolList(session, argAndTempNames, argAndTempOops);
+  const selector = symbolListOop === null ? 'evaluateInContext:' : 'evaluateInContext:symbolList:';
+  const args = symbolListOop === null ? [receiverOop] : [receiverOop, symbolListOop];
+
+  return runNbCall(
+    session,
+    () => session.gci.GciTsNbPerform(session.handle, exprOop, OOP_ILLEGAL, selector, args, 0, 0),
+    () => {
+      const { result, err } = session.gci.GciTsNbResult(session.handle);
+      if (err.number !== 0) {
+        throw new Error(err.message || `GCI error ${err.number} in ${selector}`);
+      }
+      return getObjectPrintString(session, result);
+    },
+    opts,
+  );
+}
+
 export function evaluateInFrameToOop(
   session: ActiveSession, gsProcess: bigint, expression: string, level: number,
 ): bigint {

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -304,6 +304,75 @@ rows inject: '' into: [:acc :r | acc isEmpty ifTrue: [r] ifFalse: [acc, (String 
   }
 }
 
+/** Where a frame's running method actually lives — for the "Browse" action. */
+export interface BrowseTarget {
+  /** The class (non-meta name) that DEFINES the running method (via method lookup
+   *  on the receiver), which may be a superclass of the receiver's class. */
+  className: string;
+  /** True when the method is class-side (the receiver is a class). */
+  isMeta: boolean;
+  /** The defining class's home dictionary, '' when not in the user's symbol list. */
+  dictName: string;
+  /** The method's category in the defining class ('' when uncategorized). */
+  category: string;
+}
+
+/**
+ * Resolve where a frame's running `selector` is actually DEFINED — the class
+ * method lookup finds for the receiver (the receiver's own class or a superclass
+ * for an inherited method), so "Browse" lands on the source that is really
+ * executing. Walks the receiver's class chain for the first class that
+ * `includesSelector:` (the lookup result), then reports that class's home
+ * dictionary (by NAME key in the user's symbol list — see the symbol-list
+ * home-dict gotcha) and the selector's method category. A class receiver walks
+ * its class-side chain (isMeta true). Returns undefined when the selector can't
+ * be found anywhere in the chain or on any failure, so the caller degrades to a
+ * clear message rather than opening a misleading browser.
+ */
+export function getBrowseTarget(
+  session: ActiveSession, receiverOop: bigint, selector: string,
+): BrowseTarget | undefined {
+  try {
+    const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
+      session.handle, 'Utf8', OOP_NIL,
+    );
+    if (resErr.number !== 0) return undefined;
+
+    const sel = selector.replace(/'/g, "''");
+    const code = `| rcvr meta cls sel def dn |
+rcvr := Object _objectForOop: ${receiverOop}.
+(rcvr isKindOf: Class)
+  ifTrue: [ cls := rcvr. meta := true ]
+  ifFalse: [ cls := rcvr class. meta := false ].
+sel := '${sel}' asSymbol.
+def := nil.
+[ cls notNil and: [ def isNil ] ] whileTrue: [
+  (cls includesSelector: sel) ifTrue: [ def := cls ].
+  cls := cls superclass ].
+def isNil ifTrue: [ '' ] ifFalse: [
+  dn := ''.
+  System myUserProfile symbolList do: [:d |
+    (d includesKey: def theNonMetaClass name asSymbol) ifTrue: [ dn := d name ]].
+  def theNonMetaClass name asString, String tab,
+    (meta ifTrue: ['class'] ifFalse: ['instance']), String tab, dn, String tab,
+    ((def categoryOfSelector: sel environmentId: 0) ifNil: ['']) ]`;
+
+    const { data, err } = session.gci.GciTsExecuteFetchBytes(
+      session.handle, code, -1, classUtf8, OOP_ILLEGAL, OOP_NIL, 64 * 1024,
+    );
+    if (err.number !== 0) return undefined;
+    if (data.length === 0) return undefined; // selector not found in the chain
+
+    const parts = data.split('\t');
+    return {
+      className: parts[0], isMeta: parts[1] === 'class',
+      dictName: parts[2] ?? '', category: parts[3] ?? '',
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * The pieces needed to create the method a `doesNotUnderstand:` is asking for.
  * `className` is the (non-meta) name of the class the method should be added to;

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -8,6 +8,7 @@ import * as queries from './browserQueries';
 import { unwrapTranscriptCapture, transcriptCaptureUserCodeOffset } from './transcriptCapture';
 import { buildLineOffsets, mapOffsetToStepPoint } from './breakpointManager';
 import { GtInspector } from './gtInspector';
+import { SystemBrowser } from './systemBrowser';
 import { logError, logInfo } from './gciLog';
 import { NbCancelledError, NbRunOptions } from './nbRunner';
 import { extensionPathFrom } from './extensionPath';
@@ -86,6 +87,7 @@ type DebuggerInbound =
   | { command: 'revertVariable'; level: number; kind: 'instvar' | 'temp'; index: number }
   | { command: 'createDnuMethod' }
   | { command: 'implementInReceiver'; level: number }
+  | { command: 'browseFrame'; level: number }
   | { command: 'implementSubclassResponsibility' }
   | { command: 'cancelOp' }
   | { command: 'saveLayout'; stackBasis?: string; evalHeight?: string };
@@ -457,6 +459,12 @@ interface FrameSummary {
    * unresolvable `<frame N>`.
    */
   breakable?: boolean;
+  /**
+   * True when this frame runs a real `Class>>#selector` method we can open in a
+   * System Browser — drives the right-click "Browse" item. False for an
+   * Executed-Code (doit) frame or an unresolvable `<frame N>` (no class/selector).
+   */
+  browsable?: boolean;
 }
 
 /**
@@ -1250,6 +1258,7 @@ export class DebuggerPanel {
       }
       case 'createDnuMethod': { void this.createDnuMethod(); return; }
       case 'implementInReceiver': { void this.implementInReceiver(msg.level); return; }
+      case 'browseFrame': { void this.browseFrame(msg.level); return; }
       case 'implementSubclassResponsibility': { void this.implementSubclassResponsibility(); return; }
       case 'setVariable': {
         const frame = this.frames.find(f => f.level === msg.level);
@@ -1290,7 +1299,7 @@ export class DebuggerPanel {
       stack: this.frames.map(f => ({
         level: f.level, label: f.label, position: f.position,
         overridable: f.overridable, receiverClass: f.receiverClass,
-        breakable: f.breakable, homeDisplayLevel: f.homeDisplayLevel,
+        breakable: f.breakable, browsable: f.browsable, homeDisplayLevel: f.homeDisplayLevel,
       })),
       // When parked on a doesNotUnderstand:, drive the "Create #sel in Class" button.
       dnu: this.dnuInfo
@@ -1471,6 +1480,57 @@ export class DebuggerPanel {
     await this.pickAndOpenImplementTemplate({
       selector, chain, contextLabel: `${frame.label}@sv${frame.serverLevel}`,
     });
+  }
+
+  /**
+   * "Browse" a stack frame (right-click menu): open a NEW System Browser to the
+   * right of the debugger pane, navigated to the class+method actually running in
+   * this frame. The target is resolved by method lookup on the receiver
+   * (`getBrowseTarget`), so an inherited method opens on its DEFINING class — the
+   * source that's really executing — rather than the receiver's concrete class.
+   * Degrades to an in-panel message for a doit frame, a receiver we can't resolve,
+   * a selector not found in the chain, or a class outside the user's symbol list.
+   */
+  private async browseFrame(displayLevel: number): Promise<void> {
+    const frame = this.frames.find(f => f.level === displayLevel);
+    if (!frame) return;
+    const raw = this.rawFrames.find(r => r.serverLevel === frame.serverLevel);
+    if (!raw || raw.isExecutedCode || !raw.selector) {
+      this.errorMessage = 'Cannot browse this frame — it has no class or method.';
+      this.postInit();
+      return;
+    }
+
+    let receiverOop: bigint;
+    try {
+      receiverOop = debug.getFrameInfo(this.session, this.gsProcess, frame.serverLevel).receiverOop;
+    } catch (e: unknown) {
+      logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      this.errorMessage = `Could not resolve the receiver of ${frame.label}.`;
+      this.postInit();
+      return;
+    }
+
+    const target = debug.getBrowseTarget(this.session, receiverOop, raw.selector);
+    if (!target) {
+      this.errorMessage = `Could not locate #${raw.selector} to browse it.`;
+      this.postInit();
+      return;
+    }
+    if (!target.dictName) {
+      this.errorMessage = `Can't browse #${raw.selector}: ${target.className} isn't in your symbol list.`;
+      this.postInit();
+      return;
+    }
+
+    // Open the browser to the RIGHT of the debugger pane: focus the debugger's
+    // group so ViewColumn.Beside resolves relative to it, then open a fresh
+    // browser there and navigate it to the running method's defining class.
+    this.panel.reveal(this.panel.viewColumn, false);
+    SystemBrowser.openAndNavigate(this.session, {
+      dictName: target.dictName, className: target.className,
+      isMeta: target.isMeta, selector: raw.selector, category: target.category,
+    }, vscode.ViewColumn.Beside);
   }
 
   /**
@@ -3210,6 +3270,9 @@ export class DebuggerPanel {
         overridable: r.overridable,
         receiverClass: r.receiverClassName,
         breakable: r.breakable,
+        // Browsable iff the frame runs a real Class>>#selector (not a doit, and the
+        // home method resolved to a defining class + selector).
+        browsable: !r.isExecutedCode && !!r.definingClassName && !!r.selector,
         homeDisplayLevel,
         // Executed-code frames have no meaningful step point/line once unwrapped (#3).
         position: r.isExecutedCode ? '' : formatFramePosition(r.stepPoint, r.line),
@@ -3694,6 +3757,7 @@ export class DebuggerPanel {
   </div>
   <div id="ctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="copyFrameItem" role="menuitem">Copy Frame</div>
+    <div class="ctx-item" id="browseFrameItem" role="menuitem" style="display:none;">Browse</div>
     <div class="ctx-item" id="homeFrameItem" role="menuitem" style="display:none;">Go to home method</div>
     <div class="ctx-item" id="frameImplItem" role="menuitem" style="display:none;">Implement in…</div>
   </div>
@@ -3715,6 +3779,7 @@ export class DebuggerPanel {
       list: document.getElementById('stack'),
       menu: document.getElementById('ctxmenu'),
       copyFrameItem: document.getElementById('copyFrameItem'),
+      browseFrameItem: document.getElementById('browseFrameItem'),
       homeFrameItem: document.getElementById('homeFrameItem'),
       frameImplItem: document.getElementById('frameImplItem'),
       copyBtn: document.getElementById('copyBtn'),

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -9,7 +9,7 @@ import { unwrapTranscriptCapture, transcriptCaptureUserCodeOffset } from './tran
 import { buildLineOffsets, mapOffsetToStepPoint } from './breakpointManager';
 import { GtInspector } from './gtInspector';
 import { logError, logInfo } from './gciLog';
-import { NbCancelledError } from './nbRunner';
+import { NbCancelledError, NbRunOptions } from './nbRunner';
 import { extensionPathFrom } from './extensionPath';
 
 // The webview's DOM behavior lives in a standalone file (like listFilter.js /
@@ -87,6 +87,7 @@ type DebuggerInbound =
   | { command: 'createDnuMethod' }
   | { command: 'implementInReceiver'; level: number }
   | { command: 'implementSubclassResponsibility' }
+  | { command: 'cancelOp' }
   | { command: 'saveLayout'; stackBasis?: string; evalHeight?: string };
 
 /**
@@ -1097,6 +1098,17 @@ export class DebuggerPanel {
    * set. Cleared when the operation settles (resolve / reject / cancel).
    */
   private nbBusy = false;
+  /**
+   * Cancel handle for the in-flight non-blocking op (#9 cancel). Set from the nb
+   * runner's `onStart` while a cancellable op runs; calling it requests a soft
+   * break, then a hard break on a second call. Drives the in-panel Cancel button
+   * (which the webview shows only while the busy spinner is up). Undefined when
+   * nothing cancellable is running.
+   */
+  private activeNbCancel: (() => void) | undefined;
+  /** How many times Cancel was clicked for the current op (1 = soft break, 2+ = hard).
+   *  Reset to 0 when a cancellable op begins; drives the acknowledgement wording. */
+  private cancelClicks = 0;
   /** Set in dispose() so an in-flight Nb op's continuation skips touching a dead panel. */
   private disposed = false;
 
@@ -1218,9 +1230,10 @@ export class DebuggerPanel {
       }
       case 'evalInFrame': {
         const frame = this.frames.find(f => f.level === msg.level);
-        this.evalInFrame(frame?.serverLevel, msg.expr);
+        void this.evalInFrame(frame?.serverLevel, msg.expr);
         return;
       }
+      case 'cancelOp': { this.cancelActiveOp(); return; }
       case 'resume': { this.resume(); return; }
       case 'runToCursor': { this.runToCursor(msg.level); return; }
       case 'terminate': { this.panel.dispose(); return; } // dispose → clearStack
@@ -1953,17 +1966,61 @@ export class DebuggerPanel {
   }
 
   /** Evaluate an expression in the selected frame and post the printString back. */
-  private evalInFrame(serverLevel: number | undefined, expr: string): void {
+  private async evalInFrame(serverLevel: number | undefined, expr: string): Promise<void> {
     if (serverLevel == null) return;
-    let value: string;
+    if (this.nbBusy) { this.notifyBusy('Evaluate'); return; }
+    this.nbBusy = true;
+    // Reset here, not only in onStart: the blocking frame-setup inside
+    // evaluateInFrameNb can fail BEFORE polling starts (so onStart never fires), and
+    // a stale count from a prior cancelled op would mislabel that error as cancelled.
+    this.cancelClicks = 0;
+    // The eval runs non-blocking so a runaway expression doesn't freeze the panel
+    // and CAN be cancelled. The in-panel overlay owns cancel (suppressNotification),
+    // and onStart marks it cancellable + captures the handle the Cancel button hits.
+    let value = '';
     let isError = false;
     try {
-      value = debug.evaluateInFrame(this.session, this.gsProcess, expr, serverLevel);
+      value = await debug.evaluateInFrameNb(this.session, this.gsProcess, expr, serverLevel, {
+        suppressNotification: true,
+        onStart: (cancel) => { this.activeNbCancel = cancel; this.setCancellable(true); },
+      });
     } catch (e: unknown) {
-      value = `Error: ${e instanceof Error ? e.message : String(e)}`;
+      const raw = e instanceof Error ? e.message : String(e);
+      if (this.cancelClicks > 0) {
+        // The user interrupted this eval. Show a clean header (with which break it
+        // was — soft = stop at a safe point, hard = forced) plus the raw gem error
+        // for context, in the eval-result area below the bar (no top-banner error).
+        const kind = this.cancelClicks === 1 ? 'soft break' : 'hard break';
+        value = `Evaluation Cancelled (${kind})${raw ? ` — ${raw}` : ''}`;
+      } else {
+        value = `Error: ${raw}`;
+      }
       isError = true;
+    } finally {
+      this.activeNbCancel = undefined;
+      this.nbBusy = false;
+      this.setCancellable(false);
     }
+    if (this.disposed) return;
     this.panel.webview.postMessage({ command: 'evalResult', expr, value, isError });
+  }
+
+  /** Tell the webview whether the in-flight busy op can be cancelled (#9). */
+  private setCancellable(on: boolean): void {
+    if (this.disposed) return;
+    this.panel.webview.postMessage({ command: 'cancellable', on });
+  }
+
+  /** Webview Cancel button → request a break of the active nb op (soft, then hard). */
+  private cancelActiveOp(): void {
+    if (!this.activeNbCancel) return;
+    this.cancelClicks += 1;
+    // Acknowledge the click so it visibly registers — the break is asynchronous
+    // (the gem stops at a safe point), so without this the Cancel feels unheard.
+    this.flash(this.cancelClicks === 1
+      ? 'Break sent — waiting for the gem to stop…'
+      : 'Forcing interrupt…');
+    this.activeNbCancel();
   }
 
   /**
@@ -2394,12 +2451,13 @@ export class DebuggerPanel {
       const raw = this.rawFrames.find(r => r.serverLevel === frame.serverLevel);
       if (raw) level = this.stopFrameLevel(raw.homeMethodOop, frame.serverLevel);
     }
-    await this.runNb('Step', async () => {
+    await this.runNb('Step', async (opts) => {
       // Stepping moves the stack → the prior halt's revert slots are now invalid.
       this.clearUndoState();
       // Non-blocking + cancellable: a step that crawls hidden machinery or steps
       // a looping method no longer freezes the extension host (see nbRunner.ts).
-      const result = await fn(this.session, this.gsProcess, level);
+      // Forwarding opts wires the in-panel Cancel button for a runaway step.
+      const result = await fn(this.session, this.gsProcess, level, opts);
       if (this.disposed) return; // panel closed while the step ran
       if (result.completed) {
         this.onCompleted(result);
@@ -2452,17 +2510,32 @@ export class DebuggerPanel {
    * told to retry (otherwise a save-driven edit-and-continue or a click would
    * just vanish).
    */
-  private async runNb(action: string, op: () => Promise<void>): Promise<void> {
+  private async runNb(action: string, op: (opts: NbRunOptions) => Promise<void>): Promise<void> {
     if (this.nbBusy) {
       this.notifyBusy(action);
       return;
     }
     this.nbBusy = true;
+    this.cancelClicks = 0; // reset before the op (onStart may not fire if start fails)
+    // Hand the op nb options that (a) suppress the 2s toast — the in-panel overlay
+    // owns cancel for debugger ops — and (b) wire the in-panel Cancel button: when
+    // the op forwards these to its nb call, onStart fires and we mark it cancellable
+    // and capture its cancel handle. Ops that don't forward them simply show the
+    // spinner with no Cancel button (never a dead button).
+    const opts: NbRunOptions = {
+      suppressNotification: true,
+      onStart: (cancel) => {
+        this.activeNbCancel = cancel;
+        this.setCancellable(true);
+      },
+    };
     try {
-      await op();
+      await op(opts);
     } catch (e: unknown) {
       this.handleNbError(action, e);
     } finally {
+      this.activeNbCancel = undefined;
+      this.setCancellable(false);
       this.nbBusy = false;
     }
   }
@@ -2501,10 +2574,23 @@ export class DebuggerPanel {
       this.postInit();
       return;
     }
-    await this.runNb('Restart frame', async () => {
+    // An Executed Code (doit) frame can't be a restart target: the kernel's
+    // trimStackToLevel: does `oldHome inClass compiledMethodAt:…` to reinstall the
+    // (possibly recompiled) method, and a doit's home method has a NIL class — so
+    // the trim fails with a raw `UndefinedObject doesNotUnderstand`. Guard it with a
+    // clear message instead, mirroring the edit-and-continue re-enter guard.
+    if (this.rawFrames.find(r => r.serverLevel === serverLevel)?.isExecutedCode) {
+      this.errorMessage = 'Cannot restart an Executed Code frame — it has no home class for '
+        + 'GemStone to reset. Re-run the expression instead.';
+      this.postInit();
+      return;
+    }
+    await this.runNb('Restart frame', async (opts) => {
       // The trim rebuilds the stack → revert slots no longer apply.
       this.clearUndoState();
-      await debug.trimStackToLevelNb(this.session, this.gsProcess, serverLevel);
+      // Forwarding opts wires the in-panel Cancel button — a trim can run unwind/
+      // ensure: blocks (infinite kernel timeout), so a runaway restart is cancellable.
+      await debug.trimStackToLevelNb(this.session, this.gsProcess, serverLevel, opts);
       if (this.disposed) return;
       this.staleTopActivation = false; // the trim discarded any stale top activation
       this.uncontinuable = false;      // …and a fresh activation is continuable again
@@ -3290,6 +3376,36 @@ export class DebuggerPanel {
     /* Suppress text selection / the default Cut-Copy-Paste affordances; the
        Copy button is the supported way to copy the stack. */
     body { user-select: none; -webkit-user-select: none; }
+    /* Progress / busy indicator (#9). The host posts {command:'busy', on} around
+       blocking server round-trips (class-chain resolve, save→fetchStack, etc.);
+       the webview reveals this only if the op outlives BUSY_DELAY_MS (~500ms), so
+       fast calls never flash. The webview is a SEPARATE process from the frozen
+       extension host, so this keeps animating while the host is blocked. */
+    body.busy { cursor: progress; }
+    .busy-overlay {
+      position: fixed; inset: 0; z-index: 50;
+      display: flex; align-items: center; justify-content: center;
+      background: transparent; pointer-events: none; /* don't trap clicks */
+    }
+    .busy-box { display: flex; flex-direction: column; align-items: center; gap: 0.6rem; }
+    .busy-overlay .busy-spinner {
+      width: 30px; height: 30px; border-radius: 50%;
+      border: 3px solid var(--vscode-foreground);
+      border-top-color: transparent;
+      opacity: 0.45;
+      animation: jasper-busy-spin 0.8s linear infinite;
+    }
+    @keyframes jasper-busy-spin { to { transform: rotate(360deg); } }
+    /* The Cancel button is the one part of the overlay that takes clicks — it
+       appears only for cancellable (non-blocking) ops, so it's never a dead link. */
+    .busy-cancel {
+      pointer-events: auto;
+      color: var(--vscode-button-foreground);
+      background: var(--vscode-button-background);
+      border: none; padding: 0.25rem 0.9rem; border-radius: 2px; cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .busy-cancel:hover { background: var(--vscode-button-hoverBackground, var(--vscode-button-background)); }
     .titlebar { display: flex; align-items: baseline; gap: 0.6rem; margin: 0 0 0.25rem; flex-wrap: wrap; }
     h1 { font-size: 1.3rem; margin: 0; }
     .subtitle { color: var(--vscode-descriptionForeground); font-size: 0.85rem; }
@@ -3584,6 +3700,14 @@ export class DebuggerPanel {
   <div id="varctxmenu" class="ctx-menu" role="menu">
     <div class="ctx-item" id="varInspectItem" role="menuitem">GT Inspect</div>
   </div>
+  <!-- Progress/busy overlay (#9): hidden until a slow server op crosses the delay.
+       The Cancel button shows only when the running op is cancellable. -->
+  <div id="busyOverlay" class="busy-overlay" style="display:none;" aria-hidden="true">
+    <div class="busy-box">
+      <div class="busy-spinner"></div>
+      <button id="busyCancel" class="busy-cancel" type="button" style="display:none;">Cancel</button>
+    </div>
+  </div>
   <script nonce="${nonce}">${debuggerViewJs}</script>
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
@@ -3612,6 +3736,8 @@ export class DebuggerPanel {
       hsplitter: document.getElementById('hsplitter'),
       varMenu: document.getElementById('varctxmenu'),
       varInspectItem: document.getElementById('varInspectItem'),
+      busyOverlay: document.getElementById('busyOverlay'),
+      busyCancel: document.getElementById('busyCancel'),
     }, vscode);
     vscode.postMessage({ command: 'ready' });
   </script>

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -255,6 +255,13 @@ export interface InlineVar {
   value: string;
   /** Full printString, shown on hover (un-truncated, may be multi-line). */
   full: string;
+  /**
+   * When present, this var is editable in-frame from the hover overlay (a `$(edit)`
+   * command-link → `gemstone.editInlineValue`), exactly like its row in the
+   * Variables pane. Carries the server write target — same `{kind,index}` as the
+   * pane's `VarRow.edit`. Absent for `self` and the synthetic `.tN` stack temps.
+   */
+  edit?: { kind: 'instvar' | 'temp'; index: number };
 }
 
 /** One source line's inline overlay: the rendered text + per-var hover parts. */
@@ -430,6 +437,28 @@ export function computeInlineValueLines(
     label: h.vars.map(v => `${v.name} = ${v.value}`).join(INLINE_VALUE_SEP),
     padCh: Math.max(INLINE_VALUE_GAP, targetCol - lines[h.line].length),
   }));
+}
+
+/**
+ * The hover markdown for one inline-overlay line: a `**name** = value` part per
+ * variable, joined one-per-line. Each *editable* var (#5 Phase 2) gets a `$(edit)`
+ * pencil command-link beside its name that opens the same set-value prompt as the
+ * Variables pane — `self` and the synthetic stack temps carry no `edit`, so they
+ * get no pencil and stay read-only. The link encodes `[uri, serverLevel, kind,
+ * index, name]`; the caller marks the `MarkdownString` trusted for the single
+ * `gemstone.editInlineValue` command (and enables codicons).
+ */
+export function inlineHoverMarkdown(vars: InlineVar[]): string {
+  // Escape markdown-significant chars in the (server-supplied) printString so it
+  // renders verbatim rather than as accidental markup.
+  const safe = (s: string): string => s.replace(/[\\[\]`*_<>]/g, '\\$&');
+  const body = vars.map(v => `**${v.name}** = ${safe(v.full)}`).join('  \n');
+  // Editing in the source is by double-clicking the variable's name (command-links
+  // in hovers don't fire in all hosts, so the hover only hints — it isn't the
+  // trigger). The hint shows only when something on this line is editable.
+  return vars.some(v => v.edit)
+    ? `${body}\n\n_Double-click the variable name to set its value._`
+    : body;
 }
 
 /** Minimal HTML-escape for interpolating session text into the page. */
@@ -984,6 +1013,21 @@ export class DebuggerPanel {
   /** The editor currently carrying the inline-value overlay, if any. */
   private inlineDecoratedEditor: vscode.TextEditor | undefined;
   /**
+   * The current overlay's per-line variables and frame, so the inline-value
+   * HoverProvider (#5 Phase 2) can serve the value+edit-pencil hover on demand.
+   * A registered HoverProvider is used rather than the decoration's `hoverMessage`
+   * because command-links only fire from provider hovers, not decoration hovers.
+   */
+  private inlineHoverByLine = new Map<number, InlineVar[]>();
+  private inlineHoverLevel: number | undefined;
+  /**
+   * Editable in-scope variables for the shown frame, keyed by source name → write
+   * target. Drives click-to-edit: while the overlay is on, a mouse click on one of
+   * these names in the source opens its set-value prompt. Built in
+   * `updateInlineValues`; empty when the overlay is off (so clicks behave normally).
+   */
+  private inlineEditableByName = new Map<string, { kind: 'instvar' | 'temp'; index: number }>();
+  /**
    * The selected frame's variable groups, cached so toggling the inline overlay
    * (or its mode) re-renders from memory instead of re-running N blocking
    * getObjectPrintString round-trips per click. Keyed by server level; dropped
@@ -1200,6 +1244,37 @@ export class DebuggerPanel {
       null,
       this.disposables,
     );
+    // Double-click-to-edit (#5 Phase 2): double-clicking an editable variable's
+    // name in the companion source (while the inline overlay is on) opens its
+    // set-value prompt — a direct selection handler, since hover command-links
+    // don't fire here. A single click is left alone (cursor / Run to Cursor).
+    vscode.window.onDidChangeTextEditorSelection(
+      (e) => this.onSourceSelectionChanged(e),
+      null,
+      this.disposables,
+    );
+  }
+
+  /**
+   * Double-click-to-edit handler: a double-click selects the whole word, so when
+   * the mouse selects an editable in-scope variable's name in this panel's source
+   * pane (overlay on), open that variable's set-value prompt. A single click
+   * leaves an EMPTY selection and is ignored — the cursor stays put for normal
+   * navigation and Run to Cursor (#2).
+   */
+  private onSourceSelectionChanged(e: vscode.TextEditorSelectionChangeEvent): void {
+    if (e.kind !== vscode.TextEditorSelectionChangeKind.Mouse) return; // mouse, not keyboard
+    if (!this.inlineValuesEnabled || this.inlineHoverLevel === undefined) return;
+    // Compare by document URI, not editor identity — VS Code can hand back a
+    // different TextEditor instance for the same view, which a `!==` would miss.
+    const uri = this.sourceEditor?.document.uri.toString();
+    if (uri === undefined || e.textEditor.document.uri.toString() !== uri) return;
+    const sel = e.selections[0];
+    if (!sel || sel.isEmpty) return;                                   // single click → leave the cursor
+    const word = e.textEditor.document.getText(sel);                   // the double-clicked word
+    const edit = this.inlineEditableByName.get(word);
+    if (!edit) return;                                                 // not an editable variable
+    void this.editInlineValue(this.inlineHoverLevel, edit.kind, edit.index, word);
   }
 
   private handleMessage(msg: DebuggerInbound): void {
@@ -2103,6 +2178,27 @@ export class DebuggerPanel {
       this.panel.webview.postMessage({ command: 'setVariableResult', ok: false, error: 'Busy — try again' });
       return;
     }
+    const result = this.writeVariableInFrame(serverLevel, kind, index, expr);
+    // Success → the host's `postVariables` (inside the write) already re-rendered
+    // the pane, which removes the open editor; this ok just confirms it. Failure →
+    // keep the editor open and flag the error on it so the expression can be fixed.
+    this.panel.webview.postMessage(result.ok
+      ? { command: 'setVariableResult', ok: true }
+      : { command: 'setVariableResult', ok: false, error: result.error });
+  }
+
+  /**
+   * The shared variable write: evaluate `expr` in the frame, capture+pin the
+   * slot's original (for revert), write the new OOP into the instVar / temp, then
+   * refresh the Variables pane and inline overlay. Returns `{ ok }` so each caller
+   * surfaces failures its own way — the webview pane flags the inline editor
+   * (`setVariableResult`), the source-pane inline edit shows an error toast (it has
+   * no webview). On failure nothing is written and the pane is NOT re-rendered (so
+   * the pane's editor stays open). Callers must guard `nbBusy` first.
+   */
+  private writeVariableInFrame(
+    serverLevel: number, kind: 'instvar' | 'temp', index: number, expr: string,
+  ): { ok: boolean; error?: string } {
     try {
       const valueOop = debug.evaluateInFrameToOop(this.session, this.gsProcess, expr, serverLevel);
       const info = debug.getFrameInfo(this.session, this.gsProcess, serverLevel);
@@ -2115,16 +2211,64 @@ export class DebuggerPanel {
         debug.setFrameTemp(this.session, this.gsProcess, serverLevel, index, valueOop);
       }
       this.undoDirty.add(this.undoKey(serverLevel, kind, index));
-      this.panel.webview.postMessage({ command: 'setVariableResult', ok: true });
       this.invalidateVariablesCache(); // the slot points at a new object — re-fetch
       this.postVariables(serverLevel);
       // The slot now points at a new object — refresh the inline overlay so its
       // value (and hover) track, just like the Variables pane.
       if (this.sourceEditor) this.updateInlineValues(this.sourceEditor, serverLevel);
+      return { ok: true };
     } catch (e: unknown) {
       const error = e instanceof Error ? e.message : String(e);
       logError(this.sessionId, error);
-      this.panel.webview.postMessage({ command: 'setVariableResult', ok: false, error });
+      return { ok: false, error };
+    }
+  }
+
+  /**
+   * Edit an inline-overlay variable from its hover `$(edit)` pencil (#5 Phase 2):
+   * prompt for a new value (prefilled with the current printString, like the
+   * Variables pane's inline editor), then route through the shared
+   * `writeVariableInFrame` — so the pane, the inline overlay, undo/revert and the
+   * GC-pin all update exactly as a pane edit does. The source pane has no webview,
+   * so a rejected expression surfaces as an error toast. Resolved from the hover
+   * command args by `editInlineValueForUri`.
+   */
+  private async editInlineValue(
+    serverLevel: number, kind: 'instvar' | 'temp', index: number, name: string,
+  ): Promise<void> {
+    try {
+      if (this.nbBusy) { this.notifyBusy('Set variable'); return; }
+      // Prefill with the current printString (like the pane), but never let a
+      // failed prefetch abort the edit — fall back to an empty box.
+      let prefill = '';
+      try {
+        prefill = this.inlineVarsForFrame(serverLevel)
+          .find(v => v.name === name && v.edit?.kind === kind && v.edit?.index === index)?.full ?? '';
+      } catch (e: unknown) {
+        logError(this.sessionId, e instanceof Error ? e.message : String(e));
+      }
+      const expr = await vscode.window.showInputBox({
+        title: `Set ${name}`,
+        prompt: `New value for ${name} — evaluated in the selected frame`,
+        value: prefill,
+        ignoreFocusOut: true,
+      });
+      if (expr === undefined) return; // cancelled (Esc / focus-out off)
+      const trimmed = expr.trim();
+      if (trimmed === '') return; // empty → no-op, matching the pane's editor
+      // The prompt is modeless; re-check before the blocking write in case a
+      // step/trim claimed the session while it was open.
+      if (this.nbBusy) { this.notifyBusy('Set variable'); return; }
+      const result = this.writeVariableInFrame(serverLevel, kind, index, trimmed);
+      if (!result.ok) {
+        void vscode.window.showErrorMessage(`Could not set ${name}: ${result.error}`);
+      }
+    } catch (e: unknown) {
+      // A throw here would otherwise be a silent unhandled rejection (the command
+      // is invoked via `void`), which reads as "the pencil does nothing".
+      const msg = e instanceof Error ? e.message : String(e);
+      logError(this.sessionId, msg);
+      void vscode.window.showErrorMessage(`Jasper: inline edit of ${name} failed: ${msg}`);
     }
   }
 
@@ -2889,6 +3033,9 @@ export class DebuggerPanel {
     }
     if (!this.inlineValuesEnabled) {
       editor.setDecorations(DebuggerPanel.inlineValueDecoration, []);
+      this.inlineHoverByLine.clear();
+      this.inlineEditableByName.clear();
+      this.inlineHoverLevel = undefined;
       return;
     }
     try {
@@ -2898,14 +3045,18 @@ export class DebuggerPanel {
         perLine: this.inlineValuesPerLine,
         signatureLine: this.shownFrameIsMethod,
       });
+      // Record this frame's overlay so the HoverProvider can serve the full-value
+      // hover for a hovered line (the decoration carries only the rendered `after`
+      // text). Also index the editable variables by name for click-to-edit.
+      this.inlineHoverByLine = new Map(overlay.map(o => [o.line, o.vars]));
+      this.inlineEditableByName = new Map(
+        vars.filter(v => v.edit).map(v => [v.name, v.edit!]),
+      );
+      this.inlineHoverLevel = serverLevel;
       const decorations: vscode.DecorationOptions[] = overlay.map(o => {
         const line = editor.document.lineAt(o.line);
-        const hover = new vscode.MarkdownString(
-          o.vars.map(v => `**${v.name}** = ${v.full}`).join('  \n'),
-        );
         return {
           range: new vscode.Range(line.range.end, line.range.end),
-          hoverMessage: hover,
           // `padCh` left-pads each annotation so they align in one right-hand
           // column, out of the way of the code (see computeInlineValueLines).
           renderOptions: { after: { contentText: o.label, margin: `0 0 0 ${o.padCh}ch` } },
@@ -2916,6 +3067,31 @@ export class DebuggerPanel {
     } catch (e: unknown) {
       logError(this.sessionId, e instanceof Error ? e.message : String(e));
     }
+  }
+
+  /**
+   * The inline-value hover for `line` of the source `uriStr`: each variable's full
+   * (un-truncated) printString, plus a hint that editable ones can be set by
+   * clicking their name. Undefined when the overlay is off, the hovered document
+   * isn't this panel's live source, or the line has no annotated variable.
+   */
+  private inlineHoverForLine(uriStr: string, line: number): vscode.MarkdownString | undefined {
+    if (!this.inlineValuesEnabled || this.inlineHoverLevel === undefined) return undefined;
+    // Only answer for the source the overlay was computed against, so a stale
+    // (other-frame) map can't mislabel a different document.
+    if (this.sourceEditor?.document.uri.toString() !== uriStr) return undefined;
+    const vars = this.inlineHoverByLine.get(line);
+    if (!vars || vars.length === 0) return undefined;
+    return new vscode.MarkdownString(inlineHoverMarkdown(vars));
+  }
+
+  /**
+   * HoverProvider entry point (#5 Phase 2): the inline-value hover for a hovered
+   * source line, resolved to the panel showing that source. Returns undefined when
+   * no live panel owns the document or it has nothing to show on that line.
+   */
+  static provideInlineHover(uriStr: string, line: number): vscode.MarkdownString | undefined {
+    return DebuggerPanel.panelForSourceUri(uriStr)?.inlineHoverForLine(uriStr, line);
   }
 
   /**
@@ -2930,7 +3106,7 @@ export class DebuggerPanel {
     for (const group of this.variablesForFrame(serverLevel)) {
       if (group.kind === 'stacktemps') continue;
       for (const v of group.vars) {
-        vars.push({ name: v.name, value: shortenInlineValue(v.value), full: v.value });
+        vars.push({ name: v.name, value: shortenInlineValue(v.value), full: v.value, edit: v.edit });
       }
     }
     return vars;

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -295,7 +295,7 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, homeFrameItem, frameImplItem, copyBtn, dumpBtn, saveNotice, savePath, copyPathBtn, error, flash, dnuBar, toolbar, runToCursorBtn, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar, varMenu, varInspectItem, busyOverlay, busyCancel } = refs;
+    const { list, menu, copyFrameItem, browseFrameItem, homeFrameItem, frameImplItem, copyBtn, dumpBtn, saveNotice, savePath, copyPathBtn, error, flash, dnuBar, toolbar, runToCursorBtn, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar, varMenu, varInspectItem, busyOverlay, busyCancel } = refs;
     // Progress indicator (#9). A blocking GCI call FREEZES the extension host, and
     // postMessage delivery needs that event loop — so the host cannot tell us "I'm
     // busy" while it's busy (the on/off pair would arrive together, after the work).
@@ -434,6 +434,11 @@
       e.stopPropagation();
       select(level);
       const frame = currentStack.find((f) => f.level === level);
+      // "Browse" — only for a frame that runs a real Class>>#selector (the host
+      // sets `browsable`); hidden for Executed-Code (doit) and unresolvable frames.
+      if (browseFrameItem) {
+        browseFrameItem.style.display = frame && frame.browsable ? '' : 'none';
+      }
       // "Go to home method" — only for a block frame whose home method is also on
       // the visible stack (host sets homeDisplayLevel to that frame's level).
       if (homeFrameItem) {
@@ -459,6 +464,14 @@
       if (selectedLevel != null) post({ command: 'copyFrame', level: selectedLevel });
       hideMenu(menu);
     });
+
+    if (browseFrameItem) {
+      browseFrameItem.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (selectedLevel != null) post({ command: 'browseFrame', level: selectedLevel });
+        hideMenu(menu);
+      });
+    }
 
     if (homeFrameItem) {
       homeFrameItem.addEventListener('click', (e) => {

--- a/client/src/debuggerView.js
+++ b/client/src/debuggerView.js
@@ -295,7 +295,66 @@
    * editor and highlight the current line.
    */
   function init(refs, vscode) {
-    const { list, menu, copyFrameItem, homeFrameItem, frameImplItem, copyBtn, dumpBtn, saveNotice, savePath, copyPathBtn, error, flash, dnuBar, toolbar, runToCursorBtn, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar, varMenu, varInspectItem } = refs;
+    const { list, menu, copyFrameItem, homeFrameItem, frameImplItem, copyBtn, dumpBtn, saveNotice, savePath, copyPathBtn, error, flash, dnuBar, toolbar, runToCursorBtn, variables, evalInput, evalResult, main, splitter, hsplitter, evalbar, varMenu, varInspectItem, busyOverlay, busyCancel } = refs;
+    // Progress indicator (#9). A blocking GCI call FREEZES the extension host, and
+    // postMessage delivery needs that event loop — so the host cannot tell us "I'm
+    // busy" while it's busy (the on/off pair would arrive together, after the work).
+    // Instead the WEBVIEW drives it: when we send a server-bound request we start a
+    // reveal timer HERE (this is a separate process, so the timer fires and the CSS
+    // spinner animates even while the host is frozen). We hide it when the host's
+    // response lands. The timer's delay means fast round-trips never flash.
+    const BUSY_DELAY_MS = 500;
+    // Outbound commands that make the host do a server round-trip and then post a
+    // reply back. Local-only commands (copyText/saveLayout/dump/terminate/etc.) and
+    // ops with no webview reply (inspectVariable) are intentionally excluded.
+    const SERVER_BOUND = {
+      ready: 1, selectFrame: 1, evalInFrame: 1, stepOver: 1, stepInto: 1,
+      stepThrough: 1, restartFrame: 1, setVariable: 1, revertVariable: 1,
+      runToCursor: 1, resume: 1, createDnuMethod: 1,
+    };
+    let busyTimer = null;       // reveal-delay timer; non-null ⇒ a span is pending/shown
+    let busyActive = false;     // a server request is in flight (timer pending or shown)
+    let busyCancellable = false; // the running op can be cancelled (host said so)
+    let busyShown = false;       // the spinner is currently revealed
+    function showBusyOverlay(on) {
+      busyShown = on;
+      if (document.body) document.body.classList.toggle('busy', on);
+      if (busyOverlay) busyOverlay.style.display = on ? '' : 'none';
+      // The Cancel button rides the spinner, but only for cancellable ops — so it
+      // never shows for a blocking op the host couldn't actually interrupt.
+      if (busyCancel) busyCancel.style.display = (on && busyCancellable) ? '' : 'none';
+    }
+    function beginBusy() {
+      if (busyActive) return; // already in a span; keep the existing reveal timer
+      busyActive = true;
+      busyTimer = setTimeout(function () { busyTimer = null; showBusyOverlay(true); }, BUSY_DELAY_MS);
+    }
+    function endBusy() {
+      busyActive = false;
+      busyCancellable = false;
+      if (busyTimer != null) { clearTimeout(busyTimer); busyTimer = null; }
+      showBusyOverlay(false);
+      if (busyCancel) busyCancel.textContent = 'Cancel'; // reset for the next op
+    }
+    function applyBusy(on) { if (on) beginBusy(); else endBusy(); }
+    // Host tells us the in-flight op can be cancelled → reveal Cancel if the
+    // spinner is already up (else showBusyOverlay picks it up when it reveals).
+    function setCancellable(on) {
+      busyCancellable = on;
+      if (busyShown && busyCancel) busyCancel.style.display = on ? '' : 'none';
+    }
+    if (busyCancel) {
+      busyCancel.addEventListener('click', function () {
+        // Each click escalates host-side: first = soft break, second = hard break.
+        vscode.postMessage({ command: 'cancelOp' });
+        busyCancel.textContent = 'Cancelling… (click again to force)';
+      });
+    }
+    // Single send path: starts the busy span for server-bound requests, then posts.
+    function post(msg) {
+      if (msg && SERVER_BOUND[msg.command]) beginBusy();
+      vscode.postMessage(msg);
+    }
     let dumpedPath = null; // the last-dumped file path, for the Copy-path button
     let saveNoticeTimer = null;
     const COPY_GLYPH = copyPathBtn ? copyPathBtn.textContent : '';
@@ -330,10 +389,10 @@
         showMenu(varMenu, e.clientX, e.clientY);
       },
       commit: function (edit, expr) {
-        vscode.postMessage({ command: 'setVariable', level: selectedLevel, kind: edit.kind, index: edit.index, expr: expr });
+        post({ command: 'setVariable', level: selectedLevel, kind: edit.kind, index: edit.index, expr: expr });
       },
       revert: function (edit) {
-        vscode.postMessage({ command: 'revertVariable', level: selectedLevel, kind: edit.kind, index: edit.index });
+        post({ command: 'revertVariable', level: selectedLevel, kind: edit.kind, index: edit.index });
       },
       setActiveEditor: setActiveVarEditor,
     };
@@ -356,7 +415,7 @@
       selectFrame(list, level);
       selectedLevel = level;
       updateRunToCursor(level);
-      vscode.postMessage({ command: 'selectFrame', level });
+      post({ command: 'selectFrame', level });
     }
 
     // Left-click selects a frame (will drive the source pane in later Stage 1 work).
@@ -397,7 +456,7 @@
 
     copyFrameItem.addEventListener('click', (e) => {
       e.stopPropagation();
-      if (selectedLevel != null) vscode.postMessage({ command: 'copyFrame', level: selectedLevel });
+      if (selectedLevel != null) post({ command: 'copyFrame', level: selectedLevel });
       hideMenu(menu);
     });
 
@@ -415,7 +474,7 @@
     if (frameImplItem) {
       frameImplItem.addEventListener('click', (e) => {
         e.stopPropagation();
-        if (selectedLevel != null) vscode.postMessage({ command: 'implementInReceiver', level: selectedLevel });
+        if (selectedLevel != null) post({ command: 'implementInReceiver', level: selectedLevel });
         hideMenu(menu);
       });
     }
@@ -424,7 +483,7 @@
     if (varInspectItem) {
       varInspectItem.addEventListener('click', (e) => {
         e.stopPropagation();
-        if (varMenuTarget) vscode.postMessage({ command: 'inspectVariable', oop: varMenuTarget.oop, name: varMenuTarget.name });
+        if (varMenuTarget) post({ command: 'inspectVariable', oop: varMenuTarget.oop, name: varMenuTarget.name });
         if (varMenu) hideMenu(varMenu);
       });
     }
@@ -459,14 +518,14 @@
 
     // #10 Copy Stack: the full stack (short stack + each frame's variable values).
     copyBtn.addEventListener('click', () => {
-      vscode.postMessage({ command: 'copyStack' });
+      post({ command: 'copyStack' });
       flashIcon(copyBtn);
     });
 
     // #11 Dump Stack: write the full stack to ~/.jasper/stacks (no tab opened).
     if (dumpBtn) {
       dumpBtn.addEventListener('click', () => {
-        vscode.postMessage({ command: 'dumpStackToFile' });
+        post({ command: 'dumpStackToFile' });
         flashIcon(dumpBtn);
       });
     }
@@ -475,7 +534,7 @@
     // appears only when the user asks for it.
     if (savePath) {
       savePath.addEventListener('click', () => {
-        if (dumpedPath != null) vscode.postMessage({ command: 'openDumpFile', path: dumpedPath });
+        if (dumpedPath != null) post({ command: 'openDumpFile', path: dumpedPath });
       });
     }
 
@@ -485,7 +544,7 @@
     if (copyPathBtn) {
       copyPathBtn.addEventListener('click', () => {
         if (dumpedPath == null) return;
-        vscode.postMessage({ command: 'copyText', text: dumpedPath });
+        post({ command: 'copyText', text: dumpedPath });
         if (saveNoticeTimer) { clearTimeout(saveNoticeTimer); saveNoticeTimer = null; }
         copyPathBtn.textContent = '✓';
         setTimeout(() => { copyPathBtn.textContent = COPY_GLYPH; hideSaveNotice(); }, 1200);
@@ -499,7 +558,7 @@
         const btn = e.target && e.target.closest ? e.target.closest('button[data-cmd]') : null;
         if (!btn) return;
         const command = btn.dataset.cmd;
-        vscode.postMessage(selectedLevel != null ? { command, level: selectedLevel } : { command });
+        post(selectedLevel != null ? { command, level: selectedLevel } : { command });
       });
     }
 
@@ -508,7 +567,7 @@
       evalInput.addEventListener('keydown', (e) => {
         if (e.key !== 'Enter') return;
         const expr = evalInput.value.trim();
-        if (expr) vscode.postMessage({ command: 'evalInFrame', level: selectedLevel, expr });
+        if (expr) post({ command: 'evalInFrame', level: selectedLevel, expr });
       });
     }
 
@@ -546,7 +605,7 @@
           state.stackBasis = basis;
           vscode.setState(state);
         }
-        vscode.postMessage({ command: 'saveLayout', stackBasis: basis });
+        post({ command: 'saveLayout', stackBasis: basis });
       }
       splitter.addEventListener('mousedown', (e) => {
         startBasis = main.style.getPropertyValue('--stack-basis').trim();
@@ -583,7 +642,7 @@
           state.evalHeight = height;
           vscode.setState(state);
         }
-        vscode.postMessage({ command: 'saveLayout', evalHeight: height });
+        post({ command: 'saveLayout', evalHeight: height });
       }
       hsplitter.addEventListener('mousedown', (e) => {
         startY = e.clientY;
@@ -607,15 +666,32 @@
     // Inbound messages from the host.
     window.addEventListener('message', (event) => {
       const msg = event.data;
+      if (msg.command === 'busy') {
+        // The host can still nudge busy explicitly; the webview-driven send path
+        // (post → beginBusy) is the primary trigger that survives a host freeze.
+        applyBusy(!!msg.on);
+        return;
+      }
+      if (msg.command === 'cancellable') {
+        // Control signal during an in-flight op (not a reply) — don't end the span.
+        setCancellable(!!msg.on);
+        return;
+      }
+      // `flash`/`banner` are transient status the host posts DURING an op (e.g. the
+      // "Break sent…" acknowledgement on Cancel) — they must NOT end the busy span,
+      // or the spinner + Cancel would vanish mid-op and the second Cancel click
+      // (hard break) would be unreachable. Every other message is a genuine reply,
+      // so it ends the span the send path started.
+      if (msg.command !== 'flash' && msg.command !== 'banner') endBusy();
       if (msg.command === 'init') {
         if (error) error.textContent = msg.errorMessage || '';
         // Show the create-method action when parked on a doesNotUnderstand:, or the
         // implement action when parked on a subclassResponsibility (T4). Mutually
         // exclusive; renderDnu(undefined) clears the bar before the SR button renders.
-        renderDnu(dnuBar, msg.dnu, function () { vscode.postMessage({ command: 'createDnuMethod' }); });
+        renderDnu(dnuBar, msg.dnu, function () { post({ command: 'createDnuMethod' }); });
         if (!msg.dnu) {
           renderSubclassResp(dnuBar, msg.subclassResp,
-            function () { vscode.postMessage({ command: 'implementSubclassResponsibility' }); });
+            function () { post({ command: 'implementSubclassResponsibility' }); });
         }
         // Clear stale variables / eval output; the default-select below re-fetches.
         if (variables) variables.innerHTML = '';

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -327,6 +327,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerHoverProvider(providerSelectors, hoverProvider),
     vscode.languages.registerCompletionItemProvider(providerSelectors, completionProvider),
     vscode.languages.registerCodeLensProvider(providerSelectors, codeLensProvider),
+    codeLensProvider, // dispose() cancels pending count lookups + releases the emitter
   );
 
   // ── Breakpoints + Debugger ───────────────────────────────

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -156,6 +156,17 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerCodeLensProvider(
       [{ scheme: 'gemstone' }, { scheme: 'gemstone-debug' }], inlineValuesLens,
     ),
+    // The inline-value hover (#5): serves each variable's full printString for a
+    // hovered line, plus a hint that editable ones are set by clicking the name.
+    vscode.languages.registerHoverProvider(
+      [{ scheme: 'gemstone' }, { scheme: 'gemstone-debug' }],
+      {
+        provideHover(doc, pos) {
+          const md = DebuggerPanel.provideInlineHover(doc.uri.toString(), pos.line);
+          return md ? new vscode.Hover(md) : undefined;
+        },
+      },
+    ),
   );
 
   try {

--- a/client/src/gemstoneCodeLensProvider.ts
+++ b/client/src/gemstoneCodeLensProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { SessionManager } from './sessionManager';
+import { SessionManager, ActiveSession } from './sessionManager';
 import { parseTopazDocument } from './topazFileIn';
 import { extractSelector } from './systemBrowser';
 import * as queries from './browserQueries';
@@ -16,9 +16,14 @@ interface CodeLensData {
   kind: 'senders' | 'implementors';
 }
 
-export class GemStoneCodeLensProvider implements vscode.CodeLensProvider {
+export class GemStoneCodeLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
   private _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
   readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
+
+  /** Pending {@link scheduleCount} timers, so disposal can cancel deferred lookups
+   *  (which would otherwise run blocking GCI against a torn-down session). */
+  private countTimers = new Set<ReturnType<typeof setTimeout>>();
+  private disposed = false;
 
   private codeLensData = new Map<vscode.CodeLens, CodeLensData>();
 
@@ -35,10 +40,22 @@ export class GemStoneCodeLensProvider implements vscode.CodeLensProvider {
    */
   private countCache = new Map<string, number>();
 
+  /**
+   * Counts currently being computed (keyed like {@link countCache}). The
+   * sendersOf/implementorsOf lookups BLOCK the extension host — for a popular
+   * selector (`initialize`: hundreds of hits) that freeze lasts seconds. So a
+   * lens shows a spinner placeholder and the count is computed on a later tick
+   * ({@link scheduleCount}); the spinner paints first and keeps animating (it
+   * lives in the editor's process, not the frozen host) until the count lands.
+   * This set dedupes concurrent re-resolves so the lookup runs once per key.
+   */
+  private pending = new Set<string>();
+
   constructor(private sessionManager: SessionManager) {}
 
   refresh(): void {
     this.countCache.clear();
+    this.pending.clear();
     this._onDidChangeCodeLenses.fire();
   }
 
@@ -128,48 +145,74 @@ export class GemStoneCodeLensProvider implements vscode.CodeLensProvider {
       return codeLens;
     }
 
-    try {
-      const maxEnv = vscode.workspace.getConfiguration('gemstone')
-        .get<number>('maxEnvironment', 0);
+    const maxEnv = vscode.workspace.getConfiguration('gemstone')
+      .get<number>('maxEnvironment', 0);
+    // Each lens computes only its own count. Cached so a forced re-resolve
+    // (another provider on this doc changing) doesn't repeat the server work.
+    const cacheKey = `${data.kind}|${data.selector}|${data.className ?? ''}|${data.isMeta}|${session.id}|${maxEnv}`;
 
-      // Each lens computes only its own count. Half the GCI work per lens
-      // compared to the old combined link, so total work for the pair is
-      // unchanged from the user's perspective. Cached so a forced re-resolve
-      // (another provider on this doc changing) doesn't repeat the server work.
-      const cacheKey = `${data.kind}|${data.selector}|${data.className ?? ''}|${data.isMeta}|${session.id}|${maxEnv}`;
-      let count = this.countCache.get(cacheKey);
-      if (count === undefined) {
-        count = 0;
-        for (let env = 0; env <= maxEnv; env++) {
-          try {
-            count += data.kind === 'senders'
-              ? queries.sendersOf(session, data.selector, env).length
-              : queries.implementorsOf(session, data.selector, env).length;
-          } catch {
-            // Session may be busy or selector not found in this env
-          }
-        }
-        this.countCache.set(cacheKey, count);
-      }
-
-      const noun = data.kind === 'senders' ? 'sender' : 'implementor';
-      const title = count === 1 ? `1 ${noun}` : `${count} ${noun}s`;
-      const command = data.kind === 'senders'
-        ? 'gemstone.sendersOfSelector'
-        : 'gemstone.implementorsOfSelector';
-
-      codeLens.command = {
-        title,
-        command,
-        arguments: [{ selector: data.selector, sessionId: session.id }],
-      };
-    } catch {
-      codeLens.command = {
-        title: '...',
-        command: '',
-      };
+    const count = this.countCache.get(cacheKey);
+    if (count !== undefined) {
+      codeLens.command = this.countCommand(count, data, session.id);
+      return codeLens;
     }
 
+    // Not counted yet: show a spinner and compute on a later tick (see
+    // `pending`). When the count lands, scheduleCount fires a change so VS Code
+    // re-resolves this lens — now a cache hit — and the number replaces the spin.
+    this.scheduleCount(data, session, maxEnv, cacheKey);
+    const noun = data.kind === 'senders' ? 'senders' : 'implementors';
+    codeLens.command = { title: `$(loading~spin) ${noun}…`, command: '' };
     return codeLens;
+  }
+
+  /** The resolved link for a known count (singular/plural + click command). */
+  private countCommand(count: number, data: CodeLensData, sessionId: number): vscode.Command {
+    const noun = data.kind === 'senders' ? 'sender' : 'implementor';
+    const title = count === 1 ? `1 ${noun}` : `${count} ${noun}s`;
+    const command = data.kind === 'senders'
+      ? 'gemstone.sendersOfSelector'
+      : 'gemstone.implementorsOfSelector';
+    return { title, command, arguments: [{ selector: data.selector, sessionId }] };
+  }
+
+  /**
+   * Compute a senders/implementors count off the resolve path so the spinner
+   * placeholder renders first, then cache it and fire a change to re-resolve.
+   * Deferred (not awaited) because the lookups block the host; running them here
+   * — after the placeholder is already on screen — keeps the spin visible.
+   */
+  private scheduleCount(
+    data: CodeLensData, session: ActiveSession, maxEnv: number, cacheKey: string,
+  ): void {
+    if (this.pending.has(cacheKey)) return;
+    this.pending.add(cacheKey);
+    const timer = setTimeout(() => {
+      this.countTimers.delete(timer);
+      if (this.disposed) return; // editor/extension torn down before the timer fired
+      let count = 0;
+      for (let env = 0; env <= maxEnv; env++) {
+        try {
+          count += data.kind === 'senders'
+            ? queries.sendersOf(session, data.selector, env).length
+            : queries.implementorsOf(session, data.selector, env).length;
+        } catch {
+          // Session may be busy or selector not found in this env
+        }
+      }
+      this.countCache.set(cacheKey, count);
+      this.pending.delete(cacheKey);
+      this._onDidChangeCodeLenses.fire();
+    }, 0);
+    this.countTimers.add(timer);
+  }
+
+  /** Cancel pending count lookups and release the change emitter on teardown. */
+  dispose(): void {
+    this.disposed = true;
+    for (const timer of this.countTimers) clearTimeout(timer);
+    this.countTimers.clear();
+    this.pending.clear();
+    this._onDidChangeCodeLenses.dispose();
   }
 }

--- a/client/src/nbRunner.ts
+++ b/client/src/nbRunner.ts
@@ -62,6 +62,21 @@ export function pollNbResultReady(session: ActiveSession): { result: number; err
 export interface NbRunOptions {
   /** Progress-notification title shown only if the call runs past ~2s. */
   title?: string;
+  /**
+   * Skip the ~2s notification toast entirely. The debugger uses this because its
+   * in-panel busy overlay (with its own Cancel) already covers these ops — the
+   * toast would be a redundant second cancel UI. Editor Execute/Display It leaves
+   * this off, so it keeps the toast (it has no panel overlay to fall back on).
+   */
+  suppressNotification?: boolean;
+  /**
+   * Called once when polling begins, handed a `cancel` fn. Invoking it requests
+   * a break — soft on the first call, hard on the second — exactly the escalation
+   * the progress notification's Cancel does. Lets a caller drive cancellation
+   * from its own UI (e.g. the debugger's in-panel Cancel button) instead of only
+   * the notification toast. The fn is a no-op once the call has settled.
+   */
+  onStart?: (cancel: () => void) => void;
 }
 
 /**
@@ -103,6 +118,26 @@ export function pollNbToCompletion<T>(
       fn();
     };
 
+    // Lets the notification's Cancel report progress text; null until/unless the
+    // ~2s notification is showing (an external cancel can fire before then).
+    let progressReport: ((value: { message?: string }) => void) | null = null;
+
+    // Soft-then-hard break, shared by the notification's Cancel and any external
+    // canceller handed out via opts.onStart. First call asks the gem to stop at a
+    // safe point; a second interrupts now and gives up on the call.
+    const requestCancel = (): void => {
+      if (settled) return;
+      if (!softBreakSent) {
+        session.gci.GciTsBreak(session.handle, false);
+        softBreakSent = true;
+        progressReport?.({ message: 'Soft break sent — waiting for the gem to stop…' });
+      } else {
+        session.gci.GciTsBreak(session.handle, true);
+        settle(() => reject(new NbCancelledError()));
+      }
+    };
+    if (opts.onStart) opts.onStart(requestCancel);
+
     const doPoll = (): void => {
       if (settled) return;
       const { result: pollResult, err: pollErr } = pollNbResultReady(session);
@@ -122,7 +157,7 @@ export function pollNbToCompletion<T>(
       pollIndex++;
       elapsedMs += interval;
 
-      if (elapsedMs >= PROGRESS_THRESHOLD_MS && !progressShown) {
+      if (elapsedMs >= PROGRESS_THRESHOLD_MS && !progressShown && !opts.suppressNotification) {
         progressShown = true;
         void vscode.window.withProgress(
           {
@@ -131,19 +166,8 @@ export function pollNbToCompletion<T>(
             cancellable: true,
           },
           (progress, token) => {
-            token.onCancellationRequested(() => {
-              if (!softBreakSent) {
-                // First cancel: soft break — ask the gem to stop at a safe point —
-                // and acknowledge it so the user knows the click registered.
-                session.gci.GciTsBreak(session.handle, false);
-                softBreakSent = true;
-                progress.report({ message: 'Soft break sent — waiting for the gem to stop…' });
-              } else {
-                // Second cancel: hard break — interrupt now and give up on the call.
-                session.gci.GciTsBreak(session.handle, true);
-                settle(() => reject(new NbCancelledError()));
-              }
-            });
+            progressReport = (value) => progress.report(value);
+            token.onCancellationRequested(requestCancel);
             return new Promise<void>(res => { progressResolve = res; });
           },
         );

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -184,6 +184,23 @@ export class SystemBrowser {
     SystemBrowser.show(session, SystemBrowser.sharedExportManager, vscode.ViewColumn.Beside);
   }
 
+  /**
+   * ALWAYS open a NEW browser in `viewColumn` and navigate it to `result` once it
+   * signals ready (via `pendingNavigation`). Unlike `navigateBeside`, this never
+   * reuses an existing browser — the caller (the Enhanced Debugger's "Browse"
+   * frame action) wants a fresh browser to the right of the debugger each time.
+   * The deferred navigation runs with `skipClassBrowser`, so the layout-disruptive
+   * side effects (setEditorLayout / ClassBrowser / GlobalsBrowser) that would
+   * displace open inspector panels are suppressed.
+   */
+  static openAndNavigate(
+    session: ActiveSession, result: queries.MethodSearchResult, viewColumn: vscode.ViewColumn,
+  ): void {
+    if (!SystemBrowser.sharedExportManager) return;
+    SystemBrowser.pendingNavigation.set(session.id, result);
+    SystemBrowser.show(session, SystemBrowser.sharedExportManager, viewColumn);
+  }
+
   private readonly panel: vscode.WebviewPanel;
   private disposables: vscode.Disposable[] = [];
   private state: BrowserState;


### PR DESCRIPTION
## Summary

Three Enhanced Debugger improvements on top of 1.7.3 (branch base `274e34a`):

1. **Progress indicator + Cancel** (`7066e74`)
2. **"Browse" stack-frame menu item** (`12beabf`)
3. **Editable inline variable values** (`90b7088`)

All client-side; no server/kernel changes.

## What's in this branch

### 1. Progress indicator, Cancel, and Executed-Code restart guard
- **Webview-driven busy spinner** over the debugger panel. A blocking GCI call freezes the ext-host (so a host-driven "busy" message can't reach the webview during the freeze); instead the **webview** starts its own 500 ms reveal timer when it sends a server-bound request and hides it on the reply, so the spinner appears even while the host is blocked. Fast round-trips never flash.
- **Cancel** for eval / step / restart, unified: in-frame eval is now **non-blocking** (`GciTsNbPerform`) so a runaway can be interrupted. One in-panel Cancel button, shown only for cancellable ops; **soft break** on first click, **hard break** on second, with ack text and a clear "Evaluation Cancelled (soft|hard break)" result.
- **Senders/implementors CodeLens** shows a `$(loading~spin)` placeholder, then swaps in the resolved count.
- **Executed-Code (doit) restart guard**: restarting a doit frame now shows a clear message instead of the raw kernel DNU.

### 2. "Browse" stack-frame menu item
- Right-click a stack frame → **Browse** opens a **new** System Browser to the right of the debugger, navigated to the class + method running in that frame. An **inherited** method opens on its **defining** class (resolved by method lookup on the receiver). Always a new browser; existing inspectors aren't disturbed. Degrades to an in-panel message for doit / unresolvable / non-symbol-list frames.

### 3. Editable inline variable values
- Inline values previously showed read-only at the end of each referencing line; they're now **editable**: **double-click an editable in-scope variable's name** in the companion source (while the overlay is on) → a **Set-value prompt** (Enter saves, Esc cancels), prefilled with the current value.
- The edit reuses the Variables pane's **in-frame write**, so the pane, the inline overlay, undo/revert, and the GC-pin all update exactly as a pane edit does. A **single click is left untouched**, so cursor placement and Run to Cursor still work.
- The value/edit **hover** is served by a registered `HoverProvider` (not a decoration `hoverMessage`) and shows each variable's full printString plus a "double-click to set" hint.

#### Mechanism notes (why it's built this way)
- Command-links in hovers/decorations don't fire reliably across hosts, and a code editor can't host an in-place `<input>`. So editing is driven by a direct `onDidChangeTextEditorSelection` handler that opens `showInputBox`; true in-place editing remains in the Variables pane webview.
- Still open (not in this PR): inline editing of **class variables** (needs a new server query) and **globals** (out of scope).

## Testing
- **~73 new tests** across the three features (debuggerPanel, debuggerView, debugQueries, nbRunner, gemstoneCodeLensProvider).
- **Full client suite: 2297 passing** (green); `tsc` + esbuild clean.
- Coverage audited for every new function/method: inline-value hover/markdown, the double-click edit handler (incl. cancel / blank / rejected-expression / busy guards), the shared in-frame write, the HoverProvider entry point, and the real `updateInlineValues` map-population path.

## Files
13 files changed (~+2049 / −134): `debuggerPanel.ts`, `debuggerView.js`, `debugQueries.ts`, `nbRunner.ts`, `gemstoneCodeLensProvider.ts`, `systemBrowser.ts`, `extension.ts`, plus tests and the vscode test mock.
