### PR TITLE
GemStone Explorer: instance-variable sub-tree, refresh-in-place, and refresh-on-abort

### DIFF
--- a/client/src/__tests__/definedInstVars.test.ts
+++ b/client/src/__tests__/definedInstVars.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getDefinedInstVarNames } from '../queries/getDefinedInstVarNames';
+import { getDefinedInstVarCounts } from '../queries/getDefinedInstVarCounts';
+
+describe("a class's locally-defined instance variable names", () => {
+  it('lists one variable per line, in declared order', () => {
+    const execute = vi.fn().mockReturnValue('x\ny\nz\n');
+
+    expect(getDefinedInstVarNames(execute, 'Point')).toEqual(['x', 'y', 'z']);
+  });
+
+  it('asks for the class\'s own variables, not the inherited ones', () => {
+    const execute = vi.fn().mockReturnValue('');
+
+    getDefinedInstVarNames(execute, 'Point');
+
+    const code = execute.mock.calls[0][1];
+    expect(code).toContain('Point instVarNames');
+    expect(code).not.toContain('allInstVarNames');
+  });
+
+  it('returns nothing for a class that defines no variables', () => {
+    const execute = vi.fn().mockReturnValue('');
+
+    expect(getDefinedInstVarNames(execute, 'Object')).toEqual([]);
+  });
+});
+
+describe('counting locally-defined instance variables across a dictionary', () => {
+  it('maps each class name to its own variable count', () => {
+    const execute = vi.fn().mockReturnValue('Object\t0\nPoint\t2\nAssociation\t2\n');
+
+    const counts = getDefinedInstVarCounts(execute, 1);
+
+    expect(counts.get('Object')).toBe(0);
+    expect(counts.get('Point')).toBe(2);
+    expect(counts.get('Association')).toBe(2);
+  });
+
+  it('looks the dictionary up by name when given a string', () => {
+    const execute = vi.fn().mockReturnValue('');
+
+    getDefinedInstVarCounts(execute, 'UserGlobals');
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('UserGlobals'),
+      expect.stringContaining("objectNamed: #'UserGlobals'"),
+    );
+  });
+
+  it('has no entries for an empty dictionary', () => {
+    const execute = vi.fn().mockReturnValue('');
+
+    expect(getDefinedInstVarCounts(execute, 5).size).toBe(0);
+  });
+});

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -31,6 +31,8 @@ import { fileOutClass as sharedFileOutClass } from './queries/fileOutClass';
 import { describeClass as sharedDescribeClass } from './queries/describeClass';
 import { loadClassInfo as sharedLoadClassInfo } from './queries/loadClassInfo';
 import { getInstVarNames as sharedGetInstVarNames } from './queries/getInstVarNames';
