### PR TITLE
Adjust and align Node/VSCode/Electron/Typescript versions

### DIFF
--- a/.claude/rules/version-pins.md
+++ b/.claude/rules/version-pins.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "package.json"
+  - "client/package.json"
+  - "tsconfig.base.json"
+  - "esbuild.mjs"
+  - ".github/workflows/health-check.yml"
+---
+
+# VS Code / Node version pins
+
+These paths together encode one coordinated VS Code/Node/TypeScript version floor — not independent knobs. Never change one in isolation. Read [docs/how-to/raising-the-version-floor.md](../../docs/how-to/raising-the-version-floor.md) for the full coordinated-file list and the TypeScript devDependency note before touching any of them.

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.read-gemstone-integration-versions.outputs.versions }}
+      oldest-version: ${{ steps.read-gemstone-integration-versions.outputs.oldest-version }}
     steps:
       # zizmor(unpinned-uses): actions must be pinned to a commit SHA, not
       # a mutable tag like @v6
@@ -42,7 +43,9 @@ jobs:
         id: read-gemstone-integration-versions
         # actionlint/shellcheck(SC2086): quote $GITHUB_OUTPUT to prevent
         # word splitting/globbing
-        run: echo "versions=$(node client/bin/gemstone-integration-versions.js)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "versions=$(node client/bin/gemstone-integration-versions.js)" >> "$GITHUB_OUTPUT"
+          echo "oldest-version=$(node client/bin/gemstone-integration-versions.js --oldest)" >> "$GITHUB_OUTPUT"
 
   lint-workflows:
     name: Lint GitHub Actions workflows
@@ -71,12 +74,22 @@ jobs:
 
   health-check:
     timeout-minutes: 5
-    name: GemStone S/64 ${{ matrix.gemstone-version }}
+    name: GemStone S/64 ${{ matrix.gemstone-version }}${{ matrix.node-version && format(' (Node {0})', matrix.node-version) || '' }}
     needs: prepare
     runs-on: ubuntu-latest
     strategy:
       matrix:
         gemstone-version: ${{ fromJson(needs.prepare.outputs.versions) }}
+        node-version: ['']            # empty ⇒ dev jobs resolve Node from .nvmrc (node-version-file); floor include overrides
+        # node-version's declared axis value is only '' (which falls back to
+        # the .nvmrc Node version); '22.15.1' isn't one of the declared
+        # values, so GitHub can't merge this into an existing combination —
+        # it adds an additional job pinned to the oldest GemStone version
+        # and the Node floor, as a smoke test to verify tests run on the
+        # Node floor too. This is to support older VS Code versions.
+        include:
+          - gemstone-version: ${{ needs.prepare.outputs.oldest-version }}
+            node-version: '22.15.1'   # pin the floor for the smoke-test
 
     steps:
       - name: Checkout code
@@ -92,7 +105,10 @@ jobs:
         # not a mutable tag like @v6
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.15.1'
+          # Dev jobs leave node-version empty → Node resolved from .nvmrc.
+          # The floor include job sets node-version, which takes precedence.
+          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
       - name: Compile

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -92,7 +92,7 @@ jobs:
         # not a mutable tag like @v6
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: '.nvmrc'
+          node-version: '22.15.1'
       - name: Install dependencies
         run: npm ci
       - name: Compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Fixed
+
+- **Minimum supported VS Code version is now 1.101.0** (bundled Node 22.15.1), up from 1.85.0. `@types/node`, `@types/vscode`, `tsconfig.base.json`'s `lib`, and `esbuild.mjs`'s bundle target are aligned to this floor so a passing type-check once again implies the extension runs on the oldest VS Code it declares support for; CI adds a floor smoke-test job (Node 22.15.1 against the oldest supported GemStone version) alongside its existing `.nvmrc`-Node matrix. See CONTRIBUTING.md's "Supported VS Code & Node versions" section for the policy and the full list of coordinated knobs.
+- **`typescript` devDependency floor raised to `^5.7.2`**, the minimum version that recognizes the new `ES2024` lib entry declared above.
+
 ### Changed
 
 - **Backup actions regrouped to de-crowd the Sessions row.** **Online Extent Backup** is now an inline button on the running **Stone** row in the Databases view — its natural home, since it snapshots a local stone's extent files on the stone's own host — rather than being Command-Palette-only; run from there it binds to a live session on that stone. **Full Logical Backup** and **Full Logical Restore** moved off the session's inline button row into its right-click menu, so the everyday Commit/Abort/Logout actions are no longer crowded against (or one mis-click away from) the rarely-used backup pair.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ Follow these steps in order after cloning the repo:
 
    > **Destructive:** re-running `test:server:start` stops any running stone, resets the database to a pristine state, and overwrites `.env.test`.
 
+## Supported VS Code & Node versions
+
+**Current floor:** VS Code `1.101.0` → bundled Node `22.15.1`.
+
+See [docs/how-to/raising-the-version-floor.md](docs/how-to/raising-the-version-floor.md) for the policy behind this floor and the steps to raise it.
+
 ## Build and test
 
 - Build: `npm run compile`
