### PR TITLE
grail #28: Full Logical Backup and Restore

### DIFF
--- a/client/src/__tests__/backup.integration.test.ts
+++ b/client/src/__tests__/backup.integration.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Real GCI, but stub the `vscode` module the query layer pulls in via gciLog.
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+
+import { useIntegrationTest } from './useIntegrationTest';
+import { GciLibrary } from '../gciLibrary';
+import * as q from '../browserQueries';
+import type { ActiveSession } from '../sessionManager';
+import { hasFileControlPrivilege, sessionNeedsCommit, fullBackupCode } from '../queries/backup';
+import { DatabaseTreeProvider } from '../databaseTreeProvider';
+import type { GemStoneDatabase } from '../sysadminTypes';
+
+/**
+ * Automatic GCI integration tests for the full logical backup, run against a
+ * live stone (localhost, so the gem writes files the test process can read).
+ *
+ * The read-only pre-flight checks are transient. The real-backup test writes an
+ * actual .dbf — a filesystem side effect the harness's per-test GciTsAbort can't
+ * roll back — so it targets a throwaway temp dir and cleans it up in `finally`.
+ * All emitted Smalltalk is ASCII-only so it stays valid on the 3.6.x stones.
+ */
+describe('full logical backup (integration)', () => {
+  let gci: GciLibrary;
+  let handle: unknown;
+  useIntegrationTest((testContext) => { gci = testContext.gciLibrary; handle = testContext.session; });
+
+  const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
+  const exec = (label: string, code: string): string => q.executeFetchString(session(), label, code);
+
+  it('confirms the connected user holds the FileControl privilege backups require', () => {
+    expect(hasFileControlPrivilege(exec)).toBe(true);
+  });
+
+  it('sees a freshly begun transaction as having no uncommitted changes', () => {
+    expect(sessionNeedsCommit(exec)).toBe(false);
+  });
+
+  it('writes a real backup file that then appears in the Backups tree node', () => {
+    const dbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jasper-it-db-'));
+    const dest = path.join(dbDir, 'backups', 'itbackup.dbf');
+    fs.mkdirSync(path.dirname(dest));
+    const db: GemStoneDatabase = {
+      dirName: path.basename(dbDir),
+      path: dbDir,
+      config: { version: '3.7.5', stoneName: 'itstone', ldiName: 'itldi', baseExtent: 'extent0.dbf' },
+    };
+
+    try {
+      const modeBefore = exec('mode', 'System transactionMode printString').trim();
+
+      const result = exec('full backup', fullBackupCode(dest)).trim();
+
+      expect(result).toBe('OK');
+      expect(fs.existsSync(dest)).toBe(true);
+      expect(fs.statSync(dest).size).toBeGreaterThan(0);
+      // fullBackupTo: leaves the session in manualBegin; the ensure: block in
+      // fullBackupCode must put the transaction mode back where it was.
+      expect(exec('mode', 'System transactionMode printString').trim()).toBe(modeBefore);
+
+      // The produced file is discovered by the real (unmocked) tree provider.
+      const provider = new DatabaseTreeProvider(
+        { getDatabases: () => [db] } as never,
+        { isStoneRunning: () => false, isNetldiRunning: () => false, getProcesses: () => [] } as never,
+      );
+      const topLevelKinds = provider.getChildren({ kind: 'database', db }).map(c => c.kind);
+      const backupFiles = provider.getChildren({ kind: 'backups', db })
+        .map(c => (c.kind === 'backupFile' ? c.filePath : ''));
+
+      expect(topLevelKinds).toContain('backups');
+      expect(backupFiles).toContain(dest);
+    } finally {
+      fs.rmSync(dbDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/client/src/__tests__/backupManager.test.ts
+++ b/client/src/__tests__/backupManager.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+vi.mock('../wslFs');
+
+import * as vscode from 'vscode';
+import { wslExistsSync } from '../wslFs';
+import { runLogicalBackup, LogicalBackupDeps } from '../backupManager';
+
+function makeDeps(overrides?: Partial<LogicalBackupDeps>): LogicalBackupDeps {
+  return {
+    execute: vi.fn((_label: string, code: string) => {
+      if (code.includes('FileControl')) return 'true';
+      if (code.includes('needsCommit')) return 'false';
+      return 'aborted';
+    }),
+    runBackup: vi.fn(async () => 'OK'),
+    stoneName: 'gs64stone',
+    dbPath: '/root/db-1',
+    ...overrides,
+  };
+}
+
+describe('runLogicalBackup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(wslExistsSync).mockReturnValue(true);
+    vi.mocked(vscode.window.showSaveDialog).mockResolvedValue(
+      vscode.Uri.file('/root/db-1/backups/gs64stone.dbf') as any,
+    );
+    // Default: user dismisses the success toast without clicking an action.
+    // (clearAllMocks resets call history but not mockResolvedValue, so set it here.)
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as any);
+  });
+
+  it('backs up to the chosen destination and reports success', async () => {
+    const deps = makeDeps();
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(true);
+    expect(deps.runBackup).toHaveBeenCalledOnce();
+    const backupCode = vi.mocked(deps.runBackup).mock.calls[0][0];
+    expect(backupCode).toContain("fullBackupTo: '/root/db-1/backups/gs64stone.dbf'");
+    expect(vscode.window.showInformationMessage).toHaveBeenCalled();
+  });
+
+  it('ends on a green success status-bar item so a fast backup is still noticed', async () => {
+    const deps = makeDeps();
+
+    await runLogicalBackup(deps);
+
+    const item = vi.mocked(vscode.window.createStatusBarItem).mock.results.at(-1)?.value;
+    expect(item.text).toContain('Full logical backup');
+    expect(item.color).toEqual(new vscode.ThemeColor('charts.green'));
+  });
+
+  it('offers to reveal a locally-managed backup and opens the file manager on request', async () => {
+    const deps = makeDeps();
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue('Reveal in File Explorer' as any);
+
+    await runLogicalBackup(deps);
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('revealFileInOS', expect.anything());
+  });
+
+  it('omits the reveal action for a stone that is not locally managed', async () => {
+    const deps = makeDeps({ dbPath: undefined });
+
+    await runLogicalBackup(deps);
+
+    const infoArgs = vi.mocked(vscode.window.showInformationMessage).mock.calls[0];
+    expect(infoArgs).toHaveLength(1);
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith('revealFileInOS', expect.anything());
+  });
+
+  it('reports a pre-flight failure when the privilege check itself errors', async () => {
+    const deps = makeDeps({ execute: vi.fn(() => { throw new Error('gci down'); }) });
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('privileges'));
+    expect(deps.runBackup).not.toHaveBeenCalled();
+  });
+
+  it('reports a pre-flight failure when the uncommitted-changes check errors', async () => {
+    const execute = vi.fn((_l: string, code: string) => {
+      if (code.includes('FileControl')) return 'true';
+      throw new Error('gci down');
+    });
+    const deps = makeDeps({ execute });
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('session state'));
+    expect(deps.runBackup).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure when aborting the uncommitted changes errors', async () => {
+    const execute = vi.fn((_l: string, code: string) => {
+      if (code.includes('FileControl')) return 'true';
+      if (code.includes('needsCommit')) return 'true';
+      throw new Error('abort failed');
+    });
+    const deps = makeDeps({ execute });
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Discard changes and back up' as any);
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('abort'));
+    expect(deps.runBackup).not.toHaveBeenCalled();
+  });
+
+  it('stops with an explanatory error when the user lacks FileControl', async () => {
+    const deps = makeDeps({ execute: vi.fn(() => 'false') });
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('FileControl'),
+    );
+    expect(deps.runBackup).not.toHaveBeenCalled();
+  });
+
+  it('does not back up when the user declines to discard uncommitted changes', async () => {
+    const deps = makeDeps({
+      execute: vi.fn((_l: string, code: string) => (code.includes('needsCommit') ? 'true' : 'true')),
+    });
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined as any);
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(deps.runBackup).not.toHaveBeenCalled();
+  });
+
+  it('aborts the session then backs up when the user agrees to discard changes', async () => {
+    const execute = vi.fn((_l: string, code: string) => {
+      if (code.includes('FileControl')) return 'true';
+      if (code.includes('needsCommit')) return 'true';
+      return 'aborted';
+    });
+    const deps = makeDeps({ execute });
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(
+      'Discard changes and back up' as any,
+    );
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(true);
+    expect(execute.mock.calls.some(([, code]) => code.includes('System abortTransaction'))).toBe(true);
+    expect(deps.runBackup).toHaveBeenCalledOnce();
+  });
+
+  it('is cancelled without backing up when the save dialog is dismissed', async () => {
+    vi.mocked(vscode.window.showSaveDialog).mockResolvedValue(undefined);
+    const deps = makeDeps();
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(deps.runBackup).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a GCI failure from the backup as an error', async () => {
+    const deps = makeDeps({
+      runBackup: vi.fn(async () => { throw new Error('device full'); }),
+    });
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('device full'),
+    );
+  });
+
+  it('reports a non-OK result from the stone as a failure', async () => {
+    const deps = makeDeps({ runBackup: vi.fn(async () => 'fullBackupTo: returned false') });
+
+    const ok = await runLogicalBackup(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/databaseTreeProviderBackups.test.ts
+++ b/client/src/__tests__/databaseTreeProviderBackups.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+vi.mock('../wslFs');
+
+import { DatabaseTreeProvider, DatabaseNode } from '../databaseTreeProvider';
+import { GemStoneDatabase } from '../sysadminTypes';
+import { wslExistsSync, wslReaddirSync, wslIsFile } from '../wslFs';
+
+function makeDatabase(): GemStoneDatabase {
+  return {
+    dirName: 'db-1',
+    path: '/root/db-1',
+    config: { version: '3.7.5', stoneName: 'gs64stone', ldiName: 'gs64ldi', baseExtent: 'extent0.dbf' },
+  };
+}
+
+function makeProvider(): DatabaseTreeProvider {
+  const storage = { getDatabases: vi.fn(() => [makeDatabase()]) };
+  const processManager = {
+    isStoneRunning: vi.fn(() => false),
+    isNetldiRunning: vi.fn(() => false),
+    getProcesses: vi.fn(() => []),
+  };
+  return new DatabaseTreeProvider(storage as never, processManager as never);
+}
+
+const db = makeDatabase();
+const dbNode: DatabaseNode = { kind: 'database', db };
+
+describe('DatabaseTreeProvider backups node', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(wslIsFile).mockReturnValue(true);
+  });
+
+  it('hides the Backups node when the backups folder does not exist', () => {
+    vi.mocked(wslExistsSync).mockReturnValue(false);
+
+    const kinds = makeProvider().getChildren(dbNode).map(c => c.kind);
+
+    expect(kinds).toEqual(['stone', 'netldi', 'logs', 'config']);
+  });
+
+  it('hides the Backups node when the folder holds no .dbf files', () => {
+    vi.mocked(wslExistsSync).mockReturnValue(true);
+    vi.mocked(wslReaddirSync).mockReturnValue(['README.txt']);
+
+    const kinds = makeProvider().getChildren(dbNode).map(c => c.kind);
+
+    expect(kinds).not.toContain('backups');
+  });
+
+  it('shows the Backups node once at least one backup exists', () => {
+    vi.mocked(wslExistsSync).mockReturnValue(true);
+    vi.mocked(wslReaddirSync).mockReturnValue(['gs64stone_2026-07-10_20-00-00.dbf']);
+
+    const kinds = makeProvider().getChildren(dbNode).map(c => c.kind);
+
+    expect(kinds).toContain('backups');
+  });
+
+  it('lists only .dbf backups, newest first', () => {
+    vi.mocked(wslExistsSync).mockReturnValue(true);
+    vi.mocked(wslReaddirSync).mockReturnValue([
+      'gs64stone_2026-01-01_00-00-00.dbf',
+      'gs64stone_2026-03-01_00-00-00.dbf',
+      'notes.txt',
+    ]);
+
+    const children = makeProvider().getChildren({ kind: 'backups', db });
+
+    expect(children.map(c => c.kind === 'backupFile' && c.filePath)).toEqual([
+      '/root/db-1/backups/gs64stone_2026-03-01_00-00-00.dbf',
+      '/root/db-1/backups/gs64stone_2026-01-01_00-00-00.dbf',
+    ]);
+  });
+
+  it('renders a backup file to reveal in the OS rather than open in an editor', () => {
+    const item = makeProvider().getTreeItem({
+      kind: 'backupFile',
+      filePath: '/root/db-1/backups/gs64stone_2026-03-01.dbf',
+    });
+
+    expect(item.contextValue).toBe('gemstoneDbBackupFile');
+    expect(item.command?.command).toBe('revealFileInOS');
+  });
+
+  it('explains in a tooltip what the Backups node can show', () => {
+    const item = makeProvider().getTreeItem({ kind: 'backups', db });
+
+    expect(item.label).toBe('Backups');
+    expect(String(item.tooltip)).toContain('backups/');
+  });
+});

