### PR TITLE
Clean up unsafe types and unnecessary regex escapes ahead of enabling ESLint (phase 4)

### DIFF
--- a/client/src/__tests__/rowanLoad.test.ts
+++ b/client/src/__tests__/rowanLoad.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -139,7 +140,6 @@ describe('deriveRepoName', () => {
 });
 
 describe('updateGitRepo', () => {
-  const { execFileSync } = require('child_process') as typeof import('child_process');
   const g = (args: string[], cwd: string) => execFileSync('git', args, { cwd, stdio: 'pipe' });
 
   // A bare remote, plus a clone of it. Advancing the remote is done through a

--- a/client/src/__tests__/vitest.customErrorMatchers.ts
+++ b/client/src/__tests__/vitest.customErrorMatchers.ts
@@ -1,5 +1,10 @@
 import {expect} from 'vitest';
 
+// Constructor of an `Error` subclass. `NewableFunction` (not `new (...) => Error`)
+// so it also accepts classes with non-public constructors, and still exposes
+// `.name` / works with `instanceof`.
+type ErrorClass = NewableFunction & { prototype: Error };
+
 expect.extend({
     /**
      * Used to test that a function throws exactly the given error instance,
@@ -40,7 +45,7 @@ expect.extend({
      * @param ExpectedClass - The `Error` subclass `callback` must throw an instance of.
      * @param expectedMessage - The exact `message` the thrown error must have.
      */
-    toThrowInstanceOf(callback: () => unknown, ExpectedClass: Function & { prototype: Error }, expectedMessage: string) {
+    toThrowInstanceOf(callback: () => unknown, ExpectedClass: ErrorClass, expectedMessage: string) {
         try {
             callback();
             return {
@@ -89,6 +94,6 @@ declare module 'vitest' {
          * @param ExpectedClass - The `Error` subclass the received function must throw an instance of.
          * @param expectedMessage - The exact `message` the thrown error must have.
          */
-        toThrowInstanceOf(ExpectedClass: Function & { prototype: Error }, expectedMessage: string): void;
+        toThrowInstanceOf(ExpectedClass: ErrorClass, expectedMessage: string): void;
     }
 }

--- a/client/src/enhancedInspector.ts
+++ b/client/src/enhancedInspector.ts
@@ -978,7 +978,7 @@ export class EnhancedInspector {
     // A1: JSON syntax highlighting
     function highlightJson(str) {
       return esc(str).replace(
-        /(&quot;(\\\\u[a-fA-F0-9]{4}|\\\\[^u]|[^\\\\&])*&quot;(\s*:)?|\b(true|false|null)\b|-?\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d+)?)/g,
+        /(&quot;(\\\\u[a-fA-F0-9]{4}|\\\\[^u]|[^\\\\&])*&quot;(s*:)?|\b(true|false|null)\b|-?\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d+)?)/g,
         m => {
           let col = 'color:#b5cea8';
           if (m.startsWith('&quot;')) col = m.endsWith(':') ? 'color:#9cdcfe' : 'color:#ce9178';

--- a/client/src/enhancedInspectorPerfTracker.ts
+++ b/client/src/enhancedInspectorPerfTracker.ts
@@ -122,7 +122,7 @@ export function wrapWithEnhancedInspectorPerfProxy(gci: GciLibrary): GciLibrary 
           return (val as (...a: unknown[]) => unknown).apply(target, args);
         };
       }
-      return typeof val === 'function' ? (val as Function).bind(target) : val;
+      return typeof val === 'function' ? (val as (...args: unknown[]) => unknown).bind(target) : val;
     },
   }) as GciLibrary;
 }

--- a/client/src/processManager.ts
+++ b/client/src/processManager.ts
@@ -42,7 +42,7 @@ export function classifyPidOwnership(
   // basename (matched at a word boundary so unrelated apps like
   // "ssh-agent" or "iTunesHelper" do not get a false positive).
   const lowered = command.toLowerCase();
-  const looksLikeServer = /(?:^|[\/\s])(?:stoned|netldid)(?:\s|$)/.test(lowered);
+  const looksLikeServer = /(?:^|[/\s])(?:stoned|netldid)(?:\s|$)/.test(lowered);
   return { pidGone: false, isGemStoneServer: looksLikeServer, command };
 }
 

--- a/client/src/queries/getEnhancedInspectorViewSpecs.ts
+++ b/client/src/queries/getEnhancedInspectorViewSpecs.ts
@@ -1,7 +1,7 @@
 import { QueryExecutor } from './types';
 import { escapeString } from './util';
 
-const VALID_SELECTOR = /^[a-zA-Z_][a-zA-Z0-9_]*:?$|^([a-zA-Z_][a-zA-Z0-9_]*:)+$|^[+\-*\/<>=~&|@%?,]{1,2}$/;
+const VALID_SELECTOR = /^[a-zA-Z_][a-zA-Z0-9_]*:?$|^([a-zA-Z_][a-zA-Z0-9_]*:)+$|^[+\-*/<>=~&|@%?,]{1,2}$/;
 
 export function isValidSelector(selector: string): boolean {
   return VALID_SELECTOR.test(selector);

--- a/client/src/queries/getEnhancedInspectorViewSpecs.ts
+++ b/client/src/queries/getEnhancedInspectorViewSpecs.ts
@@ -105,7 +105,7 @@ STONJSON toString: textData`;
   const result = enhancedInspectorExecute(execute, 'fetchEnhancedInspectorPrintTabData', code);
   let truncated = false;
   if (result) {
-    try { truncated = JSON.parse(result).truncated === true; } catch {}
+    try { truncated = JSON.parse(result).truncated === true; } catch { /* non-JSON result: leave truncated = false */ }
   }
   return { data: result, truncated };
 }

--- a/client/src/wslFs.ts
+++ b/client/src/wslFs.ts
@@ -208,7 +208,7 @@ export function wslRmSync(p: string, options?: { recursive?: boolean; force?: bo
  */
 export function toWslPath(p: string): string {
   if (isWslUncPath(p)) return windowsPathToWsl(p);
-  const drive = p.match(/^([A-Za-z]):[\\\/](.*)$/);
+  const drive = p.match(/^([A-Za-z]):[\\/](.*)$/);
   if (drive) return `/mnt/${drive[1].toLowerCase()}/${drive[2].replace(/\\/g, '/')}`;
   return p;
 }


### PR DESCRIPTION
## What & why

This continues the phased work of **preparing to enable ESLint in Jasper**. Following the test-suite cleanup in #153, the client-source cleanup in #156, and the server-source cleanup in #157, this phase clears remaining lint-relevant issues so that turning the linter on later stays a small, low-noise change instead of a wall of errors.

## Changes

* Replace unsafe `Function` type with precise function-shaped types in the custom error matchers (`vitest.customErrorMatchers.ts`) and the enhanced-inspector perf proxy (`enhancedInspectorPerfTracker.ts`).
* Document the intentionally empty `catch` block in `getEnhancedInspectorViewSpecs.ts` (non-JSON result path) instead of leaving it unexplained.
* Drop unnecessary regex escapes (`\/`, `\s` inside character classes) from `wslFs.ts`, `processManager.ts`, `getEnhancedInspectorViewSpecs.ts`, and the inspector's JSON syntax highlighter.
* Use an ESM `import` for `child_process` in `rowanLoad.test.ts` instead of a `require()` call.

All changes are pure cleanup with no behavior change.

## Verification

* `npm run compile` — clean across all workspaces.