### PR TITLE
Enforce minimum GemStone version 3.6.2

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -13,6 +13,7 @@ jobs:
           sparse-checkout: |
             client/.gemstone-integration-releases.json
             client/bin/gemstone-integration-versions.js
+            client/src/gemStoneVersion.js
           sparse-checkout-cone-mode: false
       - id: read
         run: echo "versions=$(node client/bin/gemstone-integration-versions.js)" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Changed
+
+- **Integration test default version is now the oldest supported release.** `npm run test:server:start` (and the `--oldest` flag on `gemstone-integration-versions.js`) now defaults to the oldest version in `.gemstone-integration-releases.json` instead of the latest, ensuring new releases do not silently drop the minimum-version bar.
+
 ## [1.7.5] - 2026-07-02
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Follow these steps in order after cloning the repo:
    npm run test:server:list   # list all running GemStone processes for the test stone
    ```
 
-   To use a specific GemStone version instead of the latest, pass it as an argument: `npm run test:server:start -- 3.7.2`.
+   To use a specific GemStone version instead of the oldest, pass it as an argument: `npm run test:server:start -- 3.7.5`.
 
    **Supported on Linux and macOS (Apple Silicon) only — Windows is not yet supported.**
 

--- a/client/.gemstone-integration-releases.json
+++ b/client/.gemstone-integration-releases.json
@@ -1,6 +1,6 @@
 [
   {
-    "version": "3.6.1",
+    "version": "3.6.2",
     "reasons": [
       "Minimum supported version.",
       "Validates core GCI functionality that Jasper depends on is present and working."

--- a/client/bin/gemstone-integration-versions.js
+++ b/client/bin/gemstone-integration-versions.js
@@ -3,7 +3,7 @@
 // Lists the GemStone versions available for integration testing.
 //
 //   node gemstone-integration-versions.js            → JSON array of all versions, oldest first
-//   node gemstone-integration-versions.js --latest   → just the latest version string
+//   node gemstone-integration-versions.js --oldest   → just the oldest version string
 //
 // Versions come from .gemstone-integration-releases.json. Other scripts use
 // this to pick which GemStone build to download and run tests against.
@@ -11,7 +11,7 @@
 const fs = require('fs');
 
 const releasesFileContents = fs.readFileSync(`${__dirname}/../.gemstone-integration-releases.json`, 'utf8');
-const releases = JSON.parse(releasesFileContents)
+const releasesInAscendingOrder = JSON.parse(releasesFileContents)
     .sort((release, anotherRelease) => compareVersions(release.version, anotherRelease.version));
 
 function compareVersions(versionString, anotherVersionString) {
@@ -42,9 +42,9 @@ function assertIsValidVersionString(versionString) {
         throw new Error(`Invalid version: ${versionString}`);
 }
 
-if (process.argv.includes('--latest')) {
-    console.log(releases[releases.length - 1].version);
+if (process.argv.includes('--oldest')) {
+    console.log(releasesInAscendingOrder[0].version);
     return;
 }
 
-console.log(JSON.stringify(releases.map(release => release.version)));
+console.log(JSON.stringify(releasesInAscendingOrder.map(release => release.version)));

--- a/client/bin/gemstone-integration-versions.js
+++ b/client/bin/gemstone-integration-versions.js
@@ -9,38 +9,11 @@
 // this to pick which GemStone build to download and run tests against.
 
 const fs = require('fs');
+const { compareGemStoneVersions } = require('../src/gemStoneVersion.js');
 
 const releasesFileContents = fs.readFileSync(`${__dirname}/../.gemstone-integration-releases.json`, 'utf8');
 const releasesInAscendingOrder = JSON.parse(releasesFileContents)
-    .sort((release, anotherRelease) => compareVersions(release.version, anotherRelease.version));
-
-function compareVersions(versionString, anotherVersionString) {
-    const version = parseVersion(versionString);
-    const anotherVersion = parseVersion(anotherVersionString);
-    
-    for (let segmentIndex = 0; segmentIndex < 4; segmentIndex++) {
-        const difference = version[segmentIndex] - anotherVersion[segmentIndex];
-        if (difference !== 0) return difference;
-    }
-    
-    return 0;
-}
-
-function parseVersion(versionString) {
-    assertIsValidVersionString(versionString);
-    
-    const segments = versionString.split('.').map(Number);
-
-    // normalize to 4 parts so compareVersions can always iterate exactly 4
-    if (segments.length === 3) segments.push(0);
-    
-    return segments;
-}
-
-function assertIsValidVersionString(versionString) {
-    if (!/^\d+\.\d+\.\d+(\.\d+)?$/.test(versionString))
-        throw new Error(`Invalid version: ${versionString}`);
-}
+    .sort((release, anotherRelease) => compareGemStoneVersions(release.version, anotherRelease.version));
 
 if (process.argv.includes('--oldest')) {
     console.log(releasesInAscendingOrder[0].version);

--- a/client/bin/gs-test-server.sh
+++ b/client/bin/gs-test-server.sh
@@ -8,12 +8,12 @@ set -euo pipefail
 #
 # Arguments:
 #   command   Action to perform: --list, --start, or --stop
-#   version   GemStone version; defaults to the latest integration release
+#   version   GemStone version; defaults to the oldest integration release
 #             in .gemstone-integration-releases.json
 #   name      Instance name; defaults to 'jasper-test'
 
 SCRIPT_DIR="$(dirname "$0")"
-VERSION="${2:-$("$SCRIPT_DIR/gemstone-integration-versions.js" --latest)}"
+VERSION="${2:-$("$SCRIPT_DIR/gemstone-integration-versions.js" --oldest)}"
 NAME="${3:-jasper-test}"
 
 case "${1:-}" in
@@ -24,7 +24,7 @@ case "${1:-}" in
     cat >&2 <<EOF
 Usage: $0 <command> [version] [name]
 
-  version defaults to the latest integration release; name defaults to 'jasper-test'.
+  version defaults to the oldest integration release; name defaults to 'jasper-test'.
 
   --list [version]         List all running GemStone processes for the test stone.
   --start [version] [name] Install GemStone (if needed) and start a fresh test stone.

--- a/client/src/__tests__/localVersion.test.ts
+++ b/client/src/__tests__/localVersion.test.ts
@@ -329,6 +329,44 @@ describe('VersionManager.fetchAvailableVersions', () => {
     const versionStrings = versions.map(v => `${v.version}${v.local ? ' (local)' : ''}`);
     expect(versionStrings).toEqual(['3.8.0', '3.7.6 (local)', '3.6.4']);
   });
+
+  it('excludes remote versions older than the minimum supported gemstone version', async () => {
+    const storage = new SysadminStorage();
+    const manager = new VersionManager(storage);
+    const platformKey = storage.getPlatformKey();
+    const ext = storage.getDownloadExtension();
+
+    const html = [
+      `<a href="GemStone64Bit3.6.1-${platformKey}.${ext}">file</a>  01-Jan-2021 12:00  160000000`,
+      `<a href="GemStone64Bit3.6.1.9-${platformKey}.${ext}">file</a>  01-Jun-2021 12:00  161000000`,
+      `<a href="GemStone64Bit3.6.2-${platformKey}.${ext}">file</a>  01-Jun-2021 12:00  161000000`,
+      `<a href="GemStone64Bit3.7.0-${platformKey}.${ext}">file</a>  01-Jan-2022 12:00  170000000`,
+    ].join('\n');
+    vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue(html);
+
+    const versions = await manager.fetchAvailableVersions();
+
+    expect(versions.map(v => v.version)).toEqual(['3.7.0', '3.6.2']);
+  });
+
+  it('keeps a local version even when it is older than 3.6.2', async () => {
+    const storage = new SysadminStorage();
+    const manager = new VersionManager(storage);
+    const suffix = storage.getPlatformSuffix();
+
+    const productDir = path.join(tmpDir, 'product');
+    fs.mkdirSync(productDir);
+    writeVersionTxt(productDir, SAMPLE_VERSION_TXT);
+    fs.symlinkSync(productDir, path.join(tmpDir, `GemStone64Bit3.5.0${suffix}`));
+
+    vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue('');
+
+    const versions = await manager.fetchAvailableVersions();
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0].version).toBe('3.5.0');
+    expect(versions[0].local).toBe(true);
+  });
 });
 
 // ── GCI library auto-detection ───────────────────────────────

--- a/client/src/gemStoneVersion.d.ts
+++ b/client/src/gemStoneVersion.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Compares two GemStone version strings.
+ * @param {string} versionString
+ * @param {string} anotherVersionString
+ * @returns {number} Negative if versionsString < anotherVersionString,
+ *                   0 if equal,
+ *                   positive if versionsString > anotherVersionString.
+ */
+export function compareGemStoneVersions(versionString: string, anotherVersionString: string): number;

--- a/client/src/gemStoneVersion.js
+++ b/client/src/gemStoneVersion.js
@@ -1,0 +1,53 @@
+// Plain CJS module (not TypeScript) so it can be require()'d directly by
+// client/bin/gemstone-integration-versions.js without a build step. That
+// script runs in CI before the TypeScript compilation step (to determine
+// which GemStone versions to test against), so it cannot depend on compiled
+// output. The TypeScript declaration file (gemStoneVersion.d.ts) provides
+// types for the compiled extension.
+
+/**
+ * Throws if versionString is not a 3- or 4-part numeric version (e.g. "3.6.2" or "3.6.2.1").
+ * @param {string} versionString
+ */
+function assertIsValidVersionString(versionString) {
+    if (!/^\d+\.\d+\.\d+(\.\d+)?$/.test(versionString))
+        throw new Error(`Invalid version: ${versionString}`);
+}
+
+/**
+ * Parses a version string into a 4-element numeric array, padding with 0 if needed.
+ * @param {string} versionString
+ * @returns {number[]}
+ */
+function parseGemStoneVersion(versionString) {
+    assertIsValidVersionString(versionString);
+
+    const segments = versionString.split('.').map(Number);
+
+    // normalize to 4 parts so compareVersions can always iterate exactly 4
+    if (segments.length === 3) segments.push(0);
+
+    return segments;
+}
+
+/**
+ * Compares two GemStone version strings.
+ * @param {string} versionString
+ * @param {string} anotherVersionString
+ * @returns {number} Negative if versionString < anotherVersionString,
+ *                   0 if equal,
+ *                   positive if versionString > anotherVersionString.
+ */
+function compareGemStoneVersions(versionString, anotherVersionString) {
+    const va = parseGemStoneVersion(versionString);
+    const vb = parseGemStoneVersion(anotherVersionString);
+
+    for (let i = 0; i < 4; i++) {
+        const diff = va[i] - vb[i];
+        if (diff !== 0) return diff;
+    }
+
+    return 0;
+}
+
+module.exports = { compareGemStoneVersions };

--- a/client/src/versionManager.ts
+++ b/client/src/versionManager.ts
@@ -9,8 +9,10 @@ import { appendSysadmin, showSysadmin } from './sysadminChannel';
 import { needsWsl, wslSpawn, wslExecSync } from './wslBridge';
 import { wslExistsSync } from './wslFs';
 import { bundledWindowsClientVersions, bundledGciArchSupported } from './bundledGci';
+import { compareGemStoneVersions } from './gemStoneVersion';
 
 const WIN_CLIENT_BASE_URL = 'https://downloads.gemtalksystems.com/pub/GemStone64/';
+const MINIMUM_SUPPORTED_GEMSTONE_VERSION = '3.6.2';
 
 export class VersionManager {
   constructor(private storage: SysadminStorage) {}
@@ -79,13 +81,19 @@ export class VersionManager {
       });
     }
 
+    // Drop remote versions older than the minimum; local installs are always kept
+    const supportedVersions = versions.filter(
+      version => version.local || compareGemStoneVersions(version.version, MINIMUM_SUPPORTED_GEMSTONE_VERSION) >= 0,
+    );
+
     // Sort newest first; local versions before remote at same version
-    versions.sort((a, b) => {
-      const cmp = b.version.localeCompare(a.version, undefined, { numeric: true });
-      if (cmp !== 0) return cmp;
+    supportedVersions.sort((a, b) => {
+      const comparison = compareGemStoneVersions(a.version, b.version);
+      if (comparison !== 0) return -comparison; // negate for newest first
       return (b.local ? 1 : 0) - (a.local ? 1 : 0);
     });
-    return versions;
+    
+    return supportedVersions;
   }
 
   /** Download a version with progress reporting */

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "allowJs": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.js"]
 }


### PR DESCRIPTION
## Summary

- Hides remote GemStone versions below 3.6.2 from the versions panel and Quick Setup picker (local/symlinked installs are always kept regardless of age)
- Extracts version comparison logic into a shared `gemStoneVersion.js` module (plain CJS so CI can use it without a build step; typed via `gemStoneVersion.d.ts`)
- Bumps the oldest integration test release from 3.6.1 → 3.6.2 to match the new minimum
- Fixes CI sparse-checkout to include the new shared module

## Test plan

- [ ] Versions panel no longer shows releases older than 3.6.2
- [ ] Local (symlinked) installs below 3.6.2 still appear
- [ ] `npm test` passes
- [ ] `npm run compile` passes
- [ ] CI health-check matrix runs against 3.6.2 as its oldest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)