### PR TITLE
Clean up npm test plumbing across workspaces

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP server for GemStone database interaction",
   "main": "out/index.js",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-require-module npx vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "url": "https://github.com/jgfoster/Jasper/issues"
   },
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.85.0",
+    "node": ">=22.12"
   },
   "icon": "resources/gemstone-icon.png",
   "categories": [
@@ -1337,13 +1338,13 @@
     "compile:mcp": "tsc -p mcp-server/tsconfig.json",
     "bundle": "node esbuild.mjs",
     "watch": "tsc -b -w client/tsconfig.json server/tsconfig.json",
-    "test": "npm run test:server && npm run test:client && npm run test:mcp",
+    "test": "npm run test --workspaces",
     "test:server:start": "npm run test:server:start --workspace client",
     "test:server:stop": "npm run test:server:stop --workspace client",
     "test:server:list": "npm run test:server:list --workspace client",
-    "test:server": "cd server && npx vitest run",
+    "test:server": "npm test --workspace server",
     "test:client": "npm test --workspace client",
-    "test:mcp": "cd mcp-server && npx vitest run",
+    "test:mcp": "npm test --workspace mcp-server",
     "//test:gci": "Runs only the on-demand 'gci' vitest project (client/vitest.config.ts); needs a live test stone (npm run test:server:start). `npm test` runs the 'default' project and excludes these.",
     "test:gci": "cd client && npx vitest run --project gci",
     "package": "vsce package",

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,9 @@
   "name": "gemstone-smalltalk-server",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "test": "vitest run"
+  },
   "dependencies": {
     "esbuild": "^0.28.1",
     "vscode-languageserver": "^9.0.0",


### PR DESCRIPTION
## Goal

Bring the monorepo's `npm test` plumbing closer to a conventional npm-workspaces setup: make the three workspaces (`client`, `server`, `mcp-server`) run tests consistently, remove a latent divergence between how the root and the workspaces invoked their tests, and drop a Node flag that is now a no-op. Verified `npm test` still passes across all three workspaces on the supported toolchain (Node pinned to 24.15.0 via `.nvmrc`).

## What changed

**`server/package.json`** — the workspace had no `scripts` block at all, which is why the root had to `cd server && npx vitest run` as a workaround. Added a standard `"test": "vitest run"`, so it can be driven like any other workspace.

**`package.json`** — the root `test` script hand-chained three legs with `&&`, each invoking their workspace differently (`cd server && npx vitest run`, `npm test --workspace client`, `cd mcp-server && npx vitest run`). Now:
- `test` → `npm run test --workspaces`, the documented mechanism for running a script across all workspaces.
- `test:server` / `test:mcp` → `npm test --workspace <name>`, consistent with the existing `test:client`, so all per-workspace legs route through the workspace's own script.

**Behavior change:** the old `&&`-chained root `test` was fail-fast — it stopped at the first workspace to fail, leaving the remaining workspaces' tests unrun. `npm run test --workspaces` runs the script in every workspace regardless of earlier failures, then exits non-zero if any of them failed. So `npm test` now always reports results from all three workspaces instead of stopping early on the first failure.
If in the future we think this is not the ideal solution, it's easy to change it back.

**`mcp-server/package.json` + `package.json`** — the mcp-server test script carried `NODE_OPTIONS=--experimental-require-module` to let CommonJS `require()` the ESM-only `@modelcontextprotocol/sdk`. On Node 24 that flag is a no-op: `require(ESM)` has been enabled by default since Node v23.0.0 / v22.12.0 / v20.19.0. The inline `NODE_OPTIONS=...` syntax is also POSIX-shell-only (breaks on Windows `cmd.exe`). So:
- Dropped the flag; the script is now just `"vitest run"` (matching `server`).
- Added `"engines": { "node": ">=22.12" }` to the root to make explicit the Node floor the flag used to paper over.

Removing the flag also eliminates the divergence class at its root: with no special flag, the root and workspace invocations can no longer differ.

## Verification

- `npm test` passes across all three workspaces.
- `npm run test:mcp` → 95/95 pass, exit 0, no `ExperimentalWarning`, no `ERR_REQUIRE_ESM`, with the flag removed on Node 24.15.0.