--- a/client/src/__tests__/databaseTreeProviderBackups.test.ts
+++ b/client/src/__tests__/databaseTreeProviderBackups.test.ts
@@ -80,6 +80,7 @@ describe('DatabaseTreeProvider backups node', () => {
     const item = makeProvider().getTreeItem({
       kind: 'backupFile',
       filePath: '/root/db-1/backups/gs64stone_2026-03-01.dbf',
+      db,
     });
 
     expect(item.contextValue).toBe('gemstoneDbBackupFile');

--- a/client/src/__tests__/gci/gciBackupRestore.test.ts
+++ b/client/src/__tests__/gci/gciBackupRestore.test.ts
@@ -1,0 +1,139 @@
+// On-demand GCI round-trip for the full logical backup + restore feature.
+//
+// Exercises the exact Smalltalk we ship (queries/backup.ts + queries/restore.ts)
+// against a live stone: commit a marker, take a full backup, commit a SECOND
+// marker, restore from the backup, and prove the first marker survived while the
+// post-backup one is gone. That is the whole contract of a logical restore —
+// it rolls the repository back to the moment the backup was taken.
+//
+// DESTRUCTIVE — READ THIS. restoreFromBackup: replaces the ENTIRE repository, so
+// this test cannot live in the automatic suite (`npm test`); it is in the
+// on-demand `gci` project only (`npm run test:gci`). It runs an IN-PLACE restore
+// (no fresh extent, no stone stop/start), so it needs no process management. It
+// is written to be near-idempotent against the shared test stone: the backup is
+// taken at the very start, so the restore only discards this test's own
+// post-backup marker, and we delete the pre-backup marker on the way out. The
+// gci project runs serially (fileParallelism: false), so no other session is
+// disrupted by the mid-restore 4046 auto-logout. The shared test stone is
+// re-provisionable via `npm run test:server:start` regardless.
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GciLibrary } from '../../gciLibrary';
+import { GCI_LIBRARY_PATH, STONE_NRS, GEM_NRS, GS_USER, GS_PASSWORD } from './gciTestConfig';
+import { fullBackupCode } from '../../queries/backup';
+import { restoreFromBackupCode, commitRestoreCode, RESTORE_NO_LOGOUT_MARKER } from '../../queries/restore';
+
+const OOP_NIL = 0x14n;
+const OOP_ILLEGAL = 0x01n;
+const MAX_RESULT = 256 * 1024;
+
+// GemStone raises this on a successful full-logging restore, then auto-logs-out.
+const RESTORE_SUCCESS_LOGOUT_ERROR = 4046;
+
+// A persistent restore takes a while (backup + multi-threaded restore of the
+// whole repo), so give the single round-trip a generous ceiling.
+const ROUND_TRIP_TIMEOUT_MS = 180_000;
+
+const KEY_BEFORE = 'JasperRoundTripCommittedBeforeBackup';
+const KEY_AFTER = 'JasperRoundTripCommittedAfterBackup';
+
+interface RunResult {
+  data: string;
+  errNumber: number;
+  errMessage: string;
+}
+
+function connect(gci: GciLibrary): unknown {
+  const r = gci.GciTsLogin(STONE_NRS, null, null, false, GEM_NRS, GS_USER, GS_PASSWORD, 0, 0);
+  if (!r.session) {
+    throw new Error(`GciTsLogin failed: ${r.err.message || `error ${r.err.number}`}`);
+  }
+  return r.session;
+}
+
+// The Smalltalk source is interpreted as this class; Utf8 matches production.
+function sourceClass(gci: GciLibrary, session: unknown): bigint {
+  const { result, err } = gci.GciTsResolveSymbol(session, 'Utf8', OOP_NIL);
+  if (err.number !== 0) throw new Error(`Could not resolve Utf8: ${err.message}`);
+  return result;
+}
+
+// Execute and surface the raw GCI error NUMBER (not just a thrown message) so the
+// caller can treat the 4046 auto-logout as success rather than failure.
+function run(gci: GciLibrary, session: unknown, src: bigint, code: string): RunResult {
+  const { data, err } = gci.GciTsExecuteFetchBytes(
+    session, code, -1, src, OOP_ILLEGAL, OOP_NIL, MAX_RESULT,
+  );
+  return { data: (data ?? '').trim(), errNumber: err.number, errMessage: err.message || '' };
+}
+
+describe('full logical backup + restore round-trip', () => {
+  it(
+    'restores committed state as of the backup and drops changes committed after it',
+    () => {
+      const gci = new GciLibrary(GCI_LIBRARY_PATH);
+      const backupFile = path.join(os.tmpdir(), `jasper-restore-roundtrip-${process.pid}.dbf`);
+
+      try {
+        // ── Commit a marker, back up, then commit a second marker ──
+        let session = connect(gci);
+        let src = sourceClass(gci, session);
+
+        const committedBefore = run(gci, session, src,
+          `System abortTransaction. `
+          + `UserGlobals at: #${KEY_BEFORE} put: 'before-backup'. `
+          + `System commitTransaction. 'ok'`);
+        expect(committedBefore.errNumber).toBe(0);
+
+        const backup = run(gci, session, src, fullBackupCode(backupFile));
+        expect(backup.errNumber).toBe(0);
+        expect(backup.data).toBe('OK');
+        expect(fs.existsSync(backupFile)).toBe(true);
+
+        const committedAfter = run(gci, session, src,
+          `UserGlobals at: #${KEY_AFTER} put: 'after-backup'. `
+          + `System commitTransaction. 'ok'`);
+        expect(committedAfter.errNumber).toBe(0);
+
+        // ── Restore. Full logging → 4046 auto-logout (success) then commitRestore;
+        //    partial logging → returns the marker, already fully restored. ──
+        const restore = run(gci, session, src, restoreFromBackupCode(backupFile));
+        if (restore.errNumber === RESTORE_SUCCESS_LOGOUT_ERROR) {
+          try { gci.GciTsLogout(session); } catch { /* already gone */ }
+
+          session = connect(gci);
+          src = sourceClass(gci, session);
+          const commit = run(gci, session, src, commitRestoreCode());
+          // commitRestore raises a benign warning when we don't roll forward the
+          // current tranlogs (out of scope); the commit still completes.
+          const committed = commit.errNumber === 0
+            || /restoreFromCurrentLogs|may not be restored/i.test(commit.errMessage);
+          expect(committed).toBe(true);
+          try { gci.GciTsLogout(session); } catch { /* ignore */ }
+        } else {
+          expect(restore.errNumber).toBe(0);
+          expect(restore.data).toBe(RESTORE_NO_LOGOUT_MARKER);
+        }
+
+        // ── Verify the rollback: before-backup survived, after-backup is gone ──
+        session = connect(gci);
+        src = sourceClass(gci, session);
+        const hasBefore = run(gci, session, src, `(UserGlobals includesKey: #${KEY_BEFORE}) printString`);
+        const hasAfter = run(gci, session, src, `(UserGlobals includesKey: #${KEY_AFTER}) printString`);
+        expect(hasBefore.data).toBe('true');
+        expect(hasAfter.data).toBe('false');
+
+        // Leave the shared stone as we found it.
+        run(gci, session, src,
+          `UserGlobals removeKey: #${KEY_BEFORE} ifAbsent: []. System commitTransaction. 'ok'`);
+        try { gci.GciTsLogout(session); } catch { /* ignore */ }
+      } finally {
+        fs.rmSync(backupFile, { force: true });
+        gci.close();
+      }
+    },
+    ROUND_TRIP_TIMEOUT_MS,
+  );
+});

--- a/client/src/__tests__/restoreManager.test.ts
+++ b/client/src/__tests__/restoreManager.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+
+import * as vscode from 'vscode';
+import { runLogicalRestore, LogicalRestoreDeps, RestoreSession } from '../restoreManager';
+import { RESTORE_NO_LOGOUT_MARKER } from '../queries/restore';
+
+// A fake restore session. By default the restoreFromBackup: call raises the 4046
+// auto-logout (the full-logging success path); commitRestore answers 'OK'.
+function makeSession(opts?: { restoreReturnsNormally?: boolean }) {
+  const logout = vi.fn();
+  const run = vi.fn(async (_label: string, code: string) => {
+    if (code.includes('restoreFromBackup')) {
+      if (opts?.restoreReturnsNormally) return RESTORE_NO_LOGOUT_MARKER;
+      const err = new Error('RestoreBackupSuccess') as Error & { gciErrorNumber: number };
+      err.gciErrorNumber = 4046;
+      throw err;
+    }
+    if (code.includes('commitRestore')) return 'OK';
+    return '';
+  });
+  return { run, logout } as RestoreSession & { run: ReturnType<typeof vi.fn>; logout: ReturnType<typeof vi.fn> };
+}
+
+function makeDeps(overrides?: Partial<LogicalRestoreDeps>) {
+  const session = makeSession();
+  const deps: LogicalRestoreDeps = {
+    stoneName: 'gs64stone',
+    dbPath: '/root/db-1',
+    backupFile: '/root/db-1/backups/backup.dbf',
+    hasFileControl: vi.fn(() => true),
+    closeCurrentSession: vi.fn(async () => {}),
+    stopStone: vi.fn(async () => {}),
+    startStone: vi.fn(async () => {}),
+    copyCurrentExtentAside: vi.fn(async () => {}),
+    swapInFreshExtent: vi.fn(async () => {}),
+    loginAsDefaultAdmin: vi.fn(async () => session),
+    loginAsSessionUser: vi.fn(async () => session),
+    ...overrides,
+  };
+  return { deps, session };
+}
+
+describe('runLogicalRestore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: user picks the fresh-extent option, confirms the destructive modal.
+    vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items: any) => items[0]);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Restore' as any);
+    vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
+      vscode.Uri.file('/root/db-1/backups/backup.dbf'),
+    ] as any);
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as any);
+  });
+
+  it('runs the stop, safety-copy, swap, start, restore, and commit steps in order for a fresh extent', async () => {
+    const { deps, session } = makeDeps();
+    const order: string[] = [];
+    vi.mocked(deps.closeCurrentSession).mockImplementation(async () => { order.push('close'); });
+    vi.mocked(deps.stopStone).mockImplementation(async () => { order.push('stop'); });
+    vi.mocked(deps.copyCurrentExtentAside).mockImplementation(async () => { order.push('copy'); });
+    vi.mocked(deps.swapInFreshExtent).mockImplementation(async () => { order.push('swap'); });
+    vi.mocked(deps.startStone).mockImplementation(async () => { order.push('start'); });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(true);
+    expect(order).toEqual(['close', 'stop', 'copy', 'swap', 'start']);
+    expect(session.run.mock.calls.some(([, code]) => code.includes('restoreFromBackup'))).toBe(true);
+    expect(session.run.mock.calls.some(([, code]) => code.includes('commitRestore'))).toBe(true);
+  });
+
+  it('preserves the current extent under backups/backupExtents with a stone-stamped name', async () => {
+    const { deps } = makeDeps();
+
+    await runLogicalRestore(deps);
+
+    const destPath = vi.mocked(deps.copyCurrentExtentAside).mock.calls[0][0];
+    expect(destPath).toContain('/root/db-1/backups/backupExtents/');
+    expect(destPath).toContain('extent0_preRestore_gs64stone');
+    expect(destPath.endsWith('.dbf')).toBe(true);
+  });
+
+  it('authenticates as the default admin when restoring into a fresh extent', async () => {
+    const { deps } = makeDeps();
+
+    await runLogicalRestore(deps);
+
+    expect(deps.loginAsDefaultAdmin).toHaveBeenCalled();
+    expect(deps.loginAsSessionUser).not.toHaveBeenCalled();
+  });
+
+  it('restores onto the current extent without a fresh extent when that option is chosen', async () => {
+    const { deps } = makeDeps();
+    vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items: any) => items[1]);
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(true);
+    expect(deps.swapInFreshExtent).not.toHaveBeenCalled();
+    expect(deps.loginAsSessionUser).toHaveBeenCalled();
+    expect(deps.loginAsDefaultAdmin).not.toHaveBeenCalled();
+  });
+
+  it('reuses the same login for the restore and the commit', async () => {
+    const { deps } = makeDeps();
+
+    await runLogicalRestore(deps);
+
+    expect(deps.loginAsDefaultAdmin).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips the commit step when the stone restores in a single call (partial logging)', async () => {
+    const session = makeSession({ restoreReturnsNormally: true });
+    const { deps } = makeDeps({
+      loginAsDefaultAdmin: vi.fn(async () => session),
+    });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(true);
+    expect(session.run.mock.calls.some(([, code]) => code.includes('commitRestore'))).toBe(false);
+  });
+
+  it('stops with an explanatory error and no teardown when the user lacks FileControl', async () => {
+    const { deps } = makeDeps({ hasFileControl: vi.fn(() => false) });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('FileControl'));
+    expect(deps.stopStone).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure when the privilege check itself errors', async () => {
+    const { deps } = makeDeps({ hasFileControl: vi.fn(() => { throw new Error('gci down'); }) });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('privileges'));
+    expect(deps.stopStone).not.toHaveBeenCalled();
+  });
+
+  it('prompts for a backup file when none was pre-selected', async () => {
+    const { deps } = makeDeps({ backupFile: undefined });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(true);
+    expect(vscode.window.showOpenDialog).toHaveBeenCalled();
+  });
+
+  it('is cancelled without teardown when the backup-file dialog is dismissed', async () => {
+    const { deps } = makeDeps({ backupFile: undefined });
+    vi.mocked(vscode.window.showOpenDialog).mockResolvedValue(undefined);
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(false);
+    expect(deps.stopStone).not.toHaveBeenCalled();
+  });
+
+  it('is cancelled without teardown when the fresh-extent choice is dismissed', async () => {
+    const { deps } = makeDeps();
+    vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined as any);
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(false);
+    expect(deps.stopStone).not.toHaveBeenCalled();
+  });
+
+  it('does not touch the stone when the destructive confirmation is declined', async () => {
+    const { deps } = makeDeps();
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined as any);
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(false);
+    expect(deps.stopStone).not.toHaveBeenCalled();
+    expect(deps.loginAsDefaultAdmin).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a mid-restore failure and points the user at the saved-aside extent', async () => {
+    const { deps } = makeDeps({
+      startStone: vi.fn(async () => { throw new Error('startstone failed'); }),
+    });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('backupExtents'),
+    );
+  });
+
+  it('treats the no-roll-forward commitRestore warning as success', async () => {
+    const session = makeSession();
+    session.run.mockImplementation(async (_label: string, code: string) => {
+      if (code.includes('restoreFromBackup')) {
+        const err = new Error('RestoreBackupSuccess') as Error & { gciErrorNumber: number };
+        err.gciErrorNumber = 4046;
+        throw err;
+      }
+      if (code.includes('commitRestore')) {
+        throw new Error(
+          'commitRestore not immediately preceeded by restoreFromCurrentLogs. '
+          + 'WARNING: Some transactions may not be restored.',
+        );
+      }
+      return '';
+    });
+    const { deps } = makeDeps({ loginAsDefaultAdmin: vi.fn(async () => session) });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(true);
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('treats a genuine restore error (not 4046) as a failure', async () => {
+    const session = makeSession();
+    session.run.mockImplementation(async (_label: string, code: string) => {
+      if (code.includes('restoreFromBackup')) {
+        const err = new Error('file not found') as Error & { gciErrorNumber: number };
+        err.gciErrorNumber = 2318;
+        throw err;
+      }
+      return '';
+    });
+    const { deps } = makeDeps({ loginAsDefaultAdmin: vi.fn(async () => session) });
+
+    const ok = await runLogicalRestore(deps);
+
+    expect(ok).toBe(false);
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('file not found'));
+  });
+
+  it('ends on a green success status-bar item', async () => {
+    const { deps } = makeDeps();
+
+    await runLogicalRestore(deps);
+
+    const item = vi.mocked(vscode.window.createStatusBarItem).mock.results.at(-1)?.value;
+    expect(item.color).toEqual(new vscode.ThemeColor('charts.green'));
+  });
+});

