### PR TITLE
Clean up server source ahead of enabling ESLint (phase 3)

### DIFF
--- a/client/src/__tests__/browserColumnResize.test.ts
+++ b/client/src/__tests__/browserColumnResize.test.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 // BrowserColumnResize, exactly as the webview does when it injects the file.
 beforeAll(() => {
   const source = fs.readFileSync(path.resolve(__dirname, '../browserColumnResize.js'), 'utf8');
-  // eslint-disable-next-line no-new-func
   new Function(source)();
 });
 

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 // exactly as the webview does when it injects the file as a <script> tag.
 beforeAll(() => {
   const source = fs.readFileSync(path.resolve(__dirname, '../debuggerView.js'), 'utf8');
-  // eslint-disable-next-line no-new-func
   new Function(source)();
 });
 

--- a/client/src/__tests__/enhancedInspectorColumns.test.ts
+++ b/client/src/__tests__/enhancedInspectorColumns.test.ts
@@ -12,7 +12,6 @@ import * as path from 'path';
 // takes it as injected callbacks — so we stub them minimally.
 beforeAll(() => {
   const source = fs.readFileSync(path.resolve(__dirname, '../enhancedInspectorColumns.js'), 'utf8');
-  // eslint-disable-next-line no-new-func
   new Function(source)();
 });
 

--- a/client/src/__tests__/enhancedInspectorRunBasedText.test.ts
+++ b/client/src/__tests__/enhancedInspectorRunBasedText.test.ts
@@ -67,7 +67,6 @@ function loadCellHtml(): (raw: unknown) => string {
     extractFunction(CLIENT_SRC, 'cellHtml'),
     'return cellHtml;',
   ];
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
   const factory = new Function(parts.join('\n')) as () => (raw: unknown) => string;
   return factory();
 }

--- a/client/src/__tests__/listFilter.test.ts
+++ b/client/src/__tests__/listFilter.test.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
   const source = fs.readFileSync(path.resolve(__dirname, '../listFilter.js'), 'utf8');
-  // eslint-disable-next-line no-new-func
   new Function(source)();
 });
 

