### PR TITLE
Restore CLAUDE.md improvements lost in merge conflict, add context-file maintenance harness

### DIFF
--- a/.claude/hooks/context-contract.md
+++ b/.claude/hooks/context-contract.md
@@ -1,0 +1,61 @@
+This file is loaded automatically, *only* when you are about to edit a context
+file (a `CLAUDE.md` or a `.claude/rules/*.md`). It is the contract for such
+edits — read it before writing the change.
+
+## Whether it belongs (inclusion)
+
+Litmus test: would a fresh session need this *before* touching code, and will
+it still be true in a month? If not, it doesn't belong here.
+
+- Fixes, incident write-ups, and "what I just did" summaries belong in commit
+  messages and PR descriptions, not in context files — git history is
+  authoritative for what changed and why.
+- State stable rules once, tersely. Don't restate what the code already makes
+  obvious to a careful reader.
+- No duplication: link to the single source of truth instead of inlining a
+  copy that will drift out of sync.
+- Prefer replacing an existing line with a corrected one over appending a new
+  paragraph next to it.
+- **Exception — don't over-extract.** A rule needed to read the code
+  correctly on first contact, or a prerequisite whose violation corrupts any
+  debugging session (e.g. "you must run against the patched dependency or
+  failures are misleading"), stays inline even though it's short-lived-looking
+  or narrow. Moving it out just to hit a smaller file is the failure mode in
+  the opposite direction — don't do that either.
+
+## Where it belongs (placement)
+
+Decide *before* adding. Push content DOWN (toward the subtree it governs) and
+OUT (toward the most deterministic mechanism that fits), in this order:
+
+1. **Applies to one subtree** (`client/` or `server/`) → that subtree's own
+   `CLAUDE.md`, not the root one.
+2. **Applies to a path or file-type pattern** → a `.claude/rules/*.md` with a
+   `paths:` frontmatter glob, so it auto-loads only when a matching file is
+   opened. Not prose bolted onto a `CLAUDE.md`.
+3. **Is a multi-step procedure or workflow** → a skill, not a paragraph of
+   steps in a `CLAUDE.md`.
+4. **Is a deterministic "every time X, do Y" guardrail** → a hook (like this
+   one), not a prose instruction hoping the model remembers. Prose guardrails
+   fail under pressure; hooks don't.
+5. **Needed only during one kind of task** (e.g. packaging, acceptance
+   testing) → an on-demand doc, **task-named** (`adding-a-menu-entry.md`, not
+   `gotchas.md`), referenced from the relevant `CLAUDE.md`'s docs index by a
+   task- or symptom-keyed trigger ("hit `MessageNotUnderstood nil`? read X") —
+   never a bare "see also" link with no firing condition.
+6. **Stable, repo-wide, and needed before any work at all** → the top-level
+   `CLAUDE.md`. This is the last resort, not the default — every line here is
+   loaded into every session.
+
+## Map of the current structure
+
+- `CLAUDE.md` (root) — repo-wide, always loaded.
+- `client/CLAUDE.md`, `server/CLAUDE.md` — loaded when working in that
+  workspace.
+- `.claude/rules/tests.md` — repo-wide test rules, path-scoped to test files.
+- `.claude/rules/client/tests.md`, `.claude/rules/client/gci.md` — client-only
+  rules, path-scoped further within `client/`.
+
+If what you're adding doesn't clearly belong at the tier you're editing,
+prefer the more specific tier, or reconsider whether it's derivable from the
+code instead of documented at all.

--- a/.claude/hooks/context-file-guard.sh
+++ b/.claude/hooks/context-file-guard.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# PreToolUse hook: when an Edit/Write targets a context file (a CLAUDE.md or a
+# .claude/rules/*.md), inject the editing contract in .claude/hooks/context-contract.md
+# as additionalContext so the model sees it before making the change. No-op
+# (silent, exit 0) for every other file, and for anything that fails to parse.
+#
+set -euo pipefail
+
+input="$(cat)"
+
+file_path="$(node -e '
+  try {
+    const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+    process.stdout.write(data?.tool_input?.file_path || "");
+  } catch {
+    process.stdout.write("");
+  }
+' <<<"$input")"
+
+if [[ -z "$file_path" ]]; then
+  exit 0
+fi
+
+case "$file_path" in
+  */CLAUDE.md | CLAUDE.md | */.claude/rules/*.md)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+contract_path="$script_dir/context-contract.md"
+
+node -e '
+  const fs = require("fs");
+  const contractPath = process.argv[1];
+  const contract = fs.readFileSync(contractPath, "utf8");
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: contract,
+    },
+  }));
+' "$contract_path"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/context-file-guard.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tsconfig.tsbuildinfo
 # Only the curated dirs/files below are un-ignored and shared with the team —
 # opt a new one in by adding a `!` line once the team has agreed to adopt it.
 .claude/*
+!.claude/hooks/
 !.claude/rules/
 !.claude/skills/
 !.claude/commands/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,7 @@ npm run test:gci           # deep GCI binding tests (requires a running stone)
 npm run package          # produce .vsix package
 
 # Dev helpers
-npm run dev:fresh        # launch the extension in a throwaway editor window (see below)
-npm run serve:seaside    # start a Seaside server gem for the loaded hello app (see below)
+npm run dev:fresh        # launch the extension in a throwaway editor window
 
 # End-user acceptance tests (Playwright drives a real editor window; see acceptance/)
 npm run test:acceptance         # run the specs locally (opens a window — macOS can't headless it)
@@ -41,101 +40,6 @@ npm run test:acceptance:seaside # the Seaside Hello World e2e (install → serve
 npm run test:acceptance:report  # open the HTML report / flip through per-step screenshots
 ```
 
-### Running the extension in a clean slate
-
-`npm run dev:fresh [-- <folder>]` (`scripts/dev-fresh.sh`) launches the editor
-(`codium`, falling back to `code`) with `--extensionDevelopmentPath` pointing at
-this repo and throwaway `--user-data-dir`/`--extensions-dir` — **none of your
-personal settings, extensions, or login keychain** (`--password-store=basic`,
-the keychain-isolation flag the acceptance harness also needs). It compiles the
-extension first if `client/out` is missing; use `npm run watch` + Reload Window
-for a live loop. It does **not** isolate `gemstone.rootPath`, so it still sees
-your real GemStone installs (to connect).
-
-### Serving Seaside
-
-After loading Seaside + the `hello-seaside-rowan` project through Jasper, view
-the app two ways:
-
-- **From the editor:** the **GemStone: Serve Seaside** command
-  (`gemstone.serveSeaside` in `seasideServer.ts`) — spawns a detached serving
-  gem (`WAGsZincAdaptor startOn:` blocks, so it can't run in the GCI session) as
-  SystemUser and opens the URL in the integrated browser; **GemStone: Stop
-  Seaside Server** stops it.
-- **From the shell:** `npm run serve:seaside [-- <port> <stone>]` /
-  `npm run serve:seaside -- stop` (`scripts/serve-seaside.sh`) does the same
-  detached gem; then open `http://localhost:8383/hello` via the editor's
-  "Simple Browser: Show" command.
-
-Run a single test file: `cd client && npx vitest run src/__tests__/extension.test.ts` (or use the equivalent path for the workspace you're in).
-
-Tests run in a random order on every run. The seed is printed at the top of the output — to reproduce a specific run, pass `--sequence.seed=<seed>` to that workspace's vitest directly (e.g. `cd client && npx vitest run --sequence.seed=<seed>`).
-
-Before considering something done: `npm run compile && npm test` must pass. 
-`npm test` bundles an automatic integration test that logs into a live stone, 
-so run `npm run test:server:start` once first since without a running test stone, 
-running `npm test` will **hard-fails** (it does not skip).
-
-## Architecture
-
-### client workspace (`client/src/`)
-
-The extension entry point is `extension.ts` — it registers all commands, tree views, and language features, starts the LSP client and MCP socket server, and manages the active sessions.
-
-Key subsystems:
-- **GCI bridge** (`gciLibrary.ts`) — FFI bindings to the native `libgcits` shared library via [koffi](https://github.com/Koromix/koffi). All GemStone VM calls go through here.
-- **Queries** (`queries/`) — pure functions with the signature `(execute: QueryExecutor, ...args) => string`. Each builds a Smalltalk snippet and calls `execute(label, code)`. `QueryExecutor` is `(label: string, code: string) => string` — the caller supplies it, so the same query works in the extension (where the executor wraps `gciLibrary`) and in the MCP server (its own session). Helpers in `util.ts` (`escapeString`, `classLookupExpr`, etc.) are shared across queries.
-- **Views** — each major UI surface is its own module: `systemBrowser.ts`, `globalsBrowser.ts`, `gtInspector.ts`, `debuggerPanel.ts`, `classBrowser.ts`. They run in the extension host and communicate with their webview counterparts via `webview.postMessage()` / `window.addEventListener('message', ...)`.
-- **Webview scripts** (`debuggerView.js`, `listFilter.js`, `methodListView.js`) — plain JavaScript that runs in the webview (browser-like DOM), **not** compiled into the extension bundle. Each is read at runtime via `fs.readFileSync` and injected as a `<script>` tag. They expose globals (`DebuggerView`, `ListFilter`, etc.) consumed by the webview HTML. They live in separate files so they can be unit-tested in jsdom. New webview-side behavior should follow this pattern.
-- **Class sync** (`sync/`) — the incremental class-export engine used by `exportManager.ts`. `syncProtocol.ts` generates Smalltalk expressions that build a manifest and class-source payloads on the GemStone side; `syncTransport.ts` handles chunked streaming for payloads that exceed a single GCI response; `manifestDiff.ts` diffs the remote manifest against the local mirror to compute the minimal fetch/delete set; `syncFraming.ts` parses the manifest wire format.
-- **Session management** (`sessionManager.ts`) — tracks open GemStone login sessions; `codeExecutor.ts` is the central dispatcher for executing Smalltalk code in a session.
-- **Transcript sink** (`transcriptSink.ts`) — Jade-style server-side Transcript: at login a small class is compiled into the session (never committed, held via `SessionTemps`) and installed as the stream behind GemStone's `Transcript` global. In **live** mode (Execute/Display/Inspect It, notebook cells) each write reaches the client mid-execution as a ClientForwarder send (GCI error 2336) that `settleNbResult` displays in the "GemStone Transcript" output channel and resumes via an async `GciTsContinueWith`; everywhere else (queries, MCP tools, debugger stepping) writes **buffer** server-side and are drained after the call — the FetchBytes-family GCI calls cannot host a forwarder send.
-- **Infrastructure** (`versionManager.ts`, `databaseManager.ts`, `processManager.ts`, `sysadminStorage.ts`) — download/extract GemStone releases, manage stone/NetLDI processes, configure OS shared memory.
-- **MCP integration** (`mcpSocketServer.ts`, `mcpHttpServer.ts`, `mcpTools.ts`) — exposes GemStone operations via MCP so AI tools (Claude Desktop, Claude Code) can interact with a running GemStone session.
-- **Virtual file system** (`gemstoneFileSystemProvider.ts`) — implements `gemstone://` URIs so method source can be opened, edited, and compiled in-place.
-- **Debugger** (`gemstoneDebugSession.ts`, `debuggerPanel.ts`, `debugQueries.ts`) — DAP (Debug Adapter Protocol) implementation backed by GCI step/continue/inspect calls.
-- **WSL support** (`wslBridge.ts`, `wslFs.ts`) — transparent Windows ↔ WSL bridging for paths and process management.
-
-### server workspace (`server/src/`)
-
-A standard LSP server that parses Smalltalk source files (Topaz `.gs`/`.tpz`, Tonel `.st`, GemStone Smalltalk `.gst`) and provides:
-- **Lexer/Parser** (`lexer/`, `parser/`) — produces an AST for each document
-- **Services** (`services/`) — completion, hover, definition, diagnostics, folding, formatting, semantic tokens, document symbols — each is a standalone module operating on the AST
-- **Utilities** (`utils/`) — `DocumentManager` (LSP text-document lifecycle), `WorkspaceIndex` (cross-file symbol index), `ScopeAnalyzer`, `AstUtils`
-- Format-specific parsers: `tonel/tonelParser.ts` and `topaz/topazParser.ts`
-
-### mcp-server workspace (`mcp-server/src/`)
-
-A standalone Node.js process that can run as stdio, SSE, or proxy transport. `tools.ts` registers MCP tools; `mcpSession.ts` wraps a GCI session for AI tool calls. Used when Claude Code or Claude Desktop connects directly (as opposed to the in-extension MCP server).
-
-## Tests
-
-`client/src/__tests__/CLAUDE.md` contains the authoritative test authoring rules — read it before writing or editing tests.
-
-### VS Code API mocking (client workspace)
-
-The VS Code API is not available in tests. Vitest picks up `src/__mocks__/vscode.ts` automatically — it is a comprehensive manual mock of the `vscode` module. Any test that imports extension code which touches the VS Code API gets this mock for free; no explicit import or `vi.mock()` call is needed.
-
-The mock exposes two test helpers:
-- `__resetConfig()` — clears all stored configuration values; call this in `beforeEach` if your test uses `workspace.getConfiguration`.
-- `__setConfig(section, key, value)` — pre-seeds a config value before the test runs.
-
-The two vitest setup files (`vitest.windowSetup.cjs`, `vitest.uriSetup.ts`) run before every suite. The first polyfills `CSS.escape` for jsdom environments; the second registers a custom URI equality tester so `expect(uri).toEqual(otherUri)` compares by string value rather than object identity.
-
-Query functions in `queries/` take a `QueryExecutor` argument — in tests, pass a `vi.fn()` that returns a canned string. This avoids any GCI dependency for unit tests of query-dependent code.
-
-### Integration tests
-
-Tests using `useIntegrationTest` require a live GemStone instance. Run `npm run test:server:start` once to provision one; it writes connection details to `.env.test`. Override with `.env.test.local` for a custom instance. CI runs these as a matrix over `client/.gemstone-integration-releases.json`.
-
-`npm run test:gci` is a deeper suite that tests the GCI native library bindings directly (`client/src/__tests__/gci/**`). It is defined as a separate vitest project named `gci` (in `client/vitest.config.ts`) and is excluded from `npm test` (which runs the `unit` project); run it on demand with `npm run test:gci` (which passes `--project gci`). Like the automatic integration tests, it reads its connection from `.env.test` (`VITE_GEMSTONE_*`) via `client/src/__tests__/gci/gciTestConfig.ts`, so `npm run test:server:start` is enough to run it; plain `GCI_LIBRARY_PATH` / `GS_*` shell variables are honored as a fallback for a custom stone. It needs a running stone at localhost. Only needed when working on the GCI bindings layer (`gciLibrary.ts`).
-
-## GCI / native library
-
-The GCI library (`libgcits`) is a platform-native `.so`/`.dylib`/`.dll` bundled with each GemStone distribution. `gciLibrary.ts` loads it at runtime via koffi. When adding new GCI calls, follow the struct and pointer patterns already in that file.
-
-## GemStone documentation
-
-`docs/3.7/` contains the GCI header files (`gcits.hf`, `gci.ht`, `gcicmn.ht`, `gcits.ht`) — the authoritative reference for GCI function signatures, struct layouts, and constants. Consult these when working with `gciLibrary.ts` or any GCI call.
+Before considering something done: `npm run compile && npm test` must pass. `npm test` bundles an automatic integration test that logs into a live stone, so run `npm run test:server:start` once first — without a running test stone `npm test` **hard-fails** (it does not skip).
 
 <!-- Maintainer note (stripped from agent context): Be careful with the edits to this file, anything included here will be auto-loaded in the context for ALL conversations. Keep only the most relevant and non-obvious details that are needed on all conversations. And only details that agents won't typically auto-discover by browsing the code -->

--- a/acceptance/CLAUDE.md
+++ b/acceptance/CLAUDE.md
@@ -1,0 +1,9 @@
+# Acceptance tests (Playwright)
+
+End-to-end tests that drive a real VS Code window via Playwright's Electron support — see [README.md](README.md) for how to run them (docker vs. local), flip through trace screenshots, and current scope. They are **not** part of `npm test`; specs live in `tests/*.spec.ts`, not `*.test.ts`, so the repo-wide `.claude/rules/tests.md` naming/structure conventions do **not** auto-load for these files — Playwright's own `test.describe`/`test` idioms apply instead.
+
+- `helpers/vscode.ts` — downloads a pinned VS Code build and launches it with this repo as the extension-development path.
+- `helpers/testStone.ts` / `helpers/containerStone.ts` — provision the GemStone stone a spec connects to (local vs. in-container).
+- `helpers/rowan.ts`, `helpers/seaside.ts` — scenario-specific setup for the Rowan load and Seaside serve e2e flows.
+
+<!-- Maintainer note (stripped from agent context): keep this file a pointer to README.md, not a duplicate of it — README is the human-facing usage doc, this is what an agent needs before touching acceptance/ code. -->

--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -4,6 +4,10 @@
 
 Run a single test file: `cd client && npx vitest run src/__tests__/extension.test.ts`.
 
+## Manual dev workflow
+
+`npm run dev:fresh [-- <folder>]` (`scripts/dev-fresh.sh`) launches the editor (`codium`, falling back to `code`) with `--extensionDevelopmentPath` pointing at this repo and throwaway `--user-data-dir`/`--extensions-dir` — **none of your personal settings, extensions, or login keychain** (`--password-store=basic`, the keychain-isolation flag the acceptance harness also needs). It compiles the extension first if `client/out` is missing; use `npm run watch` + Reload Window for a live loop. It does **not** isolate `gemstone.rootPath`, so it still sees your real GemStone installs (to connect).
+
 ## Conventions (non-standard — read before editing these areas)
 
 - **Queries** (`client/src/queries/`) are pure functions `(execute: QueryExecutor, ...args) => string` that build a Smalltalk snippet and call `execute(label, code)`. `QueryExecutor` is `(label: string, code: string) => string`, supplied by the caller, so the same query runs in the extension (executor wraps `gciLibrary`) and in the MCP server (its own session). Shared helpers live in `util.ts` (`escapeString`, `classLookupExpr`, …).


### PR DESCRIPTION
## Summary
- Restores CLAUDE.md improvements that were unintentionally overridden during a prior merge conflict resolution.
- Adds a hook-based harness (`.claude/hooks/context-contract.md`, `.claude/hooks/context-file-guard.sh`, wired via `.claude/settings.json`) that dynamically surfaces guidelines to agents on how to correctly maintain the repo's context files (CLAUDE.md et al.) going forward.

## Test plan
- [ ] Confirm CLAUDE.md content matches the intended pre-conflict state plus new additions
- [ ] Exercise the context-file-guard hook to verify it surfaces guidance without blocking normal edits