--- a/client/src/__tests__/sessionMenuOrder.test.ts
+++ b/client/src/__tests__/sessionMenuOrder.test.ts
@@ -42,6 +42,7 @@ describe('session row inline button order', () => {
       'gemstone.sessionCommit',
       'gemstone.sessionAbort',
       'gemstone.sessionPing',
+      'gemstone.fullLogicalBackup',
       'gemstone.sessionLogout',
     ]);
   });

--- a/client/src/__tests__/sessionMenuOrder.test.ts
+++ b/client/src/__tests__/sessionMenuOrder.test.ts
@@ -33,7 +33,7 @@ function inlineOrderFor(viewItemClause: string): string[] {
 }
 
 describe('session row inline button order', () => {
-  it('leads with the most-used safe actions and trails with the session-ending Logout', () => {
+  it('leads with the most-used safe actions, groups the backup/restore pair, and trails with Logout', () => {
     const order = inlineOrderFor('viewItem == gemstoneSession');
 
     expect(order).toEqual([
@@ -43,6 +43,7 @@ describe('session row inline button order', () => {
       'gemstone.sessionAbort',
       'gemstone.sessionPing',
       'gemstone.fullLogicalBackup',
+      'gemstone.fullLogicalRestore',
       'gemstone.sessionLogout',
     ]);
   });

--- a/client/src/backupManager.ts
+++ b/client/src/backupManager.ts
@@ -1,0 +1,164 @@
+// Orchestrates a logical (object) backup of a running stone: pre-flight checks,
+// destination selection, and running Repository>>fullBackupTo: via a
+// non-blocking executor (which keeps VS Code responsive and shows its own
+// cancellable progress notification for the long-running call).
+//
+// Session acquisition (matching the active session to the target stone) and the
+// executor wiring live in the command handler; this module takes the executors
+// as dependencies so it stays unit-testable without a live GCI session.
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { QueryExecutor } from './queries/types';
+import * as backup from './queries/backup';
+import { wslExistsSync, wslMkdirSync } from './wslFs';
+
+export interface LogicalBackupDeps {
+  // Fast, synchronous executor for the pre-flight queries.
+  execute: QueryExecutor;
+  // Non-blocking executor for the long-running backup itself. Returns the
+  // stone's result string ('OK' on success). Should suppress its own progress
+  // toast — this module shows a single always-visible progress notification.
+  runBackup: (code: string) => Promise<string>;
+  // Stone the session is connected to (used for labels and the default filename).
+  stoneName: string;
+  // Managed database directory, when the session's stone is one we manage
+  // locally; the default destination is <dbPath>/backups. Omitted for stones we
+  // don't manage — the picker then opens without a pre-filled directory.
+  dbPath?: string;
+}
+
+const BACKUP_FILTERS: Record<string, string[]> = {
+  'GemStone backup': ['dbf'],
+  'All files': ['*'],
+};
+
+// How long the green success message lingers in the status bar (ms).
+const STATUS_SUCCESS_MS = 6000;
+// Theme-color ids for the status-bar item (adapt to the active color theme).
+const WORKING_COLOR = 'charts.blue';
+const SUCCESS_COLOR = 'charts.green';
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// A filesystem-safe, sortable timestamp (YYYY-MM-DD_HH-MM-SS) for default names.
+function timestamp(): string {
+  return new Date().toISOString().replace('T', '_').replace(/[:.]/g, '-').slice(0, 19);
+}
+
+// Returns true if the backup completed, false if it was cancelled or failed
+// (all failure paths surface their own message to the user).
+export async function runLogicalBackup(deps: LogicalBackupDeps): Promise<boolean> {
+  let hasPrivilege: boolean;
+  try {
+    hasPrivilege = backup.hasFileControlPrivilege(deps.execute);
+  } catch (e) {
+    vscode.window.showErrorMessage(`Could not check backup privileges: ${errorMessage(e)}`);
+    return false;
+  }
+  if (!hasPrivilege) {
+    vscode.window.showErrorMessage(
+      'A full logical backup requires the FileControl privilege. Connect as a user that has it '
+      + '(for example DataCurator or SystemUser) and try again.',
+    );
+    return false;
+  }
+
+  let needsCommit: boolean;
+  try {
+    needsCommit = backup.sessionNeedsCommit(deps.execute);
+  } catch (e) {
+    vscode.window.showErrorMessage(`Could not check the session state: ${errorMessage(e)}`);
+    return false;
+  }
+  if (needsCommit) {
+    const proceed = await vscode.window.showWarningMessage(
+      `The session connected to "${deps.stoneName}" has uncommitted changes. A full logical backup `
+      + 'discards them (it aborts the session). Continue?',
+      { modal: true },
+      'Discard changes and back up',
+    );
+    if (proceed !== 'Discard changes and back up') return false;
+    try {
+      backup.abortTransaction(deps.execute);
+    } catch (e) {
+      vscode.window.showErrorMessage(`Could not abort the session: ${errorMessage(e)}`);
+      return false;
+    }
+  }
+
+  // Destination is a server-side path. For a local stone the client and server
+  // share a filesystem, so the file picker resolves correctly; remote-stone
+  // support is deferred (would browse via the GCI session instead).
+  const fileName = `${deps.stoneName}_${timestamp()}.dbf`;
+  let defaultUri: vscode.Uri | undefined;
+  if (deps.dbPath) {
+    const defaultDir = path.join(deps.dbPath, 'backups');
+    if (!wslExistsSync(defaultDir)) {
+      try {
+        wslMkdirSync(defaultDir, { recursive: true });
+      } catch {
+        // Non-fatal: the picker still opens on the parent directory.
+      }
+    }
+    defaultUri = vscode.Uri.file(path.join(defaultDir, fileName));
+  }
+  const uri = await vscode.window.showSaveDialog({
+    title: `Full Logical Backup of ${deps.stoneName}`,
+    defaultUri,
+    filters: BACKUP_FILTERS,
+  });
+  if (!uri) return false;
+  const destination = uri.fsPath;
+
+  // Colored status-bar item: a blue spinner while the (possibly instant) backup
+  // runs, then a green confirmation that lingers ~6s. A fast backup can outrace
+  // the progress toast, so this guarantees a visible, unmissable signal — and the
+  // color makes "working" vs "done" readable at a glance.
+  const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+  status.text = `$(sync~spin) Full logical backup of "${deps.stoneName}"…`;
+  status.color = new vscode.ThemeColor(WORKING_COLOR);
+  status.show();
+
+  // The progress notification (the nb executor suppresses its own ~2s toast) is
+  // the prominent indicator for a genuinely long backup.
+  let result: string;
+  try {
+    result = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Full logical backup of "${deps.stoneName}"…`,
+        cancellable: false,
+      },
+      async () => (await deps.runBackup(backup.fullBackupCode(destination))).trim(),
+    );
+  } catch (e) {
+    status.dispose();
+    vscode.window.showErrorMessage(`Full logical backup failed: ${errorMessage(e)}`);
+    return false;
+  }
+  if (result !== 'OK') {
+    status.dispose();
+    vscode.window.showErrorMessage(`Full logical backup did not complete: ${result}`);
+    return false;
+  }
+
+  status.text = `$(check) Full logical backup of "${deps.stoneName}" written`;
+  status.color = new vscode.ThemeColor(SUCCESS_COLOR);
+  setTimeout(() => status.dispose(), STATUS_SUCCESS_MS);
+
+  // Offer to reveal the file, but only for a locally-managed stone: the path is
+  // on the server, and revealing it in the client's file manager only makes
+  // sense when client and server share a filesystem (which dbPath implies).
+  const reveal = 'Reveal in File Explorer';
+  const actions = deps.dbPath ? [reveal] : [];
+  const choice = await vscode.window.showInformationMessage(
+    `Full logical backup of "${deps.stoneName}" written to ${destination}`,
+    ...actions,
+  );
+  if (choice === reveal) {
+    void vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(destination));
+  }
+  return true;
+}

--- a/client/src/backupManager.ts
+++ b/client/src/backupManager.ts
@@ -42,9 +42,14 @@ function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
-// A filesystem-safe, sortable timestamp (YYYY-MM-DD_HH-MM-SS) for default names.
+// A filesystem-safe, sortable timestamp in LOCAL time (YYYY-MM-DD_HH-MM-SS) for
+// default names, so they match what the user sees in their file manager (UTC
+// from toISOString() looked "off" by the local offset).
 function timestamp(): string {
-  return new Date().toISOString().replace('T', '_').replace(/[:.]/g, '-').slice(0, 19);
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+    + `_${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}`;
 }
 
 // Returns true if the backup completed, false if it was cancelled or failed

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -188,6 +188,7 @@ export function executeFetchString(session: ActiveSession, label: string, code: 
 // executeFetchString.
 export async function executeFetchStringNb(
   session: ActiveSession, label: string, code: string, progressTitle?: string,
+  suppressNotification = false,
 ): Promise<string> {
   logQuery(session.id, label, code);
 
@@ -220,7 +221,7 @@ export async function executeFetchStringNb(
       }
       return fetched.data;
     },
-    { title: progressTitle ?? `GemStone: ${label}…` },
+    { title: progressTitle ?? `GemStone: ${label}…`, suppressNotification },
   );
 
   logResult(session.id, data);

--- a/client/src/databaseTreeProvider.ts
+++ b/client/src/databaseTreeProvider.ts
@@ -13,7 +13,7 @@ export type DatabaseNode =
   | { kind: 'config'; db: GemStoneDatabase }
   | { kind: 'backups'; db: GemStoneDatabase }
   | { kind: 'file'; filePath: string }
-  | { kind: 'backupFile'; filePath: string };
+  | { kind: 'backupFile'; filePath: string; db: GemStoneDatabase };
 
 export class DatabaseTreeProvider implements vscode.TreeDataProvider<DatabaseNode> {
   private _onDidChangeTreeData = new vscode.EventEmitter<DatabaseNode | undefined>();
@@ -156,7 +156,7 @@ export class DatabaseTreeProvider implements vscode.TreeDataProvider<DatabaseNod
     }
     if (node.kind === 'backups') {
       return this.backupFiles(node.db)
-        .map(f => ({ kind: 'backupFile' as const, filePath: f }));
+        .map(f => ({ kind: 'backupFile' as const, filePath: f, db: node.db }));
     }
     return [];
   }

--- a/client/src/databaseTreeProvider.ts
+++ b/client/src/databaseTreeProvider.ts
@@ -11,7 +11,9 @@ export type DatabaseNode =
   | { kind: 'netldi'; db: GemStoneDatabase; running: boolean }
   | { kind: 'logs'; db: GemStoneDatabase }
   | { kind: 'config'; db: GemStoneDatabase }
-  | { kind: 'file'; filePath: string };
+  | { kind: 'backups'; db: GemStoneDatabase }
+  | { kind: 'file'; filePath: string }
+  | { kind: 'backupFile'; filePath: string };
 
 export class DatabaseTreeProvider implements vscode.TreeDataProvider<DatabaseNode> {
   private _onDidChangeTreeData = new vscode.EventEmitter<DatabaseNode | undefined>();
@@ -79,6 +81,16 @@ export class DatabaseTreeProvider implements vscode.TreeDataProvider<DatabaseNod
         item.iconPath = new vscode.ThemeIcon('settings-gear');
         return item;
       }
+      case 'backups': {
+        const item = new vscode.TreeItem('Backups', vscode.TreeItemCollapsibleState.Collapsed);
+        item.contextValue = 'gemstoneDbBackups';
+        item.iconPath = new vscode.ThemeIcon('archive');
+        item.tooltip =
+          "Full logical backups in this database's backups/ folder.\n"
+          + 'Backups written here by any Jasper session appear in this list; '
+          + 'backups taken outside this folder are not tracked.';
+        return item;
+      }
       case 'file': {
         const fileName = path.basename(node.filePath);
         const item = new vscode.TreeItem(fileName, vscode.TreeItemCollapsibleState.None);
@@ -88,6 +100,21 @@ export class DatabaseTreeProvider implements vscode.TreeDataProvider<DatabaseNod
         item.command = {
           command: 'vscode.open',
           title: 'Open File',
+          arguments: [vscode.Uri.file(node.filePath)],
+        };
+        return item;
+      }
+      case 'backupFile': {
+        const fileName = path.basename(node.filePath);
+        const item = new vscode.TreeItem(fileName, vscode.TreeItemCollapsibleState.None);
+        item.contextValue = 'gemstoneDbBackupFile';
+        item.iconPath = new vscode.ThemeIcon('archive');
+        item.tooltip = node.filePath;
+        // A backup is a binary .dbf — reveal it in the OS file manager rather
+        // than opening it in an editor.
+        item.command = {
+          command: 'revealFileInOS',
+          title: 'Reveal in File Explorer',
           arguments: [vscode.Uri.file(node.filePath)],
         };
         return item;
@@ -108,18 +135,28 @@ export class DatabaseTreeProvider implements vscode.TreeDataProvider<DatabaseNod
         node.db.config.ldiName,
         node.db.config.version,
       );
-      return [
+      const children: DatabaseNode[] = [
         { kind: 'stone', db: node.db, running: stoneRunning },
         { kind: 'netldi', db: node.db, running: netldiRunning },
         { kind: 'logs', db: node.db },
         { kind: 'config', db: node.db },
       ];
+      // Only surface Backups when there's something to show — the backup itself
+      // is created from the Sessions view, so this node is browse-only.
+      if (this.backupFiles(node.db).length > 0) {
+        children.push({ kind: 'backups', db: node.db });
+      }
+      return children;
     }
     if (node.kind === 'logs') {
       return this.listFiles(path.join(node.db.path, 'log'));
     }
     if (node.kind === 'config') {
       return this.listFiles(path.join(node.db.path, 'conf'));
+    }
+    if (node.kind === 'backups') {
+      return this.backupFiles(node.db)
+        .map(f => ({ kind: 'backupFile' as const, filePath: f }));
     }
     return [];
   }
@@ -130,5 +167,17 @@ export class DatabaseTreeProvider implements vscode.TreeDataProvider<DatabaseNod
       .sort()
       .filter(e => wslIsFile(path.join(dirPath, e)))
       .map(e => ({ kind: 'file' as const, filePath: path.join(dirPath, e) }));
+  }
+
+  // Absolute paths of the .dbf backup files in <db>/backups, newest first (names
+  // carry a sortable timestamp). Empty when the folder is absent or has none.
+  private backupFiles(db: GemStoneDatabase): string[] {
+    const dir = path.join(db.path, 'backups');
+    if (!wslExistsSync(dir)) return [];
+    return wslReaddirSync(dir)
+      .filter(e => e.toLowerCase().endsWith('.dbf') && wslIsFile(path.join(dir, e)))
+      .sort()
+      .reverse()
+      .map(e => path.join(dir, e));
   }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -69,12 +69,15 @@ import { getGciLog } from './gciLog';
 import { GemStoneCodeLensProvider } from './gemstoneCodeLensProvider';
 import * as queries from './browserQueries';
 import { SysadminStorage } from './sysadminStorage';
+import { GemStoneDatabase } from './sysadminTypes';
 import { appendSysadmin, getSysadminChannel } from './sysadminChannel';
 import { VersionManager } from './versionManager';
 import { VersionTreeProvider, VersionItem } from './versionTreeProvider';
 import { DatabaseManager } from './databaseManager';
 import { DatabaseTreeProvider, DatabaseNode } from './databaseTreeProvider';
 import { runLogicalBackup } from './backupManager';
+import { runLogicalRestore, RestoreSession } from './restoreManager';
+import { hasFileControlPrivilege } from './queries/backup';
 import { ProcessManager } from './processManager';
 import { openMcpInspector } from './openMcpInspector';
 import { McpSocketServer, writeClaudeDesktopMcpConfig } from './mcpSocketServer';
@@ -97,7 +100,10 @@ import {
   getWslNetworkInfoCached,
   refreshWslNetworkInfo,
 } from './wslBridge';
-import { wslExistsSync, wslSymlinkSync } from './wslFs';
+import {
+  wslExistsSync, wslSymlinkSync, wslMkdirSync, wslImportFileSync,
+  wslReaddirSync, wslUnlinkSync, wslChmodSync,
+} from './wslFs';
 import type {OutputChannel} from "vscode";
 import {initializeExtensionFolder} from "./extensionPath";
 import {initializeBundledGci, bundledWindowsClientGciPath, bundledGciArchSupported} from "./bundledGci";
@@ -2920,6 +2926,144 @@ export function activate(context: vscode.ExtensionContext) {
       // this was the first one) shows up without a manual refresh.
       if (backedUp) refreshAdminViews();
     }),
+
+    vscode.commands.registerCommand('gemstone.fullLogicalRestore',
+      async (item?: GemStoneSessionItem | DatabaseNode) => {
+        // Two entry points: the Sessions view button (a GemStoneSessionItem) and
+        // a right-click on a backup-file node in the Databases tree. Either way we
+        // need a LIVE session (for credentials to re-login through the restore's
+        // stop/start cycle) and a locally-managed database (the restore must run
+        // on the stone's own host).
+        let session: ActiveSession | undefined;
+        let backupFile: string | undefined;
+        let db: GemStoneDatabase | undefined;
+
+        if (item instanceof GemStoneSessionItem) {
+          session = item.activeSession;
+        } else if (item && 'kind' in item && item.kind === 'backupFile') {
+          backupFile = item.filePath;
+          db = item.db;
+          session = sessionManager.getSessions()
+            .find(s => s.login.stone === db!.config.stoneName);
+          if (!session) {
+            vscode.window.showWarningMessage(
+              `A full logical restore runs over a live session (it needs your login to reconnect `
+              + `through the stone restart). Log in to "${db.config.stoneName}" first, then try again.`,
+              { modal: true },
+            );
+            return;
+          }
+        } else {
+          session = sessionManager.getSelectedSession();
+        }
+        if (!session) {
+          vscode.window.showInformationMessage(
+            'No GemStone session to restore. Connect a session to the stone you want to restore first.',
+          );
+          return;
+        }
+
+        db = db ?? sysadminStorage.getDatabases()
+          .find(d => d.config.stoneName === session!.login.stone);
+        if (!db) {
+          vscode.window.showErrorMessage(
+            `Full logical restore currently requires a database created through Jasper's Databases `
+            + `panel — it needs to stop/start the stone and locate its extent, which Jasper only `
+            + `knows how to do for databases it manages. "${session.login.stone}" is not one of them `
+            + '(it was created outside Jasper), so it cannot be restored this way yet.',
+            { modal: true },
+          );
+          return;
+        }
+
+        // Capture what we need before the session is torn down. The GciLibrary
+        // outlives its session's logout, so the transient restore logins reuse it.
+        const harvested = session.login;
+        const gci = session.gci;
+        const sessionId = session.id;
+        const managed = db;
+        const dataDir = path.join(managed.path, 'data');
+        const gsPath = sysadminStorage.getGemstonePath(managed.config.version);
+
+        const toRestoreSession = (
+          t: { session: ActiveSession; logout: () => void },
+        ): RestoreSession => ({
+          run: (label, code) => queries.executeFetchStringNb(t.session, label, code, undefined, true),
+          logout: t.logout,
+        });
+
+        const restored = await runLogicalRestore({
+          stoneName: managed.config.stoneName,
+          dbPath: managed.path,
+          backupFile,
+          hasFileControl: () =>
+            hasFileControlPrivilege((label, code) => queries.executeFetchString(session!, label, code)),
+          closeCurrentSession: async () => { sessionManager.logout(sessionId); },
+          stopStone: async () => {
+            // GciTsLogout returns before the stone finishes deregistering our gem,
+            // so stopstone (which logs in itself to request shutdown) can still see
+            // our just-closed session and refuse with "Other users logged in" (exit
+            // 13). Retry briefly to ride out that deregistration lag; a genuine
+            // other-user situation simply fails after the retries with that message.
+            let lastErr: unknown;
+            for (let attempt = 0; attempt < 6; attempt++) {
+              try {
+                await processManager.stopStone(managed);
+                return;
+              } catch (e) {
+                lastErr = e;
+                await new Promise((resolve) => setTimeout(resolve, 1500));
+              }
+            }
+            throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+          },
+          startStone: async () => { await processManager.startStone(managed); },
+          copyCurrentExtentAside: async (destPath) => {
+            wslMkdirSync(path.dirname(destPath), { recursive: true });
+            wslImportFileSync(path.join(dataDir, 'extent0.dbf'), destPath);
+          },
+          swapInFreshExtent: async () => {
+            if (!gsPath) {
+              throw new Error(
+                `GemStone ${managed.config.version} installation not found; cannot obtain a fresh extent.`,
+              );
+            }
+            const pristine = path.join(gsPath, 'bin', 'extent0.dbf');
+            if (!wslExistsSync(pristine)) {
+              throw new Error(`Fresh extent not found at ${pristine}.`);
+            }
+            for (const entry of wslReaddirSync(dataDir)) {
+              if (entry.toLowerCase().endsWith('.dbf')) {
+                wslUnlinkSync(path.join(dataDir, entry));
+              }
+            }
+            const dest = path.join(dataDir, 'extent0.dbf');
+            wslImportFileSync(pristine, dest);
+            wslChmodSync(dest, 0o644);
+          },
+          loginAsDefaultAdmin: async () => toRestoreSession(
+            sessionManager.loginTransient(
+              { ...harvested, gs_user: 'DataCurator', gs_password: 'swordfish' }, gci,
+            ),
+          ),
+          loginAsSessionUser: async () =>
+            toRestoreSession(sessionManager.loginTransient(harvested, gci)),
+        });
+
+        if (restored) {
+          // Best-effort: re-establish the user's normal interactive session (the
+          // restored repo carries the real accounts again). If it fails, the
+          // success toast already told the user to reconnect manually.
+          const libraryPath = storage.getGciLibraryPath(harvested.version);
+          if (libraryPath) {
+            try {
+              const s = sessionManager.login(harvested, libraryPath);
+              refreshEnhancedInspectorAvailable(s);
+            } catch { /* user reconnects manually */ }
+          }
+          refreshAdminViews();
+        }
+      }),
   );
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -74,6 +74,7 @@ import { VersionManager } from './versionManager';
 import { VersionTreeProvider, VersionItem } from './versionTreeProvider';
 import { DatabaseManager } from './databaseManager';
 import { DatabaseTreeProvider, DatabaseNode } from './databaseTreeProvider';
+import { runLogicalBackup } from './backupManager';
 import { ProcessManager } from './processManager';
 import { openMcpInspector } from './openMcpInspector';
 import { McpSocketServer, writeClaudeDesktopMcpConfig } from './mcpSocketServer';
@@ -2891,6 +2892,33 @@ export function activate(context: vscode.ExtensionContext) {
       if (replaced) {
         refreshAdminViews();
       }
+    }),
+
+    vscode.commands.registerCommand('gemstone.fullLogicalBackup', async (item?: GemStoneSessionItem) => {
+      // A full backup runs over GCI against the connected stone, so it operates
+      // on a specific session: the one clicked in the Sessions tree, or the
+      // selected session when invoked from the palette.
+      const session = item ? item.activeSession : sessionManager.getSelectedSession();
+      if (!session) {
+        vscode.window.showInformationMessage(
+          'No GemStone session to back up. Connect a session first.',
+        );
+        return;
+      }
+      // Default the destination next to the extents when this session's stone is
+      // one we manage locally; otherwise the picker opens without a default dir.
+      const db = sysadminStorage.getDatabases()
+        .find(d => d.config.stoneName === session.login.stone);
+      const backedUp = await runLogicalBackup({
+        execute: (label, code) => queries.executeFetchString(session, label, code),
+        runBackup: (code) =>
+          queries.executeFetchStringNb(session, 'gemstone.fullLogicalBackup', code, undefined, true),
+        stoneName: session.login.stone,
+        dbPath: db?.path,
+      });
+      // Re-read the Databases tree so the new backup (and the Backups node, if
+      // this was the first one) shows up without a manual refresh.
+      if (backedUp) refreshAdminViews();
     }),
   );
 }

