### PR TITLE
Session methods: browser display + base-vs-override diff (grail #13)

### DIFF
--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -228,7 +228,7 @@ export const window = {
   showOpenDialog: vi.fn(),
   showSaveDialog: vi.fn(),
   tabGroups: {
-    all: [] as { tabs: { input: unknown }[] }[],
+    all: [] as { viewColumn?: number; tabs: { input: unknown }[] }[],
     close: vi.fn(),
   },
   withProgress: vi.fn(async (_opts: unknown, task: (progress: unknown, token: unknown) => Promise<unknown>) => {
@@ -307,6 +307,10 @@ export const commands = {
 
 export class TabInputText {
   constructor(public readonly uri: Uri) {}
+}
+
+export class TabInputTextDiff {
+  constructor(public readonly original: Uri, public readonly modified: Uri) {}
 }
 
 // ── FileSystemError mock ──────────────────────────────────

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -12,6 +12,7 @@ vi.mock('../browserQueries', () => ({
     }
   },
   getMethodSource: vi.fn(() => 'at: index\n  ^self basicAt: index'),
+  getBaseMethodSource: vi.fn(() => 'isVowel\n  ^ base impl'),
   getClassDefinition: vi.fn(() => "Object subclass: 'Array'\n  instVarNames: #()"),
   getClassComment: vi.fn(() => 'An ordered collection.'),
   compileMethod: vi.fn(() => 'Compiled: Array >> at:'),
@@ -69,6 +70,12 @@ describe('GemStoneFileSystemProvider', () => {
     it('returns read-only when canClassBeWritten returns false', () => {
       vi.mocked(queries.canClassBeWritten).mockReturnValue(false);
       const stat = provider.stat(Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A'));
+      expect(stat.permissions).toBe(FilePermission.Readonly);
+    });
+
+    it('returns read-only for an override-diff view URI even on a writable class', () => {
+      vi.mocked(queries.canClassBeWritten).mockReturnValue(true);
+      const stat = provider.stat(Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A%20(base)?base=1'));
       expect(stat.permissions).toBe(FilePermission.Readonly);
     });
 
@@ -133,6 +140,39 @@ describe('GemStoneFileSystemProvider', () => {
       provider.readFile(uri);
       expect(queries.getMethodSource).toHaveBeenCalledWith(
         expect.anything(), 'Array', false, '__len__', 2,
+      );
+    });
+
+    it('reads the persistent base source for a ?base=1 method URI', () => {
+      const uri = Uri.parse('gemstone://1/Globals/Character/instance/converting/isVowel?base=1');
+      const content = new TextDecoder().decode(provider.readFile(uri));
+      expect(queries.getBaseMethodSource).toHaveBeenCalledWith(
+        expect.anything(), 'Character', false, 'isVowel', 0,
+      );
+      expect(queries.getMethodSource).not.toHaveBeenCalled();
+      expect(content).toContain('base impl');
+    });
+
+    it('reads the session/merged source (not base) for a plain method URI', () => {
+      const uri = Uri.parse('gemstone://1/Globals/Character/instance/converting/isVowel');
+      provider.readFile(uri);
+      expect(queries.getMethodSource).toHaveBeenCalled();
+      expect(queries.getBaseMethodSource).not.toHaveBeenCalled();
+    });
+
+    it('strips the " (base)" diff label to recover the real selector', () => {
+      const uri = Uri.parse('gemstone://1/Globals/Character/instance/converting/isVowel%20(base)?base=1');
+      provider.readFile(uri);
+      expect(queries.getBaseMethodSource).toHaveBeenCalledWith(
+        expect.anything(), 'Character', false, 'isVowel', 0,
+      );
+    });
+
+    it('strips the " (session override)" diff label to recover the real selector', () => {
+      const uri = Uri.parse('gemstone://1/Globals/Character/instance/converting/isVowel%20(session%20override)');
+      provider.readFile(uri);
+      expect(queries.getMethodSource).toHaveBeenCalledWith(
+        expect.anything(), 'Character', false, 'isVowel', 0,
       );
     });
 
@@ -751,6 +791,16 @@ describe('buildMethodUri', () => {
   it('appends the env query parameter when environmentId is non-zero', () => {
     const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Array', isMeta: false, category: 'accessing', selector: 'at', environmentId: 2 });
     expect(uri.query).toBe('env=2');
+  });
+
+  it('appends base=1 when the base flag is set', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Character', isMeta: false, category: 'converting', selector: 'isVowel', environmentId: 0, base: true });
+    expect(uri.query).toBe('base=1');
+  });
+
+  it('combines env and base in the query', () => {
+    const uri = buildMethodUri({ kind: 'method', sessionId: 1, dictName: 'Globals', className: 'Character', isMeta: false, category: 'converting', selector: 'isVowel', environmentId: 2, base: true });
+    expect(uri.query).toBe('env=2&base=1');
   });
 
   it('throws when dictName contains a slash', () => {

--- a/client/src/__tests__/listFilter.test.ts
+++ b/client/src/__tests__/listFilter.test.ts
@@ -613,4 +613,71 @@ describe('ListFilter', () => {
       expect((document.querySelector('#items .item') as HTMLElement).textContent).toBe('▲▼new');
     });
   });
+
+  // Session methods prepend a glyph (+ extension / ± override) as a leading
+  // child, the same way override arrows do. ListFilter must preserve it too.
+  describe('session-glyph preservation', () => {
+    function makeListWithSession(
+      id: string, specs: Array<{ selector: string; glyph: string; arrow?: boolean }>,
+    ): HTMLDivElement {
+      const list = document.createElement('div');
+      list.id = id;
+      for (const { selector, glyph, arrow } of specs) {
+        const div = document.createElement('div');
+        div.className = 'item';
+        div.dataset.value = selector;
+        if (arrow) {
+          const a = document.createElement('span');
+          a.className = 'override-arrow up';
+          a.textContent = '▲';
+          div.appendChild(a);
+        }
+        const g = document.createElement('span');
+        g.className = 'session-indicator';
+        g.textContent = glyph;
+        div.appendChild(g);
+        div.appendChild(document.createTextNode(selector));
+        list.appendChild(div);
+      }
+      document.body.appendChild(list);
+      return list;
+    }
+
+    it('keeps the session glyph and rebuilds selector text on an empty render', () => {
+      makeListWithSession('items', [{ selector: 'jasperGreeting', glyph: '+' }]);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = '';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item') as HTMLElement;
+      expect(item.querySelectorAll('.session-indicator')).toHaveLength(1);
+      expect(item.textContent).toBe('+jasperGreeting');
+    });
+
+    it('keeps the session glyph and highlights the match on a matched render', () => {
+      makeListWithSession('items', [{ selector: 'isVowel', glyph: '±' }]);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = 'vow';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item') as HTMLElement;
+      expect(item.querySelectorAll('.session-indicator')).toHaveLength(1);
+      expect(item.querySelector('.match-highlight')?.textContent).toBe('Vow');
+    });
+
+    it('preserves an override arrow and the session glyph together, arrow first', () => {
+      makeListWithSession('items', [{ selector: 'printOn:', glyph: '+', arrow: true }]);
+      const filter = makeFilter('items');
+
+      filter.searchBox.value = '';
+      filter.applyFilter();
+
+      const item = document.querySelector('#items .item') as HTMLElement;
+      const leading = [...item.children].map(c => c.className);
+      expect(leading).toEqual(['override-arrow up', 'session-indicator']);
+      expect(item.textContent).toBe('▲+printOn:');
+    });
+  });
 });

--- a/client/src/__tests__/methodListView.test.ts
+++ b/client/src/__tests__/methodListView.test.ts
@@ -18,7 +18,11 @@ type ClickMessage =
 
 type MethodListViewApi = {
   makeOverrideArrow(selector: string, dir: 'up' | 'down'): HTMLSpanElement;
+  makeSessionIndicator(selector: string, sessionBit: number): HTMLSpanElement;
   applyOverrideArrows(div: HTMLElement, selector: string, methodOverrideBit: number): void;
+  applyMethodIndicators(
+    div: HTMLElement, selector: string, methodOverrideBit: number, sessionBit: number,
+  ): void;
   methodListClickMessage(event: { target: Element }, listEl: HTMLElement): ClickMessage;
 };
 
@@ -28,12 +32,12 @@ function api(): MethodListViewApi {
 
 // Build a method-list <div class="item"> the way populateColumn does, applying
 // the override bits so arrows (if any) become real leading children.
-function makeItem(selector: string, methodOverrideBit = 0): HTMLDivElement {
+function makeItem(selector: string, methodOverrideBit = 0, sessionBit = 0): HTMLDivElement {
   const div = document.createElement('div');
   div.className = 'item';
   div.dataset.value = selector;
-  if (methodOverrideBit) {
-    api().applyOverrideArrows(div, selector, methodOverrideBit);
+  if (methodOverrideBit || sessionBit) {
+    api().applyMethodIndicators(div, selector, methodOverrideBit, sessionBit);
   } else {
     div.textContent = selector;
   }
@@ -91,6 +95,64 @@ describe('MethodListView.applyOverrideArrows', () => {
   });
 });
 
+describe('MethodListView.makeSessionIndicator', () => {
+  it('builds the extension glyph (+) with the extension tooltip', () => {
+    const span = api().makeSessionIndicator('isVowel', 1);
+    expect(span.textContent).toBe('+');
+    expect(span.className).toBe('session-indicator extension');
+    expect(span.title).toContain('adds new behavior');
+  });
+
+  it('builds the override glyph (±) whose tooltip names the ± icon and the compare action', () => {
+    const span = api().makeSessionIndicator('isVowel', 2);
+    expect(span.textContent).toBe('±');
+    expect(span.className).toBe('session-indicator override');
+    expect(span.title).toContain('±');
+    expect(span.title).toContain('compare');
+  });
+});
+
+describe('MethodListView.applyMethodIndicators session methods', () => {
+  it('marks an extension row italic and prefixes the + glyph', () => {
+    const div = makeItem('isVowel', 0, 1);
+    expect(div.classList.contains('session-extension')).toBe(true);
+    expect(div.querySelector('.session-indicator')!.textContent).toBe('+');
+    expect(div.textContent).toBe('+isVowel');
+  });
+
+  it('marks an override row italic and prefixes the ± glyph', () => {
+    const div = makeItem('isVowel', 0, 2);
+    expect(div.classList.contains('session-override')).toBe(true);
+    expect(div.querySelector('.session-indicator')!.textContent).toBe('±');
+  });
+
+  it('describes the session method on the whole row, without the click hint (that lives on the ± glyph)', () => {
+    const div = makeItem('isVowel', 0, 2);
+    expect(div.title).toContain('overrides a persistent base method');
+    expect(div.title.toLowerCase()).not.toContain('click');
+  });
+
+  it('renders override arrows before the session glyph when a method is both', () => {
+    const div = makeItem('printOn:', 1, 1);
+    const leading = [...div.children].map(c => c.className);
+    expect(leading).toEqual(['override-arrow up', 'session-indicator extension']);
+    expect(div.textContent).toBe('▲+printOn:');
+    expect(div.classList.contains('session-extension')).toBe(true);
+  });
+
+  it('leaves a non-session row unstyled and glyph-free', () => {
+    const div = makeItem('size', 1, 0);
+    expect(div.querySelector('.session-indicator')).toBeNull();
+    expect(div.classList.contains('session-extension')).toBe(false);
+    expect(div.classList.contains('session-override')).toBe(false);
+  });
+
+  it('keeps dataset.value the bare selector so filtering/selection still match', () => {
+    const div = makeItem('at:put:', 0, 2);
+    expect(div.dataset.value).toBe('at:put:');
+  });
+});
+
 describe('MethodListView.methodListClickMessage', () => {
   it('clicking an arrow posts showHierarchyImpls with selector and direction', () => {
     const list = document.createElement('div');
@@ -140,6 +202,30 @@ describe('MethodListView.methodListClickMessage', () => {
 
     expect(first.classList.contains('selected')).toBe(false);
     expect(second.classList.contains('selected')).toBe(true);
+  });
+
+  it('clicking the override glyph asks to compare with the base method', () => {
+    const list = document.createElement('div');
+    const item = makeItem('isVowel', 0, 2);
+    list.appendChild(item);
+    const glyph = item.querySelector('.session-indicator')!;
+
+    const msg = api().methodListClickMessage({ target: glyph }, list);
+
+    expect(msg).toEqual({ command: 'compareSessionOverride', selector: 'isVowel' });
+    expect(item.classList.contains('selected')).toBe(true);
+  });
+
+  it('clicking the extension glyph just selects the method (no base to compare)', () => {
+    const list = document.createElement('div');
+    const item = makeItem('jasperGreeting', 0, 1);
+    list.appendChild(item);
+    const glyph = item.querySelector('.session-indicator')!;
+
+    const msg = api().methodListClickMessage({ target: glyph }, list);
+
+    expect(msg).toEqual({ command: 'selectMethod', selector: 'jasperGreeting' });
+    expect(item.classList.contains('selected')).toBe(true);
   });
 
   it('clicking empty space (neither arrow nor item) returns null', () => {

--- a/client/src/__tests__/sessionMethods.integration.test.ts
+++ b/client/src/__tests__/sessionMethods.integration.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+// Real GCI, but stub the `vscode` module the query layer pulls in via gciLog.
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+
+import { useIntegrationTest } from './useIntegrationTest';
+import { GciLibrary } from '../gciLibrary';
+import * as browserQueries from '../browserQueries';
+import type { ActiveSession } from '../sessionManager';
+import type { EnvCategoryLine } from '../queries/getClassEnvironments';
+
+/**
+ * Automatic GCI integration tests for session-method detection (grail #13).
+ *
+ * Runs across the whole `npm run test:server:start` matrix (3.6.2 → 3.7.5), so
+ * it also validates the detection selectors on the 3.6.2 floor. Everything is
+ * transient: each test enables GsPackagePolicy and compiles session methods on
+ * a kernel class, and the `afterEach` disables the policy + refreshes (dropping
+ * the transient dicts) while the harness aborts the transaction — nothing is
+ * ever committed.
+ *
+ * All emitted Smalltalk is ASCII-only: on 3.6.x a non-ASCII character in
+ * compiled source trips the ComStrmSetCursor compiler bug. Session methods
+ * route only for a user that CANNOT write the kernel class's persistent
+ * dictionary — DataCurator (the standard test/GLASS user) — so the tests skip
+ * themselves if ever run as a system profile.
+ */
+describe('session methods (integration)', () => {
+  let gci: GciLibrary;
+  let handle: unknown;
+  useIntegrationTest((g, s) => { gci = g; handle = s; });
+
+  const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
+  const exec = (code: string): string => browserQueries.executeFetchString(session(), 'sessionMethods-it', code);
+
+  const isSystemProfile = (): boolean => exec('System myUserProfile isSystemProfile printString').trim() === 'true';
+  const enablePolicy = (): void => {
+    exec("GsPackagePolicy current homeSymbolDict: UserGlobals; externalSymbolList: { Globals }; enable. 'ok'");
+  };
+
+  // Compile `source` into `receiver` ('Character' or 'Character class') as a
+  // session method — it routes to a session method because DataCurator cannot
+  // write the kernel class's persistent dictionary.
+  const compileSessionMethod = (receiver: string, source: string): void => {
+    const escaped = source.replace(/'/g, "''"); // double quotes for the Smalltalk string literal
+    exec(
+      `${receiver} compileMethod: '${escaped}' ` +
+      `dictionaries: GsCurrentSession currentSession symbolList ` +
+      `category: '*jasper-it' environmentId: 0. 'ok'`,
+    );
+  };
+
+  const linesOf = (className: string): EnvCategoryLine[] => {
+    const globalsIndex = parseInt(exec('(System myUserProfile symbolList indexOf: Globals) printString'), 10);
+    return browserQueries.getClassEnvironments(session(), globalsIndex, className, 0);
+  };
+
+  // Merge a per-selector map (sessionMethodBits | methodOverrideBits) across all
+  // lines on one side (instance or class) of a class.
+  const bitsFor = (
+    className: string, isMeta: boolean, field: 'sessionMethodBits' | 'methodOverrideBits',
+  ): Record<string, number> => {
+    const out: Record<string, number> = {};
+    for (const line of linesOf(className)) {
+      if (line.isMeta === isMeta) Object.assign(out, line[field] ?? {});
+    }
+    return out;
+  };
+
+  afterEach(() => {
+    // Idempotent even if a test never enabled the policy; the harness then
+    // aborts the transaction, rolling back the (uncommitted) package/policy.
+    try {
+      exec("GsPackagePolicy current disable. GsPackagePolicy current refreshSessionMethodDictionary. 'ok'");
+    } catch { /* session already gone / never enabled */ }
+  });
+
+  it('flags a session extension as 1 and a session override as 2 on the instance side', () => {
+    if (isSystemProfile()) return;
+    enablePolicy();
+    compileSessionMethod('Character', 'jasperItSessionExt ^42');                     // new selector -> extension
+    compileSessionMethod('Character', "isVowel ^'aeiou' includes: self asLowercase"); // shadows kernel isVowel -> override
+
+    const bits = bitsFor('Character', false, 'sessionMethodBits');
+
+    expect(bits.jasperItSessionExt).toBe(1); // transient only -> extension
+    expect(bits.isVowel).toBe(2);            // transient + persistent -> override
+  });
+
+  it('does not flag anything once the policy is disabled', () => {
+    if (isSystemProfile()) return;
+    enablePolicy();
+    compileSessionMethod('Character', "isVowel ^'aeiou' includes: self asLowercase");
+    expect(bitsFor('Character', false, 'sessionMethodBits').isVowel).toBe(2);
+
+    exec("GsPackagePolicy current disable. GsPackagePolicy current refreshSessionMethodDictionary. 'ok'");
+
+    // isVowel is back to the plain persistent method — no session flag.
+    expect(bitsFor('Character', false, 'sessionMethodBits').isVowel).toBeUndefined();
+  });
+
+  it('flags a class-side (metaclass) session method', () => {
+    if (isSystemProfile()) return;
+    enablePolicy();
+    compileSessionMethod('Character class', 'jasperItClassExt ^7');
+
+    expect(bitsFor('Character', true, 'sessionMethodBits').jasperItClassExt).toBe(1);
+    // ...and it does not bleed onto the instance side.
+    expect(bitsFor('Character', false, 'sessionMethodBits').jasperItClassExt).toBeUndefined();
+  });
+
+  it('composes the session flag with the override-arrow bit when a session method also overrides a superclass', () => {
+    if (isSystemProfile()) return;
+    enablePolicy();
+    compileSessionMethod('Character', 'max: aCharacter ^super max: aCharacter'); // Magnitude defines max:
+
+    expect(bitsFor('Character', false, 'sessionMethodBits')['max:']).toBe(1); // extension (not persistent on Character)
+    expect(bitsFor('Character', false, 'methodOverrideBits')['max:'] & 1).toBe(1); // overrides a superclass (up arrow)
+  });
+
+  it('serves the persistent base for an override and a placeholder for an extension', () => {
+    if (isSystemProfile()) return;
+    enablePolicy();
+    compileSessionMethod('Character', 'jasperItSessionExt ^42');
+    compileSessionMethod('Character', "isVowel ^'aeiou' includes: self asLowercase");
+
+    const overrideSource = browserQueries.getMethodSource(session(), 'Character', false, 'isVowel', 0);
+    const baseSource = browserQueries.getBaseMethodSource(session(), 'Character', false, 'isVowel', 0);
+    expect(overrideSource).toContain('aeiou'); // session view = our override
+    expect(baseSource).not.toContain('aeiou'); // untouched kernel method
+    expect(baseSource).not.toBe(overrideSource);
+
+    // An extension has no persistent method to fall back to.
+    const extBase = browserQueries.getBaseMethodSource(session(), 'Character', false, 'jasperItSessionExt', 0);
+    expect(extBase).toContain('no base method');
+  });
+
+  it('does not flag session methods on an untouched class', () => {
+    if (isSystemProfile()) return;
+    enablePolicy();
+    compileSessionMethod('Character', 'jasperItSessionExt ^42');
+
+    // Symbol got no session methods — detection must not false-positive there.
+    expect(bitsFor('Symbol', false, 'sessionMethodBits')).toEqual({});
+  });
+});

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -52,8 +52,8 @@ vi.mock('fs', async () => {
 import * as fs from 'fs';
 
 import * as path from 'path';
-import { window, workspace, ViewColumn, TextEditorRevealType, Range, Selection, Position, commands, Uri, __setConfig, __resetConfig } from '../__mocks__/vscode';
-import { SystemBrowser, extractSelector, planDictionaryFileOut, ALL_CLASSES_CATEGORY, ALL_METHODS_CATEGORY } from '../systemBrowser';
+import { window, workspace, ViewColumn, TextEditorRevealType, Range, Selection, Position, commands, Uri, TabInputText, TabInputTextDiff, __setConfig, __resetConfig } from '../__mocks__/vscode';
+import { SystemBrowser, extractSelector, planDictionaryFileOut, isComputedMethodCategory, ALL_CLASSES_CATEGORY, ALL_METHODS_CATEGORY, SESSION_METHODS_CATEGORY } from '../systemBrowser';
 import * as queries from '../browserQueries';
 import { GlobalsBrowser } from '../globalsBrowser';
 import { ClassBrowser } from '../classBrowser';
@@ -134,6 +134,21 @@ describe('extractSelector', () => {
 
 // ── File-out planning ───────────────────────────────────────
 
+describe('isComputedMethodCategory', () => {
+  it('treats the ALL METHODS and SESSION METHODS sentinels as computed', () => {
+    expect(isComputedMethodCategory(ALL_METHODS_CATEGORY)).toBe(true);
+    expect(isComputedMethodCategory(SESSION_METHODS_CATEGORY)).toBe(true);
+  });
+
+  it('treats a real category, empty, null, and undefined as not computed', () => {
+    expect(isComputedMethodCategory('accessing')).toBe(false);
+    expect(isComputedMethodCategory('*mypkg-override')).toBe(false);
+    expect(isComputedMethodCategory('')).toBe(false);
+    expect(isComputedMethodCategory(null)).toBe(false);
+    expect(isComputedMethodCategory(undefined)).toBe(false);
+  });
+});
+
 describe('planDictionaryFileOut', () => {
   it('names each class file after the class and preserves the given order', () => {
     const plan = planDictionaryFileOut('Animals', ['Object', 'Animal', 'Dog']);
@@ -204,6 +219,7 @@ describe('SystemBrowser', () => {
     (SystemBrowser as unknown as { sharedExportManager: unknown }).sharedExportManager = undefined;
     (SystemBrowser as unknown as { pendingNavigation: Map<number, unknown> }).pendingNavigation = new Map();
     window.visibleTextEditors = [];
+    window.tabGroups.all = [];
 
     session = makeSession();
     exportManager = makeExportManager();
@@ -399,6 +415,7 @@ describe('SystemBrowser', () => {
         command: 'loadMethods',
         items: ['=', 'hash', 'name', 'name:'],
         methodOverrideBits: {},
+        sessionMethodBits: {},
       });
     });
 
@@ -427,6 +444,7 @@ describe('SystemBrowser', () => {
         command: 'loadMethods',
         items: ['new', 'new:'],
         methodOverrideBits: {},
+        sessionMethodBits: {},
       });
     });
 
@@ -441,6 +459,7 @@ describe('SystemBrowser', () => {
         command: 'loadMethods',
         items: ['=', 'hash', 'name', 'name:'],
         methodOverrideBits: {},
+        sessionMethodBits: {},
       });
     });
 
@@ -455,6 +474,7 @@ describe('SystemBrowser', () => {
         command: 'loadMethods',
         items: ['name', 'name:'],
         methodOverrideBits: {},
+        sessionMethodBits: {},
       });
     });
 
@@ -509,6 +529,167 @@ describe('SystemBrowser', () => {
         const msg = lastLoadMethods();
         expect(msg.items).toEqual(['new', 'new:']);
         expect(msg.methodOverrideBits).toEqual({ new: 2 });
+      });
+    });
+
+    describe('session methods', () => {
+      type LoadMethodsMsg = { command: string; items: string[]; sessionMethodBits: Record<string, number> };
+      type LoadCategoriesMsg = { command: string; items: string[] };
+
+      beforeEach(() => {
+        // Instance side carries session methods (an extension and an override
+        // living in a *package category); the class side carries none.
+        vi.mocked(queries.getClassEnvironments).mockReturnValue([
+          { isMeta: false, envId: 0, category: 'Accessing', selectors: ['name', 'name:'],
+            methodOverrideBits: {}, sessionMethodBits: {} },
+          { isMeta: false, envId: 0, category: '*mypkg', selectors: ['ext1', 'isVowel'],
+            methodOverrideBits: {}, sessionMethodBits: { ext1: 1, isVowel: 2 } },
+          { isMeta: true, envId: 0, category: 'Instance Creation', selectors: ['new'],
+            methodOverrideBits: {}, sessionMethodBits: {} },
+        ]);
+      });
+
+      function selectArray(): void {
+        messageHandler({ command: 'ready' });
+        messageHandler({ command: 'selectDictionary', index: 1 });
+        messageHandler({ command: 'selectCategory', name: ALL_CLASSES_CATEGORY });
+        vi.mocked(fs.existsSync).mockReturnValue(false);
+        messageHandler({ command: 'selectClass', name: 'Array' });
+      }
+
+      function lastCategories(): LoadCategoriesMsg {
+        const calls = vi.mocked(mockPanel.webview.postMessage).mock.calls
+          .map(c => c[0] as LoadCategoriesMsg)
+          .filter(m => m.command === 'loadMethodCategories');
+        return calls[calls.length - 1];
+      }
+
+      function lastLoadMethods(): LoadMethodsMsg {
+        const calls = vi.mocked(mockPanel.webview.postMessage).mock.calls
+          .map(c => c[0] as LoadMethodsMsg)
+          .filter(m => m.command === 'loadMethods');
+        return calls[calls.length - 1];
+      }
+
+      it('offers the computed Session Methods category at the head, right after ALL METHODS', () => {
+        selectArray();
+        expect(lastCategories().items).toEqual(
+          [ALL_METHODS_CATEGORY, SESSION_METHODS_CATEGORY, '*mypkg', 'Accessing'],
+        );
+      });
+
+      it('omits the Session Methods category on a side that has no session methods', () => {
+        selectArray();
+        messageHandler({ command: 'toggleSide', isMeta: true });
+        expect(lastCategories().items).toEqual([ALL_METHODS_CATEGORY, 'Instance Creation']);
+      });
+
+      it('lists every session method (extension and override) when the category is selected', () => {
+        selectArray();
+        messageHandler({ command: 'selectMethodCategory', name: SESSION_METHODS_CATEGORY });
+        const msg = lastLoadMethods();
+        expect(msg.items).toEqual(['ext1', 'isVowel']);
+        expect(msg.sessionMethodBits).toEqual({ ext1: 1, isVowel: 2 });
+      });
+
+      it('does not list ordinary persistent methods under the Session Methods category', () => {
+        selectArray();
+        messageHandler({ command: 'selectMethodCategory', name: SESSION_METHODS_CATEGORY });
+        expect(lastLoadMethods().items).not.toContain('name');
+      });
+
+      it('attaches session flags for the displayed selectors of a normal category', () => {
+        selectArray();
+        messageHandler({ command: 'selectMethodCategory', name: '*mypkg' });
+        expect(lastLoadMethods().sessionMethodBits).toEqual({ ext1: 1, isVowel: 2 });
+      });
+
+      function lastDiffCall(): [string, Uri, Uri, string, unknown] | undefined {
+        return vi.mocked(commands.executeCommand).mock.calls
+          .filter(c => c[0] === 'vscode.diff')
+          .pop() as [string, Uri, Uri, string, unknown] | undefined;
+      }
+
+      function diffCallCount(): number {
+        return vi.mocked(commands.executeCommand).mock.calls.filter(c => c[0] === 'vscode.diff').length;
+      }
+
+      it('compares an override against its persistent base, labeling each pane', async () => {
+        selectArray();
+        messageHandler({ command: 'compareSessionOverride', selector: 'isVowel' });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const call = lastDiffCall();
+        expect(call).toBeDefined();
+        const [, baseUri, overrideUri] = call!;
+        expect(baseUri.query).toContain('base=1');   // left = persistent base
+        expect(overrideUri.query).not.toContain('base=1'); // right = session view
+        expect(decodeURIComponent(baseUri.path)).toContain('isVowel (base)');
+        expect(decodeURIComponent(overrideUri.path)).toContain('isVowel (session override)');
+      });
+
+      it('toggles the diff off and reopens the plain session source when the same override is clicked again', async () => {
+        selectArray();
+        messageHandler({ command: 'compareSessionOverride', selector: 'isVowel' });
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const [, baseUri, overrideUri] = lastDiffCall()!;
+        window.tabGroups.all = [{ tabs: [{ input: new TabInputTextDiff(baseUri, overrideUri) }] }];
+        const before = diffCallCount();
+        vi.mocked(workspace.openTextDocument).mockClear();
+
+        messageHandler({ command: 'compareSessionOverride', selector: 'isVowel' });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Reopened the plain method source — no diff, no "(base)/(session override)" label.
+        const opened = vi.mocked(workspace.openTextDocument).mock.calls.map(c => decodeURIComponent(String(c[0])));
+        expect(opened.some(u => u.includes('isVowel') && !u.includes('(base)') && !u.includes('(session override)'))).toBe(true);
+        expect(diffCallCount()).toBe(before);              // no new diff opened
+        expect(window.tabGroups.close).toHaveBeenCalled(); // diff closed
+        // Source opens BEFORE the diff closes, so the diff's group is reused
+        // (closing first would strand a webview-only group → new split group).
+        const lastOpen = vi.mocked(window.showTextDocument).mock.invocationCallOrder.at(-1)!;
+        const lastClose = vi.mocked(window.tabGroups.close).mock.invocationCallOrder.at(-1)!;
+        expect(lastOpen).toBeLessThan(lastClose);
+        window.tabGroups.all = [];
+      });
+
+      it('ignores a second ± click while the first toggle is still opening', async () => {
+        selectArray();
+        let releaseGroup: () => void = () => {};
+        vi.mocked(commands.executeCommand).mockImplementation((cmd: string) => {
+          if (cmd === 'workbench.action.newGroupBelow') return new Promise<void>(r => { releaseGroup = r; });
+          return undefined as unknown as Thenable<unknown>;
+        });
+        try {
+          // First click starts opening the diff and blocks awaiting the new group.
+          messageHandler({ command: 'compareSessionOverride', selector: 'isVowel' });
+          await new Promise(resolve => setTimeout(resolve, 0));
+          // Second click lands mid-flight — the busy guard must drop it.
+          messageHandler({ command: 'compareSessionOverride', selector: 'isVowel' });
+          await new Promise(resolve => setTimeout(resolve, 0));
+
+          releaseGroup();
+          await new Promise(resolve => setTimeout(resolve, 0));
+
+          expect(diffCallCount()).toBe(1); // only the first click opened a diff
+        } finally {
+          vi.mocked(commands.executeCommand).mockReset();
+        }
+      });
+
+      it('closes the override diff when navigating to another method', async () => {
+        selectArray();
+        messageHandler({ command: 'compareSessionOverride', selector: 'isVowel' });
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const [, baseUri, overrideUri] = lastDiffCall()!;
+        const diffTab = { input: new TabInputTextDiff(baseUri, overrideUri) };
+        window.tabGroups.all = [{ tabs: [diffTab] }];
+
+        messageHandler({ command: 'selectMethod', selector: 'name' });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(window.tabGroups.close).toHaveBeenCalledWith(diffTab);
+        window.tabGroups.all = [];
       });
     });
 
@@ -1682,6 +1863,7 @@ describe('SystemBrowser', () => {
         command: 'loadMethods',
         items: ['rb_name'],
         methodOverrideBits: {},
+        sessionMethodBits: {},
       });
     });
 
@@ -1814,6 +1996,7 @@ describe('SystemBrowser', () => {
         command: 'loadMethods',
         items: ['name', 'name:'],
         methodOverrideBits: {},
+        sessionMethodBits: {},
       });
     });
 
@@ -1879,6 +2062,7 @@ describe('SystemBrowser', () => {
         command: 'loadMethods',
         items: ['name', 'name:'],
         methodOverrideBits: {},
+        sessionMethodBits: {},
       });
     });
 
@@ -2028,6 +2212,26 @@ describe('SystemBrowser', () => {
         expect.anything(),
         expect.objectContaining({ viewColumn: ViewColumn.Two }),
       );
+    });
+
+    it('reuses the group holding a background session tab (definition/method), not just visible editors', async () => {
+      window.visibleTextEditors = [];
+      window.tabGroups.all = [{
+        viewColumn: ViewColumn.Two,
+        tabs: [{ input: new TabInputText(Uri.parse(`gemstone://${session.id}/Globals/Array/definition`)) }],
+      }];
+      vi.mocked(commands.executeCommand).mockClear();
+      vi.mocked(window.showTextDocument).mockClear();
+
+      SystemBrowser.navigateTo(session.id, result);
+      await vi.waitFor(() => expect(window.showTextDocument).toHaveBeenCalled());
+
+      expect(commands.executeCommand).not.toHaveBeenCalledWith('workbench.action.newGroupBelow');
+      expect(window.showTextDocument).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ viewColumn: ViewColumn.Two }),
+      );
+      window.tabGroups.all = [];
     });
 
     it('calls newGroupBelow only on the first navigation, reuses the column on subsequent ones', async () => {

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -6,6 +6,7 @@ import { QueryExecutor } from './queries/types';
 
 // Read-path shared queries.
 import { getMethodSource as sharedGetMethodSource } from './queries/getMethodSource';
+import { getBaseMethodSource as sharedGetBaseMethodSource } from './queries/getBaseMethodSource';
 import { getDictionaryNames as sharedGetDictionaryNames } from './queries/getDictionaryNames';
 import { getPoolDictionaryNames as sharedGetPoolDictionaryNames } from './queries/getPoolDictionaryNames';
 import { getClassNames as sharedGetClassNames } from './queries/getClassNames';
@@ -261,6 +262,13 @@ export function getMethodSource(
   environmentId: number = 0,
 ): string {
   return sharedGetMethodSource(bind(session), className, isMeta, selector, environmentId);
+}
+
+export function getBaseMethodSource(
+  session: ActiveSession, className: string, isMeta: boolean, selector: string,
+  environmentId: number = 0,
+): string {
+  return sharedGetBaseMethodSource(bind(session), className, isMeta, selector, environmentId);
 }
 
 export function getClassDefinition(session: ActiveSession, className: string): string {

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -22,6 +22,13 @@ interface ParsedMethodUri {
   category: string;
   selector: string;
   environmentId: number;
+  // When true, serve the PERSISTENT base method source (what a session override
+  // shadows) rather than the session/merged source. Used by the override diff.
+  base?: boolean;
+  // True when the selector segment carried a " (…)" display label (the override
+  // diff decorates each side so its filename reads "sel (base)" / "sel (session
+  // override)"). Such view URIs are always read-only.
+  diffView?: boolean;
 }
 
 interface ParsedDefinitionUri {
@@ -65,6 +72,7 @@ function parseUri(uri: vscode.Uri): ParsedUri {
   // Parse optional ?env=N from query string
   const envMatch = uri.query?.match(/env=(\d+)/);
   const environmentId = envMatch ? parseInt(envMatch[1], 10) : 0;
+  const base = /(?:^|&)base=1(?:&|$)/.test(uri.query ?? '');
 
   if (parts.length === 3 && parts[2] === 'new-class') {
     const catMatch = uri.query?.match(/category=([^&]+)/);
@@ -89,6 +97,10 @@ function parseUri(uri: vscode.Uri): ParsedUri {
     };
   }
   if (parts.length === 6) {
+    // The override diff decorates each side's selector segment with a display
+    // label — "sel (base)" / "sel (session override)". Strip it for the real
+    // selector; its presence marks a read-only comparison view.
+    const labelled = parts[5].match(/^(.*) \((?:base|session override)\)$/);
     return {
       kind: 'method',
       sessionId,
@@ -96,8 +108,10 @@ function parseUri(uri: vscode.Uri): ParsedUri {
       className: parts[2],
       isMeta: parts[3] === 'class',
       category: parts[4],
-      selector: parts[5],
+      selector: labelled ? labelled[1] : parts[5],
       environmentId,
+      base,
+      diffView: labelled != null,
     };
    }
    throw vscode.FileSystemError.FileNotFound(uri);
@@ -131,11 +145,14 @@ export function buildMethodUri(parsedUri: ParsedMethodUri): vscode.Uri {
   assertIsValidUriPath('Selector', parsedUri.selector);
   
   const side = parsedUri.isMeta ? 'class' : 'instance';
+  const params: string[] = [];
+  if (parsedUri.environmentId > 0) params.push(`env=${parsedUri.environmentId}`);
+  if (parsedUri.base) params.push('base=1');
   return vscode.Uri.from({
     scheme: 'gemstone',
     authority: String(parsedUri.sessionId),
     path: `/${parsedUri.dictName}/${parsedUri.className}/${side}/${parsedUri.category}/${parsedUri.selector}`,
-    query: parsedUri.environmentId > 0 ? `env=${parsedUri.environmentId}` : '',
+    query: params.join('&'),
   });
 }
 
@@ -191,6 +208,12 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     const parsed = parseUri(uri);
     // New documents are always writable — no existing class to check
     if (parsed.kind === 'new-class' || parsed.kind === 'new-method') return stat;
+    // Override-diff view URIs are read-only on both sides — it's a comparison,
+    // not an editor.
+    if (parsed.kind === 'method' && parsed.diffView) {
+      stat.permissions = vscode.FilePermission.Readonly;
+      return stat;
+    }
     const session = this.sessionManager.getSession(parsed.sessionId);
     if (!session) return stat;
     try {
@@ -238,7 +261,9 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     let text: string;
     switch (parsed.kind) {
       case 'method':
-        text = queries.getMethodSource(session, parsed.className, parsed.isMeta, parsed.selector, parsed.environmentId);
+        text = parsed.base
+          ? queries.getBaseMethodSource(session, parsed.className, parsed.isMeta, parsed.selector, parsed.environmentId)
+          : queries.getMethodSource(session, parsed.className, parsed.isMeta, parsed.selector, parsed.environmentId);
         break;
       case 'definition':
         text = queries.getClassDefinition(session, parsed.className);

--- a/client/src/listFilter.js
+++ b/client/src/listFilter.js
@@ -148,9 +148,11 @@ class ListFilter extends HTMLElement {
     // Matched item rendering
 
     // Clear the item's text while keeping any leading indicator elements
-    // (e.g. override arrows) that were rendered before the selector text.
+    // (override arrows, session-method glyph) that were rendered before the
+    // selector text. querySelectorAll returns them in document order, so their
+    // original leading order is preserved when re-appended.
     clearItemText(item) {
-        const keep = [...item.querySelectorAll(':scope > .override-arrow')];
+        const keep = [...item.querySelectorAll(':scope > .override-arrow, :scope > .session-indicator')];
         item.textContent = '';
         for (const el of keep) item.appendChild(el);
     }

--- a/client/src/methodListView.js
+++ b/client/src/methodListView.js
@@ -10,6 +10,10 @@
  * The override bitmask carried per selector: bit 1 = overrides a superclass
  * implementation (▲), bit 2 = overridden in a subclass (▼), 3 = both.
  *
+ * The session-method flag carried per selector: 1 = session extension (adds
+ * new behavior — glyph +), 2 = session override (shadows a persistent base
+ * method — glyph ±). Session rows are also italicised via a row CSS class.
+ *
  * Exposed as the global `MethodListView` so both the webview (classic <script>)
  * and tests (new Function(source)()) can reach it.
  */
@@ -27,14 +31,44 @@
     return span;
   }
 
-  // Render leading arrow(s) followed by the selector text. The arrows are kept
-  // as the item's leading children; ListFilter preserves them when it
-  // re-renders the selector text for filtering/highlighting.
-  function applyOverrideArrows(div, selector, methodOverrideBit) {
+  // Build the leading session-method glyph. Not clickable — purely a marker;
+  // its title carries the explanation. sessionBit 2 = override, else extension.
+  function makeSessionIndicator(selector, sessionBit) {
+    const span = document.createElement('span');
+    const isOverride = sessionBit === 2;
+    span.className = 'session-indicator ' + (isOverride ? 'override' : 'extension');
+    span.dataset.value = selector;
+    span.textContent = isOverride ? '±' : '+';
+    span.title = isOverride
+      ? 'Click the ± icon to compare this session override with its base method (click again to return to the session source)'
+      : 'Session method - adds new behavior (extension)';
+    return span;
+  }
+
+  // Render leading indicator(s) then the selector text: override arrows first,
+  // then the session glyph, then the text. They are kept as the item's leading
+  // children; ListFilter preserves them when it re-renders the selector text
+  // for filtering/highlighting. A session row is also tagged with a session-*
+  // class (italic) and a title so the whole row explains itself on hover.
+  function applyMethodIndicators(div, selector, methodOverrideBit, sessionBit) {
     div.textContent = '';
     if (methodOverrideBit & 1) div.appendChild(makeOverrideArrow(selector, 'up'));
     if (methodOverrideBit & 2) div.appendChild(makeOverrideArrow(selector, 'down'));
+    if (sessionBit) {
+      div.classList.add(sessionBit === 2 ? 'session-override' : 'session-extension');
+      // Row tooltip is descriptive only — the click-to-compare hint lives on the
+      // ± glyph itself, so hovering the method name doesn't imply clicking it.
+      div.title = sessionBit === 2
+        ? 'Session method that overrides a persistent base method'
+        : 'Session method that adds new behavior (extension)';
+      div.appendChild(makeSessionIndicator(selector, sessionBit));
+    }
     div.appendChild(document.createTextNode(selector));
+  }
+
+  // Back-compat shim: override arrows only (no session glyph).
+  function applyOverrideArrows(div, selector, methodOverrideBit) {
+    applyMethodIndicators(div, selector, methodOverrideBit, 0);
   }
 
   // Decide what a click in the methods column means and update selection.
@@ -50,6 +84,16 @@
         direction: arrow.dataset.dir,
       };
     }
+    // Clicking the override glyph (±) compares the session override against the
+    // base method it shadows. The row is also selected so it reads as current.
+    const sessionOverride = event.target.closest('.session-indicator.override');
+    if (sessionOverride) {
+      const row = event.target.closest('.item');
+      const prevSel = listEl.querySelector('.item.selected');
+      if (prevSel) prevSel.classList.remove('selected');
+      if (row) row.classList.add('selected');
+      return { command: 'compareSessionOverride', selector: sessionOverride.dataset.value };
+    }
     const item = event.target.closest('.item');
     if (!item) return null;
     const prev = listEl.querySelector('.item.selected');
@@ -59,5 +103,8 @@
   }
 
   const root = typeof globalThis !== 'undefined' ? globalThis : window;
-  root.MethodListView = { makeOverrideArrow, applyOverrideArrows, methodListClickMessage };
+  root.MethodListView = {
+    makeOverrideArrow, makeSessionIndicator,
+    applyOverrideArrows, applyMethodIndicators, methodListClickMessage,
+  };
 })();

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -4,6 +4,7 @@ import { getDictionaryEntries } from '../getDictionaryEntries';
 import { getGlobalsForDictionary } from '../getGlobalsForDictionary';
 import { getAllClassNames } from '../getAllClassNames';
 import { getClassEnvironments } from '../getClassEnvironments';
+import { getBaseMethodSource } from '../getBaseMethodSource';
 import { getClassHierarchy } from '../getClassHierarchy';
 import { getMethodList } from '../getMethodList';
 import { getStepPointSelectorRanges } from '../getStepPointSelectorRanges';
@@ -57,9 +58,9 @@ describe('getAllClassNames', () => {
 
 describe('getClassEnvironments', () => {
   it('detects class side via " class" suffix on receiver name', () => {
-    // Each selector token carries a leading override-flag digit (0..3).
-    const raw = 'Array class\t0\tinstance creation\t0new\t0with:\n'
-              + 'Array\t0\taccessing\t0size\n';
+    // Each selector token carries a fixed 2-digit leading flag byte (00..15).
+    const raw = 'Array class\t0\tinstance creation\t00new\t00with:\n'
+              + 'Array\t0\taccessing\t00size\n';
     const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
     expect(results).toHaveLength(2);
     expect(results[0]).toMatchObject({
@@ -71,24 +72,55 @@ describe('getClassEnvironments', () => {
 
   it('parses the per-selector override bitmask and strips its prefix', () => {
     // 1 = overrides super (▲), 2 = overridden in subclass (▼), 3 = both.
-    const raw = 'Array\t0\taccessing\t1at:\t2size\t3printOn:\t0name\n';
+    const raw = 'Array\t0\taccessing\t01at:\t02size\t03printOn:\t00name\n';
     const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
     expect(results[0].selectors).toEqual(['at:', 'name', 'printOn:', 'size']);
     expect(results[0].methodOverrideBits).toEqual({ 'at:': 1, size: 2, 'printOn:': 3 });
+    expect(results[0].sessionMethodBits).toEqual({});
   });
 
   it('omits zero-bit (neither overrides nor overridden) selectors from the map', () => {
-    const raw = 'Array\t0\taccessing\t0a\t0b\n';
+    const raw = 'Array\t0\taccessing\t00a\t00b\n';
     const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
     expect(results[0].selectors).toEqual(['a', 'b']);
     expect(results[0].methodOverrideBits).toEqual({});
   });
 
   it('records override bits on the class side too', () => {
-    const raw = 'Array class\t0\tinstance creation\t3new\t1basicNew\n';
+    const raw = 'Array class\t0\tinstance creation\t03new\t01basicNew\n';
     const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Array', 0);
     expect(results[0].isMeta).toBe(true);
     expect(results[0].methodOverrideBits).toEqual({ new: 3, basicNew: 1 });
+  });
+
+  it('parses the session-method flag: bit 4 = extension, bit 8 = override', () => {
+    // 04 = session extension (transient only), 12 = session override (4+8,
+    // also in persistent dict). 00 = ordinary persistent method.
+    const raw = 'Object\t0\t*mypkg\t04sessionExt\t12isVowel\t00hash\n';
+    const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Object', 0);
+    expect(results[0].selectors).toEqual(['hash', 'isVowel', 'sessionExt']);
+    expect(results[0].sessionMethodBits).toEqual({ sessionExt: 1, isVowel: 2 });
+    expect(results[0].methodOverrideBits).toEqual({});
+  });
+
+  it('records session and override bits independently when they co-occur', () => {
+    // 05 = overrides super (1) + session extension (4); a session method may
+    // also shadow a superclass impl. Both maps must carry their own bits.
+    const raw = 'Object\t0\t*mypkg\t05foo\t14bar\n';
+    const results = getClassEnvironments(vi.fn<QueryExecutor>(() => raw), 1, 'Object', 0);
+    // 14 = overridden-in-subclass (2) + session override (4+8) -> not asserted
+    // on override map beyond bit 2; session map sees an override.
+    expect(results[0].methodOverrideBits).toEqual({ foo: 1, bar: 2 });
+    expect(results[0].sessionMethodBits).toEqual({ foo: 1, bar: 2 });
+  });
+
+  it('emits the session-detection primitives (transient/persistent dicts, at:otherwise:)', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    getClassEnvironments(execute, 1, 'Object', 0);
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('transientMethodDictForEnv:');
+    expect(code).toContain('persistentMethodDictForEnv:');
+    expect(code).toContain('at: each otherwise: nil'); // NOT includesKey: on the transient dict
   });
 
   it('embeds dictIndex, escaped class name, and maxEnv', () => {
@@ -110,6 +142,36 @@ describe('getClassEnvironments', () => {
     expect(code).toContain('whichClassIncludesSelector:'); // walks all ancestors
     expect(code).toContain('allSubclasses');               // walks all descendants
     expect(code).not.toContain('lookupSelector:');         // the rejected approach
+  });
+});
+
+describe('getBaseMethodSource', () => {
+  it('reads the persistent (base) method, not the merged/session view', () => {
+    const execute = vi.fn<QueryExecutor>(() => 'isVowel\n  ^ base');
+    getBaseMethodSource(execute, 'Character', false, 'isVowel', 0);
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('persistentMethodDictForEnv: 0');
+    expect(code).toContain("at: #'isVowel' otherwise: nil");
+    expect(code).not.toContain('compiledMethodAt:'); // that would return the override
+  });
+
+  it('targets the metaclass for a class-side selector', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    getBaseMethodSource(execute, 'Character', true, 'foo', 0);
+    expect(execute.mock.calls[0][1]).toContain('Character class');
+  });
+
+  it('threads a non-zero environment id into the persistent lookup', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    getBaseMethodSource(execute, 'Character', false, 'foo', 2);
+    expect(execute.mock.calls[0][1]).toContain('persistentMethodDictForEnv: 2');
+  });
+
+  it('emits ASCII-only source (3.6.x miscompiles non-ASCII: ComStrmSetCursor)', () => {
+    const execute = vi.fn<QueryExecutor>(() => '');
+    getBaseMethodSource(execute, 'Character', false, 'isVowel', 0);
+    // eslint-disable-next-line no-control-regex
+    expect(/[^\x00-\x7F]/.test(execute.mock.calls[0][1])).toBe(false);
   });
 });
 

--- a/client/src/queries/getBaseMethodSource.ts
+++ b/client/src/queries/getBaseMethodSource.ts
@@ -1,0 +1,27 @@
+import { QueryExecutor } from './types';
+import { escapeString, receiver } from './util';
+
+// Source of the PERSISTENT (base) method that a session override shadows on the
+// same class. Read straight from persistentMethodDictForEnv: — NOT the merged /
+// session view (compiledMethodAt:, which would return the override itself).
+// Returns a placeholder when there is no persistent implementation (i.e. the
+// selector is a session-only extension, not an override).
+export function getBaseMethodSource(
+  execute: QueryExecutor,
+  className: string,
+  isMeta: boolean,
+  selector: string,
+  environmentId: number = 0,
+): string {
+  const recv = receiver(className, isMeta);
+  const sel = escapeString(selector);
+  // Single expression, ASCII-only literal: on 3.6.x the compiler miscomputes
+  // source cursor positions (ComStrmSetCursor error 1001) when the compiled
+  // source contains a non-ASCII character, so keep the placeholder plain ASCII.
+  const code =
+    `((${recv} persistentMethodDictForEnv: ${environmentId}) ` +
+    `ifNotNil: [:d | d at: #'${sel}' otherwise: nil]) ` +
+    `ifNil: ['"(no base method: this selector has no persistent implementation on this class)"'] ` +
+    `ifNotNil: [:m | m sourceString]`;
+  return execute(`getBaseMethodSource(${recv}>>#${selector} env:${environmentId})`, code);
+}

--- a/client/src/queries/getClassEnvironments.ts
+++ b/client/src/queries/getClassEnvironments.ts
@@ -10,16 +10,28 @@ export interface EnvCategoryLine {
   // superclass impl (▲), bit 2 = overridden in a subclass (▼). Selectors with
   // no indicator are absent. Always populated by the parser below.
   methodOverrideBits?: Record<string, number>;
+  // Per-selector session-method flag keyed by bare selector: 1 = session
+  // extension (installed only in the transient dict — adds new behavior),
+  // 2 = session override (also present in the persistent dict — shadows a base
+  // method). Absent = not a session method. Populated whenever the stone has
+  // session methods installed on the browsed class (see SessionMethods design).
+  sessionMethodBits?: Record<string, number>;
 }
 
 export function getClassEnvironments(
   execute: QueryExecutor, dictIndex: number, className: string, maxEnv: number,
 ): EnvCategoryLine[] {
-  // Each emitted selector token is prefixed with a single override-flag digit
-  // (0..3) so the indicator rides along on the existing method-list round trip.
+  // Each emitted selector token is prefixed with a fixed 2-digit flag byte
+  // (00..15) so the indicators ride along on the existing method-list round
+  // trip: bit 1 = overrides super (▲), bit 2 = overridden in a subclass (▼),
+  // bit 4 = session method, bit 8 = session override (also in the persistent
+  // dict). Two digits because the four bits can co-occur (max 15); selectors
+  // never begin with a digit, so a 2-char numeric prefix is unambiguous.
   // "Overridden in a subclass" is computed once by intersecting subclass-local
   // selectors with this class's own selectors, so the working set stays small
-  // even for classes with thousands of subclasses (e.g. Object).
+  // even for classes with thousands of subclasses (e.g. Object). Session state
+  // is read via `at:otherwise:` (NOT `includesKey:`) because the transient dict
+  // is a GsSessionMethodDictionary whose lookup methods are <protected>.
   const code = `| class envs stream instOwn metaOwn instSub metaSub |
 envs := ${maxEnv}.
 class := (System myUserProfile symbolList at: ${dictIndex}) at: #'${escapeString(className)}'.
@@ -37,18 +49,29 @@ stream := WriteStream on: Unicode7 new.
   subSel := isMeta ifTrue: [metaSub] ifFalse: [instSub].
   superCls := eachClass superclass.
   0 to: envs do: [:env |
+    | trDict prDict |
+    trDict := eachClass transientMethodDictForEnv: env.
+    prDict := eachClass persistentMethodDictForEnv: env.
     (eachClass _unifiedCategorys: env) keysAndValuesDo: [:categoryName :selectors |
       stream
         nextPutAll: eachClass name; tab;
         nextPutAll: env printString; tab;
         nextPutAll: categoryName; tab;
         yourself.
-      selectors do: [:each | | up down |
+      selectors do: [:each | | up down sess flag |
         up := superCls notNil and: [(superCls whichClassIncludesSelector: each) notNil].
         down := subSel includes: each.
-        stream
-          nextPutAll: ((up ifTrue: [1] ifFalse: [0]) + (down ifTrue: [2] ifFalse: [0])) printString;
-          nextPutAll: each; tab.
+        "Session method iff present in the transient dict (read via at:otherwise:,
+         the transient dict's includesKey: is <protected>). Override iff the
+         persistent dict also has it, else a session-only extension."
+        sess := trDict notNil and: [(trDict at: each otherwise: nil) notNil].
+        flag := (up ifTrue: [1] ifFalse: [0]) + (down ifTrue: [2] ifFalse: [0]).
+        sess ifTrue: [
+          flag := flag + 4.
+          (prDict notNil and: [prDict includesKey: each]) ifTrue: [flag := flag + 8].
+        ].
+        flag < 10 ifTrue: [stream nextPut: $0].
+        stream nextPutAll: flag printString; nextPutAll: each; tab.
       ].
       stream lf.
     ].
@@ -67,16 +90,20 @@ stream contents`;
     const envId = parseInt(parts[1], 10);
     const category = parts[2];
     const methodOverrideBits: Record<string, number> = {};
+    const sessionMethodBits: Record<string, number> = {};
     const selectors = parts.slice(3).map((tok) => {
-      // Leading digit is the override bitmask: 1 = overrides super, 2 =
-      // overridden in subclass, 3 = both, 0 = neither.
-      const methodOverrideBit = Number(tok[0]);
-      const sel = tok.slice(1);
-      if (methodOverrideBit) methodOverrideBits[sel] = methodOverrideBit;
+      // Leading 2 digits are the flag byte: bit 1 = overrides super, bit 2 =
+      // overridden in subclass, bit 4 = session method, bit 8 = session
+      // override (also in persistent dict).
+      const flag = Number(tok.slice(0, 2));
+      const sel = tok.slice(2);
+      const overrideBits = flag & 3;
+      if (overrideBits) methodOverrideBits[sel] = overrideBits;
+      if (flag & 4) sessionMethodBits[sel] = (flag & 8) ? 2 : 1;
       return sel;
     }).sort();
     const isMeta = receiverName.endsWith(' class');
-    results.push({ isMeta, envId, category, selectors, methodOverrideBits });
+    results.push({ isMeta, envId, category, selectors, methodOverrideBits, sessionMethodBits });
   }
   return results;
 }

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -8,7 +8,7 @@ import {parseTopazDocument} from './topazFileIn';
 import * as queries from './browserQueries';
 import {GlobalsBrowser} from './globalsBrowser';
 import {ClassBrowser} from './classBrowser';
-import {buildNewMethodUri} from './gemstoneFileSystemProvider';
+import {buildNewMethodUri, buildMethodUri} from './gemstoneFileSystemProvider';
 
 /**
  * The webview HTML is a large template literal in getHtml(). Embedding JS directly
@@ -155,6 +155,17 @@ export function planDictionaryFileOut(
 // else to keep in sync when this value changes.
 export const ALL_CLASSES_CATEGORY = '** ALL CLASSES **';
 export const ALL_METHODS_CATEGORY = '** ALL METHODS **';
+// Computed category, shown at the head of the list (right after ALL METHODS)
+// only when the browsed class carries session methods on the current side/env.
+// Selecting it lists every session method (extension + override). Like the
+// other sentinels it is interpolated into the webview template.
+export const SESSION_METHODS_CATEGORY = '** SESSION METHODS **';
+
+// The synthetic categories are display-only: they can never be the target of a
+// category operation (rename, a new method's default category, or a method drop).
+export function isComputedMethodCategory(category: string | null | undefined): boolean {
+  return category === ALL_METHODS_CATEGORY || category === SESSION_METHODS_CATEGORY;
+}
 
 // Save-dialog file filters for file-out, matching Jade's GemStone/Smalltalk/All.
 const FILE_OUT_FILTERS: Record<string, string[]> = {
@@ -217,6 +228,13 @@ export class SystemBrowser {
   private dictEntryCache = new Map<number, queries.DictEntry[]>();
   private envCache = new Map<string, queries.EnvCategoryLine[]>();
   private hierarchyCache = new Map<string, queries.ClassHierarchyEntry[]>();
+  // The `original` (base) URI string of the open session-override diff, if any,
+  // so it can be closed again when the user navigates off that override.
+  private comparisonDiffBaseUri: string | null = null;
+  // Serializes override-diff toggling: opening/closing the diff is async, so a
+  // rapid second ± click must be ignored until the first settles — otherwise
+  // overlapping runs interleave and the editor state goes haywire.
+  private comparisonBusy = false;
 
   // Dimming
   private dimDecorationType: vscode.TextEditorDecorationType;
@@ -554,6 +572,9 @@ export class SystemBrowser {
         case 'selectMethod':
           this.handleSelectMethod(message.selector as string);
           break;
+        case 'compareSessionOverride':
+          this.handleCompareSessionOverride(message.selector as string).catch(e => this.postError(e));
+          break;
         case 'refresh':
           this.handleRefresh();
           break;
@@ -799,6 +820,7 @@ export class SystemBrowser {
    * the method-category list is loaded with no category pre-selected.
    */
   private applyClassSelection(className: string, skipClassBrowser = false, autoSelectAllMethodsCategory = false): void {
+    void this.closeComparisonDiff();
     this.state.selectedClass = className;
     this.state.selectedMethodCategory = null;
     this.state.selectedMethod = null;
@@ -829,6 +851,7 @@ export class SystemBrowser {
    * categories.
    */
   private handleToggleSide(isMeta: boolean, autoSelectAllMethodsCategory = false): void {
+    void this.closeComparisonDiff();
     this.state.isMeta = isMeta;
     this.state.selectedMethodCategory = null;
     this.state.selectedMethod = null;
@@ -843,6 +866,7 @@ export class SystemBrowser {
   }
 
   private handleSelectMethodCategory(category: string): void {
+    void this.closeComparisonDiff();
     this.state.selectedMethodCategory = category;
     this.state.selectedMethod = null;
     this.clearDimming();
@@ -863,6 +887,8 @@ export class SystemBrowser {
         for (const sel of entry.selectors) set.add(sel);
       }
       methods = [...set].sort();
+    } else if (category === SESSION_METHODS_CATEGORY) {
+      methods = this.sessionMethodsFor(filtered).sort();
     } else {
       const entry = filtered.find(e => e.category === category);
       methods = entry ? [...entry.selectors] : [];
@@ -873,12 +899,89 @@ export class SystemBrowser {
   }
 
   private handleSelectMethod(selector: string): void {
+    // Leaving the override we were comparing — the diff should disappear.
+    void this.closeComparisonDiff();
     this.state.selectedMethod = selector;
 
     const className = this.state.selectedClass;
     if (!className) return;
 
     this.openClassFile(className, selector, this.state.isMeta);
+  }
+
+  // Open a side-by-side diff of a session override against the persistent base
+  // method it shadows, in the browser's source pane. Each side's selector
+  // segment is decorated ("(base)" / "(session override)") so the diff tab and
+  // per-pane breadcrumb name which is which; both are served read-only by the
+  // gemstone:// FS provider (the base via a ?base=1 variant). Clicking the same
+  // override's glyph again toggles the diff off, back to the session source.
+  private async handleCompareSessionOverride(selector: string): Promise<void> {
+    if (this.comparisonBusy) return;
+    const dictIndex = this.state.selectedDictIndex;
+    const className = this.state.selectedClass;
+    if (!dictIndex || !className) return;
+
+    this.comparisonBusy = true;
+    try {
+      const isMeta = this.state.isMeta;
+      const dictName = this.state.dictionaries[dictIndex - 1];
+      const category = (this.state.selectedMethodCategory && !isComputedMethodCategory(this.state.selectedMethodCategory))
+        ? this.state.selectedMethodCategory : 'as yet unclassified';
+      const environmentId = this.state.selectedEnvId;
+      const common = {
+        kind: 'method' as const,
+        sessionId: this.session.id, dictName, className, isMeta, category, environmentId,
+      };
+      const baseUri = buildMethodUri({ ...common, selector: `${selector} (base)`, base: true });
+
+      // Toggle: if this override's diff is actually open, a second click returns
+      // to the session source. Keyed off the live tab (not just the tracked URI)
+      // so it stays correct even if the diff was dismissed via its ✕ or Esc.
+      // Open the source FIRST — while the diff is still open — so its group is
+      // found and reused (the source replaces the diff there); THEN drop the
+      // diff tab. Closing first would leave the group holding only a non-text
+      // tab (e.g. the Globals webview) that getBrowserViewColumn can't match,
+      // spawning a new group that splits the layout.
+      if (this.findComparisonDiffTab(baseUri.toString())) {
+        this.state.selectedMethod = selector;
+        await this.openClassFile(className, selector, isMeta);
+        await this.closeComparisonDiff();
+        return;
+      }
+
+      const overrideUri = buildMethodUri({ ...common, selector: `${selector} (session override)` });
+      await this.closeComparisonDiff();
+      this.state.selectedMethod = selector;
+      const viewColumn = await this.getBrowserViewColumn();
+      const title = `${className}${isMeta ? ' class' : ''}>>${selector} - base vs session override`;
+      this.comparisonDiffBaseUri = baseUri.toString();
+      await vscode.commands.executeCommand('vscode.diff', baseUri, overrideUri, title, { viewColumn, preview: true });
+    } finally {
+      this.comparisonBusy = false;
+    }
+  }
+
+  // The open diff tab whose left/original side is `baseUriString`, if any.
+  private findComparisonDiffTab(baseUriString: string): vscode.Tab | undefined {
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        const input = tab.input;
+        if (input instanceof vscode.TabInputTextDiff && input.original.toString() === baseUriString) {
+          return tab;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  // Close the open session-override diff, if any (matched by its base/original
+  // URI). Safe to call when nothing is open.
+  private async closeComparisonDiff(): Promise<void> {
+    const target = this.comparisonDiffBaseUri;
+    if (!target) return;
+    this.comparisonDiffBaseUri = null;
+    const tab = this.findComparisonDiffTab(target);
+    if (tab) await vscode.window.tabGroups.close(tab);
   }
 
   private handleNavigateTo(result: queries.MethodSearchResult, openFile = true, skipClassBrowser = false): void {
@@ -1096,6 +1199,7 @@ export class SystemBrowser {
   }
 
   private handleSelectHierarchyClass(className: string): void {
+    void this.closeComparisonDiff();
     // Find which dictionary contains this class from the hierarchy entries
     const entry = this.state.hierarchyEntries.find(e => e.className === className);
     if (!entry) return;
@@ -1112,6 +1216,7 @@ export class SystemBrowser {
   }
 
   private handleToggleEnvironment(envId: number): void {
+    void this.closeComparisonDiff();
     const previousCategory = this.state.selectedMethodCategory;
     this.state.selectedEnvId = envId;
     this.state.selectedMethod = null;
@@ -1490,7 +1595,7 @@ export class SystemBrowser {
     }
 
     const dictName = this.state.dictionaries[dictIndex - 1];
-    const category = (this.state.selectedMethodCategory && this.state.selectedMethodCategory !== ALL_METHODS_CATEGORY)
+    const category = (this.state.selectedMethodCategory && !isComputedMethodCategory(this.state.selectedMethodCategory))
       ? this.state.selectedMethodCategory : 'as yet unclassified';
     const uri = buildNewMethodUri(this.session.id, dictName, className, this.state.isMeta, category, this.state.selectedEnvId);
     const viewColumn = await this.getBrowserViewColumn();
@@ -1501,7 +1606,7 @@ export class SystemBrowser {
   private async handleRenameCategory(): Promise<void> {
     const className = this.state.selectedClass;
     const oldCategory = this.state.selectedMethodCategory;
-    if (!className || !oldCategory || oldCategory === ALL_METHODS_CATEGORY) return;
+    if (!className || !oldCategory || isComputedMethodCategory(oldCategory)) return;
 
     const newName = await vscode.window.showInputBox({
       prompt: `Rename category "${oldCategory}" to:`,
@@ -1697,6 +1802,38 @@ export class SystemBrowser {
     return bits;
   }
 
+  // Session methods (extensions + overrides) among the given already-filtered
+  // (current side/env) category lines, derived from cached env data — no extra
+  // round trip. Empty when the class carries no session methods here.
+  private sessionMethodsFor(filtered: queries.EnvCategoryLine[]): string[] {
+    const set = new Set<string>();
+    for (const entry of filtered) {
+      if (!entry.sessionMethodBits) continue;
+      for (const sel of entry.selectors) {
+        if (entry.sessionMethodBits[sel]) set.add(sel);
+      }
+    }
+    return [...set];
+  }
+
+  // Per-selector session-method flag (1 = extension, 2 = override) for the
+  // currently displayed selectors on the current side. Same cheap derivation as
+  // methodOverrideBitsFor — no extra round trip.
+  private sessionMethodBitsFor(items: string[]): Record<string, number> {
+    const dictIndex = this.state.selectedDictIndex;
+    const className = this.state.selectedClass;
+    if (!dictIndex || !className || items.length === 0) return {};
+    const itemSet = new Set(items);
+    const bits: Record<string, number> = {};
+    for (const line of this.getCachedEnvData(dictIndex, className)) {
+      if (line.isMeta !== this.state.isMeta || !line.sessionMethodBits) continue;
+      for (const sel of Object.keys(line.sessionMethodBits)) {
+        if (itemSet.has(sel)) bits[sel] = line.sessionMethodBits[sel];
+      }
+    }
+    return bits;
+  }
+
   // Post the methods column to the webview with override bits attached.
   private postMethods(items: string[], selected?: string | null): void {
     this.panel.webview.postMessage({
@@ -1704,6 +1841,7 @@ export class SystemBrowser {
       items,
       selected: selected ?? undefined,
       methodOverrideBits: this.methodOverrideBitsFor(items),
+      sessionMethodBits: this.sessionMethodBitsFor(items),
     });
   }
 
@@ -1730,7 +1868,13 @@ export class SystemBrowser {
     );
 
     const categories = filtered.map(e => e.category).sort();
-    this.state.methodCategories = [ALL_METHODS_CATEGORY, ...categories];
+    // Surface the computed Session Methods category at the head, right after
+    // ALL METHODS, only when this side/env actually has session methods — so it
+    // is never buried among the real categories and absent when there are none.
+    const head = this.sessionMethodsFor(filtered).length > 0
+      ? [ALL_METHODS_CATEGORY, SESSION_METHODS_CATEGORY]
+      : [ALL_METHODS_CATEGORY];
+    this.state.methodCategories = [...head, ...categories];
 
     this.panel.webview.postMessage({
       command: 'loadMethodCategories',
@@ -1790,7 +1934,7 @@ export class SystemBrowser {
 
     // Open the method in a gemstone:// editor tab (editable, one method at a time)
     const side = isMeta ? 'class' : 'instance';
-    const category = (this.state.selectedMethodCategory && this.state.selectedMethodCategory !== ALL_METHODS_CATEGORY)
+    const category = (this.state.selectedMethodCategory && !isComputedMethodCategory(this.state.selectedMethodCategory))
       ? this.state.selectedMethodCategory : 'as yet unclassified';
     const envQuery = this.state.selectedEnvId > 0 ? `?env=${this.state.selectedEnvId}` : '';
     const uri = vscode.Uri.parse(
@@ -1805,16 +1949,30 @@ export class SystemBrowser {
   private async getBrowserViewColumn(): Promise<vscode.ViewColumn> {
     const sessionId = String(this.session.id);
     const sessionRoot = this.exportManager.getSessionRoot(this.session);
-    for (const editor of vscode.window.visibleTextEditors) {
-      const { scheme, authority, fsPath } = editor.document.uri;
-      if (scheme === 'gemstone' && authority === sessionId) {
-        return editor.viewColumn ?? vscode.ViewColumn.Beside;
-      }
-      if (sessionRoot && scheme === 'file' && fsPath.startsWith(sessionRoot)) {
-        return editor.viewColumn ?? vscode.ViewColumn.Beside;
+    const matches = (uri: vscode.Uri | undefined): boolean =>
+      !!uri && (
+        (uri.scheme === 'gemstone' && uri.authority === sessionId) ||
+        (!!sessionRoot && uri.scheme === 'file' && uri.fsPath.startsWith(sessionRoot))
+      );
+
+    // Prefer the group that already hosts a session editor — even a BACKGROUND
+    // tab (the class definition, another method, or the override diff), which
+    // `visibleTextEditors` can't see. This keeps method source and diffs as
+    // peers in that group instead of spawning a new group that squeezes it.
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        const input = tab.input;
+        const uri = input instanceof vscode.TabInputText ? input.uri
+          : input instanceof vscode.TabInputTextDiff ? input.modified
+          : undefined;
+        if (matches(uri) && group.viewColumn) return group.viewColumn;
       }
     }
-    // No existing editor — split the browser's column vertically so the source
+    // Fallback: any currently-visible session editor.
+    for (const editor of vscode.window.visibleTextEditors) {
+      if (matches(editor.document.uri)) return editor.viewColumn ?? vscode.ViewColumn.Beside;
+    }
+    // Nothing open yet — split the browser's column vertically so the source
     // appears below the browser, not beside the inspector in a separate column.
     // Focus the browser first so newGroupBelow targets column 1, then the new
     // (now-active) group below is where we open the file.
@@ -1963,7 +2121,7 @@ export class SystemBrowser {
 
     .column-list .item {
       padding: 1px 8px;
-      cursor: pointer;
+      cursor: default;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -2010,6 +2168,41 @@ export class SystemBrowser {
 
     .override-arrow:hover {
       opacity: 1;
+      color: var(--vscode-textLink-activeForeground);
+    }
+
+    /* Session methods: italic row + a muted leading glyph (+ extension, ±
+       override). Italic gives an at-a-glance "this is a session method"; the
+       glyph disambiguates the kind. The glyph stays upright and sits in its own
+       fixed leading slot so rows do not shift relative to the override arrows. */
+    .column-list .item.session-extension,
+    .column-list .item.session-override {
+      font-style: italic;
+    }
+
+    .session-indicator {
+      display: inline-block;
+      width: 0.9em;
+      margin-right: 3px;
+      text-align: center;
+      font-size: 1em;
+      font-weight: bold;
+      line-height: 1;
+      vertical-align: middle;
+      font-style: normal;
+      color: var(--vscode-descriptionForeground);
+    }
+
+    .column-list .item.selected .session-indicator {
+      color: var(--vscode-list-activeSelectionForeground);
+    }
+
+    /* The override glyph is clickable: it opens a base-vs-override diff. */
+    .session-indicator.override {
+      cursor: pointer;
+    }
+
+    .session-indicator.override:hover {
       color: var(--vscode-textLink-activeForeground);
     }
 
@@ -2224,16 +2417,17 @@ export class SystemBrowser {
     const hierBtn = document.getElementById('hierBtn');
     const errorBanner = document.getElementById('errorBanner');
     // ── Populate a column with items ───────────────
-    function populateColumn(listEl, items, virtualItems, draggable, methodOverrideBits) {
+    function populateColumn(listEl, items, virtualItems, draggable, methodOverrideBits, sessionMethodBits) {
       listEl.innerHTML = '';
       const virtualSet = new Set(virtualItems || []);
       for (const item of items) {
         const div = document.createElement('div');
         div.className = 'item' + (virtualSet.has(item) ? ' virtual' : '');
         div.dataset.value = item;
-        const methodOverrideBit = methodOverrideBits && methodOverrideBits[item];
-        if (methodOverrideBit) {
-          MethodListView.applyOverrideArrows(div, item, methodOverrideBit);
+        const methodOverrideBit = (methodOverrideBits && methodOverrideBits[item]) || 0;
+        const sessionBit = (sessionMethodBits && sessionMethodBits[item]) || 0;
+        if (methodOverrideBit || sessionBit) {
+          MethodListView.applyMethodIndicators(div, item, methodOverrideBit, sessionBit);
         } else {
           div.textContent = item;
         }
@@ -2411,7 +2605,7 @@ export class SystemBrowser {
     // Methods can be dragged onto method categories
     setupDragSource(cols.methods, 'method');
     setupDropTarget(cols.methodCats, 'method', (selector, category) => {
-      if (category === '${ALL_METHODS_CATEGORY}') return;
+      if (category === '${ALL_METHODS_CATEGORY}' || category === '${SESSION_METHODS_CATEGORY}') return;
       vscode.postMessage({ command: 'dropMethodOnCategory', selector, category });
     });
 
@@ -2558,6 +2752,10 @@ export class SystemBrowser {
           { separator: true },
           { label: 'Senders Of', action: () => vscode.postMessage({ command: 'ctxSendersOf' }) },
           { label: 'Implementors Of', action: () => vscode.postMessage({ command: 'ctxImplementorsOf' }) },
+          ...(item.classList.contains('session-override') ? [
+            { separator: true },
+            { label: 'Compare with base method', action: () => vscode.postMessage({ command: 'compareSessionOverride', selector: item.dataset.value }) },
+          ] : []),
           { separator: true },
           { label: 'Run SUnit Test', action: () => vscode.postMessage({ command: 'ctxRunMethodTests' }) },
         ] : []),
@@ -2584,12 +2782,12 @@ export class SystemBrowser {
           break;
         case 'loadMethodCategories':
           clearFrom('methodCats');
-          populateColumn(cols.methodCats, msg.items, ['${ALL_METHODS_CATEGORY}']);
+          populateColumn(cols.methodCats, msg.items, ['${ALL_METHODS_CATEGORY}', '${SESSION_METHODS_CATEGORY}']);
           if (msg.selected) selectItemInColumn(cols.methodCats, msg.selected);
           break;
         case 'loadMethods':
           cols.methods.innerHTML = '';
-          populateColumn(cols.methods, msg.items, [], true, msg.methodOverrideBits);
+          populateColumn(cols.methods, msg.items, [], true, msg.methodOverrideBits, msg.sessionMethodBits);
           if (msg.selected) selectItemInColumn(cols.methods, msg.selected);
           break;
         case 'setViewMode':


### PR DESCRIPTION
Implements [GemStone/grail work item 13](https://code.gemtalksystems.com/GemStone/grail/-/work_items/13) — show GemStone session methods in the System Browser and let users compare an override against the base method it shadows.

## What
- **Detection** — `getClassEnvironments` emits a per-selector session flag (extension vs override) alongside the existing override-arrow bits, read via `transientMethodDictForEnv:` / `persistentMethodDictForEnv:` (using `at:otherwise:`, since the transient dict's `includesKey:` is `<protected>`).
- **Render** — session rows are italic with a muted leading glyph (`+` extension, `±` override) and a hover tooltip; `listFilter` preserves the glyph on filter re-render. Row cursor is the arrow; only clickable glyphs show the hand.
- **Computed `** SESSION METHODS **` category** — shown at the head of the list only when the current side/env actually has session methods.
- **Override diff** — clicking the `±` glyph (or a "Compare with base method" context-menu item) opens a base-vs-override diff in the source pane with labeled, read-only panes; clicking `±` again toggles back to the session source, and it auto-closes on navigation. Base source is served via a `gemstone://` `?base=1` URI variant (ASCII-only query to avoid the 3.6.x `ComStrmSetCursor` compiler bug).

## Tests
45 added, including **6 automatic GCI integration tests** (extension/override flags, disabled-policy negative, class-side, arrow composition, base-vs-override source, specificity) verified against **both 3.6.2 and 3.7.5**. `npm run compile` clean; full client suite green.

## Notes
- Session methods can **override or add** behavior — both are surfaced.
- Display + view-base only; editing/removing session methods (which must target the `GsPackage`) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
