### PR TITLE
Find Method in Class: fix and rename picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Changed
+
+- **"Find Method…" renamed to "Find Method in Class…" and now always shows a filterable class picker.** The command searches within a single class, so the title now says so. With no class selected in the System Browser it previously prompted with a plain text box and then failed to select or open the picked method; it now offers the same filterable class list as **Find Class**, and when a class *is* selected in the browser that class is pre-highlighted as the default (one Enter reproduces the old scoped behavior, but the list is right there to pick another). Picking a method navigates to and opens it. The command id changed from `gemstone.findMethod` to `gemstone.findMethodInClass` — **breaking for any custom keybinding referencing the old id** (the built-in `Ctrl/Cmd+K M` chord is unaffected).
+
 ## [1.8.3] - 2026-07-13
 
 ### Added

--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -226,6 +226,43 @@ export const window = {
   })),
   showInputBox: vi.fn(),
   showQuickPick: vi.fn(),
+  // Controllable low-level QuickPick. Each call returns a fresh instance whose
+  // registered handlers can be fired from a test via `__accept()` / `__hide()`
+  // (or `hide()`), after inspecting/setting `items`, `activeItems`, and
+  // `selectedItems`. Grab the created instance with
+  // `vi.mocked(vscode.window.createQuickPick).mock.results.at(-1).value`.
+  createQuickPick: vi.fn(() => {
+    const acceptHandlers: Array<() => void | Promise<void>> = [];
+    const hideHandlers: Array<() => void> = [];
+    const qp: Record<string, unknown> = {
+      title: '',
+      placeholder: '',
+      value: '',
+      items: [] as unknown[],
+      selectedItems: [] as unknown[],
+      activeItems: [] as unknown[],
+      enabled: true,
+      busy: false,
+      matchOnDescription: false,
+      matchOnDetail: false,
+      onDidAccept: vi.fn((h: () => void | Promise<void>) => {
+        acceptHandlers.push(h);
+        return { dispose: vi.fn() };
+      }),
+      onDidHide: vi.fn((h: () => void) => {
+        hideHandlers.push(h);
+        return { dispose: vi.fn() };
+      }),
+      show: vi.fn(),
+      hide: vi.fn(() => hideHandlers.forEach((h) => h())),
+      dispose: vi.fn(),
+      __accept: async () => {
+        for (const h of acceptHandlers) await h();
+      },
+      __hide: () => hideHandlers.forEach((h) => h()),
+    };
+    return qp;
+  }),
   showOpenDialog: vi.fn(),
   showSaveDialog: vi.fn(),
   tabGroups: {

--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -234,6 +234,16 @@ export const window = {
   createQuickPick: vi.fn(() => {
     let onAccept: (() => void | Promise<void>) | undefined;
     let onHide: (() => void) | undefined;
+    let visible = false;
+    // Mirror real VS Code: hide()/dispose() only fire onDidHide while the input
+    // is still visible, and at most once — dispose() cascades to a hide if the
+    // input hasn't been hidden yet, so `dispose()` after a still-visible show()
+    // fires onDidHide (which a disposed-then-nothing input does not re-fire).
+    const fireHide = () => {
+      if (!visible) return;
+      visible = false;
+      onHide?.();
+    };
     const qp: Record<string, unknown> = {
       title: '',
       placeholder: '',
@@ -253,13 +263,15 @@ export const window = {
         onHide = h;
         return { dispose: vi.fn() };
       }),
-      show: vi.fn(),
-      hide: vi.fn(() => onHide?.()),
-      dispose: vi.fn(),
+      show: vi.fn(() => {
+        visible = true;
+      }),
+      hide: vi.fn(() => fireHide()),
+      dispose: vi.fn(() => fireHide()),
       __accept: async () => {
         await onAccept?.();
       },
-      __hide: () => onHide?.(),
+      __hide: () => fireHide(),
     };
     return qp;
   }),

--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -232,8 +232,8 @@ export const window = {
   // `selectedItems`. Grab the created instance with
   // `vi.mocked(vscode.window.createQuickPick).mock.results.at(-1).value`.
   createQuickPick: vi.fn(() => {
-    const acceptHandlers: Array<() => void | Promise<void>> = [];
-    const hideHandlers: Array<() => void> = [];
+    let onAccept: (() => void | Promise<void>) | undefined;
+    let onHide: (() => void) | undefined;
     const qp: Record<string, unknown> = {
       title: '',
       placeholder: '',
@@ -246,20 +246,20 @@ export const window = {
       matchOnDescription: false,
       matchOnDetail: false,
       onDidAccept: vi.fn((h: () => void | Promise<void>) => {
-        acceptHandlers.push(h);
+        onAccept = h;
         return { dispose: vi.fn() };
       }),
       onDidHide: vi.fn((h: () => void) => {
-        hideHandlers.push(h);
+        onHide = h;
         return { dispose: vi.fn() };
       }),
       show: vi.fn(),
-      hide: vi.fn(() => hideHandlers.forEach((h) => h())),
+      hide: vi.fn(() => onHide?.()),
       dispose: vi.fn(),
       __accept: async () => {
-        for (const h of acceptHandlers) await h();
+        await onAccept?.();
       },
-      __hide: () => hideHandlers.forEach((h) => h()),
+      __hide: () => onHide?.(),
     };
     return qp;
   }),

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -861,9 +861,13 @@ describe('buildMethodUri', () => {
       .toThrow("Method category name must not contain '/': accessing/stuff");
   });
 
-  it('throws when selector contains a slash', () => {
-    expect(() => buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'foo/bar', environmentId: 0 }))
-      .toThrow("Selector must not contain '/': foo/bar");
+  it('does not throw for a raw binary selector containing a slash', () => {
+    // '/' and '//' are ordinary Smalltalk binary selectors; buildMethodUri must
+    // escape them into the path rather than reject them.
+    expect(() => buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Number', isMeta: false, category: 'arithmetic', selector: '/', environmentId: 0 }))
+      .not.toThrow();
+    expect(() => buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Integer', isMeta: false, category: 'arithmetic', selector: '//', environmentId: 0 }))
+      .not.toThrow();
   });
 });
 
@@ -1110,6 +1114,18 @@ describe('parseUri', () => {
 
   it('recovers a selector that contains a slash', () => {
     const uri = buildMethodUri({ ...method, isMeta: false, category: 'arithmetic', selector: escapeSelectorSlashes('//'), environmentId: 0 });
+
+    expect(parseUri(uri)).toMatchObject({ selector: '//' });
+  });
+
+  it('round-trips a raw single-slash binary selector', () => {
+    const uri = buildMethodUri({ ...method, isMeta: false, category: 'arithmetic', selector: '/', environmentId: 0 });
+
+    expect(parseUri(uri)).toMatchObject({ selector: '/' });
+  });
+
+  it('round-trips a raw double-slash binary selector', () => {
+    const uri = buildMethodUri({ ...method, isMeta: false, category: 'arithmetic', selector: '//', environmentId: 0 });
 
     expect(parseUri(uri)).toMatchObject({ selector: '//' });
   });

--- a/client/src/__tests__/keybindings.test.ts
+++ b/client/src/__tests__/keybindings.test.ts
@@ -53,7 +53,7 @@ describe('keybindings', () => {
       i: 'gemstone.inspectIt',
       b: 'gemstone.openBrowser',
       c: 'gemstone.findClass',
-      m: 'gemstone.findMethod',
+      m: 'gemstone.findMethodInClass',
     };
 
     for (const kb of chordBindings) {

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -2564,7 +2564,7 @@ describe('SystemBrowser', () => {
       messageHandler({ command: 'selectClass', name: 'Array' });
 
       const result = SystemBrowser.getSelectedClassName(session.id);
-      expect(result).toEqual({ dictName: 'UserGlobals', className: 'Array' });
+      expect(result).toEqual({ dictName: 'UserGlobals', className: 'Array', dictIndex: 1 });
     });
   });
 

--- a/client/src/commands/__tests__/findMethodInClass.test.ts
+++ b/client/src/commands/__tests__/findMethodInClass.test.ts
@@ -10,14 +10,17 @@ import { findMethodInClass } from '../findMethodInClass';
 
 const noErr = { number: 0, message: '', context: 0n, category: 0, fatal: false, argCount: 0, exceptionObj: 0n, args: [] };
 
-function createMockSession(executeFetchData = ''): ActiveSession {
+const classListPayload = '1\tUserGlobals\tArray\n2\tGlobals\tString\n';
+const methodListPayload = '0\tprinting\tfoo\n1\taccessing\tbar\n';
+
+function createMockSession(): ActiveSession {
   const mockGci = {
     GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
     GciTsPerform: vi.fn(() => ({ result: 2000n, err: { ...noErr } })),
     GciTsNewString: vi.fn(() => ({ result: 3000n, err: { ...noErr } })),
     GciTsNewSymbol: vi.fn(() => ({ result: 4000n, err: { ...noErr } })),
     GciTsCompileMethod: vi.fn(() => ({ result: 5000n, err: { ...noErr } })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({ data: executeFetchData, err: { ...noErr } })),
+    GciTsExecuteFetchBytes: vi.fn(() => ({ data: '', err: { ...noErr } })),
     GciTsPerformFetchBytes: vi.fn(() => ({ data: '', err: { ...noErr } })),
     GciTsCallInProgress: vi.fn(() => ({ result: 0 })),
     GciTsClearStack: vi.fn(),
@@ -32,52 +35,130 @@ function createMockSession(executeFetchData = ''): ActiveSession {
   };
 }
 
+// The command loads the class list, then the method list — so the fake GCI
+// answers the first FetchBytes with the class payload and the second with the
+// method payload (empty by default = a class with no methods).
+function createSequencedSession(methodPayload = methodListPayload): ActiveSession {
+  const session = createMockSession();
+  vi.mocked(session.gci.GciTsExecuteFetchBytes)
+    .mockReturnValueOnce({ data: classListPayload, err: { ...noErr } } as any)
+    .mockReturnValueOnce({ data: methodPayload, err: { ...noErr } } as any);
+  return session;
+}
+
+function lastQuickPick(): any {
+  const results = vi.mocked(vscode.window.createQuickPick).mock.results;
+  return results[results.length - 1].value;
+}
+
+// Kicks off the command, waits for the class picker to appear, and hands back
+// everything a test needs to drive and assert on it. The command can't simply be
+// awaited here (that would deadlock: the test waiting on the command, the command
+// parked on the class-pick promise waiting for an onDidAccept/onDidHide the test
+// hasn't fired yet). So it's kicked off unawaited; vi.waitFor then polls until the
+// command has advanced through its earlier awaits (resolveSession, getAllClassNames)
+// and reached createQuickPick().show(). Polling — rather than a fixed flush tick —
+// tolerates that chain spanning however many ticks. The test then inspects/fires
+// the picker and finally awaits `done`.
+async function openClassPicker(methodPayload = methodListPayload) {
+  const session = createSequencedSession(methodPayload);
+  const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+  const done = findMethodInClass(sessionManager);
+  await vi.waitFor(() => expect(vscode.window.createQuickPick).toHaveBeenCalled());
+  return { session, qp: lastQuickPick(), done };
+}
+
+// Resolves the class picker by accepting a class, then lets the command finish.
+// With no className, accepts whatever is pre-highlighted (the default); with
+// one, selects that class from the list instead.
+async function acceptClass(qp: any, done: Promise<void>, className?: string): Promise<void> {
+  qp.selectedItems = className
+    ? [qp.items.find((i: any) => i.entry.className === className)]
+    : qp.activeItems;
+  await qp.__accept();
+  await done;
+}
+
+// Dismisses the class picker (Escape/cancel), then lets the command finish.
+async function dismissPicker(qp: any, done: Promise<void>): Promise<void> {
+  qp.__hide();
+  await done;
+}
+
+function expectNavigatedTo(sessionId: number, dictName: string, className: string): void {
+  expect(SystemBrowser.navigateTo).toHaveBeenCalledWith(sessionId, {
+    dictName,
+    className,
+    isMeta: false,
+    selector: 'foo',
+    category: 'printing',
+  });
+}
+
 describe('findMethodInClass', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(SystemBrowser, 'navigateTo').mockReturnValue(true);
+    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({
+      label: 'foo',
+      description: 'printing',
+      method: { isMeta: false, category: 'printing', selector: 'foo' },
+    } as any);
   });
 
   describe('when a class is selected in the System Browser', () => {
-    const session = createMockSession('0\tprinting\tfoo\n1\taccessing\tbar\n');
-
     beforeEach(() => {
       vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue({ dictName: 'UserGlobals', className: 'Array' });
     });
 
-    it('navigates to the picked method using the currently selected class', async () => {
-      vi.mocked(vscode.window.showQuickPick).mockResolvedValue({
-        label: 'foo',
-        description: 'printing',
-        method: { isMeta: false, category: 'printing', selector: 'foo' },
-      } as any);
-      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+    it('still shows the class picker, with the selected class pre-highlighted', async () => {
+      const { qp, done } = await openClassPicker();
 
-      await findMethodInClass(sessionManager);
+      expect(vscode.window.createQuickPick).toHaveBeenCalled();
+      expect(qp.activeItems).toHaveLength(1);
+      expect(qp.activeItems[0].entry).toEqual({ dictIndex: 1, dictName: 'UserGlobals', className: 'Array' });
 
-      expect(SystemBrowser.navigateTo).toHaveBeenCalledWith(session.id, {
-        dictName: 'UserGlobals',
-        className: 'Array',
-        isMeta: false,
-        selector: 'foo',
-        category: 'printing',
-      });
+      await dismissPicker(qp, done);
+    });
+
+    it('navigates using the pre-highlighted class when the default is accepted', async () => {
+      const { session, qp, done } = await openClassPicker();
+
+      await acceptClass(qp, done);
+
+      expectNavigatedTo(session.id, 'UserGlobals', 'Array');
+    });
+
+    it('navigates using a different class when the user picks another item', async () => {
+      const { session, qp, done } = await openClassPicker();
+
+      await acceptClass(qp, done, 'String');
+
+      expectNavigatedTo(session.id, 'Globals', 'String');
+    });
+
+    it('does not navigate when the class picker is dismissed', async () => {
+      const { qp, done } = await openClassPicker();
+
+      await dismissPicker(qp, done);
+
+      expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
+      expect(SystemBrowser.navigateTo).not.toHaveBeenCalled();
     });
 
     it('does not navigate when the method pick is cancelled', async () => {
       vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
-      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+      const { qp, done } = await openClassPicker();
 
-      await findMethodInClass(sessionManager);
+      await acceptClass(qp, done);
 
       expect(SystemBrowser.navigateTo).not.toHaveBeenCalled();
     });
 
     it('shows an informational message when the class has no methods', async () => {
-      const emptySession = createMockSession('');
-      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(emptySession) } as any;
+      const { qp, done } = await openClassPicker('');
 
-      await findMethodInClass(sessionManager);
+      await acceptClass(qp, done);
 
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('No methods found for Array.');
       expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
@@ -85,60 +166,31 @@ describe('findMethodInClass', () => {
   });
 
   describe('when no class is selected in the System Browser', () => {
-    const classListPayload = '1\tUserGlobals\tArray\n2\tGlobals\tString\n';
-    const methodListPayload = '0\tprinting\tfoo\n1\taccessing\tbar\n';
-
-    function createSequencedSession(): ActiveSession {
-      const session = createMockSession();
-      vi.mocked(session.gci.GciTsExecuteFetchBytes)
-        .mockReturnValueOnce({ data: classListPayload, err: { ...noErr } } as any)
-        .mockReturnValueOnce({ data: methodListPayload, err: { ...noErr } } as any);
-      return session;
-    }
-
     beforeEach(() => {
       vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue(null);
     });
 
+    it('shows the class picker with nothing pre-highlighted', async () => {
+      const { qp, done } = await openClassPicker();
+
+      expect(qp.activeItems).toHaveLength(0);
+
+      await dismissPicker(qp, done);
+    });
+
     it('navigates to the picked method using the class picked from the list', async () => {
-      const session = createSequencedSession();
-      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
-      vi.mocked(vscode.window.showQuickPick)
-        .mockResolvedValueOnce({
-          label: 'Array', description: 'UserGlobals',
-          entry: { dictIndex: 1, dictName: 'UserGlobals', className: 'Array' },
-        } as any)
-        .mockResolvedValueOnce({
-          label: 'foo', description: 'printing',
-          method: { isMeta: false, category: 'printing', selector: 'foo' },
-        } as any);
+      const { session, qp, done } = await openClassPicker();
 
-      await findMethodInClass(sessionManager);
+      await acceptClass(qp, done, 'Array');
 
-      expect(SystemBrowser.navigateTo).toHaveBeenCalledWith(session.id, {
-        dictName: 'UserGlobals',
-        className: 'Array',
-        isMeta: false,
-        selector: 'foo',
-        category: 'printing',
-      });
+      expectNavigatedTo(session.id, 'UserGlobals', 'Array');
     });
 
     it('opens the method directly when no System Browser is open for the session', async () => {
       vi.mocked(SystemBrowser.navigateTo).mockReturnValue(false);
-      const session = createSequencedSession();
-      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
-      vi.mocked(vscode.window.showQuickPick)
-        .mockResolvedValueOnce({
-          label: 'Array', description: 'UserGlobals',
-          entry: { dictIndex: 1, dictName: 'UserGlobals', className: 'Array' },
-        } as any)
-        .mockResolvedValueOnce({
-          label: 'foo', description: 'printing',
-          method: { isMeta: false, category: 'printing', selector: 'foo' },
-        } as any);
+      const { qp, done } = await openClassPicker();
 
-      await findMethodInClass(sessionManager);
+      await acceptClass(qp, done, 'Array');
 
       expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
       const [command, uri] = vi.mocked(vscode.commands.executeCommand).mock.calls[0];
@@ -148,13 +200,11 @@ describe('findMethodInClass', () => {
     });
 
     it('does not load methods when the class pick is cancelled', async () => {
-      const session = createSequencedSession();
-      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
-      vi.mocked(vscode.window.showQuickPick).mockResolvedValueOnce(undefined);
+      const { qp, done } = await openClassPicker();
 
-      await findMethodInClass(sessionManager);
+      await dismissPicker(qp, done);
 
-      expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
+      expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
       expect(SystemBrowser.navigateTo).not.toHaveBeenCalled();
     });
   });

--- a/client/src/commands/__tests__/findMethodInClass.test.ts
+++ b/client/src/commands/__tests__/findMethodInClass.test.ts
@@ -33,49 +33,129 @@ function createMockSession(executeFetchData = ''): ActiveSession {
 }
 
 describe('findMethodInClass', () => {
-  const session = createMockSession('0\tprinting\tfoo\n1\taccessing\tbar\n');
-
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue({ dictName: 'UserGlobals', className: 'Array' });
     vi.spyOn(SystemBrowser, 'navigateTo').mockReturnValue(true);
   });
 
-  it('navigates to the picked method using the currently selected class', async () => {
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({
-      label: 'foo',
-      description: 'printing',
-      method: { isMeta: false, category: 'printing', selector: 'foo' },
-    } as any);
-    const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+  describe('when a class is selected in the System Browser', () => {
+    const session = createMockSession('0\tprinting\tfoo\n1\taccessing\tbar\n');
 
-    await findMethodInClass(sessionManager);
+    beforeEach(() => {
+      vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue({ dictName: 'UserGlobals', className: 'Array' });
+    });
 
-    expect(SystemBrowser.navigateTo).toHaveBeenCalledWith(session.id, {
-      dictName: 'UserGlobals',
-      className: 'Array',
-      isMeta: false,
-      selector: 'foo',
-      category: 'printing',
+    it('navigates to the picked method using the currently selected class', async () => {
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValue({
+        label: 'foo',
+        description: 'printing',
+        method: { isMeta: false, category: 'printing', selector: 'foo' },
+      } as any);
+      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+
+      await findMethodInClass(sessionManager);
+
+      expect(SystemBrowser.navigateTo).toHaveBeenCalledWith(session.id, {
+        dictName: 'UserGlobals',
+        className: 'Array',
+        isMeta: false,
+        selector: 'foo',
+        category: 'printing',
+      });
+    });
+
+    it('does not navigate when the method pick is cancelled', async () => {
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
+      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+
+      await findMethodInClass(sessionManager);
+
+      expect(SystemBrowser.navigateTo).not.toHaveBeenCalled();
+    });
+
+    it('shows an informational message when the class has no methods', async () => {
+      const emptySession = createMockSession('');
+      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(emptySession) } as any;
+
+      await findMethodInClass(sessionManager);
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('No methods found for Array.');
+      expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
     });
   });
 
-  it('does not navigate when the method pick is cancelled', async () => {
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
-    const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+  describe('when no class is selected in the System Browser', () => {
+    const classListPayload = '1\tUserGlobals\tArray\n2\tGlobals\tString\n';
+    const methodListPayload = '0\tprinting\tfoo\n1\taccessing\tbar\n';
 
-    await findMethodInClass(sessionManager);
+    function createSequencedSession(): ActiveSession {
+      const session = createMockSession();
+      vi.mocked(session.gci.GciTsExecuteFetchBytes)
+        .mockReturnValueOnce({ data: classListPayload, err: { ...noErr } } as any)
+        .mockReturnValueOnce({ data: methodListPayload, err: { ...noErr } } as any);
+      return session;
+    }
 
-    expect(SystemBrowser.navigateTo).not.toHaveBeenCalled();
-  });
+    beforeEach(() => {
+      vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue(null);
+    });
 
-  it('shows an informational message when the class has no methods', async () => {
-    const emptySession = createMockSession('');
-    const sessionManager = { resolveSession: vi.fn().mockResolvedValue(emptySession) } as any;
+    it('navigates to the picked method using the class picked from the list', async () => {
+      const session = createSequencedSession();
+      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+      vi.mocked(vscode.window.showQuickPick)
+        .mockResolvedValueOnce({
+          label: 'Array', description: 'UserGlobals',
+          entry: { dictIndex: 1, dictName: 'UserGlobals', className: 'Array' },
+        } as any)
+        .mockResolvedValueOnce({
+          label: 'foo', description: 'printing',
+          method: { isMeta: false, category: 'printing', selector: 'foo' },
+        } as any);
 
-    await findMethodInClass(sessionManager);
+      await findMethodInClass(sessionManager);
 
-    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('No methods found for Array.');
-    expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
+      expect(SystemBrowser.navigateTo).toHaveBeenCalledWith(session.id, {
+        dictName: 'UserGlobals',
+        className: 'Array',
+        isMeta: false,
+        selector: 'foo',
+        category: 'printing',
+      });
+    });
+
+    it('opens the method directly when no System Browser is open for the session', async () => {
+      vi.mocked(SystemBrowser.navigateTo).mockReturnValue(false);
+      const session = createSequencedSession();
+      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+      vi.mocked(vscode.window.showQuickPick)
+        .mockResolvedValueOnce({
+          label: 'Array', description: 'UserGlobals',
+          entry: { dictIndex: 1, dictName: 'UserGlobals', className: 'Array' },
+        } as any)
+        .mockResolvedValueOnce({
+          label: 'foo', description: 'printing',
+          method: { isMeta: false, category: 'printing', selector: 'foo' },
+        } as any);
+
+      await findMethodInClass(sessionManager);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
+      const [command, uri] = vi.mocked(vscode.commands.executeCommand).mock.calls[0];
+      expect(command).toBe('gemstone.openDocument');
+      expect(String(uri)).toContain('UserGlobals');
+      expect(String(uri)).toContain('Array');
+    });
+
+    it('does not load methods when the class pick is cancelled', async () => {
+      const session = createSequencedSession();
+      const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValueOnce(undefined);
+
+      await findMethodInClass(sessionManager);
+
+      expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
+      expect(SystemBrowser.navigateTo).not.toHaveBeenCalled();
+    });
   });
 });

--- a/client/src/commands/__tests__/findMethodInClass.test.ts
+++ b/client/src/commands/__tests__/findMethodInClass.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => import('../../__mocks__/vscode'));
+
+import * as vscode from 'vscode';
+import { ActiveSession } from '../../sessionManager';
+import { GemStoneLogin } from '../../loginTypes';
+import { SystemBrowser } from '../../systemBrowser';
+import { findMethodInClass } from '../findMethodInClass';
+
+const noErr = { number: 0, message: '', context: 0n, category: 0, fatal: false, argCount: 0, exceptionObj: 0n, args: [] };
+
+function createMockSession(executeFetchData = ''): ActiveSession {
+  const mockGci = {
+    GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
+    GciTsPerform: vi.fn(() => ({ result: 2000n, err: { ...noErr } })),
+    GciTsNewString: vi.fn(() => ({ result: 3000n, err: { ...noErr } })),
+    GciTsNewSymbol: vi.fn(() => ({ result: 4000n, err: { ...noErr } })),
+    GciTsCompileMethod: vi.fn(() => ({ result: 5000n, err: { ...noErr } })),
+    GciTsExecuteFetchBytes: vi.fn(() => ({ data: executeFetchData, err: { ...noErr } })),
+    GciTsPerformFetchBytes: vi.fn(() => ({ data: '', err: { ...noErr } })),
+    GciTsCallInProgress: vi.fn(() => ({ result: 0 })),
+    GciTsClearStack: vi.fn(),
+  };
+
+  return {
+    id: 1,
+    gci: mockGci as unknown as ActiveSession['gci'],
+    handle: {},
+    login: { label: 'Test' } as GemStoneLogin,
+    stoneVersion: '3.7.2',
+  };
+}
+
+describe('findMethodInClass', () => {
+  const session = createMockSession('0\tprinting\tfoo\n1\taccessing\tbar\n');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue({ dictName: 'UserGlobals', className: 'Array' });
+    vi.spyOn(SystemBrowser, 'navigateTo').mockReturnValue(true);
+  });
+
+  it('navigates to the picked method using the currently selected class', async () => {
+    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({
+      label: 'foo',
+      description: 'printing',
+      method: { isMeta: false, category: 'printing', selector: 'foo' },
+    } as any);
+    const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+
+    await findMethodInClass(sessionManager);
+
+    expect(SystemBrowser.navigateTo).toHaveBeenCalledWith(session.id, {
+      dictName: 'UserGlobals',
+      className: 'Array',
+      isMeta: false,
+      selector: 'foo',
+      category: 'printing',
+    });
+  });
+
+  it('does not navigate when the method pick is cancelled', async () => {
+    vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
+    const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+
+    await findMethodInClass(sessionManager);
+
+    expect(SystemBrowser.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('shows an informational message when the class has no methods', async () => {
+    const emptySession = createMockSession('');
+    const sessionManager = { resolveSession: vi.fn().mockResolvedValue(emptySession) } as any;
+
+    await findMethodInClass(sessionManager);
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('No methods found for Array.');
+    expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/commands/__tests__/findMethodInClass.test.ts
+++ b/client/src/commands/__tests__/findMethodInClass.test.ts
@@ -108,7 +108,7 @@ describe('findMethodInClass', () => {
 
   describe('when a class is selected in the System Browser', () => {
     beforeEach(() => {
-      vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue({ dictName: 'UserGlobals', className: 'Array' });
+      vi.spyOn(SystemBrowser, 'getSelectedClassName').mockReturnValue({ dictName: 'UserGlobals', className: 'Array', dictIndex: 1 });
     });
 
     it('still shows the class picker, with the selected class pre-highlighted', async () => {

--- a/client/src/commands/classPicker.ts
+++ b/client/src/commands/classPicker.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+import * as queries from '../browserQueries';
+import { ActiveSession } from '../sessionManager';
+
+export interface ClassPickItem extends vscode.QuickPickItem {
+  entry: queries.ClassNameEntry;
+}
+
+/**
+ * Run `fn` behind a modal progress notification, surfacing any thrown error as
+ * an error message. Returns `undefined` when the work failed. `fn` may be
+ * synchronous — the notification still shows for the duration of the call.
+ */
+export async function withLoadingProgress<T>(
+  title: string,
+  failLabel: string,
+  fn: () => T,
+): Promise<T | undefined> {
+  try {
+    return await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title, cancellable: false },
+      () => Promise.resolve(fn()),
+    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    vscode.window.showErrorMessage(`${failLabel}: ${msg}`);
+    return undefined;
+  }
+}
+
+/**
+ * Load the full class list behind a progress notification and map it to
+ * quick-pick items. Returns `undefined` when the load failed (the error is
+ * already surfaced to the user).
+ */
+export async function loadClassPickItems(
+  session: ActiveSession,
+): Promise<ClassPickItem[] | undefined> {
+  const entries = await withLoadingProgress(
+    'Loading class list…',
+    'Failed to load classes',
+    () => queries.getAllClassNames(session),
+  );
+  if (!entries) return undefined;
+
+  return entries.map(e => ({
+    label: e.className,
+    description: e.dictName,
+    entry: e,
+  }));
+}

--- a/client/src/commands/findMethodInClass.ts
+++ b/client/src/commands/findMethodInClass.ts
@@ -2,9 +2,32 @@ import * as vscode from 'vscode';
 import * as queries from '../browserQueries';
 import { SessionManager } from '../sessionManager';
 import { SystemBrowser } from '../systemBrowser';
+import { buildMethodUri } from '../gemstoneFileSystemProvider';
 
 interface ClassPickItem extends vscode.QuickPickItem {
   entry: queries.ClassNameEntry;
+}
+
+/**
+ * Run `fn` behind a modal progress notification, surfacing any thrown error as
+ * an error message. Returns `undefined` when the work failed. `fn` may be
+ * synchronous — the notification still shows for the duration of the call.
+ */
+async function withLoadingProgress<T>(
+  title: string,
+  failLabel: string,
+  fn: () => T,
+): Promise<T | undefined> {
+  try {
+    return await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title, cancellable: false },
+      () => Promise.resolve(fn()),
+    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    vscode.window.showErrorMessage(`${failLabel}: ${msg}`);
+    return undefined;
+  }
 }
 
 /**
@@ -22,21 +45,12 @@ export async function findMethodInClass(sessionManager: SessionManager): Promise
 
   const current = SystemBrowser.getSelectedClassName(session.id);
 
-  let entries: queries.ClassNameEntry[];
-  try {
-    entries = await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: 'Loading class list…',
-        cancellable: false,
-      },
-      () => Promise.resolve(queries.getAllClassNames(session)),
-    );
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    vscode.window.showErrorMessage(`Failed to load classes: ${msg}`);
-    return;
-  }
+  const entries = await withLoadingProgress(
+    'Loading class list…',
+    'Failed to load classes',
+    () => queries.getAllClassNames(session),
+  );
+  if (!entries) return;
 
   const classItems: ClassPickItem[] = entries.map(e => ({
     label: e.className,
@@ -69,24 +83,14 @@ export async function findMethodInClass(sessionManager: SessionManager): Promise
   });
   if (!pickedClass) return;
 
-  const className = pickedClass.entry.className;
-  const dictName = pickedClass.entry.dictName;
+  const { className, dictName } = pickedClass.entry;
 
-  let methods: queries.MethodEntry[];
-  try {
-    methods = await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: `Loading methods for ${className}…`,
-        cancellable: false,
-      },
-      () => Promise.resolve(queries.getMethodList(session, className)),
-    );
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    vscode.window.showErrorMessage(`Failed to load methods: ${msg}`);
-    return;
-  }
+  const methods = await withLoadingProgress(
+    `Loading methods for ${className}…`,
+    'Failed to load methods',
+    () => queries.getMethodList(session, className),
+  );
+  if (!methods) return;
 
   if (methods.length === 0) {
     vscode.window.showInformationMessage(`No methods found for ${className}.`);
@@ -105,24 +109,10 @@ export async function findMethodInClass(sessionManager: SessionManager): Promise
   });
   if (!picked) return;
 
-  const result: queries.MethodSearchResult = {
-    dictName,
-    className,
-    isMeta: picked.method.isMeta,
-    selector: picked.method.selector,
-    category: picked.method.category,
-  };
+  const result: queries.MethodSearchResult = { dictName, className, ...picked.method };
 
   if (!SystemBrowser.navigateTo(session.id, result)) {
-    const side = result.isMeta ? 'class' : 'instance';
-    const uri = vscode.Uri.parse(
-      `gemstone://${session.id}` +
-      `/${encodeURIComponent(result.dictName)}` +
-      `/${encodeURIComponent(result.className)}` +
-      `/${side}` +
-      `/${encodeURIComponent(result.category)}` +
-      `/${encodeURIComponent(result.selector)}`
-    );
+    const uri = buildMethodUri({ kind: 'method', sessionId: session.id, ...result, environmentId: 0 });
     vscode.commands.executeCommand('gemstone.openDocument', uri);
   }
 }

--- a/client/src/commands/findMethodInClass.ts
+++ b/client/src/commands/findMethodInClass.ts
@@ -67,7 +67,7 @@ export async function findMethodInClass(sessionManager: SessionManager): Promise
     qp.placeholder = 'Type to find a class…';
     if (current) {
       const preselected = classItems.find(
-        i => i.entry.className === current.className && i.entry.dictName === current.dictName,
+        i => i.entry.className === current.className && i.entry.dictIndex === current.dictIndex,
       );
       if (preselected) qp.activeItems = [preselected];
     }

--- a/client/src/commands/findMethodInClass.ts
+++ b/client/src/commands/findMethodInClass.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode';
+import * as queries from '../browserQueries';
+import { SessionManager } from '../sessionManager';
+import { SystemBrowser } from '../systemBrowser';
+
+/**
+ * Command handler for "Find Method in Class". Resolves the target class (the
+ * System Browser's current selection, or a manually entered name), lets the
+ * user pick a method via quick-pick, and navigates the browser to it —
+ * falling back to opening the `gemstone://` virtual document if no browser
+ * is open for the session.
+ */
+export async function findMethodInClass(sessionManager: SessionManager): Promise<void> {
+  const session = await sessionManager.resolveSession();
+  if (!session) return;
+
+  let className: string | undefined;
+  let dictName: string | undefined;
+
+  const current = SystemBrowser.getSelectedClassName(session.id);
+  if (current) {
+    className = current.className;
+    dictName = current.dictName;
+  } else {
+    className = await vscode.window.showInputBox({
+      prompt: 'Enter class name',
+      placeHolder: 'e.g. Array',
+    });
+    if (!className) return;
+  }
+
+  let methods: queries.MethodEntry[];
+  try {
+    methods = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Loading methods for ${className}…`,
+        cancellable: false,
+      },
+      () => Promise.resolve(queries.getMethodList(session, className!)),
+    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    vscode.window.showErrorMessage(`Failed to load methods: ${msg}`);
+    return;
+  }
+
+  if (methods.length === 0) {
+    vscode.window.showInformationMessage(`No methods found for ${className}.`);
+    return;
+  }
+
+  const items = methods.map(m => ({
+    label: `${m.isMeta ? '(class) ' : ''}${m.selector}`,
+    description: m.category,
+    method: m,
+  }));
+
+  const picked = await vscode.window.showQuickPick(items, {
+    placeHolder: `Type to find a method in ${className}…`,
+    matchOnDescription: true,
+  });
+  if (!picked) return;
+
+  const result: queries.MethodSearchResult = {
+    dictName: dictName || '',
+    className: className!,
+    isMeta: picked.method.isMeta,
+    selector: picked.method.selector,
+    category: picked.method.category,
+  };
+
+  if (!SystemBrowser.navigateTo(session.id, result)) {
+    const side = result.isMeta ? 'class' : 'instance';
+    const uri = vscode.Uri.parse(
+      `gemstone://${session.id}` +
+      `/${encodeURIComponent(result.dictName)}` +
+      `/${encodeURIComponent(result.className)}` +
+      `/${side}` +
+      `/${encodeURIComponent(result.category)}` +
+      `/${encodeURIComponent(result.selector)}`
+    );
+    vscode.commands.executeCommand('gemstone.openDocument', uri);
+  }
+}

--- a/client/src/commands/findMethodInClass.ts
+++ b/client/src/commands/findMethodInClass.ts
@@ -3,32 +3,7 @@ import * as queries from '../browserQueries';
 import { SessionManager } from '../sessionManager';
 import { SystemBrowser } from '../systemBrowser';
 import { buildMethodUri } from '../gemstoneFileSystemProvider';
-
-interface ClassPickItem extends vscode.QuickPickItem {
-  entry: queries.ClassNameEntry;
-}
-
-/**
- * Run `fn` behind a modal progress notification, surfacing any thrown error as
- * an error message. Returns `undefined` when the work failed. `fn` may be
- * synchronous — the notification still shows for the duration of the call.
- */
-async function withLoadingProgress<T>(
-  title: string,
-  failLabel: string,
-  fn: () => T,
-): Promise<T | undefined> {
-  try {
-    return await vscode.window.withProgress(
-      { location: vscode.ProgressLocation.Notification, title, cancellable: false },
-      () => Promise.resolve(fn()),
-    );
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    vscode.window.showErrorMessage(`${failLabel}: ${msg}`);
-    return undefined;
-  }
-}
+import { ClassPickItem, loadClassPickItems, withLoadingProgress } from './classPicker';
 
 /**
  * Command handler for "Find Method in Class". Always shows a filterable class
@@ -45,18 +20,8 @@ export async function findMethodInClass(sessionManager: SessionManager): Promise
 
   const current = SystemBrowser.getSelectedClassName(session.id);
 
-  const entries = await withLoadingProgress(
-    'Loading class list…',
-    'Failed to load classes',
-    () => queries.getAllClassNames(session),
-  );
-  if (!entries) return;
-
-  const classItems: ClassPickItem[] = entries.map(e => ({
-    label: e.className,
-    description: e.dictName,
-    entry: e,
-  }));
+  const classItems = await loadClassPickItems(session);
+  if (!classItems) return;
 
   // createQuickPick (not showQuickPick) so the selected class can be
   // pre-highlighted via activeItems without also filtering the list.

--- a/client/src/commands/findMethodInClass.ts
+++ b/client/src/commands/findMethodInClass.ts
@@ -3,56 +3,74 @@ import * as queries from '../browserQueries';
 import { SessionManager } from '../sessionManager';
 import { SystemBrowser } from '../systemBrowser';
 
+interface ClassPickItem extends vscode.QuickPickItem {
+  entry: queries.ClassNameEntry;
+}
+
 /**
- * Command handler for "Find Method in Class". Resolves the target class (the
- * System Browser's current selection, or a class picked from a filterable
- * quick-pick), lets the user pick a method via quick-pick, and navigates the
- * browser to it — falling back to opening the `gemstone://` virtual document
- * if no browser is open for the session.
+ * Command handler for "Find Method in Class". Always shows a filterable class
+ * picker — pre-highlighting the System Browser's current selection when there
+ * is one, so a single Enter reproduces the scoped-to-selection behavior while
+ * the list stays right there to pick a different class. Then lets the user
+ * pick a method via quick-pick and navigates the browser to it — falling back
+ * to opening the `gemstone://` virtual document if no browser is open for the
+ * session.
  */
 export async function findMethodInClass(sessionManager: SessionManager): Promise<void> {
   const session = await sessionManager.resolveSession();
   if (!session) return;
 
-  let className: string;
-  let dictName: string;
-
   const current = SystemBrowser.getSelectedClassName(session.id);
-  if (current) {
-    className = current.className;
-    dictName = current.dictName;
-  } else {
-    let entries: queries.ClassNameEntry[];
-    try {
-      entries = await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: 'Loading class list…',
-          cancellable: false,
-        },
-        () => Promise.resolve(queries.getAllClassNames(session)),
-      );
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      vscode.window.showErrorMessage(`Failed to load classes: ${msg}`);
-      return;
-    }
 
-    const classItems = entries.map(e => ({
-      label: e.className,
-      description: e.dictName,
-      entry: e,
-    }));
-
-    const pickedClass = await vscode.window.showQuickPick(classItems, {
-      placeHolder: 'Type to find a class…',
-      matchOnDescription: true,
-    });
-    if (!pickedClass) return;
-
-    className = pickedClass.entry.className;
-    dictName = pickedClass.entry.dictName;
+  let entries: queries.ClassNameEntry[];
+  try {
+    entries = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Loading class list…',
+        cancellable: false,
+      },
+      () => Promise.resolve(queries.getAllClassNames(session)),
+    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    vscode.window.showErrorMessage(`Failed to load classes: ${msg}`);
+    return;
   }
+
+  const classItems: ClassPickItem[] = entries.map(e => ({
+    label: e.className,
+    description: e.dictName,
+    entry: e,
+  }));
+
+  // createQuickPick (not showQuickPick) so the selected class can be
+  // pre-highlighted via activeItems without also filtering the list.
+  const pickedClass = await new Promise<ClassPickItem | undefined>(resolve => {
+    const qp = vscode.window.createQuickPick<ClassPickItem>();
+    qp.items = classItems;
+    qp.matchOnDescription = true;
+    qp.placeholder = 'Type to find a class…';
+    if (current) {
+      const preselected = classItems.find(
+        i => i.entry.className === current.className && i.entry.dictName === current.dictName,
+      );
+      if (preselected) qp.activeItems = [preselected];
+    }
+    qp.onDidAccept(() => {
+      resolve(qp.selectedItems[0]);
+      qp.dispose();
+    });
+    qp.onDidHide(() => {
+      resolve(undefined);
+      qp.dispose();
+    });
+    qp.show();
+  });
+  if (!pickedClass) return;
+
+  const className = pickedClass.entry.className;
+  const dictName = pickedClass.entry.dictName;
 
   let methods: queries.MethodEntry[];
   try {

--- a/client/src/commands/findMethodInClass.ts
+++ b/client/src/commands/findMethodInClass.ts
@@ -5,28 +5,53 @@ import { SystemBrowser } from '../systemBrowser';
 
 /**
  * Command handler for "Find Method in Class". Resolves the target class (the
- * System Browser's current selection, or a manually entered name), lets the
- * user pick a method via quick-pick, and navigates the browser to it —
- * falling back to opening the `gemstone://` virtual document if no browser
- * is open for the session.
+ * System Browser's current selection, or a class picked from a filterable
+ * quick-pick), lets the user pick a method via quick-pick, and navigates the
+ * browser to it — falling back to opening the `gemstone://` virtual document
+ * if no browser is open for the session.
  */
 export async function findMethodInClass(sessionManager: SessionManager): Promise<void> {
   const session = await sessionManager.resolveSession();
   if (!session) return;
 
-  let className: string | undefined;
-  let dictName: string | undefined;
+  let className: string;
+  let dictName: string;
 
   const current = SystemBrowser.getSelectedClassName(session.id);
   if (current) {
     className = current.className;
     dictName = current.dictName;
   } else {
-    className = await vscode.window.showInputBox({
-      prompt: 'Enter class name',
-      placeHolder: 'e.g. Array',
+    let entries: queries.ClassNameEntry[];
+    try {
+      entries = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Loading class list…',
+          cancellable: false,
+        },
+        () => Promise.resolve(queries.getAllClassNames(session)),
+      );
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      vscode.window.showErrorMessage(`Failed to load classes: ${msg}`);
+      return;
+    }
+
+    const classItems = entries.map(e => ({
+      label: e.className,
+      description: e.dictName,
+      entry: e,
+    }));
+
+    const pickedClass = await vscode.window.showQuickPick(classItems, {
+      placeHolder: 'Type to find a class…',
+      matchOnDescription: true,
     });
-    if (!className) return;
+    if (!pickedClass) return;
+
+    className = pickedClass.entry.className;
+    dictName = pickedClass.entry.dictName;
   }
 
   let methods: queries.MethodEntry[];
@@ -37,7 +62,7 @@ export async function findMethodInClass(sessionManager: SessionManager): Promise
         title: `Loading methods for ${className}…`,
         cancellable: false,
       },
-      () => Promise.resolve(queries.getMethodList(session, className!)),
+      () => Promise.resolve(queries.getMethodList(session, className)),
     );
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -63,8 +88,8 @@ export async function findMethodInClass(sessionManager: SessionManager): Promise
   if (!picked) return;
 
   const result: queries.MethodSearchResult = {
-    dictName: dictName || '',
-    className: className!,
+    dictName,
+    className,
     isMeta: picked.method.isMeta,
     selector: picked.method.selector,
     category: picked.method.category,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1990,7 +1990,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand('gemstone.findMethod', () => findMethodInClass(sessionManager)),
+    vscode.commands.registerCommand('gemstone.findMethodInClass', () => findMethodInClass(sessionManager)),
   );
 
   // ── SysAdmin ──────────────────────────────────────────────

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -58,7 +58,7 @@ import { refreshEnhancedInspectorAvailable } from './enhancedInspectorAvailabili
 import { supportsEnhancedInspector } from './enhancedInspectorInstall';
 import { DebuggerPanel } from './debuggerPanel';
 import { InlineValuesCodeLensProvider } from './inlineValuesCodeLens';
-import { GemStoneFileSystemProvider, MethodCompiledEvent, ClassDefinitionCompiledEvent, closeGemstoneTabsForSession, installStaleGemstoneTabReaper } from './gemstoneFileSystemProvider';
+import { GemStoneFileSystemProvider, MethodCompiledEvent, ClassDefinitionCompiledEvent, closeGemstoneTabsForSession, installStaleGemstoneTabReaper, buildMethodUri } from './gemstoneFileSystemProvider';
 import { openWorkspace } from './workspace';
 import { openTutorialNotebook } from './tutorialNotebook';
 import { GemStoneDebugSession } from './gemstoneDebugSession';
@@ -921,15 +921,7 @@ export function activate(context: vscode.ExtensionContext) {
     // method (updates all 5 columns) and open the method editor from there.
     // Otherwise fall back to opening the document directly.
     if (!SystemBrowser.navigateTo(session.id, r)) {
-      const side = r.isMeta ? 'class' : 'instance';
-      const uri = vscode.Uri.parse(
-        `gemstone://${session.id}` +
-        `/${encodeURIComponent(r.dictName)}` +
-        `/${encodeURIComponent(r.className)}` +
-        `/${side}` +
-        `/${encodeURIComponent(r.category)}` +
-        `/${encodeURIComponent(r.selector)}`
-      );
+      const uri = buildMethodUri({ kind: 'method', sessionId: session.id, ...r, environmentId: 0 });
       vscode.commands.executeCommand('gemstone.openDocument', uri);
     }
   }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -46,6 +46,7 @@ import { RowanRepoRegistry } from './rowanRepos';
 import { RowanTreeProvider, RowanRepoItem, RowanLoadedProjectItem, RowanChangesProjectItem } from './rowanTreeProvider';
 import { RowanDecorationProvider } from './rowanDecorations';
 import { findMethodInClass } from './commands/findMethodInClass';
+import { loadClassPickItems } from './commands/classPicker';
 import { GlobalsBrowser } from './globalsBrowser';
 import { CommentBrowser } from './commentBrowser';
 import { EnhancedInspector } from './enhancedInspector';
@@ -1938,27 +1939,8 @@ export function activate(context: vscode.ExtensionContext) {
       const session = await sessionManager.resolveSession();
       if (!session) return;
 
-      let entries: queries.ClassNameEntry[];
-      try {
-        entries = await vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-            title: 'Loading class list…',
-            cancellable: false,
-          },
-          () => Promise.resolve(queries.getAllClassNames(session)),
-        );
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        vscode.window.showErrorMessage(`Failed to load classes: ${msg}`);
-        return;
-      }
-
-      const items = entries.map(e => ({
-        label: e.className,
-        description: e.dictName,
-        entry: e,
-      }));
+      const items = await loadClassPickItems(session);
+      if (!items) return;
 
       const picked = await vscode.window.showQuickPick(items, {
         placeHolder: 'Type to find a class…',

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -45,6 +45,7 @@ import { NbCancelledError } from './nbRunner';
 import { RowanRepoRegistry } from './rowanRepos';
 import { RowanTreeProvider, RowanRepoItem, RowanLoadedProjectItem, RowanChangesProjectItem } from './rowanTreeProvider';
 import { RowanDecorationProvider } from './rowanDecorations';
+import { findMethodInClass } from './commands/findMethodInClass';
 import { GlobalsBrowser } from './globalsBrowser';
 import { CommentBrowser } from './commentBrowser';
 import { EnhancedInspector } from './enhancedInspector';
@@ -1989,79 +1990,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand('gemstone.findMethod', async () => {
-      const session = await sessionManager.resolveSession();
-      if (!session) return;
-
-      let className: string | undefined;
-      let dictName: string | undefined;
-
-      const current = SystemBrowser.getSelectedClassName(session.id);
-      if (current) {
-        className = current.className;
-        dictName = current.dictName;
-      } else {
-        className = await vscode.window.showInputBox({
-          prompt: 'Enter class name',
-          placeHolder: 'e.g. Array',
-        });
-        if (!className) return;
-      }
-
-      let methods: queries.MethodEntry[];
-      try {
-        methods = await vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-            title: `Loading methods for ${className}…`,
-            cancellable: false,
-          },
-          () => Promise.resolve(queries.getMethodList(session, className!)),
-        );
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        vscode.window.showErrorMessage(`Failed to load methods: ${msg}`);
-        return;
-      }
-
-      if (methods.length === 0) {
-        vscode.window.showInformationMessage(`No methods found for ${className}.`);
-        return;
-      }
-
-      const items = methods.map(m => ({
-        label: `${m.isMeta ? '(class) ' : ''}${m.selector}`,
-        description: m.category,
-        method: m,
-      }));
-
-      const picked = await vscode.window.showQuickPick(items, {
-        placeHolder: `Type to find a method in ${className}…`,
-        matchOnDescription: true,
-      });
-      if (!picked) return;
-
-      const result: queries.MethodSearchResult = {
-        dictName: dictName || '',
-        className: className!,
-        isMeta: picked.method.isMeta,
-        selector: picked.method.selector,
-        category: picked.method.category,
-      };
-
-      if (!SystemBrowser.navigateTo(session.id, result)) {
-        const side = result.isMeta ? 'class' : 'instance';
-        const uri = vscode.Uri.parse(
-          `gemstone://${session.id}` +
-          `/${encodeURIComponent(result.dictName)}` +
-          `/${encodeURIComponent(result.className)}` +
-          `/${side}` +
-          `/${encodeURIComponent(result.category)}` +
-          `/${encodeURIComponent(result.selector)}`
-        );
-        vscode.commands.executeCommand('gemstone.openDocument', uri);
-      }
-    }),
+    vscode.commands.registerCommand('gemstone.findMethod', () => findMethodInClass(sessionManager)),
   );
 
   // ── SysAdmin ──────────────────────────────────────────────

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -191,8 +191,10 @@ export function buildMethodUri(parsedUri: ParsedMethodUri): vscode.Uri {
   assertIsValidUriPath('Dictionary name', parsedUri.dictName);
   assertIsValidUriPath('Class name', parsedUri.className);
   assertIsValidUriPath('Method category name', parsedUri.category);
-  assertIsValidUriPath('Selector', parsedUri.selector);
-  
+  // The selector is NOT asserted slash-free: '/' and '//' are ordinary binary
+  // selectors. Escape any slashes to the sentinel so they survive the path
+  // (parseUri reverses it). Idempotent, so callers that pre-escape stay correct.
+
   const side = parsedUri.isMeta ? 'class' : 'instance';
   const params: string[] = [];
   if (parsedUri.dictIndex !== undefined) params.push(`dict=${parsedUri.dictIndex}`);
@@ -201,7 +203,7 @@ export function buildMethodUri(parsedUri: ParsedMethodUri): vscode.Uri {
   return vscode.Uri.from({
     scheme: 'gemstone',
     authority: String(parsedUri.sessionId),
-    path: `/${parsedUri.dictName}/${parsedUri.className}/${side}/${parsedUri.category}/${parsedUri.selector}`,
+    path: `/${parsedUri.dictName}/${parsedUri.className}/${side}/${parsedUri.category}/${escapeSelectorSlashes(parsedUri.selector)}`,
     query: params.join('&'),
   });
 }

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -353,7 +353,7 @@ export class SystemBrowser {
    * Return the currently selected class in the first browser for this session,
    * or null if no browser is open or no class is selected.
    */
-  static getSelectedClassName(sessionId: number): { dictName: string; className: string } | null {
+  static getSelectedClassName(sessionId: number): { dictName: string; className: string; dictIndex: number } | null {
     const browsers = SystemBrowser.panels.get(sessionId);
     if (!browsers) return null;
     for (const browser of browsers) {
@@ -363,6 +363,7 @@ export class SystemBrowser {
         return {
           dictName: browser.state.dictionaries[idx - 1],
           className: cls,
+          dictIndex: idx,
         };
       }
     }

--- a/package.json
+++ b/package.json
@@ -873,8 +873,8 @@
         "icon": "$(search)"
       },
       {
-        "command": "gemstone.findMethod",
-        "title": "Find Method\u2026",
+        "command": "gemstone.findMethodInClass",
+        "title": "Find Method in Class…",
         "category": "GemStone",
         "icon": "$(search)"
       },
@@ -1916,7 +1916,7 @@
         "when": "gemstone.hasActiveSession"
       },
       {
-        "command": "gemstone.findMethod",
+        "command": "gemstone.findMethodInClass",
         "key": "ctrl+k m",
         "mac": "cmd+k m",
         "when": "gemstone.hasActiveSession"


### PR DESCRIPTION
## Summary
Fixes Gitlab#55

Fixes the "Find Method…" command (`gemstone.findMethod`), which was broken when invoked with no class selected in the System Browser: it fell back to a plain text input box, and picking a method from the resulting list would fail to navigate to or open it.

- Replaced the text-input fallback with the same filterable class quick-pick used by **Find Class**. The command now always shows this picker.
- When a class *is* selected in the System Browser, that class is pre-highlighted as the default active item — pressing Enter immediately reproduces the old scoped-to-selection behavior, while the full list is still right there to pick a different class instead.
- Renamed the command from **"Find Method…"** to **"Find Method in Class…"** (id changed from `gemstone.findMethod` to `gemstone.findMethodInClass`) since the command is scoped to a single class, to distinguish it from a possible future cross-class method search.
- Extracted the handler out of the giant `activate()` function in `extension.ts` into its own module, `client/src/commands/findMethodInClass.ts`, along with a dedicated test file.
- Reused the shared `buildMethodUri` helper for the "open the method" fallback instead of hand-rolling the `gemstone://` URI (applied to the sibling `showMethodResults` handler in `extension.ts` too), and folded the duplicated progress-notification wrappers into one helper. Besides deduplication this fixes a latent bug: keyword selectors were percent-encoded (`:` → `%3A`), yielding a different URI than the rest of the extension and opening the same method in a second, duplicate editor tab.

## Decisions

- **Command id rename is a breaking change** for anyone with a custom keybinding referencing `gemstone.findMethod` — the built-in `Ctrl/Cmd+K M` chord was updated and is unaffected. Called out explicitly in the CHANGELOG.
- Used `vscode.window.createQuickPick` instead of `showQuickPick` for the class picker specifically because pre-highlighting a default item via `activeItems` while leaving the filter text empty isn't possible with the simpler `showQuickPick` API.

## Testing

Tested manually in a running extension host against a live GemStone session:
- Find Method in Class with no class selected in the System Browser
- Find Method in Class with a class selected — confirmed it's pre-highlighted, and Enter reproduces the old scoped behavior
- Picking a different class from the list, then a method, and confirming navigation/open both when a System Browser is open and when it isn't (falls back to opening the `gemstone://` document)

Recording:

https://github.com/user-attachments/assets/d0cc5490-d6bd-4273-9a9c-d8a5ef773f50