+import { getDefinedInstVarNames as sharedGetDefinedInstVarNames } from './queries/getDefinedInstVarNames';
+import { getDefinedInstVarCounts as sharedGetDefinedInstVarCounts } from './queries/getDefinedInstVarCounts';
 import {
   getGrailStubReflection as sharedGetGrailStubReflection,
   GrailStubReflection,
@@ -493,6 +495,16 @@ export function describeClass(
 
 export function getInstVarNames(session: ActiveSession, className: string): string[] {
   return sharedGetInstVarNames(bind(session), className);
+}
+
+export function getDefinedInstVarNames(session: ActiveSession, className: string): string[] {
+  return sharedGetDefinedInstVarNames(bind(session), className);
+}
+
+export function getDefinedInstVarCounts(
+  session: ActiveSession, dict: number | string,
+): Map<string, number> {
+  return sharedGetDefinedInstVarCounts(bind(session), dict);
 }
 
 export function getGrailStubReflection(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1332,6 +1332,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
           await exportManager.refreshSession(item.activeSession);
           SystemBrowser.refresh(item.activeSession.id);
+          explorer.onSessionAborted(item.activeSession.id);
         } else {
           vscode.window.showErrorMessage(
             `Session ${item.activeSession.id}: Abort failed — ${err.message || `error ${err.number}`}`

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -118,8 +118,13 @@ class ClassCategoryItem extends vscode.TreeItem {
 }
 
 class ClassItem extends vscode.TreeItem {
-  constructor(public readonly className: string) {
-    super(className, vscode.TreeItemCollapsibleState.None);
+  // `hasIvars` drives the expansion caret: a class with locally-defined instance
+  // variables opens to reveal its ivar sub-tree; one without stays flat. It never
+  // affects the stable `id`, so TreeView.reveal still matches regardless.
+  constructor(public readonly className: string, hasIvars = false) {
+    super(className, hasIvars
+      ? vscode.TreeItemCollapsibleState.Collapsed
+      : vscode.TreeItemCollapsibleState.None);
     this.id = `k:${className}`;
     this.contextValue = 'explorerClass';
     this.iconPath = new vscode.ThemeIcon('symbol-class');
@@ -132,6 +137,20 @@ class ClassItem extends vscode.TreeItem {
     };
   }
 }
+
+// A locally-defined instance variable, shown as a child of its ClassItem. The
+// pencil (inline) action renames it; selecting the row does not navigate.
+class IvarItem extends vscode.TreeItem {
+  constructor(public readonly className: string, public readonly ivarName: string) {
+    super(ivarName, vscode.TreeItemCollapsibleState.None);
+    this.id = `k:${className}/iv:${ivarName}`;
+    this.contextValue = 'explorerIvar';
+    this.iconPath = new vscode.ThemeIcon('symbol-field');
+    this.tooltip = `Instance variable defined in ${className}`;
+  }
+}
+
+type ClassNode = ClassItem | IvarItem;
 
 // Method pane is a 3-level tree: side ▸ method-category ▸ selector.
 class MethodSideItem extends vscode.TreeItem {
@@ -286,7 +305,7 @@ function methodArg(arg: MethodCommandArg): { selector: string; isMeta: boolean }
 interface ExplorerViews {
   dict: vscode.TreeView<DictItem>;
   category: vscode.TreeView<ClassCategoryItem>;
-  klass: vscode.TreeView<ClassItem>;
+  klass: vscode.TreeView<ClassNode>;
   hierarchy: vscode.TreeView<HierarchyItem>;
   method: vscode.TreeView<MethodNode>;
 }
@@ -297,6 +316,11 @@ class ExplorerController {
   readonly state: ExplorerState = {};
   // className → category for the current dictionary; fetched once per dict.
   private classCategoryEntries: queries.ClassCategoryEntry[] = [];
+  // className → count of locally-defined instance variables, for the current
+  // dictionary; fetched once per dict so class rows know whether to show an
+  // expansion caret. Names are fetched lazily on expand and memoized here.
+  private definedIvarCounts = new Map<string, number>();
+  private readonly definedIvarNamesCache = new Map<string, string[]>();
   // Per-method metadata for the selected class; fetched once per class.
   private envLines: queries.EnvCategoryLine[] = [];
   private views?: ExplorerViews;
@@ -444,6 +468,8 @@ class ExplorerController {
     this.state.selectedIsMeta = undefined;
     this.state.selectedMethodCategory = undefined;
     this.classCategoryEntries = [];
+    this.definedIvarCounts = new Map();
+    this.definedIvarNamesCache.clear();
     this.envLines = [];
     this.hierChain = [];
     this.hierSubs = [];
@@ -478,6 +504,7 @@ class ExplorerController {
     this.classCategoryEntries = session
       ? queries.getClassesWithCategory(session, item.dictIndex)
       : [];
+    this.loadDefinedIvarCounts();
     this.categoryProvider.refresh();
     this.classProvider.refresh();
     this.hierarchyProvider.refresh();
@@ -781,6 +808,68 @@ class ExplorerController {
     );
   }
 
+  // ── Instance-variable sub-tree (Classes pane) ────────────────────────────────
+
+  // Reload the per-class defined-ivar counts for the current dictionary (one
+  // round trip) and drop any memoized name lists. Called wherever the class
+  // listing itself is (re)loaded. A failed probe leaves the counts empty rather
+  // than breaking navigation — classes just render flat.
+  private loadDefinedIvarCounts(): void {
+    const session = this.session();
+    this.definedIvarNamesCache.clear();
+    if (!session || this.state.dictIndex === undefined) {
+      this.definedIvarCounts = new Map();
+      return;
+    }
+    try {
+      this.definedIvarCounts = queries.getDefinedInstVarCounts(session, this.state.dictIndex);
+    } catch {
+      this.definedIvarCounts = new Map();
+    }
+  }
+
+  // Whether a class has locally-defined instance variables (drives the caret).
+  classHasDefinedIvars(className: string): boolean {
+    return (this.definedIvarCounts.get(className) ?? 0) > 0;
+  }
+
+  // Locally-defined instance variable names for a class, memoized per dict load.
+  definedIvarNames(className: string): string[] {
+    const cached = this.definedIvarNamesCache.get(className);
+    if (cached) return cached;
+    const session = this.session();
+    let names: string[] = [];
+    if (session) {
+      try {
+        names = queries.getDefinedInstVarNames(session, className);
+      } catch { /* leave empty — the row simply shows no children */ }
+    }
+    this.definedIvarNamesCache.set(className, names);
+    return names;
+  }
+
+  // Stage A stub: prove the pencil fires with the right (class, ivar), but the
+  // rename itself isn't wired yet — the server-side refactoring engine lands with
+  // the refactoring branch. The dialog is shown (and made explicit that nothing
+  // happens on accept) so the UX flow can be exercised end to end.
+  async renameInstVar(item: IvarItem): Promise<void> {
+    const entered = await vscode.window.showInputBox({
+      title: 'Rename Instance Variable — not available yet',
+      prompt: `'${item.ivarName}' in ${item.className}. `
+        + 'Renaming is not implemented yet; accepting will not change anything.',
+      value: item.ivarName,
+      valueSelection: [0, item.ivarName.length],
+    });
+    // Only stay silent if the user dismissed the box (Esc). Accepting it — whether
+    // they changed the name or just pressed Enter — surfaces the not-yet message.
+    if (entered === undefined) return;
+    void vscode.window.showInformationMessage(
+      `Renaming instance variables isn't available yet — '${item.ivarName}' in `
+      + `${item.className} was left unchanged. The refactoring engine wiring lands `
+      + 'in the next stage.',
+    );
+  }
+
   // Method categories for one side, with the computed ALL/SESSION rows on top,
   // plus any just-created (still empty) categories from the + button.
   methodCategories(isMeta: boolean): MethodCategoryItem[] {
@@ -943,6 +1032,7 @@ class ExplorerController {
     this.state.dictName = dictName;
     this.state.dictIndex = dictIndex;
     this.classCategoryEntries = entries;
+    this.loadDefinedIvarCounts();
     const catEntry = this.classCategoryEntries.find((e) => e.className === className);
     // Only pin the category pane when the class has a non-empty one; otherwise
     // leave it on "all classes" so the target row is guaranteed visible.
@@ -1309,6 +1399,7 @@ class ExplorerController {
     const session = this.session();
     if (!session || session.id !== sessionId || this.state.dictIndex === undefined) return;
     this.classCategoryEntries = queries.getClassesWithCategory(session, this.state.dictIndex);
+    this.loadDefinedIvarCounts();
     this.categoryProvider.refresh();
     this.classProvider.refresh();
     // If the compiled class lives in the current dictionary, select it so the
@@ -1374,16 +1465,26 @@ class CategoryProvider extends RefreshableProvider<ClassCategoryItem> {
   }
 }
 
-class ClassProvider extends RefreshableProvider<ClassItem> {
+class ClassProvider extends RefreshableProvider<ClassNode> {
   constructor(private readonly ctl: ExplorerController) {
     super();
   }
-  getParent(): ClassItem | undefined {
-    return undefined;
+  getParent(element: ClassNode): ClassNode | undefined {
+    return element instanceof IvarItem ? new ClassItem(element.className) : undefined;
   }
-  getChildren(element?: ClassItem): ClassItem[] {
-    if (element || this.ctl.state.dictName === undefined) return [];
-    return this.ctl.classNames().map((n) => new ClassItem(n));
+  getChildren(element?: ClassNode): ClassNode[] {
+    if (this.ctl.state.dictName === undefined) return [];
+    if (!element) {
+      return this.ctl.classNames().map(
+        (n) => new ClassItem(n, this.ctl.classHasDefinedIvars(n)),
+      );
+    }
+    // Expand a class to its locally-defined instance variables; ivar rows are leaves.
+    if (element instanceof ClassItem) {
+      return this.ctl.definedIvarNames(element.className)
+        .map((iv) => new IvarItem(element.className, iv));
+    }
+    return [];
   }
 }
 
@@ -1471,14 +1572,14 @@ class MethodDragAndDrop implements vscode.TreeDragAndDropController<MethodNode> 
 }
 
 // Classes pane: accept a dragged method and COPY it into the dropped-on class.
-class ClassDropController implements vscode.TreeDragAndDropController<ClassItem> {
+class ClassDropController implements vscode.TreeDragAndDropController<ClassNode> {
   readonly dragMimeTypes: readonly string[] = [];
   readonly dropMimeTypes = [METHOD_MIME];
   constructor(private readonly ctl: ExplorerController) {}
 
   handleDrag(): void { /* classes aren't draggable */ }
 
-  async handleDrop(target: ClassItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+  async handleDrop(target: ClassNode | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
     if (!(target instanceof ClassItem)) return;
     const raw = dataTransfer.get(METHOD_MIME);
     if (!raw) return;
@@ -1546,7 +1647,10 @@ export function registerGemStoneExplorer(
     if (e.selection[0]) ctl.selectClassCategory(e.selection[0]);
   });
   classView.onDidChangeSelection((e) => {
-    if (e.selection[0]) ctl.selectClass(e.selection[0]);
+    // Only a class row navigates; selecting an ivar child is inert (it's acted on
+    // via its inline pencil, not selection).
+    const node = e.selection[0];
+    if (node instanceof ClassItem) ctl.selectClass(node);
   });
   hierarchyView.onDidChangeSelection((e) => {
     if (e.selection[0]) ctl.selectHierarchyNode(e.selection[0]);
@@ -1636,6 +1740,11 @@ export function registerGemStoneExplorer(
       (item?: ClassItem | HierarchyItem) => void ctl.generateGrailStub(
         item instanceof ClassItem || item instanceof HierarchyItem ? item : undefined,
       ),
+    ),
+    // Rename a locally-defined instance variable (pencil on the ivar row).
+    vscode.commands.registerCommand(
+      'gemstone.explorer.renameIvar',
+      (item?: IvarItem) => { if (item instanceof IvarItem) void ctl.renameInstVar(item); },
     ),
     // New (+) actions, one per pane.
     vscode.commands.registerCommand('gemstone.explorer.newDictionary', () => ctl.newDictionary()),

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -489,7 +489,14 @@ class ExplorerController {
   // manual Refresh button and a session abort both use this so a stale tree
   // reloads in place (new/removed classes, recompiled methods) while the user
   // stays where they were. Unlike reset(), state and filters are preserved.
-  async refreshRetainingSelection(): Promise<void> {
+  //
+  // `reveal` re-highlights (and scrolls to) the retained rows, which also forces
+  // the Explorer view visible/forward. That's wanted for the in-Explorer Refresh
+  // button, but NOT for an abort fired from another view (e.g. the Sessions
+  // tree) — there it would yank focus over to the Explorer. The tree keeps the
+  // selection highlighted across a data refresh on its own (stable row ids), so
+  // skipping reveal loses nothing but the unwanted jump.
+  async refreshRetainingSelection({ reveal = true }: { reveal?: boolean } = {}): Promise<void> {
     const session = this.session();
     const { dictName, dictIndex, className } = this.state;
     // Remember the method row currently selected so it can be re-revealed.
@@ -526,7 +533,7 @@ class ExplorerController {
     this.hierarchyProvider.refresh();
     this.methodProvider.refresh();
 
-    await this.revealRetainedSelection(revealMethod);
+    if (reveal) await this.revealRetainedSelection(revealMethod);
     this.syncTitles();
   }
 
@@ -578,7 +585,9 @@ class ExplorerController {
   onSessionAborted(sessionId: number): void {
     const session = this.session();
     if (!session || session.id !== sessionId) return;
-    void this.refreshRetainingSelection();
+    // Reload in place but DON'T reveal — the abort was pressed from another view,
+    // so the Explorer must not jump to the foreground.
+    void this.refreshRetainingSelection({ reveal: false });
   }
 
   selectDict(item: DictItem): void {

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -485,6 +485,102 @@ class ExplorerController {
     this.syncTitles();
   }
 
+  // Re-fetch everything for the CURRENT selection WITHOUT clearing it — the
+  // manual Refresh button and a session abort both use this so a stale tree
+  // reloads in place (new/removed classes, recompiled methods) while the user
+  // stays where they were. Unlike reset(), state and filters are preserved.
+  async refreshRetainingSelection(): Promise<void> {
+    const session = this.session();
+    const { dictName, dictIndex, className } = this.state;
+    // Remember the method row currently selected so it can be re-revealed.
+    const selectedMethod = this.views?.method.selection
+      .find((n) => n instanceof MethodItem) as MethodItem | undefined;
+    const revealMethod = selectedMethod
+      ? { selector: selectedMethod.info.selector, isMeta: selectedMethod.isMeta }
+      : undefined;
+
+    if (!session || dictName === undefined || dictIndex === undefined) {
+      // Nothing meaningful selected — just reload the dictionary list.
+      this.dictProvider.refresh();
+      this.syncTitles();
+      return;
+    }
+
+    // Reload the dictionary's class listing (+ ivar counts) and, when a class is
+    // selected, its method environment and hierarchy. Keep stale data on a failed
+    // fetch rather than blanking the tree out from under the user.
+    try {
+      this.classCategoryEntries = queries.getClassesWithCategory(session, dictIndex);
+    } catch { /* keep stale on failure */ }
+    this.loadDefinedIvarCounts();
+    if (className !== undefined) {
+      try {
+        this.envLines = queries.getClassEnvironments(session, dictIndex, className, this.maxEnv());
+      } catch { /* keep stale on failure */ }
+      this.loadHierarchy();
+    }
+
+    this.dictProvider.refresh();
+    this.categoryProvider.refresh();
+    this.classProvider.refresh();
+    this.hierarchyProvider.refresh();
+    this.methodProvider.refresh();
+
+    await this.revealRetainedSelection(revealMethod);
+    this.syncTitles();
+  }
+
+  // Re-highlight the retained dict/category/class/method rows after a refresh.
+  // reveal() rejects when a row isn't in the (rebuilt) tree; treat each as a
+  // best-effort highlight, exactly like revealClass does.
+  private async revealRetainedSelection(
+    revealMethod?: { selector: string; isMeta: boolean },
+  ): Promise<void> {
+    const { dictName, dictIndex, classCategory, className } = this.state;
+    if (dictName !== undefined && dictIndex !== undefined) {
+      try {
+        await this.views?.dict.reveal(new DictItem(dictName, dictIndex), { select: true });
+      } catch { /* ignore */ }
+    }
+    if (classCategory) {
+      const segment = classCategory.split('-').pop() ?? classCategory;
+      try {
+        await this.views?.category.reveal(
+          new ClassCategoryItem(segment, classCategory, false), { select: true, expand: true },
+        );
+      } catch { /* ignore */ }
+    }
+    if (className !== undefined) {
+      try {
+        await this.views?.klass.reveal(
+          new ClassItem(className, this.classHasDefinedIvars(className)), { select: true },
+        );
+      } catch { /* ignore */ }
+    }
+    void this.revealHierarchySelf();
+    if (revealMethod) {
+      const info = this.selectorsFor(revealMethod.isMeta, ALL_METHODS_CATEGORY)
+        .find((i) => i.selector === revealMethod.selector);
+      if (info) {
+        try {
+          await this.views?.method.reveal(
+            new MethodItem(revealMethod.isMeta, info, ALL_METHODS_CATEGORY),
+            { select: true, focus: false, expand: true },
+          );
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
+  // A session abort discards uncommitted changes and refreshes the session's
+  // view of the repository, so the Explorer's cached listing can be stale.
+  // Reload in place (keeping the selection) when it's OUR current session.
+  onSessionAborted(sessionId: number): void {
+    const session = this.session();
+    if (!session || session.id !== sessionId) return;
+    void this.refreshRetainingSelection();
+  }
+
   selectDict(item: DictItem): void {
     this.state.dictName = item.dictName;
     this.state.dictIndex = item.dictIndex;
@@ -1590,10 +1686,12 @@ class ClassDropController implements vscode.TreeDragAndDropController<ClassNode>
 // ── Registration ──────────────────────────────────────────────────────────────
 
 // Handle returned to the extension so it can forward file-system compile events
-// (method / class Save) to the controller for a live panel refresh.
+// (method / class Save) and session lifecycle events (abort) to the controller
+// for a live panel refresh.
 export interface ExplorerHandle {
   onMethodCompiled(sessionId: number, className: string): void;
   onClassCompiled(sessionId: number, className: string): void;
+  onSessionAborted(sessionId: number): void;
 }
 
 export function registerGemStoneExplorer(
@@ -1678,7 +1776,9 @@ export function registerGemStoneExplorer(
       syncActiveContext();
       ctl.reset();
     }),
-    vscode.commands.registerCommand('gemstone.explorer.refresh', () => ctl.reset()),
+    // The manual Refresh button reloads in place, keeping the user's selection
+    // (a full reset only happens on a session switch, below).
+    vscode.commands.registerCommand('gemstone.explorer.refresh', () => void ctl.refreshRetainingSelection()),
     // Per-pane filter buttons: open a live filter input (prefix match, '*'
     // wildcard) that filters the pane in place — works regardless of where
     // focus currently sits (e.g. the editor).
@@ -1782,5 +1882,6 @@ export function registerGemStoneExplorer(
   return {
     onMethodCompiled: (sessionId, className) => ctl.onExternalMethodCompiled(sessionId, className),
     onClassCompiled: (sessionId, className) => ctl.onExternalClassCompiled(sessionId, className),
+    onSessionAborted: (sessionId) => ctl.onSessionAborted(sessionId),
   };
 }

--- a/client/src/queries/getDefinedInstVarCounts.ts
+++ b/client/src/queries/getDefinedInstVarCounts.ts
@@ -1,0 +1,35 @@
+import { QueryExecutor } from './types';
+import { escapeString, splitLines } from './util';
+
+// className → number of instance variables DEFINED in that class (not inherited),
+// for every class in a dictionary, in a single round trip. The GemStone Explorer
+// uses this up front to decide whether a class row shows an expansion caret for
+// its ivar sub-tree, so classes with no locally-defined ivars stay flat. Accepts
+// a dictionary by 1-based index (canonical for Jasper) or by name.
+export function getDefinedInstVarCounts(
+  execute: QueryExecutor, dict: number | string,
+): Map<string, number> {
+  const dictExpr = typeof dict === 'number'
+    ? `System myUserProfile symbolList at: ${dict}`
+    : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const code = `| ws dict |
+dict := ${dictExpr}.
+dict ifNil: [^ ''].
+ws := WriteStream on: String new.
+dict keysAndValuesDo: [:k :v |
+  v isBehavior ifTrue: [
+    | n |
+    n := [v instVarNames size] on: Error do: [:e | 0].
+    ws nextPutAll: k; tab; print: n; lf]].
+ws contents`;
+  const label = typeof dict === 'number'
+    ? `getDefinedInstVarCounts(dictIndex: ${dict})`
+    : `getDefinedInstVarCounts(dictName: ${dict})`;
+  const map = new Map<string, number>();
+  for (const line of splitLines(execute(label, code))) {
+    const tab = line.indexOf('\t');
+    if (tab < 0) continue;
+    map.set(line.slice(0, tab), parseInt(line.slice(tab + 1), 10) || 0);
+  }
+  return map;
+}

--- a/client/src/queries/getDefinedInstVarNames.ts
+++ b/client/src/queries/getDefinedInstVarNames.ts
@@ -1,0 +1,15 @@
+import { QueryExecutor } from './types';
+import { splitLines } from './util';
+
+// Instance variables DEFINED in this class only (not inherited) — GemStone's
+// `instVarNames`, unlike `allInstVarNames` (see getInstVarNames.ts) which walks
+// the whole superclass chain. Used by the GemStone Explorer's per-class ivar
+// sub-tree, where renaming an inherited ivar belongs to its defining class.
+export function getDefinedInstVarNames(execute: QueryExecutor, className: string): string[] {
+  const code = `| ws |
+ws := WriteStream on: String new.
+${className} instVarNames do: [:each |
+  ws nextPutAll: each; lf].
+ws contents`;
+  return splitLines(execute(`getDefinedInstVarNames(${className})`, code));
+}

--- a/package.json
+++ b/package.json
@@ -1058,6 +1058,12 @@
         "icon": "$(file-code)"
       },
       {
+        "command": "gemstone.explorer.renameIvar",
+        "title": "Rename Instance Variable…",
+        "category": "GemStone",
+        "icon": "$(edit)"
+      },
+      {
         "command": "gemstone.downloadVersion",
         "title": "Download",
         "category": "GemStone Admin",
@@ -1283,6 +1289,10 @@
       "commandPalette": [
         {
           "command": "gemstone.explorer.classClicked",
+          "when": "false"
+        },
+        {
+          "command": "gemstone.explorer.renameIvar",
           "when": "false"
         },
         {
@@ -1520,6 +1530,11 @@
         {
           "command": "gemstone.explorer.openDefinitionToSide",
           "when": "view == gemstoneExplorerClasses && viewItem == explorerClass",
+          "group": "inline"
+        },
+        {
+          "command": "gemstone.explorer.renameIvar",
+          "when": "view == gemstoneExplorerClasses && viewItem == explorerIvar",
           "group": "inline"
         },
         {


### PR DESCRIPTION
## Summary

GemStone Explorer UX minor improvements

- **Instance-variable sub-tree.** Class rows in the Classes pane are now expandable, listing each class's **locally-defined** instance variables. The caret only appears when a class actually defines ivars — counts are fetched once per dictionary, names lazily on expand.
- **Rename pencil (stub).** Each ivar row carries an inline `$(edit)` pencil that opens a "Rename Instance Variable" dialog.
- **Refresh in place, keeping selection.** The Explorer's Refresh button re-fetched everything via a full reset, dropping the user's selection. It now reloads the current dictionary's classes (+ ivar counts) and the selected class's methods/hierarchy, rebuilds the panes, and re-reveals the retained dict → category → class → method. A full reset still happens only on a session switch.
- **Refresh on session abort.** A session abort discards uncommitted changes and refreshes the repository view, but the Explorer wasn't updated. It now reloads in place when the aborted session is the Explorer's current one — **without** revealing/foregrounding the view, so pressing Abort from the Sessions tree no longer yanks focus over to the Explorer.

> ⚠️ **Rename does not work yet.** The pencil / "Rename Instance Variable" dialog is a **stub**: the dialog says so, and accepting shows a "not available yet" message — no instance variable is actually renamed. This PR only builds the selection surface and UX flow.

> 📌 **Groundwork for other work.** The ivar sub-tree + rename pencil exist to provide the selection surface for the forthcoming **server-side rename-instance-variable refactoring** (refactoring tools). Wiring the pencil to that engine is separate, dependent work — this PR is a prerequisite for it.

## Implementation notes

- New defined-here-only queries `getDefinedInstVarNames` / `getDefinedInstVarCounts`, wired through `browserQueries.ts`.
- `ClassProvider` widened to `ClassItem | IvarItem`; selecting an ivar row is inert (acted on via its pencil). Drop controller ignores ivar targets.
- `refreshRetainingSelection({ reveal })` — `reveal: true` for the button (focus already in the Explorer), `reveal: false` for abort. The tree keeps its selection highlighted across a data refresh via stable row ids, so skipping reveal loses nothing but the unwanted jump.
- New `ExplorerHandle.onSessionAborted(id)`, called from `gemstone.sessionAbort`.

## Tests

- New `definedInstVars.test.ts` (6): parse behavior + an assertion the query uses `instVarNames`, not `allInstVarNames`.
- Explorer registration and existing query/explorer suites green; full client compile clean.

## Not in scope

- Class variables (deferred), inherited ivars (renaming an inherited ivar belongs to its defining class — later), and the actual rename engine.
