### PR TITLE
Clean up client source ahead of enabling ESLint (phase 2)

### DIFF
--- a/client/src/__tests__/processManager.test.ts
+++ b/client/src/__tests__/processManager.test.ts
@@ -403,39 +403,40 @@ describe('ProcessManager', () => {
 
   describe('classifyPidOwnership', () => {
     it('reports the PID gone when ps fell back to the "GONE" sentinel', () => {
-      const r = classifyPidOwnership('GONE', 'gs64stone');
+      const r = classifyPidOwnership('GONE');
       expect(r.pidGone).toBe(true);
       expect(r.isGemStoneServer).toBe(false);
     });
 
     it('reports the PID gone when ps produced nothing', () => {
-      const r = classifyPidOwnership('', 'gs64stone');
+      const r = classifyPidOwnership('');
       expect(r.pidGone).toBe(true);
     });
 
     it('recognizes a real stoned command line as a GemStone server', () => {
       const cmd = '/Users/jfoster/Documents/GemStone/GemStone64Bit3.7.5/sys/stoned -l /log/x.log -e /conf/x.conf -z /conf/system.conf gs64stone';
-      const r = classifyPidOwnership(cmd, 'gs64stone');
+      const r = classifyPidOwnership(cmd);
       expect(r.pidGone).toBe(false);
       expect(r.isGemStoneServer).toBe(true);
+      expect(r.command).toBe(cmd);
     });
 
     it('recognizes a real netldid command line as a GemStone server', () => {
-      const r = classifyPidOwnership('/gs/sys/netldid gs64ldi', 'gs64ldi');
+      const r = classifyPidOwnership('/gs/sys/netldid gs64ldi');
       expect(r.isGemStoneServer).toBe(true);
     });
 
     it('does NOT mistake a recycled-PID unrelated process for a GemStone server', () => {
-      const r = classifyPidOwnership('/usr/bin/ssh-agent', 'gs64stone');
+      const r = classifyPidOwnership('/usr/bin/ssh-agent');
       expect(r.pidGone).toBe(false);
       expect(r.isGemStoneServer).toBe(false);
     });
 
     it('does NOT match substrings like "stoned-arm" or "netldid_helper" that share a prefix only', () => {
-      // Regression: word-boundary anchors prevent a substring like
-      // "/opt/stoned-arm/binary" from falsely triggering the server check.
-      const r = classifyPidOwnership('/opt/stoned-arm/binary', 'gs64stone');
-      expect(r.isGemStoneServer).toBe(false);
+      // Regression: word-boundary anchors prevent a substring that merely
+      // starts with the token from falsely triggering the server check.
+      expect(classifyPidOwnership('/opt/stoned-arm/binary').isGemStoneServer).toBe(false);
+      expect(classifyPidOwnership('/opt/netldid_helper/x').isGemStoneServer).toBe(false);
     });
   });
 

--- a/client/src/databaseManager.ts
+++ b/client/src/databaseManager.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { SysadminStorage } from './sysadminStorage';

--- a/client/src/exportManager.ts
+++ b/client/src/exportManager.ts
@@ -13,7 +13,7 @@ import {
 } from './sync/syncProtocol';
 import { parseManifest, parseContent, ClassSource } from './sync/syncFraming';
 import {
-  diffManifest, stateFromManifest, emptyState, entryKey, splitKey, chunkRefs,
+  diffManifest, emptyState, entryKey, splitKey, chunkRefs,
   MirrorState,
 } from './sync/manifestDiff';
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -108,7 +108,6 @@ import { OsConfigTreeProvider } from './sharedMemoryTreeProvider';
 import { runQuickSetup } from './quickSetup';
 import {
   isWindows,
-  getWslInfo,
   getWslInfoAsync,
   invalidateWslCache,
   getWslNetworkInfoCached,

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -10,7 +10,7 @@ const OopType = 'uint64';
 const GCI_ERR_STR_SIZE = 1024;
 const GCI_MAX_ERR_ARGS = 10;
 
-const GciErrSType = koffi.struct('GciErrSType', {
+koffi.struct('GciErrSType', {
   category:     OopType,
   context:      OopType,
   exceptionObj: OopType,
@@ -24,10 +24,10 @@ const GciErrSType = koffi.struct('GciErrSType', {
 
 // GciSession is typedef void* in gcits.hf
 const GciSessionOpaque = koffi.opaque('GciSession');
-const GciSessionPtr = koffi.pointer('GciSessionPtr', GciSessionOpaque);
+koffi.pointer('GciSessionPtr', GciSessionOpaque);
 
 // GciTsObjInfo struct (from gcits.ht)
-const GciTsObjInfoStruct = koffi.struct('GciTsObjInfo', {
+koffi.struct('GciTsObjInfo', {
   objId:                  OopType,
   objClass:               OopType,
   objSize:                'int64',
@@ -38,7 +38,7 @@ const GciTsObjInfoStruct = koffi.struct('GciTsObjInfo', {
 });
 
 // GciTsGbjInfo struct — extends GciTsObjInfo with extraBits and bytesReturned
-const GciTsGbjInfoStruct = koffi.struct('GciTsGbjInfo', {
+koffi.struct('GciTsGbjInfo', {
   objId:                  OopType,
   objClass:               OopType,
   objSize:                'int64',
@@ -66,7 +66,7 @@ export interface GciGbjInfo extends GciObjInfo {
 }
 
 // GciClampedTravArgsSType — travBuff is an opaque pointer to a raw Buffer
-const GciClampedTravArgsStruct = koffi.struct('GciClampedTravArgsSType', {
+koffi.struct('GciClampedTravArgsSType', {
   clampSpec:      OopType,
   resultOop:      OopType,
   travBuff:       'void *',
@@ -107,7 +107,7 @@ const StoreTravDoUnion = koffi.union('StoreTravDoUnion', {
   continueArgs: StoreTravContinueArgs,
 });
 
-const GciStoreTravDoArgsSType = koffi.struct('GciStoreTravDoArgsSType', {
+koffi.struct('GciStoreTravDoArgsSType', {
   doPerform:        'int',
   doFlags:          'int',
   alteredNumOops:   'int',

--- a/client/src/gemstoneDebugSession.ts
+++ b/client/src/gemstoneDebugSession.ts
@@ -306,7 +306,7 @@ export class GemStoneDebugSession extends DebugSession {
             new Source(frameName, sourcePath, sourceRef),
             line,
           ));
-        } catch (e) {
+        } catch {
           // getFrameInfo itself failed — no source reference possible
           frames.push(new StackFrame(level, `<frame ${level}>`));
         }
@@ -593,7 +593,7 @@ export class GemStoneDebugSession extends DebugSession {
 
   protected continueRequest(
     response: DebugProtocol.ContinueResponse,
-    args: DebugProtocol.ContinueArguments,
+    _args: DebugProtocol.ContinueArguments,
   ): void {
     if (!this.session) {
       this.sendResponse(response);

--- a/client/src/processManager.ts
+++ b/client/src/processManager.ts
@@ -29,13 +29,10 @@ export interface ForceKillResult {
 /** Classify what `ps -p <pid> -o command=` returned. Exported so the safety
  *  rule can be tested without spawning a shell.
  *
- *  Inputs:
- *   - psOutput: trimmed stdout from `ps -p <pid> -o command= 2>/dev/null || echo GONE`
- *   - stoneName: process name from gslist; used as a corroborating signal
- *               (it appears as the last arg of the stoned/netldid command line). */
+ *  `psOutput` is the trimmed stdout from
+ *  `ps -p <pid> -o command= 2>/dev/null || echo GONE`. */
 export function classifyPidOwnership(
   psOutput: string,
-  _stoneName: string,
 ): { pidGone: boolean; isGemStoneServer: boolean; command: string } {
   const command = psOutput.trim();
   if (command === '' || command === 'GONE') {
@@ -159,7 +156,7 @@ export class ProcessManager {
         reason: `Could not check PID ${proc.pid} (ps unavailable). Refusing to delete the lock.`,
       };
     }
-    const ownership = classifyPidOwnership(psOutput, proc.name);
+    const ownership = classifyPidOwnership(psOutput);
     if (ownership.pidGone) {
       return {
         lockPath,
@@ -289,7 +286,7 @@ export class ProcessManager {
 
     let ownership;
     try {
-      ownership = classifyPidOwnership(psFor(proc.pid), proc.name);
+      ownership = classifyPidOwnership(psFor(proc.pid));
     } catch {
       return { killed: false, reason: `Could not verify PID ${proc.pid}; refusing to kill.` };
     }
@@ -308,7 +305,7 @@ export class ProcessManager {
       wslExecSync(`kill ${proc.pid} 2>/dev/null || true`);
       const graceMs = opts.graceMs ?? 800;
       if (graceMs > 0) await new Promise((r) => setTimeout(r, graceMs));
-      if (classifyPidOwnership(psFor(proc.pid), proc.name).isGemStoneServer) {
+      if (classifyPidOwnership(psFor(proc.pid)).isGemStoneServer) {
         wslExecSync(`kill -9 ${proc.pid} 2>/dev/null || true`);
       }
     } catch {

--- a/client/src/processManager.ts
+++ b/client/src/processManager.ts
@@ -35,7 +35,7 @@ export interface ForceKillResult {
  *               (it appears as the last arg of the stoned/netldid command line). */
 export function classifyPidOwnership(
   psOutput: string,
-  stoneName: string,
+  _stoneName: string,
 ): { pidGone: boolean; isGemStoneServer: boolean; command: string } {
   const command = psOutput.trim();
   if (command === '' || command === 'GONE') {

--- a/client/src/socketPoll.ts
+++ b/client/src/socketPoll.ts
@@ -29,7 +29,7 @@ function initPoll(): void {
     if (process.platform === 'win32') {
       const ws2 = koffi.load('ws2_32.dll');
       // WSAPOLLFD { ULONG_PTR fd; SHORT events; SHORT revents; }
-      const WSAPOLLFD = koffi.struct('JasperWsaPollFd', {
+      koffi.struct('JasperWsaPollFd', {
         fd: 'uint64',
         events: 'int16',
         revents: 'int16',
@@ -47,7 +47,7 @@ function initPoll(): void {
     } else {
       const libc = koffi.load(process.platform === 'darwin' ? 'libSystem.dylib' : 'libc.so.6');
       // struct pollfd { int fd; short events; short revents; }
-      const POLLFD = koffi.struct('JasperPollFd', {
+      koffi.struct('JasperPollFd', {
         fd: 'int',
         events: 'int16',
         revents: 'int16',

--- a/client/src/sysadminStorage.ts
+++ b/client/src/sysadminStorage.ts
@@ -3,13 +3,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { DatabaseYaml, GemStoneDatabase } from './sysadminTypes';
-import { needsWsl, getWslInfo, wslPathToWindows, windowsPathToWsl, wslExecSync } from './wslBridge';
+import { needsWsl, getWslInfo, wslPathToWindows, wslExecSync } from './wslBridge';
 import {
   wslExistsSync,
   wslIsDirectory,
-  wslIsFile,
   wslIsSymlink,
-  wslFileSize,
   wslReaddirSync,
   wslReadFileSync,
 } from './wslFs';

--- a/client/src/versionManager.ts
+++ b/client/src/versionManager.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { execSync, spawnSync } from 'child_process';
 import { SysadminStorage } from './sysadminStorage';
 import { GemStoneVersion } from './sysadminTypes';
-import { appendSysadmin, showSysadmin } from './sysadminChannel';
+import { appendSysadmin } from './sysadminChannel';
 import { needsWsl, wslSpawn, wslExecSync } from './wslBridge';
 import { wslExistsSync } from './wslFs';
 import { bundledWindowsClientVersions, bundledGciArchSupported } from './bundledGci';

--- a/client/src/wslBridge.ts
+++ b/client/src/wslBridge.ts
@@ -295,14 +295,13 @@ export function updateWslConfigMirrored(content: string): string {
   const eol = content.includes('\r\n') ? '\r\n' : '\n';
 
   let wsl2Start = -1;
-  let wsl2End = lines.length;
   let existingIdx = -1;
 
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].trim();
     const section = trimmed.match(/^\[([^\]]+)\]$/);
     if (section) {
-      if (wsl2Start !== -1) { wsl2End = i; break; }
+      if (wsl2Start !== -1) { break; }
       if (section[1].trim().toLowerCase() === 'wsl2') wsl2Start = i;
       continue;
     }


### PR DESCRIPTION
## What & why

This continues the phased work of **preparing to enable ESLint in Jasper**. Following the test-suite cleanup in #153, this phase clears the unused-symbol violations in the **client source** (`client/src/`), so that turning the linter on later stays a small, low-noise change instead of a wall of errors.

## Changes

- Drop unused imports and dead local code across 10 client source files (`gciLibrary.ts`, `extension.ts`, `sysadminStorage.ts`, `wslBridge.ts`, `socketPoll.ts`, `versionManager.ts`, `exportManager.ts`, `gemstoneDebugSession.ts`, `databaseManager.ts`, `processManager.ts`).
- Remove the unused `stoneName` parameter from `classifyPidOwnership` and correct its JSDoc. The parameter had been dead since the function was introduced, while the doc still claimed it was used as a corroborating signal; the word-boundary regex already guards against false positives on its own. All call sites (3 production + the tests) are updated.
- Tighten the `classifyPidOwnership` tests while there: assert the `command` passthrough, and actually exercise the `netldid_helper` substring the regression test's name promises.

Everything except the `classifyPidOwnership` signature is pure dead-code / unused-symbol cleanup with no behavior change. Removing the unused parameter changes that function's signature but not its behavior — the argument was never read.

## Verification

- `npm run compile` — clean across all workspaces.
- `client` unit tests for `processManager` pass (46).
