### PR TITLE
Drop remaining `any` from test mocks (phase 5)

### DIFF
--- a/.claude/rules/client/tests.md
+++ b/.claude/rules/client/tests.md
@@ -31,6 +31,15 @@ Some handlers (e.g. in `systemBrowser.ts`) call async methods without awaiting t
 
 Tests run in random order; the seed is printed at the top of the output. Reproduce a run by replaying that seed via `VITEST_SEED=<seed>` (a root `SeededSequencer` in `client/vitest.config.ts` reads it and pins it into both projects for a fully reproducible file order).
 
+### Typing overloaded Node/vscode mocks without `any`
+
+`vi.mocked()` on an overloaded function (`fs.readFileSync`, `fs.readdirSync`, `child_process.exec`, `vscode.window.showInformationMessage`, ...) types the mock using the *last* declared overload, not the one production code actually hits. Don't reach for `any` when a call against one of these doesn't type-check:
+
+- First try the plain, unfixed-up value and let `npx tsc -p client/tsconfig.json --noEmit` tell you if it's actually a problem. The last overload's return/param type is often already a superset of what you need (e.g. `readFileSync`'s last overload returns `string | Buffer`, so a plain string return just works).
+- When `tsc` reports a *real* mismatch (e.g. `readdirSync`'s last overload wants `Dirent[]`, not `string[]`; `showInformationMessage`'s last overload wants `T extends MessageItem`, not a bare string), that's genuine overload friction, not a typing mistake — use a precise, narrowly-scoped `as unknown as <ExpectedType>` at that one call site rather than widening to `any`.
+- Optional callback params (e.g. `exec`'s `callback?: (...) => void`) are "possibly undefined" once you're not masking the type with `any` — call them with `cb?.(...)`, don't cast the optionality away.
+- For partial interface mocks (`vscode.Terminal`, `vscode.ExtensionContext`), confine the one unavoidable `as unknown as T` cast to a single shared test helper (e.g. a `fakeTerminal()` factory) instead of repeating it at every call site — see `osConfigTreeProvider.test.ts`.
+
 ## Integration tests
 
 Tests using `useIntegrationTest` require a live GemStone instance so plain `npm test` needs a running stone. Run `npm run test:server:start` once to provision one; it writes connection details to `.env.test` (which the user may override with `.env.test.local`). CI runs these as a matrix over `client/.gemstone-integration-releases.json`. The deep GCI binding suite (`npm run test:gci`) is separate.

--- a/client/src/__tests__/backupManager.test.ts
+++ b/client/src/__tests__/backupManager.test.ts
@@ -26,11 +26,11 @@ describe('runLogicalBackup', () => {
     vi.clearAllMocks();
     vi.mocked(wslExistsSync).mockReturnValue(true);
     vi.mocked(vscode.window.showSaveDialog).mockResolvedValue(
-      vscode.Uri.file('/root/db-1/backups/gs64stone.dbf') as any,
+      vscode.Uri.file('/root/db-1/backups/gs64stone.dbf'),
     );
     // Default: user dismisses the success toast without clicking an action.
     // (clearAllMocks resets call history but not mockResolvedValue, so set it here.)
-    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as any);
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined);
   });
 
   it('backs up to the chosen destination and reports success', async () => {
@@ -57,7 +57,7 @@ describe('runLogicalBackup', () => {
 
   it('offers to reveal a locally-managed backup and opens the file manager on request', async () => {
     const deps = makeDeps();
-    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue('Reveal in File Explorer' as any);
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue('Reveal in File Explorer' as unknown as vscode.MessageItem);
 
     await runLogicalBackup(deps);
 
@@ -105,7 +105,7 @@ describe('runLogicalBackup', () => {
       throw new Error('abort failed');
     });
     const deps = makeDeps({ execute });
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Discard changes and back up' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Discard changes and back up' as unknown as vscode.MessageItem);
 
     const ok = await runLogicalBackup(deps);
 
@@ -130,7 +130,7 @@ describe('runLogicalBackup', () => {
     const deps = makeDeps({
       execute: vi.fn((_l: string, code: string) => (code.includes('needsCommit') ? 'true' : 'true')),
     });
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined);
 
     const ok = await runLogicalBackup(deps);
 
@@ -146,7 +146,7 @@ describe('runLogicalBackup', () => {
     });
     const deps = makeDeps({ execute });
     vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(
-      'Discard changes and back up' as any,
+      'Discard changes and back up' as unknown as vscode.MessageItem,
     );
 
     const ok = await runLogicalBackup(deps);

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -224,10 +224,16 @@ function posted(panel: ReturnType<typeof lastPanel>, command: string) {
     .map((c: unknown[]) => c[0] as { command: string })
     .filter((m: { command: string }) => m.command === command);
 }
-/** The most recent payload posted with the given command (or undefined). */
-function lastPosted(panel: ReturnType<typeof lastPanel>, command: string): any {
-  const all = posted(panel, command);
-  return all[all.length - 1];
+/**
+ * The most recent payload posted with the given command (or undefined).
+ * Sourced from `mock.calls` (like `initPayload`) so the element type stays
+ * inferred rather than narrowed to `{ command: string }` — webview payloads
+ * are an untyped IPC union that assertions index into ad-hoc.
+ */
+function lastPosted(panel: ReturnType<typeof lastPanel>, command: string) {
+  const all = panel.webview.postMessage.mock.calls
+    .filter((c: unknown[]) => (c[0] as { command: string }).command === command);
+  return all[all.length - 1]?.[0];
 }
 
 /**

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -225,7 +225,6 @@ function posted(panel: ReturnType<typeof lastPanel>, command: string) {
     .filter((m: { command: string }) => m.command === command);
 }
 /** The most recent payload posted with the given command (or undefined). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function lastPosted(panel: ReturnType<typeof lastPanel>, command: string): any {
   const all = posted(panel, command);
   return all[all.length - 1];

--- a/client/src/__tests__/enhancedInspectorPanel.test.ts
+++ b/client/src/__tests__/enhancedInspectorPanel.test.ts
@@ -52,13 +52,13 @@ import { GemStoneLogin } from '../loginTypes';
 function makeMockPanel() {
   const postMessage = vi.fn();
   let title = '';
-  let messageHandler: ((msg: any) => void) | undefined;
+  let messageHandler: ((msg: unknown) => void) | undefined;
 
   const panel = {
     webview: {
       set html(_: string) {},
       postMessage,
-      onDidReceiveMessage(cb: (msg: any) => void) {
+      onDidReceiveMessage(cb: (msg: unknown) => void) {
         messageHandler = cb;
         return { dispose: vi.fn() };
       },
@@ -73,7 +73,7 @@ function makeMockPanel() {
     panel,
     get postMessage() { return postMessage; },
     get title() { return title; },
-    sendMessage(msg: any) { messageHandler!(msg); },
+    sendMessage(msg: unknown) { messageHandler!(msg); },
   };
 }
 
@@ -101,7 +101,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   session = createMockSession();
   mock = makeMockPanel();
-  vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel as any);
+  vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel as unknown as vscode.WebviewPanel);
   vi.mocked(debug.fetchPrintString).mockReturnValue({ value: 'an Object', truncated: false });
   vi.mocked(debug.getObjectClassName).mockReturnValue('Object');
   vi.mocked(queries.getEnhancedInspectorViewSpecs).mockReturnValue([]);
@@ -131,8 +131,8 @@ describe('EnhancedInspector', () => {
       expect.assertions(2);
       const mock2 = makeMockPanel();
       vi.mocked(vscode.window.createWebviewPanel)
-        .mockReturnValueOnce(mock.panel as any)
-        .mockReturnValueOnce(mock2.panel as any);
+        .mockReturnValueOnce(mock.panel as unknown as vscode.WebviewPanel)
+        .mockReturnValueOnce(mock2.panel as unknown as vscode.WebviewPanel);
       EnhancedInspector.create(session, 1000n, 'first');
       EnhancedInspector.create(session, 2000n, 'second');
       EnhancedInspector.disposeForSession(session.id);

--- a/client/src/__tests__/gemstoneCompletionProvider.test.ts
+++ b/client/src/__tests__/gemstoneCompletionProvider.test.ts
@@ -9,6 +9,7 @@ vi.mock('../browserQueries', () => ({
 }));
 
 import { Uri, CompletionItemKind } from '../__mocks__/vscode';
+import type * as vscode from 'vscode';
 import { GemStoneCompletionProvider } from '../gemstoneCompletionProvider';
 import { SessionManager } from '../sessionManager';
 import { getAllClassNames, getInstVarNames, getAllSelectors } from '../browserQueries';
@@ -33,7 +34,7 @@ function makeDocument(uri: string) {
     uri: Uri.parse(uri),
     getText: vi.fn(() => ''),
     getWordRangeAtPosition: vi.fn(() => undefined),
-  } as any;
+  } as unknown as vscode.TextDocument;
 }
 
 describe('GemStoneCompletionProvider', () => {

--- a/client/src/__tests__/gemstoneDefinitionProvider.test.ts
+++ b/client/src/__tests__/gemstoneDefinitionProvider.test.ts
@@ -48,7 +48,7 @@ function makeDocument(text: string, uri = 'gemstone://1/Globals/Array/instance/a
       if (start === end) return undefined;
       return new Range(new Position(pos.line, start), new Position(pos.line, end));
     },
-  } as any;
+  } as unknown as vscode.TextDocument;
 }
 
 describe('GemStoneDefinitionProvider', () => {

--- a/client/src/__tests__/gemstoneHoverProvider.test.ts
+++ b/client/src/__tests__/gemstoneHoverProvider.test.ts
@@ -49,7 +49,7 @@ function makeDocument(text: string) {
       if (start === end) return undefined;
       return new Range(new Position(p.line, start), new Position(p.line, end));
     },
-  } as any;
+  } as unknown as vscode.TextDocument;
 }
 
 describe('GemStoneHoverProvider', () => {

--- a/client/src/__tests__/localVersion.test.ts
+++ b/client/src/__tests__/localVersion.test.ts
@@ -16,11 +16,15 @@ vi.mock('../wslBridge', () => ({
   wslExecSync: vi.fn(),
 }));
 
+import type * as vscode from 'vscode';
 import { __setConfig, __resetConfig } from '../__mocks__/vscode';
 import { SysadminStorage } from '../sysadminStorage';
 import { VersionManager } from '../versionManager';
 import { VersionItem } from '../versionTreeProvider';
 import { GemStoneVersion } from '../sysadminTypes';
+
+/** VersionManager's private `fetchUrl`, exposed as a narrow surface for spying. */
+type FetchUrlHost = { fetchUrl(url: string): Promise<string> };
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -177,7 +181,7 @@ describe('VersionItem (local version)', () => {
     expect(item.contextValue).toBe('gemstoneVersionLocal');
     expect(item.description).toContain('(local)');
     expect(item.description).toContain('2026-03-24');
-    expect((item.iconPath as any).id).toBe('check');
+    expect((item.iconPath as vscode.ThemeIcon).id).toBe('check');
     expect(item.tooltip).toContain('local build');
     expect(item.tooltip).toContain('private build (branch 3.7.6)');
   });
@@ -196,7 +200,7 @@ describe('VersionItem (local version)', () => {
     const item = new VersionItem(version);
 
     expect(item.contextValue).toBe('gemstoneVersion');
-    expect((item.iconPath as any).id).toBe('cloud');
+    expect((item.iconPath as vscode.ThemeIcon).id).toBe('cloud');
     expect(item.description).toContain('100 MB');
   });
 
@@ -214,7 +218,7 @@ describe('VersionItem (local version)', () => {
     const item = new VersionItem(version);
 
     expect(item.contextValue).toBe('gemstoneVersionServerDownloadedServerExtracted');
-    expect((item.iconPath as any).id).toBe('check');
+    expect((item.iconPath as vscode.ThemeIcon).id).toBe('check');
   });
 
   it('marks a bundled version in description, contextValue, and tooltip', () => {
@@ -256,7 +260,7 @@ describe('VersionManager.fetchAvailableVersions', () => {
     fs.symlinkSync(productDir, path.join(tmpDir, `GemStone64Bit3.7.6${suffix}`));
 
     // Mock the network fetch to return empty HTML (no remote versions)
-    const fetchSpy = vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue('');
+    const fetchSpy = vi.spyOn(manager as unknown as FetchUrlHost, 'fetchUrl').mockResolvedValue('');
 
     const versions = await manager.fetchAvailableVersions();
 
@@ -283,7 +287,7 @@ describe('VersionManager.fetchAvailableVersions', () => {
 
     // Mock fetch to return a remote version with the same version number
     const html = `<a href="GemStone64Bit3.7.6-${platformKey}.${ext}">GemStone64Bit3.7.6-${platformKey}.${ext}</a>  24-Mar-2026 12:00  200000000`;
-    vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue(html);
+    vi.spyOn(manager as unknown as FetchUrlHost, 'fetchUrl').mockResolvedValue(html);
 
     const versions = await manager.fetchAvailableVersions();
 
@@ -321,7 +325,7 @@ describe('VersionManager.fetchAvailableVersions', () => {
       `<a href="GemStone64Bit3.6.4-${platformKey}.${ext}">file</a>  06-Jun-2022 12:00  169000000`,
       `<a href="GemStone64Bit3.8.0-${platformKey}.${ext}">file</a>  01-Jan-2027 12:00  200000000`,
     ].join('\n');
-    vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue(html);
+    vi.spyOn(manager as unknown as FetchUrlHost, 'fetchUrl').mockResolvedValue(html);
 
     const versions = await manager.fetchAvailableVersions();
 
@@ -341,7 +345,7 @@ describe('VersionManager.fetchAvailableVersions', () => {
       `<a href="GemStone64Bit3.6.2-${platformKey}.${ext}">file</a>  01-Jun-2021 12:00  161000000`,
       `<a href="GemStone64Bit3.7.0-${platformKey}.${ext}">file</a>  01-Jan-2022 12:00  170000000`,
     ].join('\n');
-    vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue(html);
+    vi.spyOn(manager as unknown as FetchUrlHost, 'fetchUrl').mockResolvedValue(html);
 
     const versions = await manager.fetchAvailableVersions();
 
@@ -358,7 +362,7 @@ describe('VersionManager.fetchAvailableVersions', () => {
     writeVersionTxt(productDir, SAMPLE_VERSION_TXT);
     fs.symlinkSync(productDir, path.join(tmpDir, `GemStone64Bit3.5.0${suffix}`));
 
-    vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue('');
+    vi.spyOn(manager as unknown as FetchUrlHost, 'fetchUrl').mockResolvedValue('');
 
     const versions = await manager.fetchAvailableVersions();
 

--- a/client/src/__tests__/loginCredentials.test.ts
+++ b/client/src/__tests__/loginCredentials.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as vscode from 'vscode';
 
 import {
   KEYCHAIN_SERVICE,
@@ -66,7 +67,7 @@ describe('loginCredentials', () => {
 
   describe('setLoginPassword', () => {
     it('stores under a key namespaced by KEYCHAIN_SERVICE and the account identifier', async () => {
-      await setLoginPassword(secrets as any, makeLogin());
+      await setLoginPassword(secrets as unknown as vscode.SecretStorage, makeLogin());
 
       expect(secrets.store).toHaveBeenCalledWith(
         'jasper-gemstone-login:DataCurator@localhost/gs64stone',
@@ -78,7 +79,7 @@ describe('loginCredentials', () => {
   describe('getLoginPassword', () => {
     it('returns the stored password from SecretStorage', async () => {
       secrets.get.mockResolvedValueOnce('stored-pw');
-      const pw = await getLoginPassword(secrets as any, makeLogin());
+      const pw = await getLoginPassword(secrets as unknown as vscode.SecretStorage, makeLogin());
 
       expect(secrets.get).toHaveBeenCalledWith(
         'jasper-gemstone-login:DataCurator@localhost/gs64stone',
@@ -88,20 +89,20 @@ describe('loginCredentials', () => {
 
     it('returns undefined when no password is stored', async () => {
       secrets.get.mockResolvedValueOnce(undefined);
-      const pw = await getLoginPassword(secrets as any, makeLogin());
+      const pw = await getLoginPassword(secrets as unknown as vscode.SecretStorage, makeLogin());
       expect(pw).toBeUndefined();
     });
 
     it('returns undefined when SecretStorage throws', async () => {
       secrets.get.mockRejectedValueOnce(new Error('SecretStorage unavailable'));
-      const pw = await getLoginPassword(secrets as any, makeLogin());
+      const pw = await getLoginPassword(secrets as unknown as vscode.SecretStorage, makeLogin());
       expect(pw).toBeUndefined();
     });
   });
 
   describe('deleteLoginPassword', () => {
     it('delegates to SecretStorage.delete and returns true on success', async () => {
-      const ok = await deleteLoginPassword(secrets as any, makeLogin());
+      const ok = await deleteLoginPassword(secrets as unknown as vscode.SecretStorage, makeLogin());
 
       expect(secrets.delete).toHaveBeenCalledWith(
         'jasper-gemstone-login:DataCurator@localhost/gs64stone',
@@ -111,7 +112,7 @@ describe('loginCredentials', () => {
 
     it('returns false when SecretStorage throws', async () => {
       secrets.delete.mockRejectedValueOnce(new Error('no entry'));
-      const ok = await deleteLoginPassword(secrets as any, makeLogin());
+      const ok = await deleteLoginPassword(secrets as unknown as vscode.SecretStorage, makeLogin());
       expect(ok).toBe(false);
     });
   });

--- a/client/src/__tests__/osConfigTreeProvider.test.ts
+++ b/client/src/__tests__/osConfigTreeProvider.test.ts
@@ -266,7 +266,7 @@ describe('OsConfigTreeProvider', () => {
       setPlatform('linux');
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readdirSync).mockReturnValue(['gemstone.conf'] as any);
+      vi.mocked(fs.readdirSync).mockReturnValue(['gemstone.conf'] as unknown as ReturnType<typeof fs.readdirSync>);
       vi.mocked(fs.readFileSync).mockImplementation((filepath: fs.PathOrFileDescriptor) => {
         if (String(filepath).endsWith('logind.conf') && !String(filepath).includes('.d/')) {
           return 'RemoveIPC=yes\n'; // main file says yes
@@ -282,7 +282,7 @@ describe('OsConfigTreeProvider', () => {
       setPlatform('linux');
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readdirSync).mockReturnValue(['zz-override.conf'] as any);
+      vi.mocked(fs.readdirSync).mockReturnValue(['zz-override.conf'] as unknown as ReturnType<typeof fs.readdirSync>);
       vi.mocked(fs.readFileSync).mockImplementation((filepath: fs.PathOrFileDescriptor) => {
         if (String(filepath).includes('logind.conf.d')) {
           return 'RemoveIPC=yes\n';
@@ -1045,7 +1045,7 @@ describe('OsConfigTreeProvider', () => {
       vi.mocked(wslBridge.updateWslConfigMirrored).mockImplementation(
         () => '[wsl2]\nnetworkingMode=mirrored\n',
       );
-      vi.mocked(vscode.window.showInformationMessage).mockResolvedValue('Restart WSL now' as any);
+      vi.mocked(vscode.window.showInformationMessage).mockResolvedValue('Restart WSL now' as unknown as vscode.MessageItem);
       const mockTerminal = fakeTerminal();
       vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 

--- a/client/src/__tests__/osConfigTreeProvider.test.ts
+++ b/client/src/__tests__/osConfigTreeProvider.test.ts
@@ -19,7 +19,7 @@ vi.mock('../wslBridge', () => ({
 import { exec } from 'child_process';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { OsConfigTreeProvider } from '../sharedMemoryTreeProvider';
+import { OsConfigTreeProvider, type OsConfigNode } from '../sharedMemoryTreeProvider';
 import * as wslBridge from '../wslBridge';
 
 // ── Helpers ────────────────────────────────────────────────
@@ -66,7 +66,7 @@ function mockExecError(): void {
 }
 
 /** Call getChildren(), wait for async load to complete, then return cached nodes. */
-async function getRootNodes(provider: OsConfigTreeProvider): Promise<any[]> {
+async function getRootNodes(provider: OsConfigTreeProvider): Promise<OsConfigNode[]> {
   const initial = provider.getChildren();
   if (Array.isArray(initial) && initial.length === 1 && initial[0].kind === 'loading') {
     // Wait for the async _loadConfig to fire onDidChangeTreeData
@@ -76,9 +76,22 @@ async function getRootNodes(provider: OsConfigTreeProvider): Promise<any[]> {
         resolve();
       });
     });
-    return provider.getChildren() as any[];
+    return provider.getChildren();
   }
-  return (Array.isArray(initial) ? initial : await initial) as any[];
+  return Array.isArray(initial) ? initial : await initial;
+}
+
+/** Find the (at most one) node of a given kind, narrowed to that variant. */
+function findByKind<K extends OsConfigNode['kind']>(
+  nodes: OsConfigNode[],
+  kind: K,
+): Extract<OsConfigNode, { kind: K }> | undefined {
+  return nodes.find((n): n is Extract<OsConfigNode, { kind: K }> => n.kind === kind);
+}
+
+/** The `command` id of each action node, in order (non-action nodes → undefined). */
+function actionCommands(nodes: OsConfigNode[]): (string | undefined)[] {
+  return nodes.map((n) => (n.kind === 'action' ? n.command : undefined));
 }
 
 // ── Suite ──────────────────────────────────────────────────
@@ -129,7 +142,7 @@ describe('OsConfigTreeProvider', () => {
       mockExec(MACOS_SYSCTL_SMALL);
       provider.refresh();
       const nodes = await getRootNodes(provider);
-      expect((nodes[0] as any).configured).toBe(false);
+      expect(findByKind(nodes, 'sharedMemoryStatus')?.configured).toBe(false);
     });
   });
 
@@ -139,7 +152,7 @@ describe('OsConfigTreeProvider', () => {
     it('returns a loading node before async data is ready', () => {
       setPlatform('darwin');
       mockExec(MACOS_SYSCTL_4GB);
-      const nodes = provider.getChildren() as any[];
+      const nodes = provider.getChildren() as OsConfigNode[];
       expect(nodes).toHaveLength(1);
       expect(nodes[0].kind).toBe('loading');
     });
@@ -185,15 +198,15 @@ describe('OsConfigTreeProvider', () => {
     it('labels large Linux default shmmax as "≥ 1"', async () => {
       setPlatform('linux');
       mockExec(LINUX_SYSCTL_UNLIMITED);
-      const [node] = await getRootNodes(provider);
-      expect(node.gbLabel).toBe('≥ 1');
+      const nodes = await getRootNodes(provider);
+      expect(findByKind(nodes, 'sharedMemoryStatus')?.gbLabel).toBe('≥ 1');
     });
 
     it('labels exact 1 GB shmmax as "1"', async () => {
       setPlatform('linux');
       mockExec(LINUX_SYSCTL_1GB);
-      const [node] = await getRootNodes(provider);
-      expect(node.gbLabel).toBe('1');
+      const nodes = await getRootNodes(provider);
+      expect(findByKind(nodes, 'sharedMemoryStatus')?.gbLabel).toBe('1');
     });
 
     it('removeIpcStatus configured=false when no logind.conf', async () => {
@@ -201,8 +214,8 @@ describe('OsConfigTreeProvider', () => {
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(false);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(false);
     });
 
     it('removeIpcStatus configured=true when logind.conf has RemoveIPC=no', async () => {
@@ -210,8 +223,8 @@ describe('OsConfigTreeProvider', () => {
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.readFileSync).mockReturnValue('[Login]\nRemoveIPC=no\n' as any);
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(true);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(true);
     });
 
     it('removeIpcStatus configured=false when logind.conf has RemoveIPC=yes', async () => {
@@ -219,8 +232,8 @@ describe('OsConfigTreeProvider', () => {
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.readFileSync).mockReturnValue('[Login]\nRemoveIPC=yes\n' as any);
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(false);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(false);
     });
 
     it('ignores commented-out RemoveIPC lines', async () => {
@@ -228,8 +241,8 @@ describe('OsConfigTreeProvider', () => {
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.readFileSync).mockReturnValue('# RemoveIPC=no\n' as any);
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(false);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(false);
     });
 
     it('drop-in file overrides main logind.conf (last wins)', async () => {
@@ -244,8 +257,8 @@ describe('OsConfigTreeProvider', () => {
         return '[Login]\nRemoveIPC=no\n' as any; // drop-in overrides to no
       });
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(true);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(true);
     });
 
     it('main logind.conf wins when drop-in sets it back to yes', async () => {
@@ -260,8 +273,8 @@ describe('OsConfigTreeProvider', () => {
         return 'RemoveIPC=no\n' as any;
       });
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(false);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(false);
     });
 
     it('returns cached nodes on second call without re-running exec', async () => {
@@ -269,8 +282,8 @@ describe('OsConfigTreeProvider', () => {
       mockExec(MACOS_SYSCTL_4GB);
       await getRootNodes(provider);
       mockExec(''); // change mock — cache should prevent this from being used
-      const nodes = provider.getChildren() as any[];
-      expect((nodes[0] as any).configured).toBe(true);
+      const nodes = provider.getChildren() as OsConfigNode[];
+      expect(findByKind(nodes, 'sharedMemoryStatus')?.configured).toBe(true);
     });
   });
 
@@ -572,8 +585,8 @@ describe('OsConfigTreeProvider', () => {
       mockExec(LINUX_SYSCTL_1GB);
       const nodes = await getRootNodes(provider);
       expect(vi.mocked(exec).mock.calls[0][0]).toBe('wsl.exe -e sysctl kernel.shmmax kernel.shmall');
-      const shm = nodes.find((n: any) => n.kind === 'sharedMemoryStatus') as any;
-      expect(shm.configured).toBe(true);
+      const shm = findByKind(nodes, 'sharedMemoryStatus');
+      expect(shm?.configured).toBe(true);
     });
 
     it('removeIpc on WSL: routes logind.conf reads through wslExecSync', async () => {
@@ -587,8 +600,8 @@ describe('OsConfigTreeProvider', () => {
         return '';
       });
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(true);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(true);
       // fs was NOT consulted for logind config on the WSL path (other
       // unrelated reads — e.g. Windows services file — are allowed).
       const logindReads = vi.mocked(fs.readFileSync).mock.calls
@@ -608,8 +621,8 @@ describe('OsConfigTreeProvider', () => {
         return '';
       });
       const nodes = await getRootNodes(provider);
-      const removeIpc = nodes.find((n: any) => n.kind === 'removeIpcStatus') as any;
-      expect(removeIpc.configured).toBe(true);
+      const removeIpc = findByKind(nodes, 'removeIpcStatus');
+      expect(removeIpc?.configured).toBe(true);
     });
 
     it('not-configured shared memory on WSL offers the Linux setup script', async () => {
@@ -777,7 +790,7 @@ describe('OsConfigTreeProvider', () => {
       const children = await provider.getChildren({
         kind: 'wslNetworkingStatus', info: natCapableInfo as any,
       });
-      expect(children.map((c: any) => c.command)).toEqual([
+      expect(actionCommands(children)).toEqual([
         'gemstone.enableMirroredNetworking',
         'gemstone.writeWslHostsEntry',
       ]);
@@ -787,7 +800,7 @@ describe('OsConfigTreeProvider', () => {
       const children = await provider.getChildren({
         kind: 'wslNetworkingStatus', info: natLegacyInfo as any,
       });
-      expect(children.map((c: any) => c.command)).toEqual([
+      expect(actionCommands(children)).toEqual([
         'gemstone.updateWslCore',
         'gemstone.writeWslHostsEntry',
       ]);
@@ -819,9 +832,9 @@ describe('OsConfigTreeProvider', () => {
     it('_loadConfig pushes a wslNetworkingStatus node with the refreshed info', async () => {
       vi.mocked(wslBridge.refreshWslNetworkInfo).mockResolvedValue(natCapableInfo as any);
       const nodes = await getRootNodes(provider);
-      const netNode = nodes.find((n: any) => n.kind === 'wslNetworkingStatus') as any;
+      const netNode = findByKind(nodes, 'wslNetworkingStatus');
       expect(netNode).toBeDefined();
-      expect(netNode.info).toEqual(natCapableInfo);
+      expect(netNode?.info).toEqual(natCapableInfo);
     });
 
     it('registers enableMirroredNetworking and updateWslCore commands', () => {
@@ -925,7 +938,7 @@ describe('OsConfigTreeProvider', () => {
           wslCoreVersion: '2.0.9.0', supportsMirrored: true,
         } as any,
       });
-      expect(children.map((c: any) => c.command)).toEqual([
+      expect(actionCommands(children)).toEqual([
         'gemstone.enableMirroredNetworking',
         'gemstone.writeWslHostsEntry',
       ]);
@@ -939,7 +952,7 @@ describe('OsConfigTreeProvider', () => {
           wslCoreVersion: '1.2.5.0', supportsMirrored: false,
         } as any,
       });
-      expect(children.map((c: any) => c.command)).toEqual([
+      expect(actionCommands(children)).toEqual([
         'gemstone.updateWslCore',
         'gemstone.writeWslHostsEntry',
       ]);

--- a/client/src/__tests__/osConfigTreeProvider.test.ts
+++ b/client/src/__tests__/osConfigTreeProvider.test.ts
@@ -21,6 +21,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { OsConfigTreeProvider, type OsConfigNode } from '../sharedMemoryTreeProvider';
 import * as wslBridge from '../wslBridge';
+import { type WslNetworkInfo } from '../wslBridge';
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -33,7 +34,7 @@ const LINUX_SYSCTL_1GB = 'kernel.shmmax = 1073741824\nkernel.shmall = 262144\n';
 const MACOS_SYSCTL_4GB = `kern.sysv.shmmax: ${LINUX_SHMMAX_4GB}\nkern.sysv.shmall: ${LINUX_SHMALL_4GB}\n`;
 const MACOS_SYSCTL_SMALL = 'kern.sysv.shmmax: 4194304\nkern.sysv.shmall: 1024\n'; // 4 MB / 4 MB
 
-function setPlatform(platform: string) {
+function setPlatform(platform: NodeJS.Platform) {
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
 }
 
@@ -45,10 +46,10 @@ function makeContext() {
 }
 
 /** Retrieve the callback registered for a command by name. */
-function getCommand(commandId: string): (() => void) | undefined {
+function getCommand(commandId: string): (() => unknown) | undefined {
   const calls = vi.mocked(vscode.commands.registerCommand).mock.calls;
   const call = calls.find(([id]) => id === commandId);
-  return call?.[1] as (() => void) | undefined;
+  return call?.[1] as (() => unknown) | undefined;
 }
 
 /** Make exec call its callback immediately with the given stdout output. */
@@ -94,11 +95,20 @@ function actionCommands(nodes: OsConfigNode[]): (string | undefined)[] {
   return nodes.map((n) => (n.kind === 'action' ? n.command : undefined));
 }
 
+/** The codicon id of a tree item's icon — every node in this provider uses a ThemeIcon. */
+function themeIconId(item: vscode.TreeItem): string {
+  const icon = item.iconPath;
+  if (!(icon instanceof vscode.ThemeIcon)) {
+    throw new Error(`expected a ThemeIcon, got ${String(icon)}`);
+  }
+  return icon.id;
+}
+
 // ── Suite ──────────────────────────────────────────────────
 
 describe('OsConfigTreeProvider', () => {
   let provider: OsConfigTreeProvider;
-  let originalPlatform: string;
+  let originalPlatform: NodeJS.Platform;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -332,7 +342,7 @@ describe('OsConfigTreeProvider', () => {
       it('shows a spinning loading icon', () => {
         const item = provider.getTreeItem({ kind: 'loading' });
         expect(item.label).toContain('Checking');
-        expect((item.iconPath as any).id).toBe('loading~spin');
+        expect(themeIconId(item)).toBe('loading~spin');
         expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
       });
     });
@@ -343,14 +353,14 @@ describe('OsConfigTreeProvider', () => {
         expect(item.label).toContain('4');
         expect(item.label).toContain('configured');
         expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
-        expect((item.iconPath as any).id).toBe('check');
+        expect(themeIconId(item)).toBe('check');
       });
 
       it('not configured: warning icon, Expanded state, tooltip set', () => {
         const item = provider.getTreeItem({ kind: 'sharedMemoryStatus', configured: false, gbLabel: '1' });
         expect(item.label).toContain('not configured');
         expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
-        expect((item.iconPath as any).id).toBe('warning');
+        expect(themeIconId(item)).toBe('warning');
         expect(item.tooltip).toBeTruthy();
       });
 
@@ -365,14 +375,14 @@ describe('OsConfigTreeProvider', () => {
         const item = provider.getTreeItem({ kind: 'removeIpcStatus', configured: true });
         expect(item.label).toContain('configured');
         expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
-        expect((item.iconPath as any).id).toBe('check');
+        expect(themeIconId(item)).toBe('check');
         expect(item.tooltip).toBeUndefined();
       });
 
       it('not configured: warning icon, Expanded state, tooltip explains risk', () => {
         const item = provider.getTreeItem({ kind: 'removeIpcStatus', configured: false });
         expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
-        expect((item.iconPath as any).id).toBe('warning');
+        expect(themeIconId(item)).toBe('warning');
         expect(String(item.tooltip)).toMatch(/shared memory|IPC/i);
       });
     });
@@ -380,34 +390,34 @@ describe('OsConfigTreeProvider', () => {
     describe('action nodes', () => {
       it('runSetSharedMemory: terminal icon', () => {
         const item = provider.getTreeItem({ kind: 'action', text: 'Run', command: 'gemstone.runSetSharedMemory' });
-        expect((item.iconPath as any).id).toBe('terminal');
+        expect(themeIconId(item)).toBe('terminal');
       });
 
       it('runSetSharedMemoryLinux: terminal icon, mentions no restart in tooltip', () => {
         const item = provider.getTreeItem({ kind: 'action', text: 'Run', command: 'gemstone.runSetSharedMemoryLinux' });
-        expect((item.iconPath as any).id).toBe('terminal');
+        expect(themeIconId(item)).toBe('terminal');
         expect(String(item.tooltip)).toMatch(/no restart/i);
       });
 
       it('runSetSharedMemory: terminal icon, mentions no restart in tooltip', () => {
         const item = provider.getTreeItem({ kind: 'action', text: 'Run', command: 'gemstone.runSetSharedMemory' });
-        expect((item.iconPath as any).id).toBe('terminal');
+        expect(themeIconId(item)).toBe('terminal');
         expect(String(item.tooltip)).toMatch(/no restart/i);
       });
 
       it('runSetRemoveIPC: terminal icon', () => {
         const item = provider.getTreeItem({ kind: 'action', text: 'Run', command: 'gemstone.runSetRemoveIPC' });
-        expect((item.iconPath as any).id).toBe('terminal');
+        expect(themeIconId(item)).toBe('terminal');
       });
 
       it('sharedMemoryInfo: info icon', () => {
         const item = provider.getTreeItem({ kind: 'action', text: 'Info', command: 'gemstone.sharedMemoryInfo' });
-        expect((item.iconPath as any).id).toBe('info');
+        expect(themeIconId(item)).toBe('info');
       });
 
       it('removeIpcInfo: info icon, tooltip mentions systemd-logind', () => {
         const item = provider.getTreeItem({ kind: 'action', text: 'Info', command: 'gemstone.removeIpcInfo' });
-        expect((item.iconPath as any).id).toBe('info');
+        expect(themeIconId(item)).toBe('info');
         expect(String(item.tooltip)).toMatch(/systemd-logind/);
       });
 
@@ -605,7 +615,7 @@ describe('OsConfigTreeProvider', () => {
       // fs was NOT consulted for logind config on the WSL path (other
       // unrelated reads — e.g. Windows services file — are allowed).
       const logindReads = vi.mocked(fs.readFileSync).mock.calls
-        .filter((c: any[]) => /logind\.conf/.test(String(c[0])));
+        .filter((c) => /logind\.conf/.test(String(c[0])));
       expect(logindReads).toHaveLength(0);
     });
 
@@ -638,7 +648,7 @@ describe('OsConfigTreeProvider', () => {
 
       getCommand('gemstone.runSetSharedMemoryLinux')?.();
 
-      const createArgs = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as any;
+      const createArgs = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as vscode.TerminalOptions;
       expect(createArgs.shellPath).toBe('wsl.exe');
       expect(mockTerminal.sendText).toHaveBeenCalledWith(
         expect.stringContaining('/mnt/c/ext/resources/setSharedMemoryLinux.sh'),
@@ -652,7 +662,7 @@ describe('OsConfigTreeProvider', () => {
 
       getCommand('gemstone.runSetRemoveIPC')?.();
 
-      const createArgs = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as any;
+      const createArgs = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as vscode.TerminalOptions;
       expect(createArgs.shellPath).toBe('wsl.exe');
       expect(mockTerminal.sendText).toHaveBeenCalledWith(
         expect.stringContaining('/mnt/c/ext/resources/setRemoveIPC.sh'),
@@ -663,7 +673,7 @@ describe('OsConfigTreeProvider', () => {
       const item = provider.getTreeItem({ kind: 'wslStatus', distro: 'Ubuntu', wslVersion: 2 });
       expect(item.label).toContain('WSL 2');
       expect(item.label).toContain('Ubuntu');
-      expect((item.iconPath as any).id).toBe('check');
+      expect(themeIconId(item)).toBe('check');
       expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
       expect(item.tooltip).toBeUndefined();
     });
@@ -672,14 +682,14 @@ describe('OsConfigTreeProvider', () => {
       const item = provider.getTreeItem({ kind: 'wslStatus', distro: 'Ubuntu', wslVersion: 1 });
       expect(item.label).toContain('WSL 1');
       expect(item.label).toContain('upgrade required');
-      expect((item.iconPath as any).id).toBe('warning');
+      expect(themeIconId(item)).toBe('warning');
       expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
       expect(String(item.tooltip)).toContain('wsl --set-version');
     });
 
     it('wslStatus unknown version: warning icon', () => {
       const item = provider.getTreeItem({ kind: 'wslStatus', distro: 'Debian', wslVersion: undefined });
-      expect((item.iconPath as any).id).toBe('warning');
+      expect(themeIconId(item)).toBe('warning');
       expect(String(item.tooltip)).toContain('Debian');
     });
 
@@ -697,7 +707,7 @@ describe('OsConfigTreeProvider', () => {
 
     it('upgradeWsl2 action: terminal icon', () => {
       const item = provider.getTreeItem({ kind: 'action', text: 'Upgrade', command: 'gemstone.upgradeWsl2' });
-      expect((item.iconPath as any).id).toBe('terminal');
+      expect(themeIconId(item)).toBe('terminal');
     });
 
     it('registers gemstone.upgradeWsl2 command', () => {
@@ -740,15 +750,15 @@ describe('OsConfigTreeProvider', () => {
   // ── wslNetworkingStatus ───────────────────────────────────
 
   describe('wslNetworkingStatus', () => {
-    const mirroredInfo = {
+    const mirroredInfo: WslNetworkInfo = {
       mirrored: true, ip: undefined, netldiHost: 'localhost',
       wslCoreVersion: '2.0.9.0', supportsMirrored: true,
     };
-    const natCapableInfo = {
+    const natCapableInfo: WslNetworkInfo = {
       mirrored: false, ip: '172.29.240.2', netldiHost: '172.29.240.2',
       wslCoreVersion: '2.0.9.0', supportsMirrored: true,
     };
-    const natLegacyInfo = {
+    const natLegacyInfo: WslNetworkInfo = {
       mirrored: false, ip: '10.0.0.5', netldiHost: '10.0.0.5',
       wslCoreVersion: '1.2.5.0', supportsMirrored: false,
     };
@@ -763,32 +773,32 @@ describe('OsConfigTreeProvider', () => {
     });
 
     it('mirrored → check icon, None collapsible state, informative tooltip', () => {
-      const item = provider.getTreeItem({ kind: 'wslNetworkingStatus', info: mirroredInfo as any });
+      const item = provider.getTreeItem({ kind: 'wslNetworkingStatus', info: mirroredInfo });
       expect(String(item.label)).toContain('mirrored');
       expect(String(item.label)).toContain('localhost');
-      expect((item.iconPath as any).id).toBe('check');
+      expect(themeIconId(item)).toBe('check');
       expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
       expect(String(item.tooltip)).toMatch(/localhost/);
     });
 
     it('NAT on WSL 2.0+ → warning icon, Expanded, tooltip mentions the IP', () => {
-      const item = provider.getTreeItem({ kind: 'wslNetworkingStatus', info: natCapableInfo as any });
+      const item = provider.getTreeItem({ kind: 'wslNetworkingStatus', info: natCapableInfo });
       expect(String(item.label)).toContain('NAT');
-      expect((item.iconPath as any).id).toBe('warning');
+      expect(themeIconId(item)).toBe('warning');
       expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
       expect(String(item.tooltip)).toContain('172.29.240.2');
     });
 
     it('NAT on legacy WSL → warning icon, tooltip mentions wsl --update', () => {
-      const item = provider.getTreeItem({ kind: 'wslNetworkingStatus', info: natLegacyInfo as any });
+      const item = provider.getTreeItem({ kind: 'wslNetworkingStatus', info: natLegacyInfo });
       expect(String(item.label)).toContain('WSL 2.0+');
-      expect((item.iconPath as any).id).toBe('warning');
+      expect(themeIconId(item)).toBe('warning');
       expect(String(item.tooltip)).toMatch(/wsl --update/);
     });
 
     it('NAT on WSL 2.0+ offers Enable-Mirrored (first) plus the hosts-file fallback', async () => {
       const children = await provider.getChildren({
-        kind: 'wslNetworkingStatus', info: natCapableInfo as any,
+        kind: 'wslNetworkingStatus', info: natCapableInfo,
       });
       expect(actionCommands(children)).toEqual([
         'gemstone.enableMirroredNetworking',
@@ -798,7 +808,7 @@ describe('OsConfigTreeProvider', () => {
 
     it('NAT on legacy WSL offers wsl --update (first) plus the hosts-file fallback', async () => {
       const children = await provider.getChildren({
-        kind: 'wslNetworkingStatus', info: natLegacyInfo as any,
+        kind: 'wslNetworkingStatus', info: natLegacyInfo,
       });
       expect(actionCommands(children)).toEqual([
         'gemstone.updateWslCore',
@@ -808,7 +818,7 @@ describe('OsConfigTreeProvider', () => {
 
     it('mirrored state has no children', async () => {
       const children = await provider.getChildren({
-        kind: 'wslNetworkingStatus', info: mirroredInfo as any,
+        kind: 'wslNetworkingStatus', info: mirroredInfo,
       });
       expect(children).toHaveLength(0);
     });
@@ -817,7 +827,7 @@ describe('OsConfigTreeProvider', () => {
       const item = provider.getTreeItem({
         kind: 'action', text: 'Enable', command: 'gemstone.enableMirroredNetworking',
       });
-      expect((item.iconPath as any).id).toBe('edit');
+      expect(themeIconId(item)).toBe('edit');
       expect(String(item.tooltip)).toMatch(/\.wslconfig/);
     });
 
@@ -825,12 +835,12 @@ describe('OsConfigTreeProvider', () => {
       const item = provider.getTreeItem({
         kind: 'action', text: 'Update', command: 'gemstone.updateWslCore',
       });
-      expect((item.iconPath as any).id).toBe('terminal');
+      expect(themeIconId(item)).toBe('terminal');
       expect(String(item.tooltip)).toMatch(/wsl --update/);
     });
 
     it('_loadConfig pushes a wslNetworkingStatus node with the refreshed info', async () => {
-      vi.mocked(wslBridge.refreshWslNetworkInfo).mockResolvedValue(natCapableInfo as any);
+      vi.mocked(wslBridge.refreshWslNetworkInfo).mockResolvedValue(natCapableInfo);
       const nodes = await getRootNodes(provider);
       const netNode = findByKind(nodes, 'wslNetworkingStatus');
       expect(netNode).toBeDefined();
@@ -863,7 +873,7 @@ describe('OsConfigTreeProvider', () => {
       });
       expect(String(item.label)).toMatch(/configured/);
       expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
-      expect((item.iconPath as any).id).toBe('check');
+      expect(themeIconId(item)).toBe('check');
     });
 
     it('neither side configured → warning icon, Expanded state', () => {
@@ -871,7 +881,7 @@ describe('OsConfigTreeProvider', () => {
         kind: 'wslServicesStatus', windowsHas: false, wslHas: false,
       });
       expect(String(item.label)).toMatch(/Windows and WSL/);
-      expect((item.iconPath as any).id).toBe('warning');
+      expect(themeIconId(item)).toBe('warning');
       expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
     });
 
@@ -924,8 +934,8 @@ describe('OsConfigTreeProvider', () => {
       const wslItem = provider.getTreeItem({
         kind: 'action', text: 'WSL', command: 'gemstone.writeServicesWsl',
       });
-      expect((winItem.iconPath as any).id).toBe('terminal');
-      expect((wslItem.iconPath as any).id).toBe('terminal');
+      expect(themeIconId(winItem)).toBe('terminal');
+      expect(themeIconId(wslItem)).toBe('terminal');
       expect(String(winItem.tooltip)).toMatch(/gs64ldi/);
       expect(String(wslItem.tooltip)).toMatch(/\/etc\/services/);
     });
@@ -936,7 +946,7 @@ describe('OsConfigTreeProvider', () => {
         info: {
           mirrored: false, ip: '172.29.240.2', netldiHost: '172.29.240.2',
           wslCoreVersion: '2.0.9.0', supportsMirrored: true,
-        } as any,
+        },
       });
       expect(actionCommands(children)).toEqual([
         'gemstone.enableMirroredNetworking',
@@ -950,7 +960,7 @@ describe('OsConfigTreeProvider', () => {
         info: {
           mirrored: false, ip: '10.0.0.5', netldiHost: '10.0.0.5',
           wslCoreVersion: '1.2.5.0', supportsMirrored: false,
-        } as any,
+        },
       });
       expect(actionCommands(children)).toEqual([
         'gemstone.updateWslCore',
@@ -973,7 +983,7 @@ describe('OsConfigTreeProvider', () => {
 
       getCommand('gemstone.writeWslHostsEntry')?.();
 
-      const args = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as any;
+      const args = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as vscode.TerminalOptions;
       expect(args.shellPath).toBe('powershell.exe');
       expect(mockTerminal.sendText).toHaveBeenCalledWith(
         expect.stringContaining('setWslHostsEntry.ps1'),
@@ -987,7 +997,7 @@ describe('OsConfigTreeProvider', () => {
 
       getCommand('gemstone.writeServicesWsl')?.();
 
-      const args = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as any;
+      const args = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as vscode.TerminalOptions;
       expect(args.shellPath).toBe('wsl.exe');
       expect(mockTerminal.sendText).toHaveBeenCalledWith(
         expect.stringContaining('/mnt/c/ext/resources/setServicesLinux.sh'),

--- a/client/src/__tests__/osConfigTreeProvider.test.ts
+++ b/client/src/__tests__/osConfigTreeProvider.test.ts
@@ -38,11 +38,16 @@ function setPlatform(platform: NodeJS.Platform) {
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
 }
 
-function makeContext() {
+function makeContext(extensionPath = '/ext') {
   return {
-    extensionPath: '/ext',
+    extensionPath,
     subscriptions: { push: vi.fn() },
   } as unknown as vscode.ExtensionContext;
+}
+
+/** A vscode.Terminal test double — only `show`/`sendText` are spied on; the rest of the interface is stubbed. */
+function fakeTerminal(): vscode.Terminal {
+  return { show: vi.fn(), sendText: vi.fn(), dispose: vi.fn() } as unknown as vscode.Terminal;
 }
 
 /** Retrieve the callback registered for a command by name. */
@@ -54,15 +59,17 @@ function getCommand(commandId: string): (() => unknown) | undefined {
 
 /** Make exec call its callback immediately with the given stdout output. */
 function mockExec(output: string): void {
-  vi.mocked(exec as any).mockImplementation((_cmd: any, _opts: any, cb: any) => {
-    cb(null, output, '');
+  vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+    cb?.(null, output, '');
+    return {} as ReturnType<typeof exec>;
   });
 }
 
 /** Make exec call its callback with an error (simulates sysctl not found). */
 function mockExecError(): void {
-  vi.mocked(exec as any).mockImplementation((_cmd: any, _opts: any, cb: any) => {
-    cb(new Error('command not found'), '', '');
+  vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+    cb?.(new Error('command not found'), '', '');
+    return {} as ReturnType<typeof exec>;
   });
 }
 
@@ -124,7 +131,7 @@ describe('OsConfigTreeProvider', () => {
     vi.mocked(fs.readdirSync).mockReturnValue([]);
     vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
     vi.mocked(vscode.commands.registerCommand).mockClear();
-    vi.mocked(vscode.window.createTerminal).mockReturnValue({ show: vi.fn(), sendText: vi.fn() } as any);
+    vi.mocked(vscode.window.createTerminal).mockReturnValue(fakeTerminal());
     vi.mocked(vscode.window.showInformationMessage).mockClear();
     vi.mocked(vscode.window.onDidCloseTerminal).mockClear();
   });
@@ -231,7 +238,7 @@ describe('OsConfigTreeProvider', () => {
     it('removeIpcStatus configured=true when logind.conf has RemoveIPC=no', async () => {
       setPlatform('linux');
       mockExec(LINUX_SYSCTL_4GB);
-      vi.mocked(fs.readFileSync).mockReturnValue('[Login]\nRemoveIPC=no\n' as any);
+      vi.mocked(fs.readFileSync).mockReturnValue('[Login]\nRemoveIPC=no\n');
       const nodes = await getRootNodes(provider);
       const removeIpc = findByKind(nodes, 'removeIpcStatus');
       expect(removeIpc?.configured).toBe(true);
@@ -240,7 +247,7 @@ describe('OsConfigTreeProvider', () => {
     it('removeIpcStatus configured=false when logind.conf has RemoveIPC=yes', async () => {
       setPlatform('linux');
       mockExec(LINUX_SYSCTL_4GB);
-      vi.mocked(fs.readFileSync).mockReturnValue('[Login]\nRemoveIPC=yes\n' as any);
+      vi.mocked(fs.readFileSync).mockReturnValue('[Login]\nRemoveIPC=yes\n');
       const nodes = await getRootNodes(provider);
       const removeIpc = findByKind(nodes, 'removeIpcStatus');
       expect(removeIpc?.configured).toBe(false);
@@ -249,7 +256,7 @@ describe('OsConfigTreeProvider', () => {
     it('ignores commented-out RemoveIPC lines', async () => {
       setPlatform('linux');
       mockExec(LINUX_SYSCTL_4GB);
-      vi.mocked(fs.readFileSync).mockReturnValue('# RemoveIPC=no\n' as any);
+      vi.mocked(fs.readFileSync).mockReturnValue('# RemoveIPC=no\n');
       const nodes = await getRootNodes(provider);
       const removeIpc = findByKind(nodes, 'removeIpcStatus');
       expect(removeIpc?.configured).toBe(false);
@@ -260,11 +267,11 @@ describe('OsConfigTreeProvider', () => {
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readdirSync).mockReturnValue(['gemstone.conf'] as any);
-      vi.mocked(fs.readFileSync).mockImplementation((filepath: any) => {
+      vi.mocked(fs.readFileSync).mockImplementation((filepath: fs.PathOrFileDescriptor) => {
         if (String(filepath).endsWith('logind.conf') && !String(filepath).includes('.d/')) {
-          return 'RemoveIPC=yes\n' as any; // main file says yes
+          return 'RemoveIPC=yes\n'; // main file says yes
         }
-        return '[Login]\nRemoveIPC=no\n' as any; // drop-in overrides to no
+        return '[Login]\nRemoveIPC=no\n'; // drop-in overrides to no
       });
       const nodes = await getRootNodes(provider);
       const removeIpc = findByKind(nodes, 'removeIpcStatus');
@@ -276,11 +283,11 @@ describe('OsConfigTreeProvider', () => {
       mockExec(LINUX_SYSCTL_4GB);
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readdirSync).mockReturnValue(['zz-override.conf'] as any);
-      vi.mocked(fs.readFileSync).mockImplementation((filepath: any) => {
+      vi.mocked(fs.readFileSync).mockImplementation((filepath: fs.PathOrFileDescriptor) => {
         if (String(filepath).includes('logind.conf.d')) {
-          return 'RemoveIPC=yes\n' as any;
+          return 'RemoveIPC=yes\n';
         }
-        return 'RemoveIPC=no\n' as any;
+        return 'RemoveIPC=no\n';
       });
       const nodes = await getRootNodes(provider);
       const removeIpc = findByKind(nodes, 'removeIpcStatus');
@@ -443,8 +450,8 @@ describe('OsConfigTreeProvider', () => {
 
     it('runSetSharedMemory opens a terminal and sends the macOS script path', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.runSetSharedMemory')?.();
 
@@ -456,8 +463,8 @@ describe('OsConfigTreeProvider', () => {
 
     it('runSetSharedMemoryLinux opens a terminal and sends the Linux script path', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.runSetSharedMemoryLinux')?.();
 
@@ -466,8 +473,8 @@ describe('OsConfigTreeProvider', () => {
 
     it('runSetRemoveIPC opens a terminal and sends the RemoveIPC script path', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.runSetRemoveIPC')?.();
 
@@ -490,8 +497,8 @@ describe('OsConfigTreeProvider', () => {
 
     it('runSetSharedMemory refreshes the panel when the terminal closes', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
       const refreshSpy = vi.spyOn(provider, 'refresh');
 
       getCommand('gemstone.runSetSharedMemory')?.();
@@ -503,8 +510,8 @@ describe('OsConfigTreeProvider', () => {
 
     it('runSetSharedMemoryLinux refreshes the panel when the terminal closes', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
       const refreshSpy = vi.spyOn(provider, 'refresh');
 
       getCommand('gemstone.runSetSharedMemoryLinux')?.();
@@ -516,8 +523,8 @@ describe('OsConfigTreeProvider', () => {
 
     it('runSetRemoveIPC refreshes the panel when the terminal closes', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
       const refreshSpy = vi.spyOn(provider, 'refresh');
 
       getCommand('gemstone.runSetRemoveIPC')?.();
@@ -529,8 +536,8 @@ describe('OsConfigTreeProvider', () => {
 
     it('does not refresh when a different terminal closes', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
       const refreshSpy = vi.spyOn(provider, 'refresh');
 
       getCommand('gemstone.runSetSharedMemory')?.();
@@ -542,16 +549,16 @@ describe('OsConfigTreeProvider', () => {
 
     it('runSetSharedMemoryLinux script path does not match macOS script', () => {
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.runSetSharedMemoryLinux')?.();
-      const [linuxCmd] = mockTerminal.sendText.mock.calls[0];
+      const [linuxCmd] = vi.mocked(mockTerminal.sendText).mock.calls[0];
 
-      mockTerminal.sendText.mockClear();
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      vi.mocked(mockTerminal.sendText).mockClear();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
       getCommand('gemstone.runSetSharedMemory')?.();
-      const [macCmd] = mockTerminal.sendText.mock.calls[0];
+      const [macCmd] = vi.mocked(mockTerminal.sendText).mock.calls[0];
 
       expect(linuxCmd).not.toBe(macCmd);
     });
@@ -642,9 +649,9 @@ describe('OsConfigTreeProvider', () => {
     });
 
     it('runSetSharedMemoryLinux on Windows opens a WSL shell with /mnt/<drive> script path', () => {
-      provider.registerCommands({ extensionPath: 'C:\\ext', subscriptions: { push: vi.fn() } } as any);
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      provider.registerCommands(makeContext('C:\\ext'));
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.runSetSharedMemoryLinux')?.();
 
@@ -656,9 +663,9 @@ describe('OsConfigTreeProvider', () => {
     });
 
     it('runSetRemoveIPC on Windows opens a WSL shell with /mnt/<drive> script path', () => {
-      provider.registerCommands({ extensionPath: 'C:\\ext', subscriptions: { push: vi.fn() } } as any);
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      provider.registerCommands(makeContext('C:\\ext'));
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.runSetRemoveIPC')?.();
 
@@ -721,8 +728,8 @@ describe('OsConfigTreeProvider', () => {
         available: true, defaultDistro: 'Ubuntu', homeDir: '/home/user', arch: 'x86_64', wslVersion: 1,
       });
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.upgradeWsl2')?.();
 
@@ -734,8 +741,8 @@ describe('OsConfigTreeProvider', () => {
         available: true, defaultDistro: 'Ubuntu', homeDir: '/home/user', arch: 'x86_64', wslVersion: 1,
       });
       provider.registerCommands(makeContext());
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
       const refreshSpy = vi.spyOn(provider, 'refresh');
 
       getCommand('gemstone.upgradeWsl2')?.();
@@ -977,9 +984,9 @@ describe('OsConfigTreeProvider', () => {
     });
 
     it('writeWslHostsEntry opens a PowerShell terminal with the script path', () => {
-      provider.registerCommands({ extensionPath: 'C:\\ext', subscriptions: { push: vi.fn() } } as any);
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      provider.registerCommands(makeContext('C:\\ext'));
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.writeWslHostsEntry')?.();
 
@@ -991,9 +998,9 @@ describe('OsConfigTreeProvider', () => {
     });
 
     it('writeServicesWsl opens a WSL shell and runs the bash script via sudo', () => {
-      provider.registerCommands({ extensionPath: 'C:\\ext', subscriptions: { push: vi.fn() } } as any);
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      provider.registerCommands(makeContext('C:\\ext'));
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       getCommand('gemstone.writeServicesWsl')?.();
 
@@ -1014,12 +1021,12 @@ describe('OsConfigTreeProvider', () => {
     });
 
     it('writes the merged .wslconfig and prompts for a restart', async () => {
-      vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nmemory=8GB\n' as any);
+      vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nmemory=8GB\n');
       vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
       vi.mocked(wslBridge.updateWslConfigMirrored).mockImplementation(
         () => '[wsl2]\nnetworkingMode=mirrored\nmemory=8GB\n',
       );
-      vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as any);
+      vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined);
 
       provider.registerCommands(makeContext());
       await getCommand('gemstone.enableMirroredNetworking')?.();
@@ -1039,8 +1046,8 @@ describe('OsConfigTreeProvider', () => {
         () => '[wsl2]\nnetworkingMode=mirrored\n',
       );
       vi.mocked(vscode.window.showInformationMessage).mockResolvedValue('Restart WSL now' as any);
-      const mockTerminal = { show: vi.fn(), sendText: vi.fn() };
-      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal as any);
+      const mockTerminal = fakeTerminal();
+      vi.mocked(vscode.window.createTerminal).mockReturnValue(mockTerminal);
 
       provider.registerCommands(makeContext());
       await getCommand('gemstone.enableMirroredNetworking')?.();
@@ -1050,10 +1057,10 @@ describe('OsConfigTreeProvider', () => {
 
     it('does nothing destructive when .wslconfig already had mirrored (no write, still prompts)', async () => {
       const already = '[wsl2]\nnetworkingMode=mirrored\n';
-      vi.mocked(fs.readFileSync).mockReturnValue(already as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(already);
       vi.mocked(wslBridge.updateWslConfigMirrored).mockReturnValue(already);
       vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
-      vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as any);
+      vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined);
 
       provider.registerCommands(makeContext());
       await getCommand('gemstone.enableMirroredNetworking')?.();

--- a/client/src/__tests__/processTreeProvider.test.ts
+++ b/client/src/__tests__/processTreeProvider.test.ts
@@ -9,6 +9,7 @@ vi.mock('../wslBridge', () => ({
 }));
 
 import { ProcessItem, ProcessTreeProvider } from '../processTreeProvider';
+import { ProcessManager } from '../processManager';
 import { GemStoneProcess } from '../sysadminTypes';
 import * as wslBridge from '../wslBridge';
 
@@ -118,7 +119,7 @@ describe('ProcessTreeProvider.getChildren', () => {
     return {
       getProcesses: vi.fn(() => processes),
       refreshProcesses: vi.fn(),
-    } as any;
+    } as unknown as ProcessManager;
   }
 
   beforeEach(() => {
@@ -151,16 +152,19 @@ describe('ProcessTreeProvider.getChildren', () => {
   it('on Windows+WSL with cold cache, kicks off a refresh and fires re-render when it lands', async () => {
     vi.mocked(wslBridge.needsWsl).mockReturnValue(true);
     vi.mocked(wslBridge.getWslNetworkInfoCached).mockReturnValue(undefined);
-    let resolveRefresh!: (v: any) => void;
+    let resolveRefresh!: (v: wslBridge.WslNetworkInfo) => void;
     vi.mocked(wslBridge.refreshWslNetworkInfo).mockReturnValue(
-      new Promise((r) => { resolveRefresh = r; }) as any,
+      new Promise<wslBridge.WslNetworkInfo>((r) => { resolveRefresh = r; }),
     );
     const provider = new ProcessTreeProvider(makeManager([netldiProcess()]));
     const listener = vi.fn();
     provider.onDidChangeTreeData(listener);
     provider.getChildren();
     expect(wslBridge.refreshWslNetworkInfo).toHaveBeenCalledOnce();
-    resolveRefresh({ mirrored: true, ip: undefined, netldiHost: 'localhost' });
+    resolveRefresh({
+      mirrored: true, ip: undefined, netldiHost: 'localhost',
+      wslCoreVersion: '2.0.9.0', supportsMirrored: true,
+    });
     // Flush the microtask chain: refresh → finally → then → event fire
     await new Promise((r) => setTimeout(r, 0));
     expect(listener).toHaveBeenCalled();
@@ -183,7 +187,7 @@ describe('ProcessTreeProvider.getChildren', () => {
   it('does not kick off a second refresh while one is in flight', () => {
     vi.mocked(wslBridge.needsWsl).mockReturnValue(true);
     vi.mocked(wslBridge.getWslNetworkInfoCached).mockReturnValue(undefined);
-    vi.mocked(wslBridge.refreshWslNetworkInfo).mockReturnValue(new Promise(() => { /* never resolves */ }) as any);
+    vi.mocked(wslBridge.refreshWslNetworkInfo).mockReturnValue(new Promise<wslBridge.WslNetworkInfo>(() => { /* never resolves */ }));
     const provider = new ProcessTreeProvider(makeManager([netldiProcess()]));
     provider.getChildren();
     provider.getChildren();

--- a/client/src/__tests__/restoreManager.test.ts
+++ b/client/src/__tests__/restoreManager.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 
 import * as vscode from 'vscode';
 import { runLogicalRestore, LogicalRestoreDeps, RestoreSession } from '../restoreManager';
 import { RESTORE_NO_LOGOUT_MARKER } from '../queries/restore';
+
+// `showQuickPick` is overloaded; production passes a `string[]`, but `vi.mocked`
+// types the mock via the (last) `QuickPickItem` overload. Narrow to the string
+// overload once so impls/return values type-check without `any`.
+const mockShowQuickPick = vi.mocked(vscode.window.showQuickPick) as unknown as
+  Mock<(items: readonly string[]) => Promise<string | undefined>>;
 
 // A fake restore session. By default the restoreFromBackup: call raises the 4046
 // auto-logout (the full-logging success path); commitRestore answers 'OK'.
@@ -46,12 +52,12 @@ describe('runLogicalRestore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: user picks the fresh-extent option, confirms the destructive modal.
-    vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items: any) => items[0]);
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Restore' as any);
+    mockShowQuickPick.mockImplementation(async (items) => items[0]);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Restore' as unknown as vscode.MessageItem);
     vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
       vscode.Uri.file('/root/db-1/backups/backup.dbf'),
-    ] as any);
-    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as any);
+    ]);
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined);
   });
 
   it('runs the stop, safety-copy, swap, start, restore, and commit steps in order for a fresh extent', async () => {
@@ -93,7 +99,7 @@ describe('runLogicalRestore', () => {
 
   it('restores onto the current extent without a fresh extent when that option is chosen', async () => {
     const { deps } = makeDeps();
-    vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items: any) => items[1]);
+    mockShowQuickPick.mockImplementation(async (items) => items[1]);
 
     const ok = await runLogicalRestore(deps);
 
@@ -164,7 +170,7 @@ describe('runLogicalRestore', () => {
 
   it('is cancelled without teardown when the fresh-extent choice is dismissed', async () => {
     const { deps } = makeDeps();
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined as any);
+    mockShowQuickPick.mockResolvedValue(undefined);
 
     const ok = await runLogicalRestore(deps);
 
@@ -174,7 +180,7 @@ describe('runLogicalRestore', () => {
 
   it('does not touch the stone when the destructive confirmation is declined', async () => {
     const { deps } = makeDeps();
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined);
 
     const ok = await runLogicalRestore(deps);
 

--- a/client/src/__tests__/selectorBreakpointManager.test.ts
+++ b/client/src/__tests__/selectorBreakpointManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 
@@ -10,6 +10,7 @@ vi.mock('../browserQueries', () => ({
 }));
 
 import { Uri, window } from '../__mocks__/vscode';
+import type * as vscode from 'vscode';
 import {
   SelectorBreakpointManager,
   findNearestStepPoint,
@@ -57,7 +58,10 @@ function makeEditor(uriStr: string, source: string) {
       active: { line: 0, character: 5 },
     },
     setDecorations: vi.fn(),
-  } as any;
+  } as unknown as vscode.TextEditor & {
+    document: { offsetAt: Mock };
+    setDecorations: Mock;
+  };
 }
 
 // ── findNearestStepPoint ──────────────────────────────────

--- a/client/src/__tests__/windowsClient.test.ts
+++ b/client/src/__tests__/windowsClient.test.ts
@@ -16,10 +16,22 @@ vi.mock('child_process');
 
 import { execSync } from 'child_process';
 
+import type * as vscode from 'vscode';
 import { __setConfig, __resetConfig } from '../__mocks__/vscode';
 import { SysadminStorage } from '../sysadminStorage';
 import { VersionManager } from '../versionManager';
 import { GemStoneVersion } from '../sysadminTypes';
+
+/** VersionManager's private download helpers, exposed as a narrow surface for spying. */
+type PrivateDownloadHost = {
+  fetchUrl(url: string): Promise<string>;
+  downloadFile(
+    url: string,
+    targetPath: string,
+    progress: vscode.Progress<{ message?: string; increment?: number }>,
+    token: vscode.CancellationToken,
+  ): Promise<void>;
+};
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -255,7 +267,7 @@ describe('VersionManager.fetchAvailableVersions (client state)', () => {
       const manager = new VersionManager(storage);
       const html =
         '<a href="GemStone64Bit3.7.5-x86_64.Linux.zip">file</a>  12-Mar-2026 10:00  100000000';
-      vi.spyOn(manager as any, 'fetchUrl').mockResolvedValue(html);
+      vi.spyOn(manager as unknown as PrivateDownloadHost, 'fetchUrl').mockResolvedValue(html);
 
       const versions = await manager.fetchAvailableVersions();
       const v = versions.find(x => x.version === '3.7.5');
@@ -269,7 +281,7 @@ describe('VersionManager.fetchAvailableVersions (client state)', () => {
 // ── VersionManager.downloadAndExtractWindowsClient ────────
 
 describe('VersionManager.downloadAndExtractWindowsClient', () => {
-  const noopToken = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose: () => {} }) } as any;
+  const noopToken = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose: () => {} }) } as unknown as vscode.CancellationToken;
 
   it('throws when version is empty', async () => {
     const storage = new SysadminStorage();
@@ -290,7 +302,7 @@ describe('VersionManager.downloadAndExtractWindowsClient', () => {
   it('translates HTTP 404 into a friendly message pointing at the base URL', async () => {
     const storage = new SysadminStorage();
     const manager = new VersionManager(storage);
-    vi.spyOn(manager as any, 'downloadFile').mockRejectedValue(
+    vi.spyOn(manager as unknown as PrivateDownloadHost, 'downloadFile').mockRejectedValue(
       new Error('HTTP 404 downloading https://example/'),
     );
     await expect(
@@ -301,7 +313,7 @@ describe('VersionManager.downloadAndExtractWindowsClient', () => {
   it('does not mask non-404 download errors', async () => {
     const storage = new SysadminStorage();
     const manager = new VersionManager(storage);
-    vi.spyOn(manager as any, 'downloadFile').mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.spyOn(manager as unknown as PrivateDownloadHost, 'downloadFile').mockRejectedValue(new Error('ECONNREFUSED'));
     await expect(
       manager.downloadAndExtractWindowsClient('3.7.5', { report: vi.fn() }, noopToken),
     ).rejects.toThrow(/ECONNREFUSED/);
@@ -311,7 +323,7 @@ describe('VersionManager.downloadAndExtractWindowsClient', () => {
     const storage = new SysadminStorage();
     const manager = new VersionManager(storage);
     const zipPath = path.join(tmpDir, 'GemStone64BitClient3.7.5-x86.Windows_NT.zip');
-    vi.spyOn(manager as any, 'downloadFile').mockImplementation(async () => {
+    vi.spyOn(manager as unknown as PrivateDownloadHost, 'downloadFile').mockImplementation(async () => {
       // Simulate the download by dropping a file at the expected location.
       fs.writeFileSync(zipPath, '');
     });

--- a/client/src/commands/__tests__/findMethodInClass.test.ts
+++ b/client/src/commands/__tests__/findMethodInClass.test.ts
@@ -3,12 +3,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('vscode', () => import('../../__mocks__/vscode'));
 
 import * as vscode from 'vscode';
-import { ActiveSession } from '../../sessionManager';
+import { ActiveSession, SessionManager } from '../../sessionManager';
 import { GemStoneLogin } from '../../loginTypes';
+import { GciError } from '../../gciLibrary';
+import { ClassPickItem } from '../classPicker';
 import { SystemBrowser } from '../../systemBrowser';
 import { findMethodInClass } from '../findMethodInClass';
 
-const noErr = { number: 0, message: '', context: 0n, category: 0, fatal: false, argCount: 0, exceptionObj: 0n, args: [] };
+const noErr: GciError = { number: 0, message: '', reason: '', context: 0n, category: 0n, exceptionObj: 0n, args: [], argCount: 0, fatal: 0 };
+
+// The class picker the command drives is a `createQuickPick` instance; the mock
+// adds `__accept`/`__hide` (see `__mocks__/vscode.ts`) to fire its handlers.
+type QuickPickHandle = vscode.QuickPick<ClassPickItem> & {
+  __accept(): Promise<void>;
+  __hide(): void;
+};
 
 const classListPayload = '1\tUserGlobals\tArray\n2\tGlobals\tString\n';
 const methodListPayload = '0\tprinting\tfoo\n1\taccessing\tbar\n';
@@ -41,14 +50,14 @@ function createMockSession(): ActiveSession {
 function createSequencedSession(methodPayload = methodListPayload): ActiveSession {
   const session = createMockSession();
   vi.mocked(session.gci.GciTsExecuteFetchBytes)
-    .mockReturnValueOnce({ data: classListPayload, err: { ...noErr } } as any)
-    .mockReturnValueOnce({ data: methodPayload, err: { ...noErr } } as any);
+    .mockReturnValueOnce({ bytesReturned: classListPayload.length, data: classListPayload, err: { ...noErr } })
+    .mockReturnValueOnce({ bytesReturned: methodPayload.length, data: methodPayload, err: { ...noErr } });
   return session;
 }
 
-function lastQuickPick(): any {
+function lastQuickPick(): QuickPickHandle {
   const results = vi.mocked(vscode.window.createQuickPick).mock.results;
-  return results[results.length - 1].value;
+  return results[results.length - 1].value as unknown as QuickPickHandle;
 }
 
 // Kicks off the command, waits for the class picker to appear, and hands back
@@ -62,7 +71,7 @@ function lastQuickPick(): any {
 // the picker and finally awaits `done`.
 async function openClassPicker(methodPayload = methodListPayload) {
   const session = createSequencedSession(methodPayload);
-  const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as any;
+  const sessionManager = { resolveSession: vi.fn().mockResolvedValue(session) } as unknown as SessionManager;
   const done = findMethodInClass(sessionManager);
   await vi.waitFor(() => expect(vscode.window.createQuickPick).toHaveBeenCalled());
   return { session, qp: lastQuickPick(), done };
@@ -71,16 +80,16 @@ async function openClassPicker(methodPayload = methodListPayload) {
 // Resolves the class picker by accepting a class, then lets the command finish.
 // With no className, accepts whatever is pre-highlighted (the default); with
 // one, selects that class from the list instead.
-async function acceptClass(qp: any, done: Promise<void>, className?: string): Promise<void> {
+async function acceptClass(qp: QuickPickHandle, done: Promise<void>, className?: string): Promise<void> {
   qp.selectedItems = className
-    ? [qp.items.find((i: any) => i.entry.className === className)]
+    ? qp.items.filter(i => i.entry.className === className)
     : qp.activeItems;
   await qp.__accept();
   await done;
 }
 
 // Dismisses the class picker (Escape/cancel), then lets the command finish.
-async function dismissPicker(qp: any, done: Promise<void>): Promise<void> {
+async function dismissPicker(qp: QuickPickHandle, done: Promise<void>): Promise<void> {
   qp.__hide();
   await done;
 }
@@ -103,7 +112,7 @@ describe('findMethodInClass', () => {
       label: 'foo',
       description: 'printing',
       method: { isMeta: false, category: 'printing', selector: 'foo' },
-    } as any);
+    } as unknown as vscode.QuickPickItem);
   });
 
   describe('when a class is selected in the System Browser', () => {

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -201,8 +201,11 @@ describe('getBaseMethodSource', () => {
   it('emits ASCII-only source (3.6.x miscompiles non-ASCII: ComStrmSetCursor)', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getBaseMethodSource(execute, 'Character', false, 'isVowel', 0);
-    // eslint-disable-next-line no-control-regex
-    expect(/[^\x00-\x7F]/.test(execute.mock.calls[0][1])).toBe(false);
+
+    const code = execute.mock.calls[0][1];
+    // eslint-disable-next-line no-control-regex -- \x00-\x7F is the intentional ASCII range, not a stray control char
+    const asciiOnly = /^[\x00-\x7F]*$/;
+    expect(asciiOnly.test(code)).toBe(true);
   });
 });
 

--- a/client/src/sharedMemoryTreeProvider.ts
+++ b/client/src/sharedMemoryTreeProvider.ts
@@ -19,7 +19,7 @@ function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
-type OsConfigNode =
+export type OsConfigNode =
   | { kind: 'loading' }
   | { kind: 'sharedMemoryStatus'; configured: boolean; gbLabel: string }
   | { kind: 'removeIpcStatus'; configured: boolean }


### PR DESCRIPTION
## What & why

This continues the phased work of **preparing to enable ESLint in Jasper**. Following the test-suite cleanup in #153, the client-source cleanup in #156, the server-source cleanup in #157, and the phase-4 cleanup, this phase clears the remaining `any` usage out of the test mocks so that turning the linter on later stays a small, low-noise change instead of a wall of errors.

## Changes

* Type `OsConfigTreeProvider` test tree nodes and drop `any` from its terminal/exec mocks, across several passes tightening the mock types further.
* Drop `any` from mocks across 14 other test files (`backupManager`, `debuggerPanel`, `enhancedInspectorPanel`, `gemstoneCompletionProvider`, `gemstoneDefinitionProvider`, `gemstoneHoverProvider`, `localVersion`, `loginCredentials`, `processTreeProvider`, `restoreManager`, `selectorBreakpointManager`, `windowsClient`, `findMethodInClass`, `structuredQueries`).
* Improve readability of an ASCII-only regex assertion in `structuredQueries.test.ts`.
* Document the test convention for typed mocks in `.claude/rules/client/tests.md`.

All changes are pure cleanup with no behavior change.

## Verification

* `npm run compile` and `npm test` pass locally.