### PR TITLE
Clean up test suites ahead of enabling ESLint (phase 1)

### DIFF
--- a/client/src/__tests__/breakpointManager.test.ts
+++ b/client/src/__tests__/breakpointManager.test.ts
@@ -10,7 +10,7 @@ vi.mock('../browserQueries', () => ({
   clearAllBreaks: vi.fn(),
 }));
 
-import { Uri, debug } from '../__mocks__/vscode';
+import { Uri } from '../__mocks__/vscode';
 import {
   BreakpointManager,
   buildLineOffsets,
@@ -171,13 +171,6 @@ describe('BreakpointManager', () => {
   });
 
   describe('setBreakpointsForSource', () => {
-    it('returns unverified when no session', () => {
-      const manager = new BreakpointManager(makeSessionManager(false));
-      const session = makeSessionManager(false).getSelectedSession()!;
-      // Can't call without a session — the method requires one
-      // This tests the URI parsing path returning unverified for non-gemstone URIs
-    });
-
     it('returns unverified for non-gemstone URI', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;

--- a/client/src/__tests__/browserQueries.test.ts
+++ b/client/src/__tests__/browserQueries.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OOP_ILLEGAL, OOP_NIL } from '../gciConstants';
+import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('vscode', () => ({
   window: {

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -27,7 +27,7 @@ const RECEIVER_OOP = 7000n;
 function createMockSession(): ActiveSession {
   const mockGci = {
     GciTsPerform: vi.fn(
-      (handle: unknown, receiver: bigint, selectorOop: bigint, selectorStr: string | null, args: bigint[]) => {
+      (handle: unknown, receiver: bigint, selectorOop: bigint, selectorStr: string | null, _args: bigint[]) => {
         if (selectorStr && selectorStr.includes(' ')) {
           return {
             result: 0n,
@@ -47,7 +47,7 @@ function createMockSession(): ActiveSession {
       },
     ),
     GciTsPerformFetchBytes: vi.fn(
-      (handle: unknown, receiver: bigint, selector: string, args: bigint[], maxBytes: number) => {
+      (handle: unknown, receiver: bigint, selector: string, _args: bigint[], _maxBytes: number) => {
         if (selector.includes(' ')) {
           return {
             data: '',

--- a/client/src/__tests__/gci/gciExecute.test.ts
+++ b/client/src/__tests__/gci/gciExecute.test.ts
@@ -104,7 +104,7 @@ describe('GciTsExecute / GciTsPerform', () => {
 
     it('executes a numeric-to-string conversion', () => {
       const source = '(3 + 4) printString';
-      const { bytesReturned, data, err } = gci.GciTsExecuteFetchBytes(
+      const { data, err } = gci.GciTsExecuteFetchBytes(
         session, source, -1, OOP_CLASS_STRING,
         OOP_ILLEGAL, OOP_NIL, 1024,
       );
@@ -179,7 +179,7 @@ describe('GciTsExecute / GciTsPerform', () => {
       const intOop = gci.GciTsI64ToOop(session, 42n);
       expect(intOop.err.number).toBe(0);
 
-      const { bytesReturned, data, err } = gci.GciTsPerformFetchBytes(
+      const { data, err } = gci.GciTsPerformFetchBytes(
         session, intOop.result, 'printString', [], 1024,
       );
       console.log('PerformFetchBytes(42 printString) - data:', data);
@@ -191,7 +191,7 @@ describe('GciTsExecute / GciTsPerform', () => {
       const strOop = gci.GciTsNewString(session, 'GemStone');
       expect(strOop.result).not.toBe(OOP_ILLEGAL);
 
-      const { bytesReturned, data, err } = gci.GciTsPerformFetchBytes(
+      const { data, err } = gci.GciTsPerformFetchBytes(
         session, strOop.result, 'reversed', [], 1024,
       );
       expect(err.number).toBe(0);

--- a/client/src/__tests__/gci/gciExportSet.test.ts
+++ b/client/src/__tests__/gci/gciExportSet.test.ts
@@ -9,8 +9,6 @@ describe('GCI Export Set and Free OOPs', () => {
   const gci = new GciLibrary(GCI_LIBRARY_PATH);
   let session: unknown;
 
-  let OOP_CLASS_STRING: bigint;
-
   beforeAll(() => {
     const login = gci.GciTsLogin(
       STONE_NRS, null, null, false,
@@ -18,8 +16,6 @@ describe('GCI Export Set and Free OOPs', () => {
     );
     expect(login.session).not.toBeNull();
     session = login.session;
-
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
   });
 
   afterAll(() => {

--- a/client/src/__tests__/gci/gciMisc.test.ts
+++ b/client/src/__tests__/gci/gciMisc.test.ts
@@ -11,7 +11,6 @@ describe('GCI Priority 5: NSC, PerformFetchOops, FetchGbjInfo, NewStringFromUtf1
 
   let OOP_CLASS_STRING: bigint;
   let OOP_CLASS_ARRAY: bigint;
-  let OOP_CLASS_IDENTITY_BAG: bigint;
 
   beforeAll(() => {
     const login = gci.GciTsLogin(
@@ -23,7 +22,6 @@ describe('GCI Priority 5: NSC, PerformFetchOops, FetchGbjInfo, NewStringFromUtf1
 
     OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
     OOP_CLASS_ARRAY = gci.GciTsResolveSymbol(session, 'Array', OOP_NIL).result;
-    OOP_CLASS_IDENTITY_BAG = gci.GciTsResolveSymbol(session, 'IdentityBag', OOP_NIL).result;
   });
 
   afterAll(() => {

--- a/client/src/__tests__/gci/gciNumeric.test.ts
+++ b/client/src/__tests__/gci/gciNumeric.test.ts
@@ -32,7 +32,7 @@ describe('GciTsDoubleToOop / GciTsOopToDouble / GciTsI64ToOop / GciTsOopToI64', 
       console.log('DoubleToOop(1.5) - oop:', oop.toString(16), 'err:', JSON.stringify(err, bigIntReplacer, 2));
       expect(err.number).toBe(0);
 
-      const { success, value, err: err2 } = gci.GciTsOopToDouble(session, oop);
+      const { success, value } = gci.GciTsOopToDouble(session, oop);
       console.log('OopToDouble - success:', success, 'value:', value);
       expect(success).toBe(true);
       expect(value).toBe(1.5);

--- a/client/src/__tests__/gci/gciObjects.test.ts
+++ b/client/src/__tests__/gci/gciObjects.test.ts
@@ -17,7 +17,6 @@ describe('GCI Object Creation and Inquiry', () => {
   let OOP_CLASS_STRING: bigint;
   let OOP_CLASS_SYMBOL: bigint;
   let OOP_CLASS_BYTE_ARRAY: bigint;
-  let OOP_CLASS_ARRAY: bigint;
 
   beforeAll(() => {
     const login = gci.GciTsLogin(
@@ -213,7 +212,7 @@ describe('GCI Object Creation and Inquiry', () => {
       const { result: oop } = gci.GciTsNewString(session, text);
       expect(oop).not.toBe(OOP_ILLEGAL);
 
-      const { result, info, err } = gci.GciTsFetchObjInfo(session, oop, false, 1024);
+      const { result, info } = gci.GciTsFetchObjInfo(session, oop, false, 1024);
       console.log('FetchObjInfo - result:', result, 'info:', JSON.stringify(info, bigIntReplacer, 2));
       expect(result).toBeGreaterThanOrEqual(0n);
       expect(info.objId).toBe(oop);

--- a/client/src/__tests__/gci/gciSessionUtils.test.ts
+++ b/client/src/__tests__/gci/gciSessionUtils.test.ts
@@ -2,14 +2,9 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { GciLibrary } from '../../gciLibrary';
 import { GCI_LIBRARY_PATH, STONE_NRS, GEM_NRS, GS_USER, GS_PASSWORD } from './gciTestConfig';
 
-const OOP_ILLEGAL = 0x01n;
-const OOP_NIL = 0x14n;
-
 describe('GCI Priority 7: Session Utilities', () => {
   const gci = new GciLibrary(GCI_LIBRARY_PATH);
   let session: unknown;
-
-  let OOP_CLASS_STRING: bigint;
 
   beforeAll(() => {
     const login = gci.GciTsLogin(
@@ -18,8 +13,6 @@ describe('GCI Priority 7: Session Utilities', () => {
     );
     expect(login.session).not.toBeNull();
     session = login.session;
-
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
   });
 
   afterAll(() => {

--- a/client/src/__tests__/gci/gciTraversal.test.ts
+++ b/client/src/__tests__/gci/gciTraversal.test.ts
@@ -92,7 +92,7 @@ describe('GCI Traversal Functions', () => {
       expect(strOop.result).not.toBe(OOP_ILLEGAL);
 
       // Use minimum legal buffer size (2048 bytes)
-      const { status, travBuf, err } = gci.GciTsFetchTraversal(
+      const { status, err } = gci.GciTsFetchTraversal(
         session, [strOop.result], 1, 0, OOP_NIL, 2048,
       );
       console.log('FetchTraversal(small buf) - status:', status,

--- a/client/src/__tests__/gemstoneDebugSession.test.ts
+++ b/client/src/__tests__/gemstoneDebugSession.test.ts
@@ -166,7 +166,7 @@ describe('GemStoneDebugSession', () => {
     });
 
     it('fails when session not found', () => {
-      const { session, sent } = createTestSession();
+      const { session } = createTestSession();
       const response = makeResponse('attach');
       callRequest(session, 'attachRequest', response, {
         sessionId: 999,

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -21,7 +21,7 @@ vi.mock('../browserQueries', () => ({
   canClassBeWritten: vi.fn(() => true),
 }));
 
-import { Uri, FileSystemError, FilePermission, window, languages, TabInputText, TabInputTextDiff } from '../__mocks__/vscode';
+import { Uri, FilePermission, window, languages, TabInputText, TabInputTextDiff } from '../__mocks__/vscode';
 import { GemStoneFileSystemProvider, buildMethodUri, buildNewMethodUri, buildClassDefinitionUri, closeGemstoneTabsForSession, installStaleGemstoneTabReaper, escapeSelectorSlashes, parseUri, listOpenGemstoneTabs } from '../gemstoneFileSystemProvider';
 import { SessionManager } from '../sessionManager';
 import * as queries from '../browserQueries';
@@ -754,7 +754,7 @@ describe('GemStoneFileSystemProvider', () => {
   describe('URI parsing', () => {
     it('parses method URI with special characters', () => {
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3Aput%3A');
-      const content = provider.readFile(uri);
+      provider.readFile(uri);
       expect(queries.getMethodSource).toHaveBeenCalledWith(
         expect.anything(), 'Array', false, 'at:put:', 0, 'Globals',
       );

--- a/client/src/__tests__/gemstoneHoverProvider.test.ts
+++ b/client/src/__tests__/gemstoneHoverProvider.test.ts
@@ -8,7 +8,7 @@ vi.mock('../browserQueries', () => ({
   getClassComment: vi.fn(() => ''),
 }));
 
-import { Position, Range, Hover, MarkdownString, __setConfig, __resetConfig } from '../__mocks__/vscode';
+import { Position, Range, MarkdownString, __setConfig, __resetConfig } from '../__mocks__/vscode';
 import type * as vscode from 'vscode';
 import { GemStoneHoverProvider } from '../gemstoneHoverProvider';
 import { SelectorResolver } from '../gemstoneDefinitionProvider';

--- a/client/src/__tests__/localVersion.test.ts
+++ b/client/src/__tests__/localVersion.test.ts
@@ -18,9 +18,8 @@ vi.mock('../wslBridge', () => ({
 
 import { __setConfig, __resetConfig } from '../__mocks__/vscode';
 import { SysadminStorage } from '../sysadminStorage';
-import { LoginStorage } from '../loginStorage';
 import { VersionManager } from '../versionManager';
-import { VersionTreeProvider, VersionItem } from '../versionTreeProvider';
+import { VersionItem } from '../versionTreeProvider';
 import { GemStoneVersion } from '../sysadminTypes';
 
 // ── Helpers ────────────────────────────────────────────────

--- a/client/src/__tests__/loginEditorPanel.test.ts
+++ b/client/src/__tests__/loginEditorPanel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 vi.mock('../sysadminStorage');

--- a/client/src/__tests__/osConfigTreeProvider.test.ts
+++ b/client/src/__tests__/osConfigTreeProvider.test.ts
@@ -29,10 +29,8 @@ const LINUX_SHMALL_4GB = 1048576;
 const LINUX_SYSCTL_4GB = `kernel.shmmax = ${LINUX_SHMMAX_4GB}\nkernel.shmall = ${LINUX_SHMALL_4GB}\n`;
 const LINUX_SYSCTL_UNLIMITED = 'kernel.shmmax = 18446744073692774399\nkernel.shmall = 18446744073692774399\n';
 const LINUX_SYSCTL_1GB = 'kernel.shmmax = 1073741824\nkernel.shmall = 262144\n';
-const LINUX_SYSCTL_SMALL = 'kernel.shmmax = 4194304\nkernel.shmall = 1024\n'; // 4 MB / 4 MB
 
 const MACOS_SYSCTL_4GB = `kern.sysv.shmmax: ${LINUX_SHMMAX_4GB}\nkern.sysv.shmall: ${LINUX_SHMALL_4GB}\n`;
-const MACOS_SYSCTL_1GB = 'kern.sysv.shmmax: 1073741824\nkern.sysv.shmall: 262144\n';
 const MACOS_SYSCTL_SMALL = 'kern.sysv.shmmax: 4194304\nkern.sysv.shmall: 1024\n'; // 4 MB / 4 MB
 
 function setPlatform(platform: string) {

--- a/client/src/__tests__/rowanLoad.test.ts
+++ b/client/src/__tests__/rowanLoad.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { findRowanLoadSpecs, deriveRepoName, normalizeGitUrl, updateGitRepo, cloneGitRepo } from '../rowanLoad';
+import { findRowanLoadSpecs, deriveRepoName, normalizeGitUrl, updateGitRepo } from '../rowanLoad';
 
 const LOAD_SPEC = (name: string) => `RwLoadSpecificationV2 {
 \t#specName : '${name}',

--- a/client/src/__tests__/sunitQueries.test.ts
+++ b/client/src/__tests__/sunitQueries.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('vscode', () => ({
   window: {

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -62,7 +62,7 @@ vi.mock('fs', async () => {
 import * as fs from 'fs';
 
 import * as path from 'path';
-import { window, workspace, ViewColumn, TextEditorRevealType, Range, Selection, Position, commands, Uri, TabInputText, TabInputTextDiff, __setConfig, __resetConfig } from '../__mocks__/vscode';
+import { window, workspace, ViewColumn, commands, Uri, TabInputText, TabInputTextDiff, __setConfig, __resetConfig } from '../__mocks__/vscode';
 import { SystemBrowser, extractSelector, planDictionaryFileOut, isComputedMethodCategory, ALL_CLASSES_CATEGORY, ALL_METHODS_CATEGORY, SESSION_METHODS_CATEGORY } from '../systemBrowser';
 import * as queries from '../browserQueries';
 import { GlobalsBrowser } from '../globalsBrowser';

--- a/client/src/__tests__/topazFileIn.test.ts
+++ b/client/src/__tests__/topazFileIn.test.ts
@@ -7,7 +7,6 @@ vi.mock('vscode', () => ({
 }));
 
 import { ActiveSession } from '../sessionManager';
-import { GemStoneLogin } from '../loginTypes';
 import { BrowserQueryError } from '../browserQueries';
 import { parseTopazDocument, fileInClass, parseFileStructure, fileInChangedRegions } from '../topazFileIn';
 import * as queries from '../browserQueries';

--- a/server/src/utils/__tests__/scopeAnalyzer.test.ts
+++ b/server/src/utils/__tests__/scopeAnalyzer.test.ts
@@ -51,9 +51,7 @@ describe('ScopeAnalyzer', () => {
 
   it('allVisibleVariables includes parent scope vars', () => {
     const { root, analyzer } = analyzeMethod('foo | x | [:a | a + x]');
-    const blockScope = root.children[0];
     const pos = createPosition(0, 0, 20);
-    const innerScope = analyzer.findScopeAt(root, pos);
     const allVars = analyzer.allVisibleVariables(root, pos);
     const names = allVars.map((v) => v.name);
     expect(names).toContain('x');


### PR DESCRIPTION
## What & why

This is the **first step in preparing to enable ESLint in Jasper**. Rather than turning the linter on all at once and drowning in violations, I'm cleaning up the places that will fail it **in phases**, so that introducing the linter itself becomes a small, low-noise change.

This phase focuses on the test suites: removing unused imports, unused local variables, and one empty no-op test stub. Unused-but-required function parameters are prefixed with `_` to satisfy `no-unused-vars`.

## Changes

- Drop unused imports across ~18 client test files and one server test file.
- Remove unused local variables and constants (e.g. dead `OOP_CLASS_*` lookups in the GCI tests, unused destructured fields).
- Delete an empty, assertion-less test stub in `breakpointManager.test.ts` (`'returns unverified when no session'`) — the scenario it named is unreachable because the method requires a session.
- Prefix intentionally-unused mock parameters with `_`.

No production code or test behavior changes — this is purely dead-code / unused-symbol cleanup.
