### PR TITLE
Lint GitHub Actions workflows: timeouts, actionlint, zizmor

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -3,30 +3,36 @@ name: Health Check
 on: push
 
 jobs:
-  load-gemstone-integration-versions:
+  prepare:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.read.outputs.versions }}
+      versions: ${{ steps.read-gemstone-integration-versions.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github/workflows
+            /package.json
+            scripts/lint-workflow-timeouts.sh
             client/.gemstone-integration-releases.json
             client/bin/gemstone-integration-versions.js
             client/src/gemStoneVersion.js
           sparse-checkout-cone-mode: false
-      - id: read
+      - name: Lint workflow timeouts
+        run: npm run lint:github:workflows
+      - name: Read GemStone integration versions
+        id: read-gemstone-integration-versions
         run: echo "versions=$(node client/bin/gemstone-integration-versions.js)" >> $GITHUB_OUTPUT
 
   health-check:
     timeout-minutes: 5
     name: GemStone S/64 ${{ matrix.gemstone-version }}
-    needs: load-gemstone-integration-versions
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemstone-version: ${{ fromJson(needs.load-gemstone-integration-versions.outputs.versions) }}
+        gemstone-version: ${{ fromJson(needs.prepare.outputs.versions) }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   load-gemstone-integration-versions:
+    timeout-minutes: 1
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.read.outputs.versions }}
@@ -19,6 +20,7 @@ jobs:
         run: echo "versions=$(node client/bin/gemstone-integration-versions.js)" >> $GITHUB_OUTPUT
 
   health-check:
+    timeout-minutes: 5
     name: GemStone S/64 ${{ matrix.gemstone-version }}
     needs: load-gemstone-integration-versions
     runs-on: ubuntu-latest

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -61,8 +61,9 @@ jobs:
           persist-credentials: false
       - name: Run actionlint
         # actionlint/shellcheck(SC2046): quote $(pwd) to prevent word
-        # splitting/globbing
-        run: docker run --rm -v "$(pwd)":/repo --workdir /repo rhysd/actionlint:1.7.12 -color
+        # splitting/globbing. Pinned to a digest, not a mutable tag, for the
+        # same supply-chain reason as the zizmor(unpinned-uses) actions above.
+        run: docker run --rm -v "$(pwd)":/repo --workdir /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color # 1.7.12
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # zizmor(unpinned-uses): actions must be pinned to a commit SHA, not
       # a mutable tag like @v6
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
             .github/workflows
@@ -51,7 +51,7 @@ jobs:
     steps:
       # zizmor(unpinned-uses): actions must be pinned to a commit SHA, not
       # a mutable tag like @v6
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
             .github/workflows
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout code
         # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
         # not a mutable tag like @v6
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # zizmor(artipacked): checkout must not persist the token past
           # this job

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -2,6 +2,11 @@ name: Health Check
 
 on: push
 
+# zizmor(excessive-permissions): an explicit permissions block is required
+# instead of relying on the default GITHUB_TOKEN scope
+permissions:
+  contents: read
+
 jobs:
   prepare:
     timeout-minutes: 1
@@ -9,7 +14,9 @@ jobs:
     outputs:
       versions: ${{ steps.read-gemstone-integration-versions.outputs.versions }}
     steps:
-      - uses: actions/checkout@v6
+      # zizmor(unpinned-uses): actions must be pinned to a commit SHA, not
+      # a mutable tag like @v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/workflows
@@ -19,11 +26,47 @@ jobs:
             client/bin/gemstone-integration-versions.js
             client/src/gemStoneVersion.js
           sparse-checkout-cone-mode: false
+          # zizmor(artipacked): checkout must not persist the token past
+          # this job
+          persist-credentials: false
+      # Fails if any job lacks timeout-minutes, since a job without one
+      # silently inherits GitHub's 360-minute default instead of failing
+      # fast on a hang. Kept here rather than in lint-workflows: it's a
+      # cheap bash+yq script with no Docker pull, so it adds negligible
+      # latency to the matrix gate. Only the slower actionlint/zizmor
+      # checks were split into their own job, to avoid blocking the matrix
+      # on their Docker image pulls.
       - name: Lint workflow timeouts
         run: npm run lint:github:workflows
       - name: Read GemStone integration versions
         id: read-gemstone-integration-versions
-        run: echo "versions=$(node client/bin/gemstone-integration-versions.js)" >> $GITHUB_OUTPUT
+        # actionlint/shellcheck(SC2086): quote $GITHUB_OUTPUT to prevent
+        # word splitting/globbing
+        run: echo "versions=$(node client/bin/gemstone-integration-versions.js)" >> "$GITHUB_OUTPUT"
+
+  lint-workflows:
+    name: Lint GitHub Actions workflows
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      # zizmor(unpinned-uses): actions must be pinned to a commit SHA, not
+      # a mutable tag like @v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: |
+            .github/workflows
+          sparse-checkout-cone-mode: false
+          # zizmor(artipacked): checkout must not persist the token past
+          # this job
+          persist-credentials: false
+      - name: Run actionlint
+        # actionlint/shellcheck(SC2046): quote $(pwd) to prevent word
+        # splitting/globbing
+        run: docker run --rm -v "$(pwd)":/repo --workdir /repo rhysd/actionlint:1.7.12 -color
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
 
   health-check:
     timeout-minutes: 5
@@ -36,9 +79,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # zizmor(artipacked): checkout must not persist the token past
+          # this job
+          persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Install dependencies
@@ -46,11 +97,17 @@ jobs:
       - name: Compile
         run: npm run compile
       - name: Cache GemStone installation
-        uses: actions/cache@v6
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: client/tmp/downloads
           key: gemstone-download-${{ runner.os }}-${{ matrix.gemstone-version }}
       - name: Setup test environment
-        run: npm run test:server:start -- ${{ matrix.gemstone-version }}
+        # zizmor(template-injection): bind the untrusted matrix value to an
+        # env var instead of interpolating ${{ }} directly into the script
+        env:
+          GEMSTONE_VERSION: ${{ matrix.gemstone-version }}
+        run: npm run test:server:start -- "$GEMSTONE_VERSION"
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -1938,6 +1938,7 @@
     "watch": "tsc -b -w client/tsconfig.json server/tsconfig.json",
     "dev:fresh": "bash scripts/dev-fresh.sh",
     "serve:seaside": "bash scripts/serve-seaside.sh",
+    "lint:github:workflows": "bash scripts/lint-workflow-timeouts.sh",
     "test": "npm run test --workspaces",
     "test:server:start": "npm run test:server:start --workspace client",
     "test:server:stop": "npm run test:server:stop --workspace client",

--- a/scripts/lint-workflow-timeouts.sh
+++ b/scripts/lint-workflow-timeouts.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Fails if any job in .github/workflows/*.yml has no timeout-minutes —
+# without one, a hang inherits GitHub's 360-minute default instead of
+# failing fast.
+#
+# Requires yq (mikefarah, Go): https://github.com/mikefarah/yq. Preinstalled
+# on GitHub-hosted runners, so CI needs no setup step. Running this locally
+# requires installing it yourself (e.g. `brew install yq` on macOS) — see
+# https://github.com/mikefarah/yq#install for other platforms.
+
+set -euo pipefail
+
+if ! command -v yq >/dev/null 2>&1; then
+    echo "error: yq is required but not installed on this machine." >&2
+    echo "Install it from https://github.com/mikefarah/yq#install (e.g. \`brew install yq\` on macOS), then re-run." >&2
+    exit 1
+fi
+
+missing=0
+
+for file in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [ -e "$file" ] || continue
+
+    while IFS= read -r job; do
+        missing=1
+        echo "  - $file: job \"$job\" has no timeout-minutes"
+    done < <(
+        yq eval '.jobs // {} | to_entries | .[] | select(.value["timeout-minutes"] == null) | .key' "$file"
+    )
+done
+
+if [ "$missing" -eq 1 ]; then
+    echo
+    echo "Add timeout-minutes to each job above so a hang fails fast instead of running for GitHub's 360-minute default." >&2
+    exit 1
+fi
+
+echo "timeout-minutes set on every job."

--- a/scripts/lint-workflow-timeouts.sh
+++ b/scripts/lint-workflow-timeouts.sh
@@ -22,12 +22,26 @@ missing=0
 for file in .github/workflows/*.yml .github/workflows/*.yaml; do
     [ -e "$file" ] || continue
 
+    # Capture yq's output into a variable instead of piping straight into
+    # the loop with `< <(yq ...)`. Process substitution runs yq in a
+    # subshell whose exit status the parent shell never checks, so a
+    # crashing/erroring yq would just produce no output — the loop would
+    # read zero lines and this script would report a clean pass instead of
+    # failing. `jobs=$(yq ...)` is a plain assignment, so its exit status
+    # is yq's exit status, and set -e (above) aborts the script right here
+    # if yq fails.
+    jobs=$(yq eval '.jobs // {} | to_entries | .[] | select(.value["timeout-minutes"] == null) | .key' "$file")
+
+    # A here-string (`<<<`) always feeds the loop one line, even when
+    # $jobs is empty — so without this guard, a file with no missing
+    # timeouts would still make the loop run once with job="", falsely
+    # reporting a job with no name.
+    [ -z "$jobs" ] && continue
+
     while IFS= read -r job; do
         missing=1
         echo "  - $file: job \"$job\" has no timeout-minutes"
-    done < <(
-        yq eval '.jobs // {} | to_entries | .[] | select(.value["timeout-minutes"] == null) | .key' "$file"
-    )
+    done <<< "$jobs"
 done
 
 if [ "$missing" -eq 1 ]; then


### PR DESCRIPTION
## Before

The Health Check workflow had no job timeouts at all — every job would
run for up to GitHub's 360-minute (6h) default before being killed on a
hang. It also had no static analysis on `.github/workflows/*.yml`: no
syntax/expression checking, and no security scanning for things like
unpinned action references or token handling.

## What this PR does

- Sets `timeout-minutes` by hand on both existing jobs (1 min for
  `prepare`, 5 min for `health-check`), so a hang fails fast instead of
  running for 6 hours.
- Adds `scripts/lint-workflow-timeouts.sh` + `npm run
  lint:github:workflows`, which fails CI if any job — present or future
  — lacks `timeout-minutes`, so that fix can't silently regress the next
  time a job is added.
- Wires in `actionlint` and `zizmor` against every workflow file, on
  every push.

## What we found once linting was actually wired in

Turning on `actionlint` and `zizmor` against this repo's own workflow
immediately surfaced several pre-existing issues:

- **Unpinned actions** (`zizmor: unpinned-uses`) — `checkout`, `setup-node`,
  and `cache` were all referenced by a mutable tag (`@v6`), which can be
  repointed to different code without any change in this repo.
- **Credential persistence** (`zizmor: artipacked`) — `checkout` steps
  didn't set `persist-credentials: false`, so the job token stayed
  configured in the local git config for the rest of the job.
- **No explicit permissions** (`zizmor: excessive-permissions`) — the
  workflow ran with default token permissions instead of a minimal,
  explicit `permissions:` block.
- **Template injection** (`zizmor: template-injection`) — the GemStone
  matrix version was interpolated directly as `${{ matrix.gemstone-version }}`
  into a shell script. That substitution happens as text, before the
  shell parses anything, so an untrusted value could inject arbitrary
  shell commands.
- Two ShellCheck findings (`actionlint`) — unquoted `$GITHUB_OUTPUT` and
  `$(pwd)`, both word-splitting/globbing hazards.

## What's here now

- `lint-workflows` is a job of its own, separate from `prepare` (not
  serialized in front of the GemStone version matrix) so its ~10s of
  Docker image pulls (`actionlint`'s pinned image, `zizmor`'s official
  `zizmor-action`) don't delay the matrix from starting — confirmed
  against an actual run: merging it into `prepare` took `prepare` from
  ~7s to ~17s, all of it attributable to two cold image pulls that cost
  the same either way; keeping it separate pays that cost in parallel
  instead of serially.
- All the findings above are fixed: actions pinned to commit SHA
  (`checkout` at v7.0.0, `setup-node` at v6.4.0, `cache` at v6.1.0),
  `persist-credentials: false` on every checkout, a top-level
  `permissions: contents: read`, and the matrix version now flows
  through an `env:` var instead of direct `${{ }}` interpolation.
- Every changed line has an inline comment naming the specific rule it
  satisfies, so a future edit that reintroduces a finding is easy to
  trace back to why the line looks the way it does.

Verified locally and in a real workflow run: `lint:github:workflows`,
`actionlint`, and `zizmor` all pass clean against the final file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)