--- a/client/src/queries/__tests__/backup.test.ts
+++ b/client/src/queries/__tests__/backup.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryExecutor } from '../types';
+import {
+  hasFileControlPrivilege,
+  sessionNeedsCommit,
+  abortTransaction,
+  fullBackupCode,
+} from '../backup';
+
+describe('full logical backup queries', () => {
+  describe('FileControl privilege check', () => {
+    it('reports the privilege is held when the stone answers true', () => {
+      const execute = vi.fn<QueryExecutor>(() => 'true\n');
+
+      const held = hasFileControlPrivilege(execute);
+
+      expect(held).toBe(true);
+      expect(execute.mock.calls[0][1]).toContain('privileges includes: #FileControl');
+    });
+
+    it('reports the privilege is missing for any non-true answer', () => {
+      const execute = vi.fn<QueryExecutor>(() => 'false');
+
+      expect(hasFileControlPrivilege(execute)).toBe(false);
+    });
+  });
+
+  describe('uncommitted-changes check', () => {
+    it('detects uncommitted changes when the session needs a commit', () => {
+      const execute = vi.fn<QueryExecutor>(() => 'true');
+
+      const dirty = sessionNeedsCommit(execute);
+
+      expect(dirty).toBe(true);
+      expect(execute.mock.calls[0][1]).toContain('System needsCommit');
+    });
+
+    it('reports a clean session as having nothing to lose', () => {
+      const execute = vi.fn<QueryExecutor>(() => 'false');
+
+      expect(sessionNeedsCommit(execute)).toBe(false);
+    });
+  });
+
+  describe('discarding changes before a backup', () => {
+    it('aborts the session to drop uncommitted changes', () => {
+      const execute = vi.fn<QueryExecutor>(() => 'aborted');
+
+      abortTransaction(execute);
+
+      expect(execute.mock.calls[0][1]).toContain('System abortTransaction');
+    });
+  });
+
+  describe('backup Smalltalk', () => {
+    it('backs the repository up to the requested destination', () => {
+      const code = fullBackupCode('/data/backups/gs.dbf');
+
+      expect(code).toContain("SystemRepository fullBackupTo: '/data/backups/gs.dbf'");
+    });
+
+    it('escapes single quotes in the destination path', () => {
+      const code = fullBackupCode("/data/o'brien/gs.dbf");
+
+      expect(code).toContain("fullBackupTo: '/data/o''brien/gs.dbf'");
+    });
+
+    it('evaluates to a success marker on completion', () => {
+      const code = fullBackupCode('/x.dbf');
+
+      expect(code).toContain("ifTrue: ['OK']");
+    });
+
+    it('restores the session transaction mode after the backup', () => {
+      const code = fullBackupCode('/x.dbf');
+
+      expect(code).toContain('mode := System transactionMode');
+      expect(code).toContain('ensure: [System transactionMode: mode]');
+    });
+  });
+});