--- a/client/src/__tests__/methodListView.test.ts
+++ b/client/src/__tests__/methodListView.test.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 // exactly as the webview does when it injects the file as a <script> tag.
 beforeAll(() => {
   const source = fs.readFileSync(path.resolve(__dirname, '../methodListView.js'), 'utf8');
-  // eslint-disable-next-line no-new-func
   new Function(source)();
 });
 

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -11,7 +11,7 @@ import {
   CharacterLiteralNode, ArrayLiteralNode, ByteArrayLiteralNode, SpecialLiteralNode,
   ArrayItemNode,
   PragmaNode, UnaryPragmaNode, KeywordPragmaNode, PragmaPairNode,
-  PrimitiveNode, ASTNode,
+  PrimitiveNode,
 } from './ast';
 
 export class Parser {

--- a/server/src/services/formatting.ts
+++ b/server/src/services/formatting.ts
@@ -1,4 +1,4 @@
-import { TextEdit, Range } from 'vscode-languageserver';
+import { TextEdit } from 'vscode-languageserver';
 import { Token, TokenType } from '../lexer/tokens';
 import { ParsedDocument, ParsedRegion } from '../utils/documentManager';
 import {
@@ -7,7 +7,7 @@ import {
   MessageNode, UnaryMessageNode, BinaryMessageNode, KeywordMessageNode,
   PrimaryNode, BlockNode, SelectionBlockNode, ParenExpressionNode,
   CurlyArrayBuilderNode, ArrayLiteralNode, ArrayItemNode, ByteArrayLiteralNode,
-  PragmaNode, PathNode,
+  PragmaNode,
 } from '../parser/ast';
 import { FormatterSettings, DEFAULT_SETTINGS } from './formatterSettings';
 

--- a/server/src/tonel/tonelParser.ts
+++ b/server/src/tonel/tonelParser.ts
@@ -38,7 +38,6 @@ export function parseTonelDocument(text: string): TopazRegion[] {
   if (i < lines.length) {
     const trimmed = lines[i].trimStart();
     if (trimmed.startsWith('"')) {
-      const commentStart = i;
       // Check if the comment closes on the same line
       const afterQuote = trimmed.slice(1);
       if (afterQuote.includes('"')) {
@@ -64,7 +63,6 @@ export function parseTonelDocument(text: string): TopazRegion[] {
 
   if (headerMatch) {
     const headerStartLine = i;
-    const headerType = headerMatch[1] as 'Class' | 'Extension' | 'Package';
 
     // Find closing } — it could be on the same line or on a later line
     let headerEndLine = i;

--- a/server/src/topaz/topazParser.ts
+++ b/server/src/topaz/topazParser.ts
@@ -31,17 +31,21 @@ export interface TopazRegion {
   selectorColumnOffset?: number;
 }
 
-/** Known Topaz commands that do NOT start Smalltalk blocks */
-const TOPAZ_COMMANDS = [
-  'abort', 'begin', 'category', 'classmethod', 'commit', 'display',
-  'doit', 'edit', 'errorcount', 'exec', 'exit', 'expecterror',
-  'expectvalue', 'fileout', 'filein', 'iferr', 'iferror', 'input',
-  'level', 'limit', 'list', 'login', 'logout', 'lookup',
-  'method', 'obj', 'object', 'omit', 'output', 'pausealiasing',
-  'print', 'printit', 'protect', 'quit', 'releaseall', 'removeallclassmethods', 'removeallmethods',
-  'run', 'send', 'set', 'shell', 'spawn', 'stack', 'stk',
-  'time', 'topaz', 'where',
-];
+// NOTE: `TOPAZ_COMMANDS` is not currently referenced by any code. It's left
+// here (commented out) as potentially useful context: the full set of Topaz
+// commands that do NOT start Smalltalk blocks. Commented rather than deleted so
+// it stays discoverable for future parsing work, and so the linter doesn't flag
+// it as an unused variable. Uncomment and wire it up if it becomes needed.
+// const TOPAZ_COMMANDS = [
+//   'abort', 'begin', 'category', 'classmethod', 'commit', 'display',
+//   'doit', 'edit', 'errorcount', 'exec', 'exit', 'expecterror',
+//   'expectvalue', 'fileout', 'filein', 'iferr', 'iferror', 'input',
+//   'level', 'limit', 'list', 'login', 'logout', 'lookup',
+//   'method', 'obj', 'object', 'omit', 'output', 'pausealiasing',
+//   'print', 'printit', 'protect', 'quit', 'releaseall', 'removeallclassmethods', 'removeallmethods',
+//   'run', 'send', 'set', 'shell', 'spawn', 'stack', 'stk',
+//   'time', 'topaz', 'where',
+// ];
 
 /** Commands that start a Smalltalk expression block (code) */
 const CODE_COMMANDS = ['run', 'doit', 'print', 'printit'];
@@ -105,7 +109,6 @@ export function parseTopazDocument(text: string): TopazRegion[] {
     // Check for code-starting commands: run, doit, print
     const codeMatch = matchCommand(line, CODE_COMMANDS);
     if (codeMatch) {
-      const commandLine = i;
       i++;
       const startLine = i;
       const codeLines: string[] = [];
@@ -136,7 +139,6 @@ export function parseTopazDocument(text: string): TopazRegion[] {
     // Check for method-starting commands: method, classmethod
     const methodMatch = matchCommand(line, METHOD_COMMANDS);
     if (methodMatch) {
-      const commandLine = i;
       // Extract class name if present: "method: ClassName" or "method ClassName"
       let className: string | undefined;
       const restTrimmed = methodMatch.rest.replace(/^:\s*/, '').trim();

--- a/server/src/utils/documentManager.ts
+++ b/server/src/utils/documentManager.ts
@@ -4,7 +4,7 @@ import { Parser } from '../parser/parser';
 import { ParseError } from '../parser/errors';
 import { MethodNode } from '../parser/ast';
 import { StatementNode } from '../parser/ast';
-import { parseTopazDocument, TopazRegion, RegionKind, findRegionAtLine, toRegionPosition } from '../topaz/topazParser';
+import { parseTopazDocument, TopazRegion, RegionKind } from '../topaz/topazParser';
 import { parseTonelDocument } from '../tonel/tonelParser';
 
 export type DocumentFormat = 'topaz' | 'tonel' | 'smalltalk';


### PR DESCRIPTION
## What & why

This continues the phased work of **preparing to enable ESLint in Jasper**. Following the test-suite cleanup in [#153](https://github.com/jgfoster/Jasper/pull/153) and the client-source cleanup in [#156](https://github.com/jgfoster/Jasper/pull/156), this phase clears the remaining unused-symbol violations in the **server source** (`server/src/`) and drops now-stale `eslint-disable` directives left behind in the tests, so that turning the linter on later stays a small, low-noise change instead of a wall of errors.

## Changes

*   Drop unused imports across the server source (`ASTNode` in `parser.ts`, `Range` and `PathNode` in `formatting.ts`, `findRegionAtLine`/`toRegionPosition` in `documentManager.ts`).
*   Remove dead local variables in the parsers (`commentStart` and `headerType` in `tonelParser.ts`; two `commandLine` assignments in `topazParser.ts`) — all assigned but never read.
*   Comment out the unused `TOPAZ_COMMANDS` array in `topazParser.ts` rather than delete it, with a note explaining it's kept as discoverable context for future parsing work while keeping the linter quiet.
*   Remove six stale `// eslint-disable-next-line` directives from test files (`browserColumnResize`, `debuggerView`, `enhancedInspectorColumns`, `enhancedInspectorRunBasedText`, `listFilter`, `methodListView`) — the suppressed rules no longer fire at those sites.

All changes are pure dead-code / unused-symbol cleanup with no behavior change.

## Verification

*   `npm run compile` — clean across all workspaces.
