### PR TITLE
Fix: hierarchy click should only open Class definition, not the source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Fixed
+
+- **System Browser: clicking a class in the hierarchy view no longer reopens its source file.** The hierarchy click already refreshed the Class Definition pane; it also called `openClassFile`, shoving a file in front of whatever the user was editing. That call is removed, matching the column click's definition-only behavior.
+
 ## [1.7.7] - 2026-07-07
 
 ### Added

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -1064,23 +1064,6 @@ describe('SystemBrowser', () => {
       );
     });
 
-    // Regression: hierarchy click opened the definition panel AND the
-    // on-disk .gs Topaz cache file, shoving a redundant read-only tab in
-    // front of whatever the user was editing. Column click only opens the
-    // definition; hierarchy click should behave the same way.
-    it('does not open a file when selecting a hierarchy class', async () => {
-      messageHandler({ command: 'toggleViewMode', mode: 'hierarchy' });
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(window.showTextDocument).mockClear();
-
-      messageHandler({ command: 'selectHierarchyClass', className: 'Array' });
-      // The redundant .gs reveal (when present) fires from an unawaited async
-      // call, so flush the microtask/macrotask queue before asserting.
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      expect(window.showTextDocument).not.toHaveBeenCalled();
-    });
-
     it('resolves correct dictionary for hierarchy class from different dict', () => {
       messageHandler({ command: 'toggleViewMode', mode: 'hierarchy' });
       vi.mocked(mockPanel.webview.postMessage).mockClear();

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -1064,6 +1064,23 @@ describe('SystemBrowser', () => {
       );
     });
 
+    // Regression: hierarchy click opened the definition panel AND the
+    // on-disk .gs Topaz cache file, shoving a redundant read-only tab in
+    // front of whatever the user was editing. Column click only opens the
+    // definition; hierarchy click should behave the same way.
+    it('does not open a file when selecting a hierarchy class', async () => {
+      messageHandler({ command: 'toggleViewMode', mode: 'hierarchy' });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(window.showTextDocument).mockClear();
+
+      messageHandler({ command: 'selectHierarchyClass', className: 'Array' });
+      // The redundant .gs reveal (when present) fires from an unawaited async
+      // call, so flush the microtask/macrotask queue before asserting.
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(window.showTextDocument).not.toHaveBeenCalled();
+    });
+
     it('resolves correct dictionary for hierarchy class from different dict', () => {
       messageHandler({ command: 'toggleViewMode', mode: 'hierarchy' });
       vi.mocked(mockPanel.webview.postMessage).mockClear();

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -803,8 +803,8 @@ export class SystemBrowser {
    * panel never goes stale relative to the column-list selection.
    *
    * Does NOT open the class's source file. Paths that should *also* reveal
-   * source (hierarchy click, external method navigation) call
-   * `openClassFile` separately afterwards. The column click leaves the
+   * source (external method navigation) call `openClassFile` separately
+   * afterwards. The column click (and the hierarchy click) leaves the
    * editor untouched on purpose — clicking a class shouldn't shove a new
    * file in front of whatever the user was editing.
    *
@@ -1217,9 +1217,9 @@ export class SystemBrowser {
     this.state.selectedDictIndex = dictIndex;
     // Route through the canonical class-selection helper so the Class
     // Definition panel updates too — the earlier inline mutations did
-    // not, so a hierarchy-view click left Class Definition stale.
+    // not, so a hierarchy-view click left Class Definition stale. This
+    // mirrors the column click: definition-only, no source-file reveal.
     this.applyClassSelection(className, false, true);
-    this.openClassFile(className);
   }
 
   private handleToggleEnvironment(envId: number): void {


### PR DESCRIPTION
## Summary

Clicking a class in the System Browser's hierarchy view opened both the Class Definition panel *and* the on-disk `.gs` Topaz cache file for that class. This shoved a redundant read-only tab in front of whatever the user was actively editing. The column-view click already only opened the definition — the hierarchy click should behave the same way.

## Changes

- Removed the extra `openClassFile` call from the hierarchy-click handler in `client/src/systemBrowser.ts`, so it now only calls `applyClassSelection`, matching column-click behavior.
- Updated surrounding comments to reflect that both the column click and hierarchy click are definition-only.
- Added a regression test in `client/src/__tests__/systemBrowser.test.ts` asserting that selecting a hierarchy class does not trigger `showTextDocument`.

Addresses Gitlab#36.

## Test plan

- [x] `npm run compile && npm test` passes
- [x] Manually tested in the extension: clicking a class in the hierarchy view now only opens/refreshes the Class Definition panel and no longer opens a redundant source file tab, confirming the fix works as intended.