--- a/client/src/queries/__tests__/restore.test.ts
+++ b/client/src/queries/__tests__/restore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RESTORE_NO_LOGOUT_MARKER,
+  restoreFromBackupCode,
+  commitRestoreCode,
+  restoreStatusInfoCode,
+} from '../restore';
+
+describe('full logical restore queries', () => {
+  describe('restore Smalltalk', () => {
+    it('restores the repository from the requested backup file', () => {
+      const code = restoreFromBackupCode('/data/backups/gs.dbf');
+
+      expect(code).toContain("SystemRepository restoreFromBackup: '/data/backups/gs.dbf'");
+    });
+
+    it('escapes single quotes in the backup path', () => {
+      const code = restoreFromBackupCode("/data/o'brien/gs.dbf");
+
+      expect(code).toContain("restoreFromBackup: '/data/o''brien/gs.dbf'");
+    });
+
+    it('marks a completion that did not auto-log-out so the partial-logging case is detectable', () => {
+      const code = restoreFromBackupCode('/x.dbf');
+
+      expect(code).toContain(`'${RESTORE_NO_LOGOUT_MARKER}'`);
+    });
+  });
+
+  describe('finalizing the restore', () => {
+    it('commits the restore to make the stone operational', () => {
+      const code = commitRestoreCode();
+
+      expect(code).toContain('SystemRepository commitRestore');
+    });
+
+    it('evaluates to a success marker once committed', () => {
+      const code = commitRestoreCode();
+
+      expect(code).toContain("'OK'");
+    });
+  });
+
+  describe('restore status', () => {
+    it('reports the current restore state', () => {
+      const code = restoreStatusInfoCode();
+
+      expect(code).toContain('SystemRepository restoreStatusInfo');
+    });
+  });
+});