@@ -67,7 +73,7 @@ All variables must be prefixed with `VITE_` to be accessible in test code (e.g. 
 
 ## Continuous integration
 
-CI runs on **GitHub Actions**. The [Health Check workflow](.github/workflows/health-check.yml) runs on every push, on the Node version pinned by `.nvmrc`. It compiles the project and runs the full test suite — including the GCI integration tests — as a matrix job, once per GemStone version listed in `client/.gemstone-integration-releases.json`. To add a version to the matrix, add an entry to that file; the `reasons` array is human-readable documentation and is not parsed by any script.
+CI runs on **GitHub Actions**. The [Health Check workflow](.github/workflows/health-check.yml) runs on every push, as a matrix job once per GemStone version listed in `client/.gemstone-integration-releases.json`. Most jobs run on the Node version pinned by `.nvmrc` (the common recent-VS-Code case); one additional job pins the supported-floor Node (see [Supported VS Code & Node versions](#supported-vs-code--node-versions)) against the oldest GemStone version, as a retrocompatibility smoke test. To add a GemStone version to the matrix, add an entry to `client/.gemstone-integration-releases.json`; the `reasons` array is human-readable documentation and is not parsed by any script.
 
 ## Publishing a release
 

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.101.0",
     "css.escape": "^1.5.1",
     "jsdom": "^27.4.0",
 "vitest": "^4.0.18",

--- a/docs/how-to/raising-the-version-floor.md
+++ b/docs/how-to/raising-the-version-floor.md
@@ -1,0 +1,36 @@
+# Raising the VS Code / Node version floor
+
+**Current floor:** VS Code `1.101.0` → bundled Node `22.15.1`. TypeScript devDependency floor: `^5.7.2`.
+
+## Why the floor is what it is
+
+Jasper's runtime floor is dictated by `engines.vscode`: VS Code bundles a specific Electron/Node build, and that bundled Node is the actual lowest common denominator the extension runs on — regardless of what `@types/node` or local dev tooling assume.
+
+We want the floor as far back as reasonably possible, to keep supporting users on VS Code installs that haven't auto-updated recently. Two independent ceilings limit how far back we're willing to go — whichever one lands on the *more recent* release wins:
+
+1. **Node LTS support.** The bundled Node must still be an actively-maintained LTS, not EOL — an EOL Node no longer receives security patches, so the extension's stated runtime floor would be unpatched.
+2. **Adoption ceiling, ~1 year.** Even when an older release's Node hasn't gone EOL yet, we don't chase VS Code installs back indefinitely. About a year is judged enough time for the userbase to have auto-updated past very old releases, so reaching back further has diminishing returns and just adds support burden.
+
+Look up the VS Code → Electron → Node mapping at [github.com/ewanharris/vscode-versions](https://github.com/ewanharris/vscode-versions) to check both bounds when re-evaluating the floor. Currently the two coincide: the release from about a year ago is also the earliest one bundling Node `22`, which is still an actively-maintained LTS.
+
+`tsconfig.base.json`'s `target` and `lib` values are sourced from [github.com/tsconfig/bases](https://github.com/tsconfig/bases)' preset for the Node version matching the floor (e.g. its `node22` preset for Node `22`). We can't `extends` that package directly, though: its presets assume ESM (`"module": "node16"`/`"nodenext"`), while this project compiles to `"module": "commonjs"` — so the matching preset's `target`/`lib` fields are copied in by hand instead of pulled in via `extends`.
+
+The `typescript` devDependency range is a separate, compiler-version concern rather than a Node-runtime one — it just needs to stay new enough to recognize whatever `tsconfig.base.json`'s `lib` array declares. Check the [TypeScript release notes](https://www.typescriptlang.org/docs/handbook/release-notes/) for the minimum version that ships each `lib` entry whenever `lib` changes.
+
+## How to raise it
+
+1. Using the [vscode-versions](https://github.com/ewanharris/vscode-versions) mapping, find both bounds and take whichever is more recent:
+   - the earliest VS Code release whose bundled Node is still an actively-maintained LTS (not EOL), and
+   - the VS Code release from about a year ago.
+
+   That release is the new floor; note its bundled Node version.
+2. Update all of these together — they encode the same runtime floor and are a **coordinated set, not independent knobs**. A partial bump lets the type checker or bundler assume APIs that don't exist on the shipped runtime floor:
+   - `engines.vscode` and `engines.node` (root `package.json`)
+   - root `@types/node`
+   - `client/package.json`'s `@types/vscode`
+   - `tsconfig.base.json`'s `target` and `lib` (copy the values from the matching Node-version preset in [tsconfig/bases](https://github.com/tsconfig/bases) — see above for why we copy rather than `extends`)
+   - `esbuild.mjs`'s `target` (the `client` and `server` build calls)
+   - the floor `node-version` in the `health-check.yml` CI `include` job (the *dev* jobs read `.nvmrc` automatically and don't need a separate edit)
+3. If the `lib` bump requires a newer TypeScript feature, raise the `typescript` devDependency range in root `package.json` to match (see the release-notes link above).
+4. Update the "Current floor" line at the top of this document.
+5. Run `npm run compile && npm test` to confirm the new floor builds and passes.

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -8,6 +8,7 @@ await esbuild.build({
   format: 'cjs',
   external: ['vscode'],
   sourcemap: true,
+  target: 'node22.15.1',
 });
 
 await esbuild.build({
@@ -18,6 +19,7 @@ await esbuild.build({
   format: 'cjs',
   external: ['vscode', 'koffi'],
   sourcemap: true,
+  target: 'node22.15.1',
 });
 
 await esbuild.build({

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,16 +19,16 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.15",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.28.1",
         "ovsx": "^0.10.5",
-        "typescript": "^5.3.0"
+        "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=22.12",
-        "vscode": "^1.85.0"
+        "node": ">=22.15.1",
+        "vscode": "^1.101.0"
       }
     },
     "client": {
@@ -40,7 +40,7 @@
       },
       "devDependencies": {
         "@types/jsdom": "^28.0.3",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "^1.101.0",
         "css.escape": "^1.5.1",
         "jsdom": "^27.4.0",
         "vitest": "^4.0.18",
@@ -2219,9 +2219,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com/jgfoster/Jasper/issues"
   },
   "engines": {
-    "vscode": "^1.85.0",
-    "node": ">=22.12"
+    "vscode": "^1.101.0",
+    "node": ">=22.15.1"
   },
   "icon": "resources/gemstone-icon.png",
   "categories": [
@@ -1966,12 +1966,12 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.15",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.28.1",
     "ovsx": "^0.10.5",
-    "typescript": "^5.3.0"
+    "typescript": "^5.7.2"
   },
   "dependencies": {
     "@vscode/debugadapter": "^1.68.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
-    "lib": ["ES2022"],
+    "lib": ["ES2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
     "strict": true,
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
## Summary

Jasper declared four unrelated, unvalidated "Node version" knobs. The real runtime floor — dictated by `engines.vscode: ^1.85.0` → Electron → bundled Node 18.15–18.17 (already EOL) — sat *below* the `@types/node@^20` the compiler trusted and *below* the Node used to build/test the repo. This raises the client/server floor to the earliest VS Code that bundles a currently-supported Node LTS (**VS Code 1.101.0 → Node 22.15.1**) and aligns every static knob to that real floor, so "type-checks pass" once again implies "runs on the floor."

- `engines.vscode` `^1.85.0` → `^1.101.0`, `engines.node` `>=22.12` → `>=22.15.1` (root `package.json`)
- `client/@types/vscode` bumped to `^1.101.0` to match
- root `@types/node` bumped to `^22.15`
- `tsconfig.base.json` `lib` updated to match `@tsconfig/node22` (`ES2024` + ESNext helper libs); `target`/`module` unchanged
- root `typescript` devDependency floor raised `^5.3.0` → `^5.7.2`, the minimum version that recognizes the new `ES2024` lib entry (ES2024 support landed in TS 5.7) — a separate, compiler-version concern from the runtime-floor knobs above
- `esbuild.mjs`: add `target: 'node22.15.1'` to the client and server builds (mcp-server intentionally left untouched — separate follow-up)
- CI (`health-check.yml`): dev jobs resolve Node from `.nvmrc` (via `node-version-file`), keeping the broad GemStone matrix on the common recent-VS-Code Node; a new `prepare` job output (`oldest-version`, from `gemstone-integration-versions.js --oldest`) feeds a new matrix `include` entry pinning Node `22.15.1` against the oldest supported GemStone version, as a floor smoke-test that won't go stale as the supported-versions list changes. Job names disambiguate the two jobs sharing that GemStone version.
- Docs split in two: `CONTRIBUTING.md` gets a short "Supported VS Code & Node versions" pointer section (current floor + link) and its stale CI note is fixed to reflect the dev/floor matrix split; the full floor-selection policy, the coordinated knob list, and the raise-the-floor steps now live in a new `docs/how-to/raising-the-version-floor.md`
- `.claude/rules/version-pins.md`: new path-scoped agent guardrail over the coordinated pin files, pointing at the how-to doc so future changes to any one knob get a warning to read the policy first rather than bumping it in isolation
- `CHANGELOG.md`: two entries under `[Unreleased]` — the VS Code/Node floor bump, and the `typescript` devDependency floor raise

Scope is client + server only — they share one floor since `server/` is forked in-process via `TransportKind.ipc`/`process.execPath`. `mcp-server/` hardening (loud version guard, absolute node path resolution, its own `engines`/CI floor, esbuild target, per-workspace `@types/node` split) is deferred to a separate follow-up ticket.

Ref: Gitlab#57

## Test plan
- [x] `npm run compile` clean under the narrowed `@types/node@22` / `@types/vscode@1.101` / `lib: ES2024` / `typescript@^5.7.2`
- [x] `npm test` against a local test stone
- [x] CI (`health-check` workflow) green across all 6 jobs: 5 dev jobs (`.nvmrc` Node × each GemStone version) + 1 floor smoke-test (Node `22.15.1` × GemStone `3.6.2`, the current oldest supported version)
