### PR TITLE
Gate Enhanced Inspector support to GemStone 3.7.5+

### DIFF
--- a/client/src/__tests__/enhancedInspectorAvailability.test.ts
+++ b/client/src/__tests__/enhancedInspectorAvailability.test.ts
@@ -9,10 +9,11 @@ vi.mock('vscode', () => ({
 import { ActiveSession } from '../sessionManager';
 import { GemStoneLogin } from '../loginTypes';
 import * as queries from '../browserQueries';
+import { refreshEnhancedInspectorAvailable } from '../enhancedInspectorAvailability';
 
 const noErr = { number: 0, message: '', context: 0n, category: 0, fatal: false, argCount: 0, exceptionObj: 0n, args: [] };
 
-function createMockSession(executeFetchData = ''): ActiveSession {
+function createMockSession(executeFetchData = '', stoneVersion = '3.7.5'): ActiveSession {
   const mockGci = {
     GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
     GciTsExecuteFetchBytes: vi.fn(() => ({ data: executeFetchData, err: { ...noErr } })),
@@ -24,7 +25,7 @@ function createMockSession(executeFetchData = ''): ActiveSession {
     gci: mockGci as unknown as ActiveSession['gci'],
     handle: {},
     login: { label: 'Test' } as GemStoneLogin,
-    stoneVersion: '3.7.2',
+    stoneVersion,
   };
 }
 
@@ -64,5 +65,42 @@ describe('checkEnhancedInspectorAvailable', () => {
     const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
     const code = mockExec.mock.calls[0][1] as string;
     expect(code).toContain('GtRemotePhlowViewedObject');
+  });
+});
+
+describe('refreshEnhancedInspectorAvailable', () => {
+  // The minimum plus future releases — a patch bump and a major bump — all pass
+  // the semantic gate with no list to update.
+  const SUPPORTED_VERSIONS = ['3.7.5', '3.7.6', '4.0'];
+
+  it.each(SUPPORTED_VERSIONS)(
+    'marks support available on a supported %s stone that has the classes',
+    (version) => {
+      const session = createMockSession('true', version);
+
+      expect(refreshEnhancedInspectorAvailable(session)).toBe(true);
+      expect(session.enhancedInspectorAvailable).toBe(true);
+    },
+  );
+
+  // 3.6.2, 3.7.0, and 3.7.2 are all below the 3.7.5 floor.
+  const UNSUPPORTED_VERSIONS = ['3.6.2', '3.7.0', '3.7.2'];
+
+  it.each(UNSUPPORTED_VERSIONS)(
+    'reports unavailable on a %s stone even when the classes are present',
+    (version) => {
+      const session = createMockSession('true', version);
+
+      expect(refreshEnhancedInspectorAvailable(session)).toBe(false);
+      expect(session.enhancedInspectorAvailable).toBe(false);
+    },
+  );
+
+  it.each(UNSUPPORTED_VERSIONS)('does not probe a %s stone at all', (version) => {
+    const session = createMockSession('true', version);
+
+    refreshEnhancedInspectorAvailable(session);
+
+    expect(session.gci.GciTsExecuteFetchBytes).not.toHaveBeenCalled();
   });
 });

--- a/client/src/__tests__/enhancedInspectorCommand.test.ts
+++ b/client/src/__tests__/enhancedInspectorCommand.test.ts
@@ -103,12 +103,18 @@ vi.mock('../browserQueries', () => ({
   checkEnhancedInspectorAvailable: vi.fn(() => true),
 }));
 
-vi.mock('../enhancedInspectorInstall', () => ({
-  installEnhancedInspectorSupport: mocks.installSupport,
-  isEnhancedInspectorInstalled: vi.fn(() => false),
-  ENHANCED_INSPECTOR_FILES: ['Announcements.gs'],
-  messageOf: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+// Partial mock: only the GCI-touching pieces are stubbed. The version gate
+// (supportsEnhancedInspector / ENHANCED_INSPECTOR_MIN_VERSION) is the real
+// implementation, so the gating tests exercise the actual semantic comparison.
+vi.mock('../enhancedInspectorInstall', async (importActual) => {
+  const actual = await importActual<typeof import('../enhancedInspectorInstall')>();
+  return {
+    ...actual,
+    installEnhancedInspectorSupport: mocks.installSupport,
+    isEnhancedInspectorInstalled: vi.fn(() => false),
+    ENHANCED_INSPECTOR_FILES: ['Announcements.gs'],
+  };
+});
 
 import { ActiveSession } from '../sessionManager';
 import {
@@ -119,7 +125,10 @@ import {
 
 const AUTO_INSTALL_KEY = 'enhancedInspector.autoInstall';
 
-function createBaseSession(systemUserLoginSucceeds = true): ActiveSession {
+function createBaseSession(
+  systemUserLoginSucceeds = true,
+  stoneVersion = '3.7.5',
+): ActiveSession {
   return {
     id: 1,
     login: { stone: 'demo', gem_host: 'localhost', netldi: 'netldi' },
@@ -131,7 +140,7 @@ function createBaseSession(systemUserLoginSucceeds = true): ActiveSession {
       ),
       GciTsLogout: vi.fn(),
     },
-    stoneVersion: '3.7.0',
+    stoneVersion,
     enhancedInspectorAvailable: false,
   } as unknown as ActiveSession;
 }
@@ -211,6 +220,50 @@ describe('maybeOfferEnhancedInspectorInstall', () => {
     await offer(createBaseSession());
 
     expect(wasOffered()).toBe(true);
+  });
+
+  // 3.6.2 (payload won't even file in), 3.7.0 (files in but views are broken),
+  // and 3.7.2 (ditto) are all below the 3.7.5 floor.
+  const UNSUPPORTED_VERSIONS = ['3.6.2', '3.7.0', '3.7.2'];
+
+  it.each(UNSUPPORTED_VERSIONS)('never offers on a %s stone', async (version) => {
+    mocks.state.config[AUTO_INSTALL_KEY] = 'ask';
+
+    await offer(createBaseSession(true, version));
+
+    expect(wasOffered()).toBe(false);
+    expect(mocks.installSupport).not.toHaveBeenCalled();
+  });
+
+  it.each(UNSUPPORTED_VERSIONS)(
+    'never auto-installs on a %s stone even when set to "always"',
+    async (version) => {
+      mocks.state.config[AUTO_INSTALL_KEY] = 'always';
+
+      await offer(createBaseSession(true, version));
+
+      expect(mocks.installSupport).not.toHaveBeenCalled();
+    },
+  );
+
+  // The minimum plus future releases — a patch bump and a major bump — all pass
+  // the semantic gate with no list to update.
+  const SUPPORTED_VERSIONS = ['3.7.5', '3.7.6', '4.0'];
+
+  it.each(SUPPORTED_VERSIONS)('offers on a supported %s stone', async (version) => {
+    mocks.state.config[AUTO_INSTALL_KEY] = 'ask';
+
+    await offer(createBaseSession(true, version));
+
+    expect(wasOffered()).toBe(true);
+  });
+
+  it.each(SUPPORTED_VERSIONS)('auto-installs on a supported %s stone when set to "always"', async (version) => {
+    mocks.state.config[AUTO_INSTALL_KEY] = 'always';
+
+    await offer(createBaseSession(true, version));
+
+    expect(mocks.installSupport).toHaveBeenCalledTimes(1);
   });
 
   it('persists "never" and skips installing when the user declines for good', async () => {
@@ -432,6 +485,20 @@ describe('runInstallEnhancedInspector', () => {
     expect(mocks.showInputBox).not.toHaveBeenCalled();
     expect(mocks.installSupport).toHaveBeenCalledTimes(1);
   });
+
+  it.each(['3.6.2', '3.7.0', '3.7.2'])(
+    'reports an error and installs nothing on a %s stone',
+    async (version) => {
+      getSelectedSessionMock.mockReturnValue(createBaseSession(true, version));
+
+      await run();
+
+      expect(mocks.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining('requires GemStone 3.7.5 or later'),
+      );
+      expect(mocks.installSupport).not.toHaveBeenCalled();
+    },
+  );
 
   it('prompts for the SystemUser password when the default is rejected, then installs', async () => {
     const base = createBaseSession(false);

--- a/client/src/__tests__/enhancedInspectorInstall.test.ts
+++ b/client/src/__tests__/enhancedInspectorInstall.test.ts
@@ -13,7 +13,9 @@ import { executeFetchString } from '../browserQueries';
 import {
   installEnhancedInspectorSupport,
   isEnhancedInspectorInstalled,
+  supportsEnhancedInspector,
   ENHANCED_INSPECTOR_FILES,
+  ENHANCED_INSPECTOR_MIN_VERSION,
 } from '../enhancedInspectorInstall';
 
 const executeFetchStringMock = executeFetchString as ReturnType<typeof vi.fn>;
@@ -43,6 +45,51 @@ function filedInFileFrom(code: string): string | undefined {
   if (!code.includes('GsFileIn fromServerPath')) return undefined;
   return ENHANCED_INSPECTOR_FILES.find((f) => code.includes(f));
 }
+
+describe('supportsEnhancedInspector', () => {
+  it('accepts the supported minimum version', () => {
+    expect(supportsEnhancedInspector(ENHANCED_INSPECTOR_MIN_VERSION)).toBe(true);
+  });
+
+  it.each(['3.6.2', '3.7.0', '3.7.2', '3.7.4', '3.7'])(
+    'rejects %s (below the supported minimum)',
+    (version) => {
+      expect(supportsEnhancedInspector(version)).toBe(false);
+    },
+  );
+
+  it('accepts later patch releases via semantic comparison', () => {
+    expect(supportsEnhancedInspector('3.7.6')).toBe(true);
+    expect(supportsEnhancedInspector('3.7.10')).toBe(true);
+  });
+
+  it('accepts a later major release', () => {
+    expect(supportsEnhancedInspector('4.0.0')).toBe(true);
+  });
+
+  it('accepts a short major.minor future version like "4.0"', () => {
+    expect(supportsEnhancedInspector('4.0')).toBe(true);
+  });
+
+  it('accepts a short future version that carries a build suffix', () => {
+    expect(supportsEnhancedInspector('4.0 build 64bit')).toBe(true);
+  });
+
+  it('accepts a raw GciTsVersion string with a trailing build suffix', () => {
+    expect(supportsEnhancedInspector('3.7.5 build 64bit')).toBe(true);
+    expect(supportsEnhancedInspector('3.7.5, gss64')).toBe(true);
+  });
+
+  it('honors the gate on a version with a trailing suffix that is below the minimum', () => {
+    expect(supportsEnhancedInspector('3.7.2 build 64bit')).toBe(false);
+  });
+
+  it('rejects a missing or unparseable version rather than throwing', () => {
+    expect(supportsEnhancedInspector(undefined)).toBe(false);
+    expect(supportsEnhancedInspector('')).toBe(false);
+    expect(supportsEnhancedInspector('not-a-version')).toBe(false);
+  });
+});
 
 describe('installEnhancedInspectorSupport', () => {
   beforeEach(() => {

--- a/client/src/__tests__/enhancedInspectorPanel.test.ts
+++ b/client/src/__tests__/enhancedInspectorPanel.test.ts
@@ -83,7 +83,7 @@ function createMockSession(): ActiveSession {
     gci: {} as unknown as ActiveSession['gci'],
     handle: {},
     login: { label: 'Test' } as GemStoneLogin,
-    stoneVersion: '3.7.2',
+    stoneVersion: '3.7.5',
   };
 }
 

--- a/client/src/__tests__/enhancedInspectorPrintString.test.ts
+++ b/client/src/__tests__/enhancedInspectorPrintString.test.ts
@@ -25,7 +25,7 @@ function createPrintStringSession(data: string, bytesReturned?: number, errNumbe
     gci: mockGci as unknown as ActiveSession['gci'],
     handle: {},
     login: { label: 'Test' } as GemStoneLogin,
-    stoneVersion: '3.7.2',
+    stoneVersion: '3.7.5',
   };
 }
 
@@ -45,7 +45,7 @@ function createFullPrintSession(data = '', resolveErrNumber = 0, execErrNumber =
     gci: mockGci as unknown as ActiveSession['gci'],
     handle: {},
     login: { label: 'Test' } as GemStoneLogin,
-    stoneVersion: '3.7.2',
+    stoneVersion: '3.7.5',
   };
 }
 

--- a/client/src/__tests__/gci/gciEnhancedInspectorRouting.smoke.test.ts
+++ b/client/src/__tests__/gci/gciEnhancedInspectorRouting.smoke.test.ts
@@ -26,7 +26,8 @@ import { ActiveSession } from '../../sessionManager';
 import { GemStoneLogin } from '../../loginTypes';
 import * as queries from '../../browserQueries';
 import * as debug from '../../debugQueries';
-import { isEnhancedInspectorInstalled } from '../../enhancedInspectorInstall';
+import { isEnhancedInspectorInstalled, supportsEnhancedInspector } from '../../enhancedInspectorInstall';
+import { refreshEnhancedInspectorAvailable } from '../../enhancedInspectorAvailability';
 
 const OOP_NIL = 0x14n;
 
@@ -47,7 +48,10 @@ describe('Inspect It routing (integration)', () => {
       gci,
       handle: login.session,
       login: { label: 'Test' } as GemStoneLogin,
-      stoneVersion: '3.7.2',
+      // Use the stone's actual version, not a hardcoded fixture — the routing
+      // decision now depends on it (the Enhanced Inspector is gated to 3.7.5+),
+      // so an honest version is what makes the gated assertion below meaningful.
+      stoneVersion: gci.GciTsVersion().version,
     };
   });
 
@@ -72,6 +76,23 @@ describe('Inspect It routing (integration)', () => {
     expect(typeof available).toBe('boolean');
     expect(typeof installed).toBe('boolean');
     expect(available).toBe(installed);
+  });
+
+  // The flag that Inspect It actually routes on is set by
+  // refreshEnhancedInspectorAvailable, which gates the raw probe behind the
+  // 3.7.5+ version requirement. On a supported stone it must equal the raw
+  // probe; on an older one it must be false regardless of what the probe finds.
+  // Written against the live stone's real version so it stays correct across the
+  // whole CI version matrix, not just 3.7.5.
+  it('routes to the enhanced inspector only on a supported version with the classes present', () => {
+    const routed = refreshEnhancedInspectorAvailable(session);
+
+    const supported = supportsEnhancedInspector(session.stoneVersion);
+    const probe = queries.checkEnhancedInspectorAvailable(session);
+    expect(routed).toBe(supported && probe);
+    if (!supported) {
+      expect(routed).toBe(false);
+    }
   });
 
   // When the enhanced inspector is absent, every Inspect It falls back to the

--- a/client/src/enhancedInspectorAvailability.ts
+++ b/client/src/enhancedInspectorAvailability.ts
@@ -9,10 +9,18 @@
  */
 import { ActiveSession } from './sessionManager';
 import { checkEnhancedInspectorAvailable } from './browserQueries';
+import { supportsEnhancedInspector } from './enhancedInspectorInstall';
 
 /** Re-probe the session and cache `enhancedInspectorAvailable` on it. Returns
- *  the freshly-probed value. */
+ *  the freshly-probed value.
+ *
+ *  Stones older than the supported minimum never route to the Enhanced
+ *  Inspector — even if the support classes happen to be present (e.g. a shared
+ *  stone, or one installed by an older build) — because the inspector returns no
+ *  views there. Short-circuit to false without probing so routing
+ *  (see inspectRouter.ts) falls back to the classic inspector. */
 export function refreshEnhancedInspectorAvailable(session: ActiveSession): boolean {
-  session.enhancedInspectorAvailable = checkEnhancedInspectorAvailable(session);
+  session.enhancedInspectorAvailable =
+    supportsEnhancedInspector(session.stoneVersion) && checkEnhancedInspectorAvailable(session);
   return session.enhancedInspectorAvailable;
 }

--- a/client/src/enhancedInspectorCommand.ts
+++ b/client/src/enhancedInspectorCommand.ts
@@ -23,7 +23,9 @@ import { refreshEnhancedInspectorAvailable } from './enhancedInspectorAvailabili
 import {
   installEnhancedInspectorSupport,
   isEnhancedInspectorInstalled,
+  supportsEnhancedInspector,
   ENHANCED_INSPECTOR_FILES,
+  ENHANCED_INSPECTOR_MIN_VERSION,
   messageOf,
 } from './enhancedInspectorInstall';
 
@@ -266,6 +268,13 @@ export async function runInstallEnhancedInspector(
     vscode.window.showErrorMessage('No active GemStone session — connect to a stone first.');
     return;
   }
+  if (!supportsEnhancedInspector(base.stoneVersion)) {
+    vscode.window.showErrorMessage(
+      `Enhanced inspector support requires GemStone ${ENHANCED_INSPECTOR_MIN_VERSION} or later. `
+        + `The stone "${base.login.stone}" is ${base.stoneVersion}.`,
+    );
+    return;
+  }
   await performInstall(base, sessionManager, extensionPath, true);
 }
 
@@ -284,6 +293,10 @@ export async function maybeOfferEnhancedInspectorInstall(
   sessionManager: SessionManager,
   extensionPath: string,
 ): Promise<void> {
+  // The support only works on 3.7.5+ stones; never offer or auto-install on
+  // older ones, regardless of the autoInstall setting.
+  if (!supportsEnhancedInspector(base.stoneVersion)) return;
+
   const mode = getAutoInstallMode();
   if (mode === 'never') return;
   if (mode === 'always') {

--- a/client/src/enhancedInspectorInstall.ts
+++ b/client/src/enhancedInspectorInstall.ts
@@ -25,6 +25,49 @@
  */
 import { ActiveSession } from './sessionManager';
 import { executeFetchString } from './browserQueries';
+import { compareGemStoneVersions } from './gemStoneVersion';
+
+/**
+ * Minimum GemStone version the Enhanced Inspector support is limited to.
+ *
+ * The vendored GT payload requires kernel classes that only exist in 3.7+
+ * (e.g. `GcFinalizeNotification`), and — more subtly — on stones before 3.7.5
+ * string literals in GCI-compiled queries compile as Unicode, which the
+ * platform refuses to `=`-compare against the byte-String dictionary keys the
+ * payload builds. That mismatch makes the inspector return no views. 3.7.5 is
+ * the first release where the whole pipeline (install + views) works, so we gate
+ * on it rather than trying to paper over the platform behavior.
+ */
+export const ENHANCED_INSPECTOR_MIN_VERSION = '3.7.5';
+
+/**
+ * True when `stoneVersion` supports the Enhanced Inspector, i.e. it is
+ * `ENHANCED_INSPECTOR_MIN_VERSION` or later. The comparison is semantic
+ * (numeric per version segment), so future releases — 3.7.6, 3.7.10, 4.0 — pass
+ * automatically without any list to maintain.
+ *
+ * `stoneVersion` is the raw `GciTsVersion` string, which starts with the numeric
+ * version but may carry a trailing build/description suffix
+ * (e.g. "3.7.5 build ..."). We extract the leading `x.y.z[.w]` token before
+ * comparing — `compareGemStoneVersions` requires a bare numeric string and would
+ * otherwise throw on the suffix (and fail closed, blocking a supported stone).
+ */
+export function supportsEnhancedInspector(stoneVersion: string | undefined): boolean {
+  // Extract the leading numeric version: major.minor with optional patch and
+  // build segments — "3.7.5", "3.7.5.1", or a future short form like "4.0" —
+  // ignoring any trailing build/description suffix from GciTsVersion.
+  const numeric = stoneVersion?.match(/^\d+\.\d+(\.\d+){0,2}/)?.[0];
+  if (!numeric) return false;
+  // compareGemStoneVersions requires 3–4 numeric segments; pad a short version
+  // (e.g. "4.0" -> "4.0.0") so it compares cleanly instead of throwing.
+  const padded = numeric.split('.').length < 3 ? `${numeric}.0` : numeric;
+  try {
+    return compareGemStoneVersions(padded, ENHANCED_INSPECTOR_MIN_VERSION) >= 0;
+  } catch {
+    // Defensive: fail closed rather than offer an install that would break.
+    return false;
+  }
+}
 
 /**
  * The payload files, in dependency order — must match the `input` order in

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -31,6 +31,7 @@ import {
   maybeOfferEnhancedInspectorInstall,
 } from './enhancedInspectorCommand';
 import { refreshEnhancedInspectorAvailable } from './enhancedInspectorAvailability';
+import { supportsEnhancedInspector } from './enhancedInspectorInstall';
 import { DebuggerPanel } from './debuggerPanel';
 import { InlineValuesCodeLensProvider } from './inlineValuesCodeLens';
 import { GemStoneFileSystemProvider, MethodCompiledEvent, ClassDefinitionCompiledEvent } from './gemstoneFileSystemProvider';
@@ -454,6 +455,23 @@ export function activate(context: vscode.ExtensionContext) {
     sessionManager.onDidChangeSelection(() => updateStatusBar()),
   );
   updateStatusBar();
+
+  // Drive the `gemstone.enhancedInspectorSupported` context key off the selected
+  // session's version, so the "Install Enhanced Inspector Support" command is
+  // only offered where it can actually work (see package.json commandPalette
+  // when-clause). Recomputed on every selection change.
+  function updateEnhancedInspectorSupportedContext(): void {
+    const selected = sessionManager.getSelectedSession();
+    vscode.commands.executeCommand(
+      'setContext',
+      'gemstone.enhancedInspectorSupported',
+      !!selected && supportsEnhancedInspector(selected.stoneVersion),
+    );
+  }
+  context.subscriptions.push(
+    sessionManager.onDidChangeSelection(() => updateEnhancedInspectorSupportedContext()),
+  );
+  updateEnhancedInspectorSupportedContext();
 
   // ── Enhanced Inspector Perf Tracking ───────────────────────────────────
   const enhancedInspectorPerfChannel = vscode.window.createOutputChannel('GemStone Enhanced Inspector Perf');

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
               "Never offer to install enhanced inspector support."
             ],
             "default": "ask",
-            "description": "What to do on connecting to a stone that does not have enhanced inspector support installed. The buttons on the install prompt update this setting."
+            "description": "What to do on connecting to a stone that does not have enhanced inspector support installed. Only applies to GemStone 3.7.5 and later, which the enhanced inspector requires; older stones are never offered it. The buttons on the install prompt update this setting."
           },
           "gemstone.displayItMode": {
             "type": "string",
@@ -447,7 +447,7 @@
           {
             "id": "enhancedInspector",
             "title": "Try the enhanced inspector",
-            "description": "Get richer, object-specific views in the Inspector. Choose how Jasper installs it when you connect.\n[Enhanced Inspector Auto-Install…](command:gemstone.configureEnhancedInspectorAutoInstall)",
+            "description": "Get richer, object-specific views in the Inspector. Requires GemStone 3.7.5 or later. Choose how Jasper installs it when you connect.\n[Enhanced Inspector Auto-Install…](command:gemstone.configureEnhancedInspectorAutoInstall)",
             "media": {
               "markdown": "resources/walkthrough/enhancedInspector.md"
             },
@@ -953,6 +953,10 @@
         {
           "command": "gemstone.showEnhancedInspectorPerfDetails",
           "when": "false"
+        },
+        {
+          "command": "gemstone.installEnhancedInspector",
+          "when": "gemstone.hasActiveSession && gemstone.enhancedInspectorSupported"
         }
       ],
       "view/title": [

--- a/resources/walkthrough/enhancedInspector.md
+++ b/resources/walkthrough/enhancedInspector.md
@@ -3,8 +3,10 @@
 The **enhanced inspector** replaces the plain list of instance variables with
 rich, object-specific views, so you can explore an object more deeply.
 
-It isn't part of a stock GemStone image, so it's installed once per stone. Rather
-than install it here, you choose *how* Jasper should handle it when you connect:
+It requires **GemStone 3.7.5 or later** and isn't part of a stock GemStone
+image, so it's installed once per stone. On older stones Jasper keeps the default
+Inspector and won't offer to install it. Rather than install it here, you choose
+*how* Jasper should handle it when you connect to a supported stone:
 
 - **Ask on connect** — Jasper offers to install it when you reach a stone that
   lacks it (the default).


### PR DESCRIPTION
## Summary

The Enhanced Inspector support is now limited to **GemStone 3.7.5 and later**. On older servers Jasper keeps the classic Inspector and never offers to install the enhanced support. The gate is a single semantic version check, so future releases (3.7.6, 4.0, …) are admitted automatically with no list to maintain.

## Why we exclude pre-3.7.5 servers

The vendored GToolkit/RSR payload cannot deliver a working Enhanced Inspector below 3.7.5. There are **two independent reasons**, which together set the floor at 3.7.5:

### 1. Pre-3.7.0 — the payload won't file in (RSR requirement)

`RemoteServiceReplication`'s `RsrAsyncMournHandler` references `GcFinalizeNotification`, a GemStone **kernel class introduced in 3.7.0**. On 3.6.x that symbol does not exist, so filing in the payload fails to compile (`CompileError 1001, undefined symbol GcFinalizeNotification`) and the install aborts. In other words, RSR itself requires GemStone ≥ 3.7.0 — it is a 3.7-era component (3.7.x even ships RSR as a bundled project).

### 2. 3.7.0–3.7.4 — it installs, but shows no views (Unicode/byte string mismatch)

On these servers the payload files in cleanly, but the inspector comes up empty. The cause is a **server-side** string-encoding behavior, not the payload files (the same files work on 3.7.5):

- On GemStone before 3.7.5, string literals in GCI-compiled queries compile as **Unicode** strings.
- The payload builds its view dictionaries with **byte-`String`** keys.
- These servers **raise `ArgumentError` on a mixed Unicode-vs-byte `String =` comparison**, so the inspector's view lookup (`... at: 'views'`) throws. The error is caught and swallowed, and the inspector renders no views.
- GemStone 3.7.5 compiles those literals as byte `String`, so the comparison is byte-vs-byte and the lookup succeeds.

Because reason (1) blocks everything below 3.7.0 and reason (2) blocks 3.7.0 through 3.7.4, the first release where the full pipeline (install **and** views) works is **3.7.5**.

We deliberately chose to gate on version rather than paper over the platform behavior in the queries (e.g. coercing every dictionary key to a byte `String`): that touches many comparison sites, is fragile, and would only mask a server limitation. Gating is the honest, maintainable fix.

## What changed

- **`supportsEnhancedInspector(stoneVersion)` / `ENHANCED_INSPECTOR_MIN_VERSION`** (`enhancedInspectorInstall.ts`) — the single source of truth. Uses the semantic `compareGemStoneVersions`, extracts the leading numeric token from the raw `GciTsVersion` string (which carries a trailing build suffix), and pads a short `major.minor` form so a future `"4.0"` compares cleanly.
- **Three gates:**
  - `refreshEnhancedInspectorAvailable` — the routing latch returns `false` without even probing on < 3.7.5, so a server that already has the classes (e.g. a shared stone) still falls back to the classic Inspector.
  - `maybeOfferEnhancedInspectorInstall` — no connect-time offer or auto-install.
  - `runInstallEnhancedInspector` — reports "requires GemStone 3.7.5 or later" and stops.
- **`gemstone.enhancedInspectorSupported` context key**, driven by session selection, hides the *Install Enhanced Inspector Support* command in the Command Palette on unsupported servers.
- **Docs/UX** — the walkthrough, the walkthrough step, and the `enhancedInspector.autoInstall` setting description all note the 3.7.5+ requirement.

## Testing

- Version-gate coverage across **unsupported** (3.6.2 / 3.7.0 / 3.7.2) and **supported** (3.7.5 / 3.7.6 / 4.0, including short `major.minor` and build-suffix forms) versions, at every gate: helper, routing latch, offer, auto-install, and manual command.
- The on-demand GCI routing smoke test now uses the stone's **real** version and asserts the gated routing decision holds across the whole CI version matrix (not just 3.7.5).
- `npm run compile` clean; full suite green (server / client / mcp) and the on-demand GCI suite green against a live 3.7.5 stone.