--- a/client/src/queries/backup.ts
+++ b/client/src/queries/backup.ts
@@ -1,0 +1,50 @@
+// Query layer for logical (object) backups — Repository>>fullBackupTo:.
+//
+// These functions follow the shared `QueryExecutor` convention (see types.ts):
+// the pre-flight checks are fast and use the synchronous executor, while the
+// backup itself is long-running, so the caller runs `fullBackupCode` through a
+// non-blocking executor. All emitted Smalltalk is ASCII-only so it compiles on
+// the 3.6.x stones too (a non-ASCII byte trips the ComStrmSetCursor bug there).
+import { QueryExecutor } from './types';
+import { escapeString } from './util';
+
+// `fullBackupTo:` requires the FileControl privilege; without it the stone
+// raises a raw GCI error. Pre-flighting lets us stop with a clear message.
+export function hasFileControlPrivilege(execute: QueryExecutor): boolean {
+  return execute(
+    'backup: FileControl privilege check',
+    '(System myUserProfile privileges includes: #FileControl) printString',
+  ).trim() === 'true';
+}
+
+// A logical backup aborts the session; `fullBackupTo:` refuses outright
+// (rtErrAbortWouldLoseData) when the session holds uncommitted changes. Pre-flight
+// so we can warn the user before anything is discarded.
+export function sessionNeedsCommit(execute: QueryExecutor): boolean {
+  return execute(
+    'backup: uncommitted-changes check',
+    'System needsCommit printString',
+  ).trim() === 'true';
+}
+
+// Discard the session's uncommitted changes so the subsequent backup won't be
+// refused. Only call this after the user has explicitly consented to lose them.
+export function abortTransaction(execute: QueryExecutor): void {
+  execute('backup: abort uncommitted changes', "System abortTransaction. 'aborted'");
+}
+
+// Smalltalk for a full backup to a server-side path. Returned verbatim as a
+// String (not a printString) so it can be run through the non-blocking executor,
+// which fetches chars directly. Evaluates to 'OK' on success.
+//
+// fullBackupTo: leaves the session in manualBegin mode on completion; we capture
+// the session's transaction mode up front and restore it afterward (via ensure:,
+// so it is restored even if the backup raises) so the user's session is left the
+// way they had it.
+export function fullBackupCode(serverPath: string): string {
+  return `| mode ok |
+mode := System transactionMode.
+[ok := SystemRepository fullBackupTo: '${escapeString(serverPath)}']
+  ensure: [System transactionMode: mode].
+ok ifTrue: ['OK'] ifFalse: ['fullBackupTo: returned false']`;
+}

