### PR TITLE
Reject non-local returns in gciLibrary's code-evaluation helpers

### DIFF
--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -485,7 +485,7 @@ describe('GciLibrary', () => {
 
                     | encodeAsUTF8LiarClass |
                     encodeAsUTF8LiarClass := Object subclass: #EncodeAsUTF8Liar instVarNames: {} inDictionary: UserGlobals.
-                    encodeAsUTF8LiarClass compileMethod: 'encodeAsUTF8 ^ self'.
+                    encodeAsUTF8LiarClass compileMethod: 'encodeAsUTF8 "returns self by default"'.
                     encodeAsUTF8LiarClass new
                 `),
                 'a ArgumentTypeError occurred (error 2103), The object anEncodeAsUTF8Liar is not implemented as a byte object.'
@@ -506,6 +506,13 @@ describe('GciLibrary', () => {
             expectPureExportSetToStayUnchanged(() =>{
                 gciLibrary.executeAndFetchString(session, `'a'`);
             });
+        });
+
+        it('fails when code contains a non-local return', () => {
+            expectToThrowGciLibraryError(
+                () => gciLibrary.executeAndFetchString(session, `^ 'a'`),
+                GciLibrary.NON_LOCAL_RETURN_NOT_ALLOWED_MESSAGE
+            )
         });
 
     })

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -239,6 +239,13 @@ describe('GciLibrary', () => {
             });
         })
 
+        it('fails when code contains a non-local return', () => {
+            expectToThrowGciLibraryError(
+                () => gciLibrary.executeDiscardingResult(session, `^ 'a'`),
+                GciLibrary.NON_LOCAL_RETURN_NOT_ALLOWED_MESSAGE
+            )
+        });
+
     });
 
     describe('evaluating an expression and releasing its result automatically', () => {

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -1984,11 +1984,19 @@ export class GciLibrary {
    * instead of retaining `code`'s own result there indefinitely.
    *
    * @param session - The GemStone session to operate in.
-   * @param code - Smalltalk source to evaluate.
-   * @throws {GciLibraryError} If the evaluated code signals an error, or if
-   *   the underlying GCI call fails.
+   * @param code - Smalltalk source to evaluate. Must not contain a non-local
+   *   return (`^`).
+   * @throws {GciLibraryError} If `code` contains a non-local return (`^`), if
+   *   the evaluated code signals an error, or if the underlying GCI call
+   *   fails.
    */
   public executeDiscardingResult(session: unknown, code: string) {
+    // A non-local return here would return before the trailing `. nil`
+    // statement below ever runs, so `code`'s own result oop would come back
+    // instead of nil -- and, since callers of this method don't expect a
+    // result to release, that oop would leak into the PureExportSet forever.
+    this.denyIncludesANonLocalReturn(code);
+
     this.execute(session, `[ ${code} ] value. nil`);
   }
 

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -2534,6 +2534,9 @@ export class GciLibrary {
   // Paged string fetching
   // ---------------------------------------------------------------------
 
+  /** The error {@link executeAndFetchString} throws when `code` contains a non-local return (`^`). */
+  public static readonly NON_LOCAL_RETURN_NOT_ALLOWED_MESSAGE = `Code with non-local returns ('^') is not allowed. Use a plain expression instead, no '^' needed.`;
+
   /**
    * Evaluates `code` and returns its result as a JS string, decoded as UTF-8.
    *
@@ -2550,13 +2553,19 @@ export class GciLibrary {
    * `GciTsFetchUtf8Bytes` itself isn't used for the fetch either.
    *
    * @param session - The GemStone session to operate in.
-   * @param code - Smalltalk source to evaluate.
+   * @param code - Smalltalk source to evaluate. Must not contain a non-local
+   *   return (`^`).
    * @returns The evaluated result, decoded as a UTF-8 JS string.
-   * @throws {GciLibraryError} If the evaluated code signals an error, if the
-   *   result cannot be sent `encodeAsUTF8`, or if the underlying GCI calls
-   *   fail.
+   * @throws {GciLibraryError} If `code` contains a non-local return (`^`), if
+   *   the evaluated code signals an error, if the result cannot be sent
+   *   `encodeAsUTF8`, or if the underlying GCI calls fail.
    */
   public executeAndFetchString(session: unknown, code: string) : string {
+    // A non-local return here would return before the `encodeAsUTF8` send
+    // below ever runs, silently skipping the encoding step `fetchUtf8String`
+    // relies on to receive a `Utf8` byte object.
+    this.denyIncludesANonLocalReturn(code);
+    
     return this.executeAndRelease(
         session,
         `[ ${code} ] value encodeAsUTF8`,
@@ -2608,6 +2617,13 @@ export class GciLibrary {
     }
 
     return Buffer.concat(chunks).toString('utf8');
+  }
+  
+  /** Throws {@link GciLibraryError} if `codeToAnalyze` contains a non-local return (`^`). */
+  private denyIncludesANonLocalReturn(codeToAnalyze: string) {
+    if (codeToAnalyze.includes('^')) {
+      throw GciLibraryError.withMessage(GciLibrary.NON_LOCAL_RETURN_NOT_ALLOWED_MESSAGE);
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- `executeAndFetchString` wraps `code` as `[ code ] value encodeAsUTF8`; a top-level `^` in `code` would non-locally return before that `encodeAsUTF8` send ran, silently skipping the encoding step `fetchUtf8String` relies on to receive a `Utf8` byte object.
- `executeDiscardingResult` has the same shape of bug: it wraps `code` as `[ code ] value. nil` specifically to keep `code`'s own result out of the PureExportSet, but a top-level `^` would skip the trailing `. nil` statement and leak `code`'s real result oop into the PureExportSet forever.
- Both methods now reject `code` containing a non-local return upfront, via a shared `denyIncludesANonLocalReturn` check, with a clear error message telling the caller to use a plain expression instead.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (client workspace `gciLibrary.test.ts`, 81/81 passing, against a live test stone)