### PR TITLE
GciLibrary: add ergonomic layer over raw GCI calls

### DIFF
--- a/.claude/rules/client/gci.md
+++ b/.claude/rules/client/gci.md
@@ -8,6 +8,8 @@ paths:
 
 The GCI library (`libgcits`) is a platform-native `.so`/`.dylib`/`.dll` bundled with each GemStone distribution. `gciLibrary.ts` loads it at runtime via [koffi](https://github.com/Koromix/koffi) (FFI). All GemStone VM calls go through here. When adding new GCI calls, follow the struct and pointer patterns already in that file.
 
+`GciLibrary` also has an ergonomic layer on top of the raw `GciTsXxx` wrappers (see the class-level doc comment in `gciLibrary.ts`). When adding a new ergonomic method: throw `GciLibraryError` (via `throwUnless`/`throwOnIllegalOop`, or `GciLibraryError.fromGciError`/`.withMessage` directly) instead of returning a `{success, err}`/`{result, err}` pair, and document it with JSDoc — including a `@throws {GciLibraryError}` line whenever the method can throw.
+
 `docs/3.7/` contains the GCI header files (`gcits.hf`, `gci.ht`, `gcicmn.ht`, `gcits.ht`) — the authoritative reference for GCI function signatures, struct layouts, and constants.
 
 ## Running the deep GCI suite (`npm run test:gci`)

--- a/.claude/rules/client/tests.md
+++ b/.claude/rules/client/tests.md
@@ -34,3 +34,5 @@ Tests run in random order; the seed is printed at the top of the output. Reprodu
 ## Integration tests
 
 Tests using `useIntegrationTest` require a live GemStone instance so plain `npm test` needs a running stone. Run `npm run test:server:start` once to provision one; it writes connection details to `.env.test` (which the user may override with `.env.test.local`). CI runs these as a matrix over `client/.gemstone-integration-releases.json`. The deep GCI binding suite (`npm run test:gci`) is separate.
+
+GCI session/oop values are koffi `External` pointer wrappers with no enumerable properties, so vitest's deep equality (`toEqual`, and therefore `expect(spy).toHaveBeenCalledWith(someSession, ...)`) cannot tell two *different* sessions or oops apart — it treats any two of them as equal regardless of the underlying native pointer. To assert *which* session/oop a call received, pull the argument out of `spy.mock.calls` and compare with `toBe` (reference equality) instead.

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -32,7 +32,7 @@ describe('GciLibrary', () => {
      * The callback receives the Smalltalk snippet as its argument so it can
      * embed it in any expression under test (e.g. pass it to `execute`).
      */
-    function expectToThrowExpectedGciLibraryError(callback: (throwOopsError: string) => unknown) {
+    function expectToThrowExpectedGciLibraryError(callback: (signalExpectedErrorExpression: string) => unknown) {
         expectToThrowGciLibraryError(
             () => callback(`self error: 'oops'`),
             'a UserDefinedError occurred (error 2318), reason:halt, oops');
@@ -108,8 +108,8 @@ describe('GciLibrary', () => {
         });
 
         it('throws when the expression signals an error', () => {
-            expectToThrowExpectedGciLibraryError(throwExpectedErrorExpression => {
-                gciLibrary.execute(session, throwExpectedErrorExpression);
+            expectToThrowExpectedGciLibraryError(signalExpectedErrorExpression => {
+                gciLibrary.execute(session, signalExpectedErrorExpression);
             });
         });
 
@@ -132,8 +132,8 @@ describe('GciLibrary', () => {
         })
 
         it('throws when the evaluated code signals an error', () => {
-            expectToThrowExpectedGciLibraryError(throwOopsError => {
-                gciLibrary.executeDiscardingResult(session, throwOopsError);
+            expectToThrowExpectedGciLibraryError(signalExpectedErrorExpression => {
+                gciLibrary.executeDiscardingResult(session, signalExpectedErrorExpression);
             });
         })
 

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -115,6 +115,30 @@ describe('GciLibrary', () => {
 
     });
 
+    describe('evaluating expressions for effect only, discarding the result', () => {
+
+        it('evaluates an expression', () => {
+            const key = gciLibrary.nextKey();
+
+            gciLibrary.executeDiscardingResult(session, `UserGlobals at: ${key} put: true`);
+
+            expectUserGlobalsToInclude(key, true);
+        })
+
+        it('does not retain the discarded result in the PureExportSet', () => {
+            expectPureExportSetToStayUnchanged(() => {
+                gciLibrary.executeDiscardingResult(session, 'Object new');
+            });
+        })
+
+        it('throws when the evaluated code signals an error', () => {
+            expectToThrowExpectedGciLibraryError(throwOopsError => {
+                gciLibrary.executeDiscardingResult(session, throwOopsError);
+            });
+        })
+
+    });
+
     describe('creating strings', () => {
 
         it('creates a String object from the given contents', () => {

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -76,6 +76,79 @@ describe('GciLibrary', () => {
     function expectUserGlobalsToInclude(key: string, shouldBeIncluded: boolean) {
         expect(gciLibrary.isIncludedInUserGlobals(session, key)).toBe(shouldBeIncluded);
     }
+
+    /**
+     * Asserts that the session's PureExportSet gains at least one new oop
+     * across `callback`, per `shouldGrow`.
+     *
+     * @param shouldGrow - Whether the PureExportSet is expected to gain a new oop.
+     * @param callback - The operation to observe.
+     */
+    function expectPureExportSetToGrow(shouldGrow: boolean, callback: () => unknown) {
+        expect(gciLibrary.didPureExportSetGrow(session, callback)).toBe(shouldGrow);
+    }
+
+    /** Spies on `resolveSymbol` for the duration of `callback`, then restores it. */
+    function spyOnResolveSymbol(callback: (spy: Mock<typeof GciLibrary.prototype.resolveSymbol>) => void) {
+        const spy =  vi.spyOn(gciLibrary, 'resolveSymbol');
+
+        try{
+            callback(spy);
+        } finally{
+            spy.mockRestore();
+        }
+    }
+
+    /**
+     * Asserts a fresh symbol lookup happens for `sessionToUse`.
+     *
+     * Checks the looked-up session with `toBe`, not `toHaveBeenCalledWith`
+     * -- koffi's session pointers have no enumerable properties, so
+     * vitest's deep equality can't tell two different sessions apart and
+     * would pass regardless of which one was actually used.
+     *
+     * @param sessionToUse - The session expected to require a fresh lookup; defaults to the shared `session`.
+     */
+    function expectUtf8OopToResolveViaSymbolLookup(sessionToUse: unknown = session) {
+        spyOnResolveSymbol(resolveSymbolSpy => {
+            gciLibrary.utf8ClassOop(sessionToUse);
+
+            expect(resolveSymbolSpy).toHaveBeenCalledTimes(1);
+            const [calledSession, calledSymbol] = resolveSymbolSpy.mock.calls[0];
+            expect(calledSession).toBe(sessionToUse);
+            expect(calledSymbol).toBe('Utf8');
+        });
+    }
+
+    /** Asserts `session`'s already-cached Utf8 oop is reused, without a fresh symbol lookup. */
+    function expectUtf8OopToBeCached() {
+        spyOnResolveSymbol(resolveSymbolSpy => {
+            gciLibrary.utf8ClassOop(session);
+
+            expect(resolveSymbolSpy).not.toHaveBeenCalled();
+        });
+    }
+
+    /**
+     * Asserts that `session`'s SessionTemps dictionary is (or is not) empty,
+     * per `shouldBeEmpty`.
+     *
+     * @param shouldBeEmpty - Whether SessionTemps is expected to be empty.
+     */
+    function expectSessionTempsToBeEmpty(shouldBeEmpty: boolean) {
+        expect(gciLibrary.isSessionTempsEmpty(session)).toBe(shouldBeEmpty);
+    }
+
+    /**
+     * Asserts that the session's PureExportSet includes (or does not
+     * include) `oop`, per `shouldBeIncluded`.
+     *
+     * @param shouldBeIncluded - Whether `oop` is expected to be included.
+     * @param oop - The oop to check for.
+     */
+    function expectPureExportSetToIncludeOop(shouldBeIncluded: boolean, oop: bigint) {
+        expect(gciLibrary.isOopIncludedInPureExportSet(session, oop)).toBe(shouldBeIncluded);
+    }
     
     describe('evaluating expressions', () => {
 
@@ -119,7 +192,7 @@ describe('GciLibrary', () => {
 
         it('evaluates an expression', () => {
             const key = gciLibrary.nextKey();
-
+            
             gciLibrary.executeDiscardingResult(session, `UserGlobals at: ${key} put: true`);
 
             expectUserGlobalsToInclude(key, true);
@@ -153,47 +226,6 @@ describe('GciLibrary', () => {
     });
 
     describe('resolving symbols', () => {
-
-        /** Spies on `resolveSymbol` for the duration of `callback`, then restores it. */
-        function spyOnResolveSymbol(callback: (spy: Mock<typeof GciLibrary.prototype.resolveSymbol>) => void) {
-            const spy =  vi.spyOn(gciLibrary, 'resolveSymbol');
-            
-            try{
-                callback(spy);
-            } finally{
-                spy.mockRestore();
-            }
-        }
-        
-        /**
-         * Asserts a fresh symbol lookup happens for `sessionToUse`.
-         *
-         * Checks the looked-up session with `toBe`, not `toHaveBeenCalledWith`
-         * -- koffi's session pointers have no enumerable properties, so
-         * vitest's deep equality can't tell two different sessions apart and
-         * would pass regardless of which one was actually used.
-         *
-         * @param sessionToUse - The session expected to require a fresh lookup; defaults to the shared `session`.
-         */
-        function expectUtf8OopToResolveViaSymbolLookup(sessionToUse: unknown = session) {
-            spyOnResolveSymbol(resolveSymbolSpy => {
-                gciLibrary.utf8ClassOop(sessionToUse);
-
-                expect(resolveSymbolSpy).toHaveBeenCalledTimes(1);
-                const [calledSession, calledSymbol] = resolveSymbolSpy.mock.calls[0];
-                expect(calledSession).toBe(sessionToUse);
-                expect(calledSymbol).toBe('Utf8');
-            });
-        }
-
-        /** Asserts `session`'s already-cached Utf8 oop is reused, without a fresh symbol lookup. */
-        function expectUtf8OopToBeCached() {
-            spyOnResolveSymbol(resolveSymbolSpy => {
-                gciLibrary.utf8ClassOop(session);
-
-                expect(resolveSymbolSpy).not.toHaveBeenCalled();
-            });
-        }
         
         it('resolves the Utf8 class', () => {
             const expectedOop = gciLibrary.execute(session, 'Utf8');
@@ -287,7 +319,7 @@ describe('GciLibrary', () => {
         it ('retrieves the stored value under the returned key', () => {
             const key = gciLibrary.storeInUniqueUserGlobalsKey(session, 'true');
 
-            const value = gciLibrary.execute(session, `UserGlobals at: ${key}`);
+            const value = gciLibrary.valueOfUserGlobalsKey(session, key);
 
             expectOopToBeTrue(value);
         })
@@ -302,31 +334,56 @@ describe('GciLibrary', () => {
             expectPureExportSetToStayUnchanged(() => gciLibrary.storeInUniqueUserGlobalsKey(session, 'true'));
         });
 
-        it('gives each call a distinct key', () => {
-            const firstKey = gciLibrary.storeInUniqueUserGlobalsKey(session, '1');
-            const secondKey = gciLibrary.storeInUniqueUserGlobalsKey(session, '2');
+        it('stores each value under a distinct key', () => {
+            const firstKey = gciLibrary.storeInUniqueUserGlobalsKey(session, 'true');
+            const secondKey = gciLibrary.storeInUniqueUserGlobalsKey(session, 'nil');
 
             expect(firstKey).not.toBe(secondKey);
-            expectOopToBeTrue(gciLibrary.execute(session, `(UserGlobals at: ${firstKey}) = 1`));
-            expectOopToBeTrue(gciLibrary.execute(session, `(UserGlobals at: ${secondKey}) = 2`));
+            expectOopToBeTrue(gciLibrary.valueOfUserGlobalsKey(session, firstKey));
+            expectOopToBeNil(gciLibrary.valueOfUserGlobalsKey(session, secondKey));
         });
     });
     
     describe('SessionTemps management', () =>{
         
         it('empties SessionTemps', () =>{
-            const key = gciLibrary.nextKey();
-            gciLibrary.executeDiscardingResult(session, `SessionTemps current at: ${key} put: true`);
+            gciLibrary.storeInUniqueSessionTempsKey(session, 'true');
 
             gciLibrary.resetSessionTemps(session);
 
-            expectOopToBeTrue(gciLibrary.execute(session, 'SessionTemps current isEmpty'));
+            expectSessionTempsToBeEmpty(true);
         })
 
         it('does not modify the PureExportSet when resetting SessionTemps', () =>{
             expectPureExportSetToStayUnchanged(()=> gciLibrary.resetSessionTemps(session));
         })
+        
+        it('is empty when nothing has been stored', () => {
+            expectSessionTempsToBeEmpty(true);
+        })
 
+        it('is not empty once a key has been stored', () => {
+            gciLibrary.storeInUniqueSessionTempsKey(session, 'true');
+
+            expectSessionTempsToBeEmpty(false);
+        })
+
+        it('retrieves the stored value under the returned key', () => {
+            const key = gciLibrary.storeInUniqueSessionTempsKey(session, 'true');
+
+            const value = gciLibrary.valueOfSessionTempsKey(session, key);
+
+            expectOopToBeTrue(value);
+        })
+
+        it('stores each value under a distinct key', () => {
+            const firstKey = gciLibrary.storeInUniqueSessionTempsKey(session, 'true');
+            const secondKey = gciLibrary.storeInUniqueSessionTempsKey(session, 'nil');
+
+            expect(firstKey).not.toBe(secondKey);
+            expectOopToBeTrue(gciLibrary.valueOfSessionTempsKey(session, firstKey));
+            expectOopToBeNil(gciLibrary.valueOfSessionTempsKey(session, secondKey));
+        })
     })
     
     describe('PureExportSet management', () => {
@@ -348,6 +405,12 @@ describe('GciLibrary', () => {
                 gciLibrary.execute(session, 'Object new');
                 return []
             });
+        });
+
+        it('does not gain only the provided oops when the callback declares an oop that was already present', () => {
+            const oopAlreadyPresent = gciLibrary.execute(session, 'Object new');
+
+            expectPureExportSetToGainOnlyOopsProvidedBy(false, () => [oopAlreadyPresent]);
         });
 
         it('gains only the provided oops when the callback does not change the PureExportSet', () => {
@@ -403,7 +466,7 @@ describe('GciLibrary', () => {
                     // Removing the key here means it's already gone by the time
                     // didPureExportSetGainOnlyOopsProvidedBy's own cleanup tries to
                     // remove it again, so that second removal genuinely fails.
-                    gciLibrary.executeDiscardingResult(session, `UserGlobals removeKey: ${snapshotName}`);
+                    gciLibrary.removeKeyFromUserGlobals(session, snapshotName);
                     return throwExpectedError();
                 })
             })
@@ -416,7 +479,21 @@ describe('GciLibrary', () => {
 
             expectOopToBeTrue(gciLibrary.execute(session, '(GsBitmap newForHiddenSet: #PureExportSet) isEmpty'));
         })
-        
+
+        it('includes an oop currently held in it', () => {
+            const existingOop = gciLibrary.execute(session, 'Object new');
+
+            expectPureExportSetToIncludeOop(true, existingOop);
+        })
+
+        it('does not include an oop after it is released', () => {
+            const oopToRelease = gciLibrary.execute(session, 'Object new');
+
+            gciLibrary.releaseObject(session, oopToRelease);
+
+            expectPureExportSetToIncludeOop(false, oopToRelease);
+        })
+
     });
 
     describe('logging in', () => {
@@ -429,5 +506,104 @@ describe('GciLibrary', () => {
         })
         
     })
-    
+
+    describe('resetting non-transactional session state', () => {
+        
+        it('empties SessionTemps', () => {
+            gciLibrary.storeInUniqueSessionTempsKey(session,'true');
+            
+            gciLibrary.resetNonTransactionalSessionState(session);
+            
+            expectSessionTempsToBeEmpty(true);
+        })
+
+        it('clears the cached Utf8 oop', () => {
+            gciLibrary.utf8ClassOop(session)
+
+            gciLibrary.resetNonTransactionalSessionState(session);
+
+           expectUtf8OopToResolveViaSymbolLookup();
+        })
+
+        it('releases previously created objects from the PureExportSet', () => {
+            const oopToRelease = gciLibrary.execute(session, 'Object new');
+
+            gciLibrary.resetNonTransactionalSessionState(session);
+
+            expectPureExportSetToIncludeOop(false, oopToRelease);
+        })
+
+        it('does not add anything new to the PureExportSet', () => {
+            expectPureExportSetToGrow(false, () => {
+                gciLibrary.resetNonTransactionalSessionState(session);
+            });
+        })
+    })
+
+    describe('checking whether the PureExportSet grew', () => {
+
+        it('does not grow when the callback does not modify the PureExportSet', () => {
+            expectPureExportSetToGrow(false, () => {});
+        })
+
+        it('grows when the callback adds a new object', () => {
+            expectPureExportSetToGrow(true, () => {
+                gciLibrary.execute(session, 'Object new')
+            });
+        })
+
+        it('does not grow when the callback only removes an object', () => {
+            const oop = gciLibrary.execute(session, 'Object new')
+
+            expectPureExportSetToGrow(false, () => {
+                gciLibrary.releaseObject(session, oop);
+            });
+        })
+        
+        it ('stores the snapshot in UserGlobals while the callback runs', () => {
+            gciLibrary.didPureExportSetGrow(session, (snapshotName) => {
+                expectUserGlobalsToInclude(snapshotName, true);
+            });
+        })
+
+        it('cleans up the snapshot key when the callback succeeds', () => {
+            let snapshotNameToRemove;
+
+            gciLibrary.didPureExportSetGrow(session, (snapshotName) => {
+                snapshotNameToRemove = snapshotName
+            });
+
+            expectUserGlobalsToInclude(snapshotNameToRemove!, false);
+        })
+
+        it('re-throws errors from the callback', () => {
+            expectToThrowExpectedError(throwExpectedError => {
+                gciLibrary.didPureExportSetGrow(session, throwExpectedError);
+            });
+        })
+
+        it('cleans up the snapshot key when the callback throws', () => {
+            let snapshotNameToRemove: string;
+            const captureSnapshotNameAndFail = (snapshotName: string) => {
+                snapshotNameToRemove = snapshotName;
+                throw new Error();
+            };
+
+            expect(() => gciLibrary.didPureExportSetGrow(session, captureSnapshotNameAndFail)).toThrow();
+
+            expectUserGlobalsToInclude(snapshotNameToRemove!, false);
+        })
+
+        it('still throws the original error when cleaning up the snapshot key also fails', () => {
+            expectToThrowExpectedError(throwExpectedError => {
+                gciLibrary.didPureExportSetGrow(session, (snapshotName: string) => {
+                    // Removing the key here means it's already gone by the time
+                    // didPureExportSetGrow's own cleanup tries to remove it again,
+                    // so that second removal genuinely fails.
+                    gciLibrary.removeKeyFromUserGlobals(session, snapshotName);
+                    return throwExpectedError();
+                })
+            })
+        });
+    })
 });

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -166,11 +166,14 @@ describe('GciLibrary', () => {
         }
         
         /**
-         * Asserts a fresh symbol lookup happens for `sessionToUse`. Checks the
-         * looked-up session with `toBe`, not `toHaveBeenCalledWith` -- koffi's
-         * session pointers have no enumerable properties, so vitest's deep
-         * equality can't tell two different sessions apart and would pass
-         * regardless of which one was actually used.
+         * Asserts a fresh symbol lookup happens for `sessionToUse`.
+         *
+         * Checks the looked-up session with `toBe`, not `toHaveBeenCalledWith`
+         * -- koffi's session pointers have no enumerable properties, so
+         * vitest's deep equality can't tell two different sessions apart and
+         * would pass regardless of which one was actually used.
+         *
+         * @param sessionToUse - The session expected to require a fresh lookup; defaults to the shared `session`.
          */
         function expectUtf8OopToResolveViaSymbolLookup(sessionToUse: unknown = session) {
             spyOnResolveSymbol(resolveSymbolSpy => {
@@ -183,10 +186,10 @@ describe('GciLibrary', () => {
             });
         }
 
-        /** Asserts `sessionToUse`'s already-cached Utf8 oop is reused, without a fresh symbol lookup. */
-        function expectUtf8OopToBeCached(sessionToUse: unknown = session) {
+        /** Asserts `session`'s already-cached Utf8 oop is reused, without a fresh symbol lookup. */
+        function expectUtf8OopToBeCached() {
             spyOnResolveSymbol(resolveSymbolSpy => {
-                gciLibrary.utf8ClassOop(sessionToUse);
+                gciLibrary.utf8ClassOop(session);
 
                 expect(resolveSymbolSpy).not.toHaveBeenCalled();
             });
@@ -247,7 +250,7 @@ describe('GciLibrary', () => {
             expectUtf8OopToResolveViaSymbolLookup();
         })
 
-        it('forces a fresh symbol lookup after logging out', () => {
+        it('re-resolves the Utf8 oop after a logout/login cycle', () => {
             gciLibrary.utf8ClassOop(session);
             testContext.logout();
 
@@ -256,15 +259,27 @@ describe('GciLibrary', () => {
             expectUtf8OopToResolveViaSymbolLookup();
         })
 
-        it('caches the Utf8 oop separately per session, without affecting others', () => {
+        it("a new session doesn't have another session's cached Utf8 oop", () => {
             gciLibrary.utf8ClassOop(session);
 
             testContext.withTransientSession(transientSession => {
                 expectUtf8OopToResolveViaSymbolLookup(transientSession);
             });
+        })
+
+        it("logging out a session does not clear another session's cached Utf8 oop", () => {
+            gciLibrary.utf8ClassOop(session);
+
+            testContext.withTransientSession(() => {
+                // Intentionally empty: withTransientSession logs it out as soon as this callback returns,
+                // which is all this test needs -- it exercises the logout cache-cleanup
+                // path for a session other than `session`, so the assertion below can
+                // check that `session`'s own cached oop survived it untouched.
+            });
 
             expectUtf8OopToBeCached();
         })
+        
     });
     
     describe('UserGlobals management', () => {

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -1,24 +1,374 @@
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, Mock, vi} from 'vitest';
 import {GciLibrary} from '../gciLibrary';
-import {useIntegrationTest} from './useIntegrationTest';
-import {OOP_ILLEGAL, OOP_NIL, OOP_TRUE} from "../gciConstants";
+import {GciTestContext, useIntegrationTest} from './useIntegrationTest';
+import {GciLibraryError} from "../gciLibraryError";
 
 describe('GciLibrary', () => {
-    
+
     let gciLibrary: GciLibrary;
     let session: unknown;
+    let testContext: GciTestContext;
 
-    useIntegrationTest((gciLibraryToUse, sessionToUse) => {
-        gciLibrary = gciLibraryToUse;
-        session = sessionToUse;
+    useIntegrationTest((testContextToUse) => {
+        gciLibrary = testContextToUse.gciLibrary;
+        session = testContextToUse.session;
+        testContext = testContextToUse;
+    });
+
+    /** Asserts that `oop` is GemStone's `true` singleton. */
+    function expectOopToBeTrue(oop: bigint) {
+        expect(gciLibrary.isTrueOop(oop)).toBe(true);
+    }
+
+    /** Asserts that `oop` is GemStone's `nil` singleton. */
+    function expectOopToBeNil(oop: bigint) {
+        expect(gciLibrary.isNilOop(oop)).toBe(true);
+    }
+
+    /**
+     * Asserts that `callback` throws a {@link GciLibraryError} when given a
+     * Smalltalk snippet that signals a user-defined error (`self error: 'oops'`).
+     *
+     * The callback receives the Smalltalk snippet as its argument so it can
+     * embed it in any expression under test (e.g. pass it to `execute`).
+     */
+    function expectToThrowExpectedGciLibraryError(callback: (throwOopsError: string) => unknown) {
+        expectToThrowGciLibraryError(
+            () => callback(`self error: 'oops'`),
+            'a UserDefinedError occurred (error 2318), reason:halt, oops');
+    }
+
+    /**
+     * Asserts that `callback` throws exactly the same `Error` instance it's
+     * given when given a thunk that throws that error.
+     *
+     * The callback receives the thunk as its argument so it can invoke it
+     * from anywhere in the expression under test (e.g. pass it to
+     * `executeAndRelease`).
+     */
+    function expectToThrowExpectedError(callback: (throwExpectedError: () => never) => unknown) {
+        const expectedError = new Error('oops');
+        
+        expect(() => callback(() => { throw expectedError })).toThrowExactly(expectedError);
+    }
+    
+    /** Asserts that `callback` throws a {@link GciLibraryError} with `expectedMessage`. */
+    function expectToThrowGciLibraryError(callback: () => unknown, expectedMessage: string) {
+        expect(callback).toThrowInstanceOf(GciLibraryError, expectedMessage);
+    }
+
+    /** Asserts that the session's PureExportSet stays unchanged across `callback`. */
+    function expectPureExportSetToStayUnchanged(callback: () => unknown) {
+        expectPureExportSetToGainOnlyOopsProvidedBy(true, () => {
+            callback();
+            return [];
+        });
+    }
+
+    /** Asserts that the session's PureExportSet gains only the oops `callback` declares, per `shouldGainOnlyProvidedOops`. */
+    function expectPureExportSetToGainOnlyOopsProvidedBy(shouldGainOnlyProvidedOops: boolean, callback: () => bigint[]) {
+        const pureExportSetGainedOnlyProvidedOops = gciLibrary.didPureExportSetGainOnlyOopsProvidedBy(session, callback);
+
+        expect(pureExportSetGainedOnlyProvidedOops).toBe(shouldGainOnlyProvidedOops);
+    }
+
+    /** Asserts that `UserGlobals` includes (or does not include) `key`, per `shouldBeIncluded`. */
+    function expectUserGlobalsToInclude(key: string, shouldBeIncluded: boolean) {
+        expect(gciLibrary.isIncludedInUserGlobals(session, key)).toBe(shouldBeIncluded);
+    }
+    
+    describe('evaluating expressions', () => {
+
+        it('returns the result of evaluating an expression', () => {
+            const resultOop = gciLibrary.execute(session, `true`);
+
+            expectOopToBeTrue(resultOop);
+        });
+
+        it('uses nil as the receiver for evaluated code', () => {
+            const resultOop = gciLibrary.execute(session, `self`);
+
+            expectOopToBeNil(resultOop);
+        });
+
+        it('resolves names against UserGlobals, Globals, and Published', () => {
+            const resultOop = gciLibrary.execute(session, `System myUserProfile symbolList asSet = {UserGlobals. Globals. Published} asSet`);
+
+            expectOopToBeTrue(resultOop);
+        });
+
+        it('executes code in the default environment', () => {
+            const resultOop = gciLibrary.execute(session, `
+                "Object class does not understand #'new' outside environment 0, so this
+                would fail if execute runs code in a non-default environment."
+                Object new.
+                true`);
+
+            expectOopToBeTrue(resultOop);
+        });
+
+        it('throws when the expression signals an error', () => {
+            expectToThrowExpectedGciLibraryError(throwExpectedErrorExpression => {
+                gciLibrary.execute(session, throwExpectedErrorExpression);
+            });
+        });
+
+    });
+
+    describe('creating strings', () => {
+
+        it('creates a String object from the given contents', () => {
+            const oop = gciLibrary.createString(session, 'hello');
+
+            // The comparison source itself compiles literals as Utf8 (see
+            // execute's doc comment) -- String>>= disallows comparing a plain
+            // String against a Unicode-kind argument, so convert explicitly.
+            expectOopToBeTrue(gciLibrary.execute(session, `(Object objectForOop: ${oop}) = 'hello' asString`));
+        });
+
+    });
+
+    describe('resolving symbols', () => {
+
+        /** Spies on `resolveSymbol` for the duration of `callback`, then restores it. */
+        function spyOnResolveSymbol(callback: (spy: Mock<typeof GciLibrary.prototype.resolveSymbol>) => void) {
+            const spy =  vi.spyOn(gciLibrary, 'resolveSymbol');
+            
+            try{
+                callback(spy);
+            } finally{
+                spy.mockRestore();
+            }
+        }
+        
+        it('resolves the Utf8 class', () => {
+            const expectedOop = gciLibrary.execute(session, 'Utf8');
+
+            const utf8ClassOop = gciLibrary.utf8ClassOop(session);
+
+            expect(utf8ClassOop).toBe(expectedOop);
+        });
+
+        it('resolves the Utf8 class via a symbol lookup the first time it is needed', () => {
+            spyOnResolveSymbol(resolveSymbolSpy => {
+                gciLibrary.utf8ClassOop(session);
+
+                expect(resolveSymbolSpy).toHaveBeenCalledTimes(1);
+                expect(resolveSymbolSpy).toHaveBeenCalledWith(session, 'Utf8');
+            });
+        });
+
+        it('reuses the cached Utf8 class oop on later lookups', () => {
+            gciLibrary.utf8ClassOop(session);
+
+            spyOnResolveSymbol(resolveSymbolSpy => {
+                gciLibrary.utf8ClassOop(session);
+
+                expect(resolveSymbolSpy).not.toHaveBeenCalled();
+            });
+        });
+        
+        it('adds only the resolved oop to the PureExportSet', () =>{
+            expectPureExportSetToGainOnlyOopsProvidedBy(true, () => [
+                gciLibrary.resolveSymbol(session, 'Object')
+            ]);
+        });
+
+        it('does not modify the PureExportSet when a symbol lookup fails', () =>{
+           expectPureExportSetToStayUnchanged(() => {
+               expect(() => gciLibrary.resolveSymbol(session, '')).toThrow();
+           });
+        });
+        
+        it('resolves a symbol that exists in the user namespace', () => {
+            const expectedOop = gciLibrary.execute(session, 'Object');
+
+            const foundOop = gciLibrary.resolveSymbol(session, 'Object');
+            
+            expect(foundOop).equals(expectedOop);
+        })
+
+        it('throws when symbols cannot be resolved', () => {
+            // Expected message is empty: GciTsResolveSymbolObj's "not found"
+            // case leaves *err unpopulated, despite gcits.hf implying it does.
+            expectToThrowGciLibraryError(
+                () => gciLibrary.resolveSymbol(session, ''),
+                ''
+            )
+        })
+        
+        it ('forces a fresh symbol lookup after releasing the cached oop', () => {
+            gciLibrary.utf8ClassOop(session);
+            
+            gciLibrary.releaseCachedSymbolOops(session);
+
+            spyOnResolveSymbol(resolveSymbolSpy => {
+                gciLibrary.utf8ClassOop(session);
+
+                expect(resolveSymbolSpy).toHaveBeenCalledTimes(1);
+                expect(resolveSymbolSpy).toHaveBeenCalledWith(session, 'Utf8');
+            });
+        })
     });
     
-    it('executes a Smalltalk expression and returns its result', () => {
-        const {result: utf8Oop} = gciLibrary.GciTsResolveSymbol(session, 'Utf8', OOP_NIL);
+    describe('UserGlobals management', () => {
+
+        it ('retrieves the stored value under the returned key', () => {
+            const key = gciLibrary.storeInUniqueUserGlobalsKey(session, 'true');
+
+            const value = gciLibrary.execute(session, `UserGlobals at: ${key}`);
+
+            expectOopToBeTrue(value);
+        })
+
+        it ('includes a key after it is stored', () => {
+            const key = gciLibrary.storeInUniqueUserGlobalsKey(session, 'true');
+
+            expectUserGlobalsToInclude(key, true);
+        })
+
+        it ('does not modify the PureExportSet when storing a UserGlobals key', () => {
+            expectPureExportSetToStayUnchanged(() => gciLibrary.storeInUniqueUserGlobalsKey(session, 'true'));
+        });
+
+        it('gives each call a distinct key', () => {
+            const firstKey = gciLibrary.storeInUniqueUserGlobalsKey(session, '1');
+            const secondKey = gciLibrary.storeInUniqueUserGlobalsKey(session, '2');
+
+            expect(firstKey).not.toBe(secondKey);
+            expectOopToBeTrue(gciLibrary.execute(session, `(UserGlobals at: ${firstKey}) = 1`));
+            expectOopToBeTrue(gciLibrary.execute(session, `(UserGlobals at: ${secondKey}) = 2`));
+        });
+    });
+    
+    describe('SessionTemps management', () =>{
         
-        const {result} = gciLibrary.GciTsExecute(session, 'false or: [ true ]', utf8Oop,OOP_ILLEGAL, OOP_NIL,0, 0);
+        it('empties SessionTemps', () =>{
+            const key = gciLibrary.nextUniqueKey();
+            gciLibrary.executeDiscardingResult(session, `SessionTemps current at: ${key} put: true`);
+
+            gciLibrary.resetSessionTemps(session);
+
+            expectOopToBeTrue(gciLibrary.execute(session, 'SessionTemps current isEmpty'));
+        })
+
+        it('does not modify the PureExportSet when resetting SessionTemps', () =>{
+            expectPureExportSetToStayUnchanged(()=> gciLibrary.resetSessionTemps(session));
+        })
+
+    })
+    
+    describe('PureExportSet management', () => {
+
+        it('does not gain only the provided oops when the callback removes an object from the PureExportSet', () => {
+            const oopToRemove = gciLibrary.execute(session, 'Object new');
+
+            expectPureExportSetToGainOnlyOopsProvidedBy(false, () => {
+                gciLibrary.releaseObject(session, oopToRemove);
+                return []
+            });
+        });
+
+        it('does not gain only the provided oops when the callback swaps objects in the PureExportSet', () => {
+            const oopToSwap = gciLibrary.execute(session, 'Object new');
+
+            expectPureExportSetToGainOnlyOopsProvidedBy(false, () => {
+                gciLibrary.releaseObject(session, oopToSwap);
+                gciLibrary.execute(session, 'Object new');
+                return []
+            });
+        });
+
+        it('gains only the provided oops when the callback does not change the PureExportSet', () => {
+            expectPureExportSetToGainOnlyOopsProvidedBy(true, () => []);
+        });
+
+        it('gains only the provided oops when the callback adds an object to the PureExportSet', () => {
+            expectPureExportSetToGainOnlyOopsProvidedBy(true, () => {
+                const addedOop = gciLibrary.execute(session, 'Object new');
+                return [addedOop];
+            });
+        });
+
+        it('does not stay unchanged when the callback adds an undeclared object to it', () => {
+            expectPureExportSetToGainOnlyOopsProvidedBy(false, () => {
+                gciLibrary.execute(session, 'Object new');
+                return [];
+            });
+        });
+
+        it('re-throws errors from the callback', () => {
+            expectToThrowExpectedError(throwExpectedError => {
+                gciLibrary.didPureExportSetGainOnlyOopsProvidedBy(session, throwExpectedError);
+            });
+        });
+
+        it('cleans up the snapshot key when the callback succeeds', () => {
+            let snapshotNameToRemove: string;
+            const captureSnapshotName = (snapshotName: string) => {
+                snapshotNameToRemove = snapshotName;
+                return [];
+            };
+
+            gciLibrary.didPureExportSetGainOnlyOopsProvidedBy(session, captureSnapshotName);
+
+            expectUserGlobalsToInclude(snapshotNameToRemove!, false);
+        });
         
-        expect(result).toBe(OOP_TRUE);
+        it('cleans up the snapshot key when the callback throws', () => {
+            let snapshotNameToRemove: string;
+            const captureSnapshotNameAndFail = (snapshotName: string) => {
+                snapshotNameToRemove = snapshotName;
+                throw new Error();
+            };
+
+            expect(() => gciLibrary.didPureExportSetGainOnlyOopsProvidedBy(session, captureSnapshotNameAndFail)).toThrow();
+            expectUserGlobalsToInclude(snapshotNameToRemove!, false);
+        });
+        
+        it('still throws the original error when cleaning up the snapshot key also fails', () => {
+            expectToThrowExpectedError(throwExpectedError => {
+                gciLibrary.didPureExportSetGainOnlyOopsProvidedBy(session, (snapshotName: string) => {
+                    // Removing the key here means it's already gone by the time
+                    // didPureExportSetGainOnlyOopsProvidedBy's own cleanup tries to
+                    // remove it again, so that second removal genuinely fails.
+                    gciLibrary.executeDiscardingResult(session, `UserGlobals removeKey: ${snapshotName}`);
+                    return throwExpectedError();
+                })
+            })
+        });
+
+        it('empties the PureExportSet', () =>{
+            gciLibrary.execute(session, 'Object new');
+
+            gciLibrary.releaseAllObjects(session);
+
+            expectOopToBeTrue(gciLibrary.execute(session, '(GsBitmap newForHiddenSet: #PureExportSet) isEmpty'));
+        })
+        
     });
 
-})
+    describe('logging in', () => {
+        
+        it('throws a GciLibraryError when the credentials are invalid', () => {
+            expectToThrowGciLibraryError(
+                () => testContext.login({user: 'NonExistentUser'}),
+                'Login failed:  the userId/password combination is invalid or expired.'
+            )
+        })
+        
+    })
+    
+    describe('logging out', () => {
+        
+        it('clears the cached Utf8 oop', () =>{
+            gciLibrary.utf8ClassOop(session);
+
+            const loggedOutSession = testContext.logout();
+
+            expect(gciLibrary.cachedUtf8OopFor(loggedOutSession)).toBeUndefined();
+        })
+        
+    })
+    
+});

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -165,6 +165,33 @@ describe('GciLibrary', () => {
             }
         }
         
+        /**
+         * Asserts a fresh symbol lookup happens for `sessionToUse`. Checks the
+         * looked-up session with `toBe`, not `toHaveBeenCalledWith` -- koffi's
+         * session pointers have no enumerable properties, so vitest's deep
+         * equality can't tell two different sessions apart and would pass
+         * regardless of which one was actually used.
+         */
+        function expectUtf8OopToResolveViaSymbolLookup(sessionToUse: unknown = session) {
+            spyOnResolveSymbol(resolveSymbolSpy => {
+                gciLibrary.utf8ClassOop(sessionToUse);
+
+                expect(resolveSymbolSpy).toHaveBeenCalledTimes(1);
+                const [calledSession, calledSymbol] = resolveSymbolSpy.mock.calls[0];
+                expect(calledSession).toBe(sessionToUse);
+                expect(calledSymbol).toBe('Utf8');
+            });
+        }
+
+        /** Asserts `sessionToUse`'s already-cached Utf8 oop is reused, without a fresh symbol lookup. */
+        function expectUtf8OopToBeCached(sessionToUse: unknown = session) {
+            spyOnResolveSymbol(resolveSymbolSpy => {
+                gciLibrary.utf8ClassOop(sessionToUse);
+
+                expect(resolveSymbolSpy).not.toHaveBeenCalled();
+            });
+        }
+        
         it('resolves the Utf8 class', () => {
             const expectedOop = gciLibrary.execute(session, 'Utf8');
 
@@ -174,22 +201,13 @@ describe('GciLibrary', () => {
         });
 
         it('resolves the Utf8 class via a symbol lookup the first time it is needed', () => {
-            spyOnResolveSymbol(resolveSymbolSpy => {
-                gciLibrary.utf8ClassOop(session);
-
-                expect(resolveSymbolSpy).toHaveBeenCalledTimes(1);
-                expect(resolveSymbolSpy).toHaveBeenCalledWith(session, 'Utf8');
-            });
+            expectUtf8OopToResolveViaSymbolLookup();
         });
 
         it('reuses the cached Utf8 class oop on later lookups', () => {
             gciLibrary.utf8ClassOop(session);
 
-            spyOnResolveSymbol(resolveSymbolSpy => {
-                gciLibrary.utf8ClassOop(session);
-
-                expect(resolveSymbolSpy).not.toHaveBeenCalled();
-            });
+            expectUtf8OopToBeCached();
         });
         
         it('adds only the resolved oop to the PureExportSet', () =>{
@@ -223,15 +241,29 @@ describe('GciLibrary', () => {
         
         it ('forces a fresh symbol lookup after releasing the cached oop', () => {
             gciLibrary.utf8ClassOop(session);
-            
+
             gciLibrary.releaseCachedUtf8Oop(session);
 
-            spyOnResolveSymbol(resolveSymbolSpy => {
-                gciLibrary.utf8ClassOop(session);
+            expectUtf8OopToResolveViaSymbolLookup();
+        })
 
-                expect(resolveSymbolSpy).toHaveBeenCalledTimes(1);
-                expect(resolveSymbolSpy).toHaveBeenCalledWith(session, 'Utf8');
+        it('forces a fresh symbol lookup after logging out', () => {
+            gciLibrary.utf8ClassOop(session);
+            testContext.logout();
+
+            testContext.login();
+
+            expectUtf8OopToResolveViaSymbolLookup();
+        })
+
+        it('caches the Utf8 oop separately per session, without affecting others', () => {
+            gciLibrary.utf8ClassOop(session);
+
+            testContext.withTransientSession(transientSession => {
+                expectUtf8OopToResolveViaSymbolLookup(transientSession);
             });
+
+            expectUtf8OopToBeCached();
         })
     });
     
@@ -379,18 +411,6 @@ describe('GciLibrary', () => {
                 () => testContext.login({user: 'NonExistentUser'}),
                 'Login failed:  the userId/password combination is invalid or expired.'
             )
-        })
-        
-    })
-    
-    describe('logging out', () => {
-        
-        it('clears the cached Utf8 oop', () =>{
-            gciLibrary.utf8ClassOop(session);
-
-            const loggedOutSession = testContext.logout();
-
-            expect(gciLibrary.cachedUtf8OopFor(loggedOutSession)).toBeUndefined();
         })
         
     })

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -244,7 +244,7 @@ describe('GciLibrary', () => {
     describe('SessionTemps management', () =>{
         
         it('empties SessionTemps', () =>{
-            const key = gciLibrary.nextUniqueKey();
+            const key = gciLibrary.nextKey();
             gciLibrary.executeDiscardingResult(session, `SessionTemps current at: ${key} put: true`);
 
             gciLibrary.resetSessionTemps(session);

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -200,7 +200,7 @@ describe('GciLibrary', () => {
         it ('forces a fresh symbol lookup after releasing the cached oop', () => {
             gciLibrary.utf8ClassOop(session);
             
-            gciLibrary.releaseCachedSymbolOops(session);
+            gciLibrary.releaseCachedUtf8Oop(session);
 
             spyOnResolveSymbol(resolveSymbolSpy => {
                 gciLibrary.utf8ClassOop(session);

--- a/client/src/__tests__/sessionMethods.integration.test.ts
+++ b/client/src/__tests__/sessionMethods.integration.test.ts
@@ -28,7 +28,7 @@ import type { EnvCategoryLine } from '../queries/getClassEnvironments';
 describe('session methods (integration)', () => {
   let gci: GciLibrary;
   let handle: unknown;
-  useIntegrationTest((g, s) => { gci = g; handle = s; });
+  useIntegrationTest((testContext) => { gci = testContext.gciLibrary; handle = testContext.session; });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
   const exec = (code: string): string => browserQueries.executeFetchString(session(), 'sessionMethods-it', code);

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -101,7 +101,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
             );
             login();
         }
-        gciLibrary.releaseCachedSymbolOops(session)
+        gciLibrary.releaseCachedUtf8Oop(session)
         gciLibrary.beginTransaction(session);
     });
 

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -1,7 +1,21 @@
 import {GciLibrary} from "../gciLibrary";
-import {afterAll, afterEach, beforeAll, beforeEach} from "vitest";
+import {afterAll, afterEach, beforeAll, beforeEach, expect} from "vitest";
 
-type UseIntegrationTestCallback = (gciLibraryToUse: GciLibrary, sessionToUse: unknown) => void;
+/** The live GCI state handed to a `useIntegrationTest` callback on every login. */
+export type GciTestContext = {
+    gciLibrary: GciLibrary,
+    session: unknown;
+    login: (options?: LoginOptions) => void
+    logout: () => unknown
+}
+
+type UseIntegrationTestCallback = (testContext: GciTestContext) => void;
+
+/** Options accepted by a `GciTestContext`'s `login`. */
+type LoginOptions = {
+    /** GemStone user to log in as. Defaults to `VITE_GEMSTONE_USER`; override to test login with different (e.g. invalid) credentials. */
+    user?: string;
+};
 
 /**
  * Sets up a full GemStone integration test environment for a Vitest describe block.
@@ -12,15 +26,18 @@ type UseIntegrationTestCallback = (gciLibraryToUse: GciLibrary, sessionToUse: un
  *   so database changes never leak between tests.
  * - Logs out and closes the library after all tests finish.
  *
- * The `callback` fires at the end of `beforeAll`, right after login — use it
- * to capture the `gciLibrary` and `session` into variables your tests can reach:
+ * The `callback` fires after every login, starting with the one at the end of
+ * `beforeAll` — use it to capture the {@link GciTestContext} fields you need
+ * into variables your tests can reach. If a test calls `logout`, a later
+ * test's `beforeEach` re-logs in automatically and the callback fires again,
+ * so these variables stay current instead of going stale:
  *
  * ```ts
  * describe('my feature', () => {
  *   let gci: GciLibrary;
  *   let session: unknown;
  *
- *   useIntegrationTest((g, s) => { gci = g; session = s; });
+ *   useIntegrationTest(({gciLibrary, session: s}) => { gci = gciLibrary; session = s; });
  *
  *   it('does something', () => { ... });
  * });
@@ -40,6 +57,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     let gciLibrary: GciLibrary;
     let session: unknown;
     let originalGemstoneGlobalDir: string | undefined;
+    let sessionCleanupFailed = false;
 
     // gciLibrary and session are created inside a beforeAll hook, so they don't
     // exist at call time. The callback fires at the end of that hook, letting
@@ -49,20 +67,15 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
         
         handleIntegrationTestSetupErrorDuring(() => {
             gciLibrary = new GciLibrary(process.env.VITE_GEMSTONE_GCI_LIBRARY_PATH!);
-            session = loginUsing(gciLibrary);
+            login();
         });
-
-        callback(gciLibrary, session);
     });
-
+    
     afterAll(() => {
+        if (!gciLibrary) return;
         try {
-            if (!gciLibrary) return;
             if (session) {
-                const {success, err} = gciLibrary.GciTsLogout(session);
-                // Warn rather than throw — the session is gone regardless, and a
-                // teardown error would obscure real test failures above it.
-                if (!success) console.warn(`GciTsLogout failed [${err.number}]: ${err.message}`);
+                logout();
             }
             gciLibrary.close();
         } finally {
@@ -73,38 +86,82 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     // Wrap each test in a GCI transaction. Always abort (never commit) so
     // database changes from one test don't leak into the next.
     beforeEach(() => {
-            const { success, err } = gciLibrary.GciTsBegin(session);
-            if (!success) {
-                throw new Error(`GciTsBegin failed [${err.number}]: ${err.message}`)
+        if (sessionCleanupFailed) {
+            throw new Error(
+                `useIntegrationTest: skipping this test — a previous test's cleanup failed, leaving the GemStone session in an unknown state. See the earlier failure in this file for the actual error.`
+            );
         }
+        
+        // A prior test may have called logout() — re-establish a session rather
+        // than leaving the rest of the file to fail, since shuffled test order
+        // means "prior" and "rest of the file" aren't fixed relative to any one test.
+        if (!session) {
+            console.warn(
+                `useIntegrationTest: no active session in beforeEach for "${expect.getState().currentTestName}" — a previous test called logout() and didn't log back in. Re-logging in automatically.`
+            );
+            login();
+        }
+        gciLibrary.releaseCachedSymbolOops(session)
+        gciLibrary.beginTransaction(session);
     });
 
     afterEach(() => {
-        const { success, err } = gciLibrary.GciTsAbort(session);
-        if (!success) {
-            throw new Error(`GciTsAbort failed [${err.number}]: ${err.message}`)
+        if (!session) return;
+        
+        try {
+            gciLibrary.abortTransaction(session);
+            gciLibrary.resetNonTransactionalSessionState(session);
+        } catch (error) {
+            sessionCleanupFailed = true;
+            throw error;
         }
     });
 
-    function loginUsing(gciLibrary: GciLibrary) {
-        const {session, err} = gciLibrary.GciTsLogin(
+    /**
+     * Logs in (using `options.user`, or `VITE_GEMSTONE_USER` by default) and
+     * stores the result as the current session, then re-invokes `callback`
+     * with a fresh {@link GciTestContext} so callers stay in sync.
+     *
+     * @throws {GciLibraryError} If login fails (see `GciLibrary.login`).
+     */
+    function login(options?: LoginOptions) {
+        session = gciLibrary.login(
             process.env.VITE_GEMSTONE_STONE_NRS!,
-            null,
-            null,
-            false,
             process.env.VITE_GEMSTONE_GEM_NRS!,
-            process.env.VITE_GEMSTONE_USER!,
-            process.env.VITE_GEMSTONE_PASSWORD!,
-            0,
-            0,
+            options?.user || process.env.VITE_GEMSTONE_USER!,
+            process.env.VITE_GEMSTONE_PASSWORD!
         );
-        
-        if (err.number !== 0) throw new Error(`Login failed [${err.number}]: ${err.message}`);
-        if (!session) throw new Error('GciTsLogin returned null session');
 
-        return session;
+        callback({
+            gciLibrary,
+            session,
+            login,
+            logout
+        });
     }
 
+    /**
+     * Logs out the current session and clears it.
+     *
+     * @returns The session that was just logged out, so a test can still
+     *   reference that specific (now invalid) session after this clears the
+     *   shared one.
+     */
+    function logout() {
+        gciLibrary.logout(session);
+        const loggedOutSession = session;
+
+        session = undefined;
+
+        return loggedOutSession;
+    }
+
+    /**
+     * Runs `callback`, and if it throws, rewrites the error's message with a
+     * banner explaining how to provision a test environment before
+     * re-throwing — so a missing `.env.test` fails with actionable guidance
+     * instead of an opaque login/library-load error.
+     */
     function handleIntegrationTestSetupErrorDuring(callback: () => void) {
         try{
             callback();
@@ -132,6 +189,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
         }
     }
     
+    /** Points `GEMSTONE_GLOBAL_DIR` at the suite's test stone for the suite's duration. */
     function configureGemstoneGlobalDir() {
         // Vite only exposes VITE_-prefixed variables to test code. GemStone
         // expects GEMSTONE_GLOBAL_DIR (no prefix), so we copy the VITE_ variant
@@ -140,6 +198,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
         process.env.GEMSTONE_GLOBAL_DIR = process.env.VITE_GEMSTONE_GLOBAL_DIR;
     }
 
+    /** Restores `GEMSTONE_GLOBAL_DIR` to whatever it was before this suite ran. */
     function restoreGemstoneGlobalDir() {
         // Restore the original value so subsequent suites — including other
         // useIntegrationTest blocks — don't inherit this suite's GEMSTONE_GLOBAL_DIR.
@@ -149,4 +208,5 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
             process.env.GEMSTONE_GLOBAL_DIR = originalGemstoneGlobalDir;
         }
     }
+    
 }

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -7,12 +7,6 @@ export type GciTestContext = {
     session: unknown;
     login: (options?: LoginOptions) => void
     logout: () => unknown
-    /**
-     * Logs into a second, independent session for the duration of `callback`,
-     * then always logs it out afterward -- for tests that need to verify
-     * behavior is isolated per session (e.g. that one session's cache doesn't
-     * leak into another's).
-     */
     withTransientSession: (callback: (transientSession: unknown) => void) => void
 }
 
@@ -144,20 +138,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
             session,
             login,
             logout,
-            withTransientSession: (callback: (transientSession: unknown) => void) => {
-                const transientSession = gciLibrary.login(
-                    process.env.VITE_GEMSTONE_STONE_NRS!,
-                    process.env.VITE_GEMSTONE_GEM_NRS!,
-                    process.env.VITE_GEMSTONE_USER!,
-                    process.env.VITE_GEMSTONE_PASSWORD!
-                );
-                
-                try{
-                    callback(transientSession);
-                } finally {
-                    gciLibrary.logout(transientSession);
-                }
-            }
+            withTransientSession
         });
     }
 
@@ -175,6 +156,31 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
         session = undefined;
 
         return loggedOutSession;
+    }
+    
+    /**
+     * Logs into a second, independent session for the duration of `callback`,
+     * then always logs it out afterward -- for tests that need to verify
+     * behavior is isolated per session (e.g. that one session's cache doesn't
+     * leak into another's).
+     *
+     * @param callback - Runs with the transient session. The session is
+     *   logged out once this returns, whether it throws or not.
+     * @throws {GciLibraryError} If logging into the transient session fails.
+     */
+    function withTransientSession(callback: (transientSession: unknown) => void) {
+        const transientSession = gciLibrary.login(
+            process.env.VITE_GEMSTONE_STONE_NRS!,
+            process.env.VITE_GEMSTONE_GEM_NRS!,
+            process.env.VITE_GEMSTONE_USER!,
+            process.env.VITE_GEMSTONE_PASSWORD!
+        );
+
+        try {
+            callback(transientSession);
+        } finally {
+            gciLibrary.logout(transientSession);
+        }
     }
 
     /**

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -7,6 +7,13 @@ export type GciTestContext = {
     session: unknown;
     login: (options?: LoginOptions) => void
     logout: () => unknown
+    /**
+     * Logs into a second, independent session for the duration of `callback`,
+     * then always logs it out afterward -- for tests that need to verify
+     * behavior is isolated per session (e.g. that one session's cache doesn't
+     * leak into another's).
+     */
+    withTransientSession: (callback: (transientSession: unknown) => void) => void
 }
 
 type UseIntegrationTestCallback = (testContext: GciTestContext) => void;
@@ -136,7 +143,21 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
             gciLibrary,
             session,
             login,
-            logout
+            logout,
+            withTransientSession: (callback: (transientSession: unknown) => void) => {
+                const transientSession = gciLibrary.login(
+                    process.env.VITE_GEMSTONE_STONE_NRS!,
+                    process.env.VITE_GEMSTONE_GEM_NRS!,
+                    process.env.VITE_GEMSTONE_USER!,
+                    process.env.VITE_GEMSTONE_PASSWORD!
+                );
+                
+                try{
+                    callback(transientSession);
+                } finally {
+                    gciLibrary.logout(transientSession);
+                }
+            }
         });
     }
 

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -128,7 +128,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
         session = gciLibrary.login(
             process.env.VITE_GEMSTONE_STONE_NRS!,
             process.env.VITE_GEMSTONE_GEM_NRS!,
-            options?.user || process.env.VITE_GEMSTONE_USER!,
+            options?.user ?? process.env.VITE_GEMSTONE_USER!,
             process.env.VITE_GEMSTONE_PASSWORD!
         );
 

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -102,7 +102,6 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
             );
             login();
         }
-        gciLibrary.releaseCachedUtf8Oop(session)
         gciLibrary.beginTransaction(session);
     });
 

--- a/client/src/__tests__/vitest.customErrorMatchers.ts
+++ b/client/src/__tests__/vitest.customErrorMatchers.ts
@@ -1,6 +1,13 @@
 import {expect} from 'vitest';
 
 expect.extend({
+    /**
+     * Used to test that a function throws exactly the given error instance,
+     * not merely an equal or same-typed one.
+     *
+     * @param callback - The function expected to throw.
+     * @param expectedError - The exact `Error` instance `callback` must throw.
+     */
     toThrowExactly(callback: () => unknown, expectedError: Error) {
         try {
             callback();
@@ -25,6 +32,14 @@ expect.extend({
         };
     },
 
+    /**
+     * Used to test that a function throws an instance of the given class
+     * with the given message.
+     *
+     * @param callback - The function expected to throw.
+     * @param ExpectedClass - The `Error` subclass `callback` must throw an instance of.
+     * @param expectedMessage - The exact `message` the thrown error must have.
+     */
     toThrowInstanceOf(callback: () => unknown, ExpectedClass: Function & { prototype: Error }, expectedMessage: string) {
         try {
             callback();
@@ -60,7 +75,20 @@ expect.extend({
 
 declare module 'vitest' {
     interface Assertion {
+        /**
+         * Used to test that a function throws exactly the given error instance,
+         * not merely an equal or same-typed one.
+         *
+         * @param expectedError - The exact `Error` instance the received function must throw.
+         */
         toThrowExactly(expectedError: Error): void;
+        /**
+         * Used to test that a function throws an instance of the given class
+         * with the given message.
+         *
+         * @param ExpectedClass - The `Error` subclass the received function must throw an instance of.
+         * @param expectedMessage - The exact `message` the thrown error must have.
+         */
         toThrowInstanceOf(ExpectedClass: Function & { prototype: Error }, expectedMessage: string): void;
     }
 }

--- a/client/src/__tests__/vitest.customErrorMatchers.ts
+++ b/client/src/__tests__/vitest.customErrorMatchers.ts
@@ -1,0 +1,66 @@
+import {expect} from 'vitest';
+
+expect.extend({
+    toThrowExactly(callback: () => unknown, expectedError: Error) {
+        try {
+            callback();
+            return {
+                pass: false,
+                message: () => `Expected callback to throw ${expectedError}, but it did not throw.`,
+            };
+        } catch (error) {
+            if (error !== expectedError) {
+                return {
+                    pass: false,
+                    message: () => `Expected callback to throw exactly ${expectedError}, but it threw ${error}.`,
+                    actual: error,
+                    expected: expectedError,
+                };
+            }
+        }
+
+        return {
+            pass: true,
+            message: () => `Expected callback not to throw ${expectedError}, but it did.`,
+        };
+    },
+
+    toThrowInstanceOf(callback: () => unknown, ExpectedClass: Function & { prototype: Error }, expectedMessage: string) {
+        try {
+            callback();
+            return {
+                pass: false,
+                message: () => `Expected callback to throw a ${ExpectedClass.name} with message '${expectedMessage}', but it did not throw.`,
+            };
+        } catch (error) {
+            if (!(error instanceof ExpectedClass)) {
+                return {
+                    pass: false,
+                    message: () => `Expected callback to throw a ${ExpectedClass.name}, but it threw ${error}.`,
+                    actual: error,
+                    expected: ExpectedClass,
+                };
+            }
+
+            const thrownError = error as Error;
+            if (thrownError.message !== expectedMessage) {
+                return {
+                    pass: false,
+                    message: () => `Expected callback to throw a ${ExpectedClass.name} with message '${expectedMessage}', but got '${thrownError.message}'.`,
+                };
+            }
+        }
+
+        return {
+            pass: true,
+            message: () => `Expected callback not to throw a ${ExpectedClass.name} with message '${expectedMessage}', but it did.`,
+        };
+    },
+});
+
+declare module 'vitest' {
+    interface Assertion {
+        toThrowExactly(expectedError: Error): void;
+        toThrowInstanceOf(ExpectedClass: Function & { prototype: Error }, expectedMessage: string): void;
+    }
+}

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -1974,7 +1974,7 @@ export class GciLibrary {
    * Returns the OOP of the `Utf8` class — see {@link resolveSymbol} for
    * error behavior. Cached per session: only resolves via a GCI round-trip
    * the first time it's called for a given session. Call
-   * {@link releaseCachedSymbolOops} to release the cached oop and clear the
+   * {@link releaseCachedUtf8Oop} to release the cached oop and clear the
    * cache for a session.
    *
    * `Utf8` is used as the source class when compiling code via {@link execute}:
@@ -2066,7 +2066,7 @@ export class GciLibrary {
    * @param session - The GemStone session to operate in.
    * @throws {GciLibraryError} If releasing the cached oop fails.
    */
-  public releaseCachedSymbolOops(session: unknown) {
+  public releaseCachedUtf8Oop(session: unknown) {
     const cachedOop = this.cachedUtf8OopFor(session);
     if (!cachedOop) return;
 
@@ -2308,11 +2308,11 @@ export class GciLibrary {
   public resetNonTransactionalSessionState(session: unknown) {
     // Order matters: resetSessionTemps evaluates code, which re-resolves (and
     // re-caches) the Utf8 class oop as a side effect if it isn't already
-    // cached, so it must run before releaseCachedSymbolOops clears that
+    // cached, so it must run before releaseCachedUtf8Oop clears that
     // cache. releaseAllObjects must run last so it sweeps up whatever that
     // re-resolution just added to the PureExportSet.
     this.resetSessionTemps(session);
-    this.releaseCachedSymbolOops(session);
+    this.releaseCachedUtf8Oop(session);
     this.releaseAllObjects(session);
   }
 }

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -2104,22 +2104,20 @@ export class GciLibrary {
   }
 
   /**
-   * Runs `expectedOopsProvider` and returns whether the session's
-   * PureExportSet ended up containing exactly its prior contents plus the
-   * oops `expectedOopsProvider` declares -- nothing removed, replaced, or
-   * added beyond that. Order does not matter: PureExportSet is a set, and
-   * newly added oops are not guaranteed to sort after existing members (oop
-   * values are not allocated in increasing order).
+   * Returns whether the session's PureExportSet ended up containing exactly
+   * its prior contents plus the oops `expectedOopsProvider` declares --
+   * nothing removed, replaced, or added beyond that. Order does not matter:
+   * PureExportSet is a set, and newly added oops are not guaranteed to sort
+   * after existing members (oop values are not allocated in increasing
+   * order).
    *
-   * Takes a snapshot of the PureExportSet (as an Array) before invoking
-   * `expectedOopsProvider`, then compares it to the PureExportSet
-   * afterwards. `expectedOopsProvider` returns the oops it expects to have
-   * added; this returns `true` only if the "after" snapshot, compared as a
-   * bag (so a duplicate can't mask a missing or extra oop), is exactly the
-   * "before" snapshot plus precisely those oops. Anything else -- oops
-   * removed or replaced, or actual additions that don't match what
-   * `expectedOopsProvider` declared (including declaring additions that
-   * never happened) -- returns `false`.
+   * `expectedOopsProvider` returns the oops it expects to have added; this
+   * returns `true` only if the "after" snapshot, compared as a bag (so a
+   * duplicate can't mask a missing or extra oop), is exactly the "before"
+   * snapshot plus precisely those oops. Anything else -- oops removed or
+   * replaced, or actual additions that don't match what `expectedOopsProvider`
+   * declared (including declaring additions that never happened) -- returns
+   * `false`.
    *
    * @param session - The GemStone session to operate in.
    * @param expectedOopsProvider - The operation to observe. Returns the oops
@@ -2127,56 +2125,115 @@ export class GciLibrary {
    *   expects none).
    * @returns `true` if the PureExportSet gained only the oops
    *   `expectedOopsProvider` declared, `false` otherwise.
+   * @throws {GciLibraryError} If the underlying GCI calls fail.
+   */
+  public didPureExportSetGainOnlyOopsProvidedBy(session: unknown, expectedOopsProvider: (snapshotName: string) => bigint[]) {
+    return this.checkAgainstPureExportSetSnapshot(
+        session,
+        (previousSnapshotName, currentSnapshotName, expectedAddedOops) => {
+          const expectedAddedObjectsExpression = `{ ${expectedAddedOops.map(oop => `Object objectForOop: ${oop}`).join('. ')} }`;
+          return `(${previousSnapshotName}, ${expectedAddedObjectsExpression}) asIdentityBag = ${currentSnapshotName} asIdentityBag`;
+        },
+        expectedOopsProvider
+    );
+  }
+
+  /**
+   * Returns whether the session's PureExportSet gained any oop it didn't
+   * already contain while running `callback`. Unlike
+   * {@link didPureExportSetGainOnlyOopsProvidedBy}, this doesn't care which
+   * oops were added, or whether any were also removed -- it only asks
+   * whether the "after" snapshot contains something the "before" snapshot
+   * didn't.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param callback - The operation to observe.
+   * @returns `true` if the PureExportSet gained at least one new oop,
+   *   `false` otherwise.
+   * @throws {GciLibraryError} If the underlying GCI calls fail.
+   */
+  public didPureExportSetGrow(session: unknown, callback: (snapshotName: string) => unknown) {
+    return this.checkAgainstPureExportSetSnapshot(
+        session,
+        (previousSnapshotName, currentSnapshotName) => `
+          (${currentSnapshotName} asIdentitySet - ${previousSnapshotName} asIdentitySet) isEmpty not
+        `,
+        callback
+    );
+  }
+
+  /**
+   * Takes a snapshot of the session's PureExportSet, runs `callback`, then
+   * evaluates `buildComparisonExpression` against the "before" and "after"
+   * snapshots (plus whatever `callback` returned) to decide the result.
+   *
+   * Shared by {@link didPureExportSetGainOnlyOopsProvidedBy} and
+   * {@link didPureExportSetGrow}, which differ only in what comparison they
+   * need performed.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param buildComparisonExpression - Builds the Smalltalk boolean
+   *   expression to evaluate, given the "before" snapshot's temp name, the
+   *   "after" snapshot's temp name, and `callback`'s return value.
+   * @param callback - The operation to observe.
    * @throws {GciLibraryError} If either of the snapshot expressions signals a
    *   GCI error.
    */
-  public didPureExportSetGainOnlyOopsProvidedBy(session: unknown, expectedOopsProvider: (snapshotName: string) => bigint[]) {
+  private checkAgainstPureExportSetSnapshot<T>(session: unknown,
+                    buildComparisonExpression: (previousSnapshotName: string, currentSnapshotName: string, callbackResult: T) => string,
+                    callback: (snapshotName: string) => T) {
     const takePureExportSetSnapshotExpression = '(GsBitmap newForHiddenSet: #PureExportSet) asArray';
     const snapshotName = this.storeInUniqueUserGlobalsKey(session, takePureExportSetSnapshotExpression);
-    
-    let expectedAddedOops: bigint[];
+
+    let callbackResult: T;
     try {
-      expectedAddedOops = expectedOopsProvider(snapshotName);
+      callbackResult = callback(snapshotName);
     } catch (error) {
       // The snippet below hasn't run yet, so the 'before' snapshot is still
       // sitting in UserGlobals under snapshotName -- clean it up before
-      // re-throwing. If expectedOopsProvider already removed it itself,
-      // this second removal fails too; that's fine, the original error is
-      // what matters here.
+      // re-throwing. If callback already removed it itself, this second
+      // removal fails too; that's fine, the original error is what matters
+      // here.
       try {
-        this.executeDiscardingResult(session, `UserGlobals removeKey: ${snapshotName}`);
+        this.removeKeyFromUserGlobals(session, snapshotName);
       } catch (cleanupError) {
         console.warn(`Failed to clean up UserGlobals key '${snapshotName}' after callback error:`, cleanupError);
       }
       throw error;
     }
 
-    const expectedAddedObjectsExpression = `{ ${expectedAddedOops.map(oop => `Object objectForOop: ${oop}`).join('. ')} }`;
-
     // No try/catch needed below: removeKey: is the snippet's first
     // statement, so by the time anything here could fail, the snapshot key
     // is already gone -- either removed successfully, or the removeKey:
     // itself is what's failing, meaning there was never anything to clean up.
-    const pureExportSetGainedOnlyTheExpectedOops = this.execute(session, `
+    const comparisonResult = this.execute(session, `
         | previousSnapshot currentSnapshot |
 
         "Grab the 'before' snapshot we stashed in UserGlobals, and remove it
         now that we're done with it -- it was only needed for this check."
         previousSnapshot := UserGlobals removeKey: ${snapshotName}.
 
-        "Take an 'after' snapshot of the PureExportSet, now that
-        expectedOopsProvider has run."
+        "Take an 'after' snapshot of the PureExportSet, now that callback has run."
         currentSnapshot := ${takePureExportSetSnapshotExpression}.
 
-        "Compare as bags, not sequences -- a newly added oop can sort
-        anywhere in currentSnapshot, not just at the end. Bag equality
-        (rather than set) also catches a caller declaring an addition that
-        never actually happened, which set equality alone could mask if it
-        duplicated an oop already in previousSnapshot."
-        (previousSnapshot, ${expectedAddedObjectsExpression}) asIdentityBag = currentSnapshot asIdentityBag
+        ${buildComparisonExpression('previousSnapshot', 'currentSnapshot', callbackResult)}
     `);
 
-    return this.isTrueOop(pureExportSetGainedOnlyTheExpectedOops);
+    return this.isTrueOop(comparisonResult);
+  }
+
+  /**
+   * Returns whether `oop` is currently a member of the session's
+   * PureExportSet.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param oop - The oop to check for.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public isOopIncludedInPureExportSet(session: unknown, oop: bigint) {
+    return this.isTrueOop(
+        this.execute(session, `(GsBitmap newForHiddenSet: #PureExportSet) includes: (Object objectForOop: ${oop})`)
+    );
   }
 
   // ---------------------------------------------------------------------
@@ -2234,6 +2291,31 @@ export class GciLibrary {
     return keyExpression;
   }
 
+  /**
+   * Returns the value stored under `keyExpression` in `UserGlobals`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param keyExpression - A Smalltalk expression evaluating to the key to
+   *   look up (e.g. a symbol literal such as `#Key_12345`).
+   * @returns The oop of the value stored under `keyExpression`.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public valueOfUserGlobalsKey(session: unknown, keyExpression: string) {
+    return this.execute(session, `UserGlobals at: ${keyExpression}`);
+  }
+
+  /**
+   * Removes the entry for `keyExpression` from `UserGlobals`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param keyExpression - A Smalltalk expression evaluating to the key to
+   *   remove (e.g. a symbol literal such as `#Key_12345`).
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public removeKeyFromUserGlobals(session: unknown, keyExpression: string) {
+    this.executeDiscardingResult(session, `UserGlobals removeKey: ${keyExpression}`);
+  }
+
   // ---------------------------------------------------------------------
   // SessionTemps management
   // ---------------------------------------------------------------------
@@ -2246,6 +2328,50 @@ export class GciLibrary {
    */
   public resetSessionTemps(session: unknown) {
     this.executeDiscardingResult(session, `SessionTemps current removeAllKeys`);
+  }
+
+  /**
+   * Evaluates `valueExpression` and stores its result under a fresh key (see
+   * {@link nextKey}) in the session's SessionTemps dictionary.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param valueExpression - A Smalltalk expression evaluating to the value
+   *   to store.
+   * @returns The Smalltalk symbol literal used as the key.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public storeInUniqueSessionTempsKey(session: unknown, valueExpression: string) {
+    const key = this.nextKey();
+
+    this.executeDiscardingResult(session, `SessionTemps current at: ${key} put: ${valueExpression}`);
+
+    return key;
+  }
+
+  /**
+   * Returns whether the session's SessionTemps dictionary is empty.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public isSessionTempsEmpty(session: unknown) {
+    return this.isTrueOop(
+        this.execute(session, 'SessionTemps current isEmpty')
+    )
+  }
+
+  /**
+   * Returns the value stored under `keyExpression` in the session's
+   * SessionTemps dictionary.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param keyExpression - A Smalltalk expression evaluating to the key to
+   *   look up (e.g. a symbol literal such as `#Key_12345`).
+   * @returns The oop of the value stored under `keyExpression`.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public valueOfSessionTempsKey(session: unknown, keyExpression: string) {
+    return this.execute(session, `SessionTemps current at: ${keyExpression}`)
   }
 
   // ---------------------------------------------------------------------

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -1,5 +1,7 @@
 import koffi from 'koffi';
 import * as path from 'path';
+import {OOP_ILLEGAL, OOP_NIL, OOP_TRUE} from "./gciConstants";
+import {GciLibraryError} from "./gciLibraryError";
 
 // OopType is uint64_t in C; koffi maps this to BigInt in JS
 const OopType = 'uint64';
@@ -148,6 +150,37 @@ function toBigInt(value: number | bigint): bigint {
   return typeof value === 'bigint' ? value : BigInt(value);
 }
 
+/**
+ * FFI bindings to GemStone's native `libgcits` shared library, loaded via koffi.
+ * All GemStone VM calls go through this class.
+ *
+ * Two tiers of methods:
+ * - Raw `GciTsXxx` methods (e.g. `GciTsExecute`, `GciTsLogin`) are thin 1:1
+ *   wrappers around the C functions of the same name — one per exported
+ *   symbol, following the struct/pointer patterns already established below.
+ * - The remaining methods (grouped into labeled sections further down: Session
+ *   lifecycle, Code execution, Symbol resolution & Utf8 caching, Object
+ *   lifecycle & PureExportSet, UserGlobals/SessionTemps management, OOP
+ *   predicates) are an ergonomic layer on top: they call one or more
+ *   `GciTsXxx` methods, throw {@link GciLibraryError} on failure instead of
+ *   returning a `{success, err}`/`{result, err}` pair, and give the raw calls
+ *   memorable names and typed parameters.
+ *
+ * Recurring GemStone vocabulary used throughout this file's JSDoc:
+ * - **OOP** — the 64-bit handle GemStone uses to reference an object across
+ *   the GCI boundary.
+ * - **PureExportSet** — a session-level set of OOPs the GCI layer pins so
+ *   they aren't garbage-collected before the client is done with them. Most
+ *   calls that hand back a new OOP add it here; callers release entries via
+ *   {@link releaseObject} / {@link releaseAllObjects} once done.
+ * - **SessionTemps** / **UserGlobals** — two session-level dictionaries for
+ *   stashing values between GCI calls. SessionTemps is GemStone's own
+ *   built-in temp store; UserGlobals is this codebase's convention for
+ *   values that need to survive a commit/abort (SessionTemps does not).
+ * - **symbol list** — the ordered set of dictionaries (UserGlobals, Globals,
+ *   Published) GemStone searches to resolve a name, e.g. via
+ *   {@link resolveSymbol} or `Smalltalk at: #someSymbol`.
+ */
 export class GciLibrary {
   private lib: koffi.IKoffiLib;
   private _netldiLib: koffi.IKoffiLib | undefined;
@@ -774,6 +807,9 @@ export class GciLibrary {
   GciTsLogout(session: unknown): { success: boolean; err: GciError } {
     const err: Record<string, unknown> = {};
     const result = this._GciTsLogout(session, err);
+    // TODO: cache cleanup lives here temporarily; move into a `logout()`
+    // ergonomic method once call sites are migrated off GciTsLogout directly.
+    this.deleteCachedUtf8OopFor(session);
     return {
       success: result !== 0,
       err: err as unknown as GciError,
@@ -1794,4 +1830,488 @@ export class GciLibrary {
   close(): void {
     this.lib.unload();
   }
+
+  // ---------------------------------------------------------------------
+  // Session lifecycle
+  // ---------------------------------------------------------------------
+
+  /**
+   * Logs into a GemStone stone and returns the resulting session.
+   *
+   * `HostUserId`/`HostPassword` are not exposed by this overload — the gem
+   * process runs as the netldi process's user. Login flags and
+   * `haltOnErrNum` are left at their defaults (see `GciTsLogin` in
+   * `gcits.hf` for what they control).
+   *
+   * @param stoneNrs - The NRS of the stone to log into.
+   * @param gemServiceNrs - The NRS of the gem service to use.
+   * @param gemstoneUsername - The GemStone user to log in as.
+   * @param gemstonePassword - The GemStone user's password, in plaintext.
+   * @returns The new session.
+   * @throws {GciLibraryError} If login fails (no session was created). A
+   *   successful login that still carries a non-fatal warning is logged via
+   *   `console.warn` rather than thrown.
+   */
+  public login(stoneNrs: string, gemServiceNrs: string, gemstoneUsername: string, gemstonePassword: string) {
+    const {session, err} = this.GciTsLogin(
+        stoneNrs,
+        null,
+        null,
+        false,
+        gemServiceNrs,
+        gemstoneUsername,
+        gemstonePassword,
+        0,
+        0,
+    );
+
+    this.throwUnless(session !== null, err);
+    
+    // A non-NULL session means login succeeded, but *err may still carry a
+    // non-fatal warning (per GciTsLogin in gcits.hf) — log it, don't fail.
+    if (err.number !== 0) {
+      console.warn(`GciTsLogin warning [${err.number}]: ${err.message}`);
+    }
+
+    return session;
+  }
+
+  /**
+   * Logs out `session`. Failures are logged via `console.warn` rather than
+   * thrown — the session is gone regardless, and a teardown error would
+   * obscure real test failures above it.
+   *
+   * @param session - The GemStone session to log out.
+   */
+  public logout(session: unknown) {
+    const {success, err} = this.GciTsLogout(session);
+    // Warn rather than throw — the session is gone regardless, and a
+    // teardown error would obscure real test failures above it.
+    if (!success) console.warn(`GciTsLogout failed [${err.number}]: ${err.message}`);
+
+  }
+
+  /**
+   * Begins a new transaction on `session`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public beginTransaction(session: unknown) {
+    const {success, err} = this.GciTsBegin(session);
+
+    this.throwUnless(success, err);
+  }
+
+  /**
+   * Aborts the current transaction on `session`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public abortTransaction(session: unknown) {
+    const { success, err } = this.GciTsAbort(session);
+
+    this.throwUnless(success, err);
+  }
+
+  // ---------------------------------------------------------------------
+  // Code execution
+  // ---------------------------------------------------------------------
+
+  /**
+   * Evaluates Smalltalk code in the current session and returns the OOP of the
+   * result.
+   *
+   * The code is compiled as an anonymous method: `self` is `nil` and there is
+   * no receiver object. Names are resolved against the user's symbol list
+   * (UserGlobals, Globals, and Published). Code runs in environment 0 (the
+   * default GemStone environment). If the code contains multiple statements
+   * separated by `.`, the value of the last statement is returned.
+   *
+   * The result OOP is retained in the session's PureExportSet — the caller is
+   * responsible for releasing it when no longer needed.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param code - Smalltalk source to evaluate.
+   * @returns The OOP of the result object.
+   * @throws {GciLibraryError} If the evaluated code signals an error, or if
+   *   the underlying GCI call fails.
+   */
+  public execute(session: unknown, code: string) {
+      const { result, err } = this.GciTsExecute(
+          session, code, this.utf8ClassOop(session), OOP_ILLEGAL, OOP_NIL, 0, 0,
+      );
+
+      this.throwOnIllegalOop(result, err);
+
+      return result;
+  }
+
+  /**
+   * Evaluates `code` for effect, discarding its result.
+   *
+   * Appends an explicit `nil` as the final statement so `execute`'s result
+   * OOP is nil — a special object that is never added to the PureExportSet —
+   * instead of retaining `code`'s own result there indefinitely.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param code - Smalltalk source to evaluate.
+   * @throws {GciLibraryError} If the evaluated code signals an error, or if
+   *   the underlying GCI call fails.
+   */
+  public executeDiscardingResult(session: unknown, code: string) {
+    this.execute(session, `[ ${code} ] value. nil`);
+  }
+
+  // ---------------------------------------------------------------------
+  // Symbol resolution & Utf8 caching
+  // ---------------------------------------------------------------------
+
+  private _utfCache: Map<unknown, bigint> = new Map<unknown, bigint>();
+
+  /**
+   * Returns the OOP of the `Utf8` class — see {@link resolveSymbol} for
+   * error behavior. Cached per session: only resolves via a GCI round-trip
+   * the first time it's called for a given session. Call
+   * {@link releaseCachedSymbolOops} to release the cached oop and clear the
+   * cache for a session.
+   *
+   * `Utf8` is used as the source class when compiling code via {@link execute}:
+   * it causes the compiler to treat string literals as UTF-8 strings rather
+   * than single-byte strings.
+   */
+  public utf8ClassOop(session: unknown) {
+    const cachedOop = this.cachedUtf8OopFor(session);
+    if (cachedOop) return cachedOop;
+
+    const resolvedOop = this.resolveSymbol(session, 'Utf8');
+    this._utfCache.set(session, resolvedOop);
+
+    return resolvedOop;
+  }
+
+  /**
+   * Resolves a symbol name to its OOP using the user's symbol list
+   * (UserGlobals, Globals, and Published).
+   *
+   * Equivalent to evaluating `Smalltalk at: #symbol` in GemStone. This method
+   * does not cache (`Utf8` is the one exception: it's cached separately by
+   * {@link utf8ClassOop}).
+   *
+   * Goes through `createString` + `GciTsResolveSymbolObj` + `releaseObject`
+   * (three GCI round-trips) rather than the single-call `GciTsResolveSymbol`
+   * (which takes the name as a raw C string). `GciTsResolveSymbol` has a
+   * known memory leak that the GemStone team is currently investigating —
+   * use this slower path until that's fixed. See TODO.md.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param symbolName - The name to resolve (e.g. `'Object'`, `'Utf8'`).
+   * @returns The OOP of the object the symbol resolves to.
+   * @throws {GciLibraryError} If the symbol is not found in the user's symbol
+   *   list, or if the underlying GCI call fails.
+   */
+  public resolveSymbol(session: unknown, symbolName: string) {
+    const symbolNameOop = this.createString(session, symbolName);
+
+    try {
+      const {result, err} = this.GciTsResolveSymbolObj(session, symbolNameOop, OOP_NIL);
+
+      this.throwOnIllegalOop(result, err);
+
+      return result;
+    } finally {
+      // Swallow release failures here -- letting one replace an in-flight
+      // resolve error (or mask a successful resolve) would hide the result
+      // that actually matters to the caller.
+      try {
+        this.releaseObject(session, symbolNameOop);
+      } catch (releaseError) {
+        console.warn(`Failed to release symbol name oop for '${symbolName}':`, releaseError);
+      }
+    }
+  }
+
+  /**
+   * Creates a GemStone String object from `contents`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param contents - The string contents to create.
+   * @returns The OOP of the newly created String object.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public createString(session: unknown, contents: string){
+    const {result, err} = this.GciTsNewString(session, contents);
+
+    this.throwOnIllegalOop(result, err);
+
+    return result;
+  }
+
+  /** Returns the cached `Utf8` class oop for `session`, or `undefined` if none is cached. */
+  public cachedUtf8OopFor(session: unknown) {
+    return this._utfCache.get(session);
+  }
+
+  /** Removes the cached `Utf8` class oop for `session`, without releasing it. */
+  private deleteCachedUtf8OopFor(session: unknown) {
+    this._utfCache.delete(session);
+  }
+
+  /**
+   * Releases the session's cached `Utf8` class oop (see {@link utf8ClassOop})
+   * from the PureExportSet and clears it from the cache. A no-op if nothing
+   * is cached for `session`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If releasing the cached oop fails.
+   */
+  public releaseCachedSymbolOops(session: unknown) {
+    const cachedOop = this.cachedUtf8OopFor(session);
+    if (!cachedOop) return;
+
+    this.releaseObject(session, cachedOop);
+    this.deleteCachedUtf8OopFor(session);
+  }
+
+  // ---------------------------------------------------------------------
+  // Object lifecycle & PureExportSet
+  // ---------------------------------------------------------------------
+
+  /**
+   * Releases a single oop from the session's PureExportSet.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param oop - The oop to release.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public releaseObject(session: unknown, oop: bigint) {
+    const {success, err} = this.GciTsReleaseObjs(session, [oop]);
+
+    this.throwUnless(success, err);
+  }
+
+  /**
+   * Releases every oop in the session's PureExportSet.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public releaseAllObjects(session: unknown) {
+    const {success, err} = this.GciTsReleaseAllObjs(session);
+
+    this.throwUnless(success, err);
+  }
+
+  /**
+   * Runs `expectedOopsProvider` and returns whether the session's
+   * PureExportSet ended up containing exactly its prior contents plus the
+   * oops `expectedOopsProvider` declares -- nothing removed, replaced, or
+   * added beyond that. Order does not matter: PureExportSet is a set, and
+   * newly added oops are not guaranteed to sort after existing members (oop
+   * values are not allocated in increasing order).
+   *
+   * Takes a snapshot of the PureExportSet (as an Array) before invoking
+   * `expectedOopsProvider`, then compares it to the PureExportSet
+   * afterwards. `expectedOopsProvider` returns the oops it expects to have
+   * added; this returns `true` only if the "after" snapshot, compared as a
+   * bag (so a duplicate can't mask a missing or extra oop), is exactly the
+   * "before" snapshot plus precisely those oops. Anything else -- oops
+   * removed or replaced, or actual additions that don't match what
+   * `expectedOopsProvider` declared (including declaring additions that
+   * never happened) -- returns `false`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param expectedOopsProvider - The operation to observe. Returns the oops
+   *   it expects to have added to the PureExportSet (an empty array if it
+   *   expects none).
+   * @returns `true` if the PureExportSet gained only the oops
+   *   `expectedOopsProvider` declared, `false` otherwise.
+   * @throws {GciLibraryError} If either of the snapshot expressions signals a
+   *   GCI error.
+   */
+  public didPureExportSetGainOnlyOopsProvidedBy(session: unknown, expectedOopsProvider: (snapshotName: string) => bigint[]) {
+    const takePureExportSetSnapshotExpression = '(GsBitmap newForHiddenSet: #PureExportSet) asArray';
+    const snapshotName = this.storeInUniqueUserGlobalsKey(session, takePureExportSetSnapshotExpression);
+    
+    let expectedAddedOops: bigint[];
+    try {
+      expectedAddedOops = expectedOopsProvider(snapshotName);
+    } catch (error) {
+      // The snippet below hasn't run yet, so the 'before' snapshot is still
+      // sitting in UserGlobals under snapshotName -- clean it up before
+      // re-throwing. If expectedOopsProvider already removed it itself,
+      // this second removal fails too; that's fine, the original error is
+      // what matters here.
+      try {
+        this.executeDiscardingResult(session, `UserGlobals removeKey: ${snapshotName}`);
+      } catch (cleanupError) {
+        console.warn(`Failed to clean up UserGlobals key '${snapshotName}' after callback error:`, cleanupError);
+      }
+      throw error;
+    }
+
+    const expectedAddedObjectsExpression = `{ ${expectedAddedOops.map(oop => `Object objectForOop: ${oop}`).join('. ')} }`;
+
+    // No try/catch needed below: removeKey: is the snippet's first
+    // statement, so by the time anything here could fail, the snapshot key
+    // is already gone -- either removed successfully, or the removeKey:
+    // itself is what's failing, meaning there was never anything to clean up.
+    const pureExportSetGainedOnlyTheExpectedOops = this.execute(session, `
+        | previousSnapshot currentSnapshot |
+
+        "Grab the 'before' snapshot we stashed in UserGlobals, and remove it
+        now that we're done with it -- it was only needed for this check."
+        previousSnapshot := UserGlobals removeKey: ${snapshotName}.
+
+        "Take an 'after' snapshot of the PureExportSet, now that
+        expectedOopsProvider has run."
+        currentSnapshot := ${takePureExportSetSnapshotExpression}.
+
+        "Compare as bags, not sequences -- a newly added oop can sort
+        anywhere in currentSnapshot, not just at the end. Bag equality
+        (rather than set) also catches a caller declaring an addition that
+        never actually happened, which set equality alone could mask if it
+        duplicated an oop already in previousSnapshot."
+        (previousSnapshot, ${expectedAddedObjectsExpression}) asIdentityBag = currentSnapshot asIdentityBag
+    `);
+
+    return this.isTrueOop(pureExportSetGainedOnlyTheExpectedOops);
+  }
+
+  // ---------------------------------------------------------------------
+  // UserGlobals management
+  // ---------------------------------------------------------------------
+
+  private uniqueKeyCounter = 0n;
+
+  /**
+   * Returns a Smalltalk symbol literal (e.g. `#Key_12345`) guaranteed not to
+   * already be in use as a key in the caller's chosen dictionary (typically
+   * `UserGlobals` or `SessionTemps`).
+   */
+  public nextUniqueKey(): string {
+    return `#Key_${this.uniqueKeyCounter++}`;
+  }
+
+  /**
+   * Returns whether `UserGlobals` already has an entry for `keyExpression`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param keyExpression - A Smalltalk expression evaluating to the key to
+   *   look up (e.g. a symbol literal such as `#Key_12345`).
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public isIncludedInUserGlobals(session: unknown, keyExpression: string) {
+    return this.isTrueOop(
+        this.execute(session, `UserGlobals includesKey: ${keyExpression}`)
+    );
+  }
+
+  /**
+   * Evaluates `valueExpression` and stores its result under a fresh key (see
+   * {@link nextUniqueKey}) in `UserGlobals`.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param valueExpression - A Smalltalk expression evaluating to the value
+   *   to store.
+   * @returns The Smalltalk symbol literal used as the key.
+   * @throws {GciLibraryError} If the generated key is already in use, or if
+   *   the underlying GCI call fails.
+   */
+  public storeInUniqueUserGlobalsKey(session: unknown, valueExpression: string) {
+    const keyExpression = this.nextUniqueKey();
+
+    this.executeDiscardingResult(session, `
+      (UserGlobals includesKey: ${keyExpression})
+        ifTrue: [ self error: 'Key is not unique' ].
+
+      UserGlobals at: ${keyExpression} put: ${valueExpression}
+    `);
+
+    return keyExpression;
+  }
+
+  // ---------------------------------------------------------------------
+  // SessionTemps management
+  // ---------------------------------------------------------------------
+
+  /**
+   * Removes every key from the session's SessionTemps dictionary.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public resetSessionTemps(session: unknown) {
+    this.executeDiscardingResult(session, `SessionTemps current removeAllKeys`);
+  }
+
+  // ---------------------------------------------------------------------
+  // OOP predicates
+  // ---------------------------------------------------------------------
+
+  /**
+   * Returns whether `oop` is `OOP_ILLEGAL` — the GCI sentinel used to signal
+   * that a call produced no valid result (symbol not found, error, etc.).
+   */
+  private isIllegalOop(oop: bigint) {
+    return OOP_ILLEGAL === oop;
+  }
+
+  /** Returns whether `oop` is the OOP of GemStone's `nil` singleton. */
+  public isNilOop(oop: bigint) {
+    return OOP_NIL === oop;
+  }
+
+  /** Returns whether `oop` is the OOP of GemStone's `true` singleton. */
+  public isTrueOop(oop: bigint) {
+    return OOP_TRUE === oop;
+  }
+
+  // ---------------------------------------------------------------------
+  // Error handling helpers
+  // ---------------------------------------------------------------------
+
+  /** Throws a {@link GciLibraryError} built from `error` unless `condition` is true. */
+  private throwUnless(condition: boolean, error: GciError) {
+    if (!condition) {
+      throw GciLibraryError.fromGciError(error);
+    }
+  }
+
+  /** Throws a {@link GciLibraryError} built from `err` if `result` is `OOP_ILLEGAL`. */
+  private throwOnIllegalOop(result: bigint, err: GciError) {
+    if (this.isIllegalOop(result)) {
+      throw GciLibraryError.fromGciError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Session reset
+  // ---------------------------------------------------------------------
+
+  /**
+   * Resets `session`'s non-transactional state — empties `SessionTemps`,
+   * releases the cached `Utf8` class oop, and releases everything remaining
+   * in the PureExportSet. Intended for use between tests (or any other point
+   * where a session needs to look freshly logged-in), alongside — but
+   * independent of — transaction cleanup: `SessionTemps` and the
+   * PureExportSet are session-level GCI structures that survive commit/abort,
+   * so this method does not touch the current transaction; callers that also
+   * need a clean transaction should abort it themselves, before calling this.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If any of the underlying GCI calls fail.
+   */
+  public resetNonTransactionalSessionState(session: unknown) {
+    // Order matters: resetSessionTemps evaluates code, which re-resolves (and
+    // re-caches) the Utf8 class oop as a side effect if it isn't already
+    // cached, so it must run before releaseCachedSymbolOops clears that
+    // cache. releaseAllObjects must run last so it sweeps up whatever that
+    // re-resolution just added to the PureExportSet.
+    this.resetSessionTemps(session);
+    this.releaseCachedSymbolOops(session);
+    this.releaseAllObjects(session);
+  }
 }
+

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -2183,15 +2183,17 @@ export class GciLibrary {
   // UserGlobals management
   // ---------------------------------------------------------------------
 
-  private uniqueKeyCounter = 0n;
+  private keyCounter = 0n;
 
   /**
-   * Returns a Smalltalk symbol literal (e.g. `#Key_12345`) guaranteed not to
-   * already be in use as a key in the caller's chosen dictionary (typically
-   * `UserGlobals` or `SessionTemps`).
+   * Returns a Smalltalk symbol literal (e.g. `#Key_12345`), unique among the
+   * keys returned by this method for this `GciLibrary` instance. This does
+   * *not* guarantee the key is unused in any particular dictionary (e.g.
+   * `UserGlobals` or `SessionTemps`) -- callers needing that guarantee must
+   * check for themselves (see {@link storeInUniqueUserGlobalsKey}).
    */
-  public nextUniqueKey(): string {
-    return `#Key_${this.uniqueKeyCounter++}`;
+  public nextKey(): string {
+    return `#Key_${this.keyCounter++}`;
   }
 
   /**
@@ -2210,7 +2212,7 @@ export class GciLibrary {
 
   /**
    * Evaluates `valueExpression` and stores its result under a fresh key (see
-   * {@link nextUniqueKey}) in `UserGlobals`.
+   * {@link nextKey}) in `UserGlobals`.
    *
    * @param session - The GemStone session to operate in.
    * @param valueExpression - A Smalltalk expression evaluating to the value
@@ -2220,7 +2222,7 @@ export class GciLibrary {
    *   the underlying GCI call fails.
    */
   public storeInUniqueUserGlobalsKey(session: unknown, valueExpression: string) {
-    const keyExpression = this.nextUniqueKey();
+    const keyExpression = this.nextKey();
 
     this.executeDiscardingResult(session, `
       (UserGlobals includesKey: ${keyExpression})

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -2049,7 +2049,7 @@ export class GciLibrary {
   }
 
   /** Returns the cached `Utf8` class oop for `session`, or `undefined` if none is cached. */
-  public cachedUtf8OopFor(session: unknown) {
+  private cachedUtf8OopFor(session: unknown) {
     return this._utfCache.get(session);
   }
 

--- a/client/src/gciLibraryError.ts
+++ b/client/src/gciLibraryError.ts
@@ -1,0 +1,26 @@
+import {GciError} from "./gciLibrary";
+
+/**
+ * Thrown by {@link GciLibrary} when it cannot complete an operation.
+ *
+ * The cause may be a communication failure with GemStone, a failed
+ * validation, or any other reason — the underlying GCI implementation is
+ * intentionally not exposed. Callers can use `instanceof GciLibraryError` to
+ * distinguish these failures from unrelated JavaScript errors.
+ */
+export class GciLibraryError extends Error {
+
+    /** Builds a {@link GciLibraryError} from a GCI error struct, using its message. */
+    static fromGciError(gciError: GciError) {
+        return this.withMessage(gciError.message);
+    }
+
+    /** Builds a {@link GciLibraryError} with a plain message, for failures that don't originate from a GCI call (e.g. a failed validation). */
+    static withMessage(message: string) {
+        return new GciLibraryError(message);
+    }
+
+    private constructor(message: string) {
+        super(message);
+    }
+}

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
           setupFiles: [
             'src/__tests__/vitest.windowSetup.cjs',
             'src/__tests__/vitest.uriSetup.ts',
+             'src/__tests__/vitest.customErrorMatchers.ts',
           ],
           sequence: {
             shuffle: true,


### PR DESCRIPTION
## Summary

- Adds an ergonomic layer on top of `GciLibrary`'s raw `GciTsXxx` FFI wrappers: `login`, `logout`, `execute`, `resolveSymbol`, `createString`, plus PureExportSet/UserGlobals/SessionTemps helpers. Each throws a new `GciLibraryError` instead of returning a raw `{success, err}`/`{result, err}` pair.
- Rewrites the integration-test harness (`useIntegrationTest`) to use these helpers, and fixes a real per-test cleanup gap in the process (see below).

**Before:** every call site that needed to log in, execute code, or resolve a symbol called the raw `GciTsXxx` functions directly and had to manually unwrap and check GCI's C-style `{success, err}` convention by hand. In the integration-test harness specifically, `afterEach` only called `GciTsAbort` — which rolls back the transaction but doesn't touch the session's PureExportSet (pinned OOPs) or SessionTemps (session-scoped temp dictionary), since those live outside the transaction boundary. `GciTsReleaseAllObjs` already existed as a raw wrapper, but its only caller anywhere in the codebase was its own dedicated unit test — nothing cleared PureExportSet or SessionTemps between tests in a shared way, so a test that retained objects or wrote SessionTemps entries could leak that state into the next test in the same file. If a test author cared about this, they had to clean up manually.

**After:** `GciLibrary` exposes a second, integration-tested tier of methods that wrap the raw calls and throw `GciLibraryError` on failure. The test harness now calls a new `resetNonTransactionalSessionState` after every test's `afterEach`, which releases every PureExportSet oop, resets SessionTemps, and clears the new per-session `Utf8`-class-oop cache — automatically, for every test using this harness, with no per-test opt-in required. It also fails every subsequent test in a describe block immediately if that cleanup itself fails, rather than risk leaking state into later tests under this project's shuffled test order.

**New capabilities** (didn't exist before this PR):

- **Catchable, structured errors.** `GciLibraryError` lets callers write `instanceof GciLibraryError` to tell "GCI operation failed" apart from any other bug. Previously a raw call returned a `{success, err}` struct (nothing to catch), and the one place that already threw manually threw a plain `Error`, indistinguishable from any other exception.
- **Tests can exercise login failure and logout, mid-suite.** `GciTestContext` now exposes `login(options)` and `logout()` to individual tests, with the harness auto-recovering if a test logs out and a later one needs a session. Previously `useIntegrationTest` logged in exactly once in `beforeAll` for the whole file, so there was no supported way to test invalid credentials or logout behavior.
- **A regression-detection primitive for oop leaks.** `didPureExportSetGainOnlyOopsProvidedBy` snapshots the PureExportSet before/after an operation and asserts it changed by exactly the oops declared — nothing extra, nothing missing. There was no shared way to make that assertion before.

**Not used yet:** this layer isn't wired into any production call site in this PR — `sessionManager.ts`, `debugQueries.ts`, and others still call the raw GCI functions directly. The next PR will use these primitives to implement the UTF8 fix (production code currently calls `execute` with no UTF8 class oop, so it can't handle non-Latin1 source) and, as a side effect, will start actually benefiting from `execute()`'s Utf8-class-oop caching. This PR is just the tested groundwork it depends on.

## Test plan

- [x] `npm run compile`
- [x] `npm test` against a live GemStone test stone (31/31 new tests passing)