--- a/client/src/queries/restore.ts
+++ b/client/src/queries/restore.ts
@@ -1,0 +1,45 @@
+// Query layer for logical (object) restore — Repository>>restoreFromBackup: and
+// the commit/status calls that finalize it. The counterpart to backup.ts.
+//
+// These follow the shared `QueryExecutor` convention (see types.ts). All emitted
+// Smalltalk is ASCII-only so it compiles on the 3.6.x stones too (a non-ASCII
+// byte trips the ComStrmSetCursor bug there).
+//
+// The 4046 quirk (full-logging stones — our case): on success `restoreFromBackup:`
+// does NOT return to the caller. The stone raises error 4046 (RestoreBackupSuccess)
+// and auto-logs-out the session, so that error number MEANS success and the caller
+// must reconnect (a fresh login) before running `commitRestore`. Because the
+// logout tears the session down, this cannot be caught in Smalltalk — the restore
+// manager inspects the GCI error number at the transport level. The code below
+// appends a marker so the *partial-logging* case (which DOES return normally,
+// fully restored, needing no commit step) stays distinguishable from that error.
+import { escapeString } from './util';
+
+// Returned only when restoreFromBackup: completes WITHOUT the 4046 auto-logout —
+// i.e. a partial-logging backup, which restores fully in a single call. The
+// manager keys on this to know no separate commitRestore step is required.
+export const RESTORE_NO_LOGOUT_MARKER = 'RESTORE_OK_NO_LOGOUT';
+
+// Smalltalk that restores the repository from a server-side backup file. On a
+// full-logging stone this never reaches the marker — the 4046 auto-logout fires
+// first and is surfaced to the caller as a GCI error (which the manager treats as
+// success). On a partial-logging stone it returns the marker, fully restored.
+export function restoreFromBackupCode(serverPath: string): string {
+  return `SystemRepository restoreFromBackup: '${escapeString(serverPath)}'.
+'${RESTORE_NO_LOGOUT_MARKER}'`;
+}
+
+// Finalizes a restore begun with restoreFromBackup:, run after reconnecting past
+// the 4046 auto-logout. Makes the stone operational again. Evaluates to 'OK' on
+// success so the (reconnected) non-blocking executor has a result to report.
+export function commitRestoreCode(): string {
+  return `SystemRepository commitRestore.
+'OK'`;
+}
+
+// A human-readable description of the current restore state (restoreStatusInfo
+// already answers a String, so it is fetched verbatim). Used to report progress
+// and to confirm the stone is operational after commitRestore.
+export function restoreStatusInfoCode(): string {
+  return 'SystemRepository restoreStatusInfo';
+}

--- a/client/src/restoreManager.ts
+++ b/client/src/restoreManager.ts
@@ -1,0 +1,265 @@
+// Orchestrates a logical (object) restore of a stone from a full backup file —
+// the destructive counterpart to backupManager.ts.
+//
+// Unlike a backup (one call on the live session), a restore spans a whole
+// stop→swap→start→login→restore→reconnect→commit lifecycle, so this module takes
+// the stone lifecycle, filesystem, and login capabilities as injected
+// dependencies. That keeps the orchestration (and the tricky 4046 handling)
+// unit-testable without a live stone or a real repository to destroy.
+//
+// The 4046 quirk (see queries/restore.ts): on a full-logging stone,
+// `restoreFromBackup:` raises error 4046 (RestoreBackupSuccess) and auto-logs-out
+// on success. That error number therefore MEANS success — we catch it, reconnect,
+// and run `commitRestore`. A partial-logging stone instead returns normally
+// (RESTORE_NO_LOGOUT_MARKER) already fully restored, needing no commit step.
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as restore from './queries/restore';
+
+// GCI error number the stone raises on a successful full-logging restore, just
+// before it auto-logs-out the session. Treated as success, not failure.
+const RESTORE_SUCCESS_LOGOUT_ERROR = 4046;
+
+// A logged-in GCI session scoped to the restore. `run` executes a code snippet
+// and returns the stone's String result; on a GCI error it throws (carrying the
+// `gciErrorNumber`, as BrowserQueryError does) so the 4046 success can be caught.
+export interface RestoreSession {
+  run: (label: string, code: string) => Promise<string>;
+  logout: () => void;
+}
+
+export interface LogicalRestoreDeps {
+  // Stone the session is connected to (labels, filenames, messages).
+  stoneName: string;
+  // Managed database root. Restore is local-only (the gem must run on the same
+  // machine as the stone), so this is always known; the safety copy of the
+  // current extent lands under <dbPath>/backups/backupExtents.
+  dbPath: string;
+  // Server-side path to the backup .dbf to restore from. Pre-selected when the
+  // restore was launched from a backup-file tree node; omitted for the Sessions
+  // view button, in which case the manager prompts with an open dialog.
+  backupFile?: string;
+
+  // Pre-flight against the CURRENT live session, before it is torn down. A
+  // restore requires the FileControl privilege.
+  hasFileControl: () => boolean;
+
+  // Tear down the user's live session so the stone can be stopped cleanly.
+  closeCurrentSession: () => Promise<void>;
+  // Stone lifecycle (wrap processManager.stop/startStone).
+  stopStone: () => Promise<void>;
+  startStone: () => Promise<void>;
+
+  // Preserve the current extent to a server-side path (a clean copy — the stone
+  // is stopped when this runs). The manager computes the destination name.
+  copyCurrentExtentAside: (destPath: string) => Promise<void>;
+  // Replace the current extent with a pristine $GEMSTONE/bin/extent0.dbf. Only
+  // called when the user chose a fresh extent (the space-reclaiming default).
+  swapInFreshExtent: () => Promise<void>;
+
+  // Log in to the freshly started stone. A fresh extent has only the default
+  // accounts (the restored user does not exist yet), so that path authenticates
+  // as DataCurator/swordfish; an in-place restore uses the harvested session
+  // creds. The commitRestore reconnect reuses the SAME login as the restore,
+  // because the restore is not yet committed (auth still reflects the
+  // pre-restore committed state).
+  loginAsDefaultAdmin: () => Promise<RestoreSession>;
+  loginAsSessionUser: () => Promise<RestoreSession>;
+}
+
+const BACKUP_FILTERS: Record<string, string[]> = {
+  'GemStone backup': ['dbf'],
+  'All files': ['*'],
+};
+
+// How long the green success message lingers in the status bar (ms).
+const STATUS_SUCCESS_MS = 6000;
+const WORKING_COLOR = 'charts.blue';
+const SUCCESS_COLOR = 'charts.green';
+const FAILURE_COLOR = 'charts.red';
+
+// User-facing labels for the fresh-extent choice.
+const FRESH_EXTENT = 'Fresh extent (recommended — reclaims space)';
+const IN_PLACE = 'Restore onto the current extent';
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// The GCI error number carried by a thrown query error (BrowserQueryError), or
+// undefined for anything else. Duck-typed so this module needn't import the
+// browser-query layer.
+function gciErrorNumberOf(e: unknown): number | undefined {
+  const n = (e as { gciErrorNumber?: unknown })?.gciErrorNumber;
+  return typeof n === 'number' ? n : undefined;
+}
+
+// A filesystem-safe, sortable timestamp in LOCAL time (YYYY-MM-DD_HH-MM-SS), so
+// names line up with what the user sees in their file manager rather than UTC.
+function timestamp(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+    + `_${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}`;
+}
+
+// Where the current extent is preserved before the restore overwrites it: a
+// smart, sortable name under <dbPath>/backups/backupExtents. Exported for tests.
+export function preRestoreExtentPath(dbPath: string, stoneName: string): string {
+  return path.join(
+    dbPath, 'backups', 'backupExtents',
+    `extent0_preRestore_${stoneName}_${timestamp()}.dbf`,
+  );
+}
+
+// Runs restoreFromBackup: on a freshly started stone and interprets the outcome.
+// Returns true when the full-logging 4046 auto-logout fired (a commitRestore step
+// is still needed); false when the stone returned normally (partial-logging, no
+// commit needed). Re-throws any genuine failure.
+async function runRestoreCall(session: RestoreSession, backupFile: string): Promise<boolean> {
+  try {
+    await session.run('restore: restoreFromBackup', restore.restoreFromBackupCode(backupFile));
+    // Returned without logging out: a partial-logging backup, fully restored.
+    return false;
+  } catch (e) {
+    if (gciErrorNumberOf(e) === RESTORE_SUCCESS_LOGOUT_ERROR) {
+      // Success: the stone restored the objects and auto-logged-out.
+      return true;
+    }
+    throw e;
+  } finally {
+    // The session is already gone on the 4046 path; log out best-effort otherwise.
+    try { session.logout(); } catch { /* already logged out */ }
+  }
+}
+
+// Returns true if the restore completed and the stone is operational again, false
+// if it was cancelled or failed (all failure paths surface their own message).
+export async function runLogicalRestore(deps: LogicalRestoreDeps): Promise<boolean> {
+  let hasPrivilege: boolean;
+  try {
+    hasPrivilege = deps.hasFileControl();
+  } catch (e) {
+    vscode.window.showErrorMessage(`Could not check restore privileges: ${errorMessage(e)}`);
+    return false;
+  }
+  if (!hasPrivilege) {
+    vscode.window.showErrorMessage(
+      'A full logical restore requires the FileControl privilege. Connect as a user that has it '
+      + '(for example DataCurator or SystemUser) and try again.',
+    );
+    return false;
+  }
+
+  // Choose the backup file (unless the tree node already pinned one).
+  let backupFile = deps.backupFile;
+  if (!backupFile) {
+    const defaultDir = path.join(deps.dbPath, 'backups');
+    const picked = await vscode.window.showOpenDialog({
+      title: `Full Logical Restore of ${deps.stoneName}`,
+      defaultUri: vscode.Uri.file(defaultDir),
+      canSelectMany: false,
+      openLabel: 'Restore',
+      filters: BACKUP_FILTERS,
+    });
+    if (!picked?.[0]) return false;
+    backupFile = picked[0].fsPath;
+  }
+
+  // Fresh extent (default) reclaims space; in-place keeps the existing bloat.
+  const extentChoice = await vscode.window.showQuickPick([FRESH_EXTENT, IN_PLACE], {
+    title: `Full Logical Restore of ${deps.stoneName}`,
+    placeHolder: 'Restore into a fresh extent (reclaims space) or onto the current extent?',
+  });
+  if (!extentChoice) return false;
+  const freshExtent = extentChoice === FRESH_EXTENT;
+
+  // Point of no return: name the stone and spell out what is lost.
+  const proceed = await vscode.window.showWarningMessage(
+    `Restore "${deps.stoneName}" from ${backupFile}? This REPLACES the entire repository. `
+    + 'Everything committed since this backup was taken will be permanently lost. '
+    + 'The current extent is saved aside first'
+    + (freshExtent ? ', then replaced with a fresh extent.' : '.'),
+    { modal: true },
+    'Restore',
+  );
+  if (proceed !== 'Restore') return false;
+
+  // A single always-blue status-bar item is the sole progress indicator: it
+  // updates per step, then turns green on success or red on failure. We do NOT
+  // use a withProgress notification — it would sit alongside this item in the
+  // default gray (reading as "blue & gray"), and notification text cannot be
+  // recolored. Plain text, no codicon (an animated $(sync~spin) renders in the
+  // default foreground rather than the item's color, which also looks two-toned).
+  const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+  status.color = new vscode.ThemeColor(WORKING_COLOR);
+  const step = (message: string) => {
+    status.text = `Restoring "${deps.stoneName}" — ${message}`;
+  };
+  step('closing the current session…');
+  status.show();
+
+  const login = freshExtent ? deps.loginAsDefaultAdmin : deps.loginAsSessionUser;
+
+  try {
+    await deps.closeCurrentSession();
+
+    step('stopping the stone…');
+    await deps.stopStone();
+
+    step('saving the current extent aside…');
+    await deps.copyCurrentExtentAside(preRestoreExtentPath(deps.dbPath, deps.stoneName));
+
+    if (freshExtent) {
+      step('installing a fresh extent…');
+      await deps.swapInFreshExtent();
+    }
+
+    step('starting the stone…');
+    await deps.startStone();
+
+    step('restoring from the backup…');
+    const needsCommit = await runRestoreCall(await login(), backupFile!);
+
+    if (needsCommit) {
+      step('finalizing the restore…');
+      const admin = await login();
+      try {
+        await admin.run('restore: commitRestore', restore.commitRestoreCode());
+      } catch (e) {
+        // commitRestore raises a benign warning when a full backup is restored
+        // WITHOUT rolling forward the current transaction logs (roll-forward is
+        // out of scope for now):
+        //   "...commitRestore not immediately preceeded by restoreFromCurrentLogs.
+        //    WARNING: Some transactions may not be restored."
+        // The commit still completes and the stone is operational (verified on
+        // 3.6.2: restoreStatus reports "Restore is not active." afterward), so
+        // this specific warning is success. Any other error is a real failure.
+        const msg = errorMessage(e);
+        if (!/restoreFromCurrentLogs|may not be restored/i.test(msg)) {
+          throw e;
+        }
+      } finally {
+        try { admin.logout(); } catch { /* ignore */ }
+      }
+    }
+  } catch (e) {
+    status.text = `Restore of "${deps.stoneName}" failed`;
+    status.color = new vscode.ThemeColor(FAILURE_COLOR);
+    setTimeout(() => status.dispose(), STATUS_SUCCESS_MS);
+    vscode.window.showErrorMessage(
+      `Full logical restore failed: ${errorMessage(e)}. The current extent was saved under `
+      + `${path.join(deps.dbPath, 'backups', 'backupExtents')}.`,
+    );
+    return false;
+  }
+
+  status.text = `"${deps.stoneName}" restored`;
+  status.color = new vscode.ThemeColor(SUCCESS_COLOR);
+  setTimeout(() => status.dispose(), STATUS_SUCCESS_MS);
+
+  vscode.window.showInformationMessage(
+    `"${deps.stoneName}" was restored from ${backupFile}. Reconnect to resume working.`,
+  );
+  return true;
+}

--- a/client/src/sessionManager.ts
+++ b/client/src/sessionManager.ts
@@ -198,6 +198,49 @@ export class SessionManager {
     return session;
   }
 
+  // A transient, unregistered login for destructive admin flows (e.g. logical
+  // restore) that log in and out repeatedly across a stone stop/start cycle. It
+  // does NOT create an interactive session — no Transcript sink, no Sessions-view
+  // entry, no single-session-mode gating, no auto-select — so it never disturbs
+  // the user's session state. Reuses an existing GciLibrary (typically the
+  // initiating session's, which survives that session's logout). The caller MUST
+  // log out via the returned `logout`.
+  loginTransient(
+    login: GemStoneLogin, gci: GciLibrary,
+  ): { session: ActiveSession; logout: () => void } {
+    const stoneNrs = `!tcp@${login.gem_host}#server!${login.stone}`;
+    const gemNrs = `!tcp@${login.gem_host}#netldi:${login.netldi}#task!gemnetobject`;
+
+    const result = gci.GciTsLogin(
+      stoneNrs,
+      login.host_user || null,
+      login.host_password || null,
+      false,
+      gemNrs,
+      login.gs_user,
+      login.gs_password,
+      0, 0,
+    );
+
+    if (!result.session) {
+      throw new Error(result.err.message || `Login failed (error ${result.err.number})`);
+    }
+
+    const { version } = gci.GciTsVersion();
+    const session: ActiveSession = {
+      id: -1,
+      gci,
+      handle: result.session,
+      login,
+      stoneVersion: version,
+      enhancedInspectorAvailable: false,
+    };
+    return {
+      session,
+      logout: () => { try { gci.GciTsLogout(result.session); } catch { /* already gone */ } },
+    };
+  }
+
   logout(id: number): void {
     const s = this.sessions.get(id);
     if (!s) return;

--- a/package.json
+++ b/package.json
@@ -1237,6 +1237,12 @@
         "icon": "$(replace-all)"
       },
       {
+        "command": "gemstone.fullLogicalBackup",
+        "title": "Full Logical Backup",
+        "category": "GemStone Admin",
+        "icon": "$(archive)"
+      },
+      {
         "command": "gemstone.openMcpInspector",
         "title": "Open MCP Inspector",
         "category": "GemStone",
@@ -1608,9 +1614,14 @@
           "group": "inline@5"
         },
         {
-          "command": "gemstone.sessionLogout",
+          "command": "gemstone.fullLogicalBackup",
           "when": "view == gemstoneLogins && viewItem == gemstoneSession",
           "group": "inline@6"
+        },
+        {
+          "command": "gemstone.sessionLogout",
+          "when": "view == gemstoneLogins && viewItem == gemstoneSession",
+          "group": "inline@7"
         },
         {
           "command": "gemstone.exportClasses",

--- a/package.json
+++ b/package.json
@@ -1243,6 +1243,12 @@
         "icon": "$(archive)"
       },
       {
+        "command": "gemstone.fullLogicalRestore",
+        "title": "Full Logical Restore",
+        "category": "GemStone Admin",
+        "icon": "$(history)"
+      },
+      {
         "command": "gemstone.openMcpInspector",
         "title": "Open MCP Inspector",
         "category": "GemStone",
@@ -1619,9 +1625,14 @@
           "group": "inline@6"
         },
         {
-          "command": "gemstone.sessionLogout",
+          "command": "gemstone.fullLogicalRestore",
           "when": "view == gemstoneLogins && viewItem == gemstoneSession",
           "group": "inline@7"
+        },
+        {
+          "command": "gemstone.sessionLogout",
+          "when": "view == gemstoneLogins && viewItem == gemstoneSession",
+          "group": "inline@8"
         },
         {
           "command": "gemstone.exportClasses",
@@ -1695,6 +1706,11 @@
         {
           "command": "gemstone.replaceExtent",
           "when": "view == gemstoneDatabases && viewItem == gemstoneDbStoneStopped",
+          "group": "inline@1"
+        },
+        {
+          "command": "gemstone.fullLogicalRestore",
+          "when": "view == gemstoneDatabases && viewItem == gemstoneDbBackupFile",
           "group": "inline@1"
         },
         {


### PR DESCRIPTION
Implements grail #28 for logical (object) backup and restore of a GemStone/S database.

## Full Logical Backup (Stage 1)
- `Repository>>fullBackupTo:` run from the Sessions view, after checking the user has the required FileControl privilege and guarding against uncommitted changes.
- Backups tree node under each managed database lists prior backups; success toast can reveal the file.

## Full Logical Restore (Stage 2)
- One guided action from the Sessions view (paired with Backup) and from a backup-file tree node — both require a live session, whose credentials carry through the stone stop/start cycle.
- Flow: close session → stop stone → save the current extent aside (`backups/backupExtents/`) → optional fresh extent (recommended, reclaims space) → start → login → `restoreFromBackup:` → `commitRestore`.
- Treats the `restoreFromBackup:` **4046 auto-logout as success** (full-logging stones) and the benign no-roll-forward `commitRestore` warning as success. `stopstone` retries to ride out gem-deregistration lag after logout.
- Gated to Jasper-managed databases (external stones deferred). Single always-blue status bar → green/red. Backup/extent filenames now use local time.

## Tests
- Unit: `queries/restore` (6), `restoreManager` (16), plus Stage-1 backup coverage.
- On-demand GCI round-trip (`gciBackupRestore`): commit a marker → back up → commit a second marker → restore → assert the first survived and the second was rolled back. Runs the shipped Smalltalk against a live stone (in-place, near-idempotent, cleans up after itself).
- Full client suite 3079/3079; gci suite 233 pass / 1 skip. F5-verified on 3.6.2 and 3.7.5.

Deferred: roll-forward/point-in-time restore, `scavengePagesWithPercentFree:`, `newSystemUserPassword:`, remote/external-stone restore, extent-copy (types #1/#2).
