### PR TITLE
Support non-local returns in GciLibrary's execute helpers

### DIFF
--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -600,6 +600,10 @@ describe('GciLibrary', () => {
             });
         });
 
+        it('returns the result of code that uses a non-local return', () => {
+            expectEvaluatedStringToBe(`^ 'a' encodeAsUTF16`, 'a');
+        });
+
     })
 
     describe('UserGlobals management', () => {

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -315,6 +315,98 @@ describe('GciLibrary', () => {
 
     });
     
+    describe('sending messages', () => {
+        
+        it ('returns the result of sending a message', () => {
+            const result = gciLibrary.perform(session, gciLibrary.falseOop(), 'not');
+
+            expectOopToBeTrue(result)
+        })
+
+        it ('throws when the selector cannot be resolved', () => {
+            expectToThrowGciLibraryError(
+                () => gciLibrary.perform(session, gciLibrary.falseOop(), 'foo'),
+                'a NameError occurred (error 2404), foo, There is no Symbol with the specified value'
+            )
+        })
+        
+    })
+    
+    describe('sending a message and releasing its result automatically', () => {
+
+        it('passes the resulting oop to the callback', () => {
+            gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'not', resultOop => {
+                expectOopToBeTrue(resultOop);
+            });
+        });
+
+        it('returns the result of evaluating the callback', () => {
+            const expectedResult = 'callback result';
+
+            const result = gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'not', () => expectedResult);
+
+            expect(result).toBe(expectedResult);
+        });
+
+        it('releases the resulting oop after the callback returns', () => {
+            let oopToRelease: bigint;
+            
+            gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'asString', resultOop => { oopToRelease = resultOop; });
+
+            expectPureExportSetToIncludeOop(false, oopToRelease!);
+        });
+
+        it('releases the resulting oop even when the callback throws', () => {
+            let oopToRelease: bigint;
+            const captureResultOopAndFail = (resultOop: bigint) => {
+                oopToRelease = resultOop;
+                throw new Error();
+            };
+
+            expect(() => gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'asString', captureResultOopAndFail)).toThrow();
+
+            expectPureExportSetToIncludeOop(false, oopToRelease!);
+        });
+
+        it("re-throws the callback's error unchanged", () => {
+            expectToThrowExpectedError(throwExpectedError => {
+                gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'not', () => throwExpectedError());
+            });
+        });
+
+        it('throws when sending a message signals an error', () => {
+            expectToThrowGciLibraryError(
+                () => gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'foo', () => {}),
+                'a NameError occurred (error 2404), foo, There is no Symbol with the specified value'
+            );
+        });
+
+        it('does not evaluate the callback when sending a message signals an error', () => {
+            let callbackEvaluated = false;
+
+            expect(() => gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'foo', () => { callbackEvaluated = true; })).toThrow();
+
+            expect(callbackEvaluated).toBe(false);
+        });
+
+        it("still returns the callback's result when releasing the oop fails", () => {
+            simulateReleaseObjectFailure(() => {
+                const result = gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'not', () => 'callback result');
+
+                expect(result).toBe('callback result');
+            });
+        });
+
+        it('still throws the original error when the callback and its cleanup both fail', () => {
+            simulateReleaseObjectFailure(() => {
+                expectToThrowExpectedError(throwExpectedError => {
+                    gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'not', () => throwExpectedError());
+                });
+            });
+        });
+        
+    })
+    
     describe('creating strings', () => {
 
         it('creates a String object from the given contents', () => {

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -239,6 +239,12 @@ describe('GciLibrary', () => {
             });
         })
 
+        it('does not retain the discarded result in the PureExportSet when evaluating non-local returns', () => {
+            expectPureExportSetToStayUnchanged(() => {
+                gciLibrary.executeDiscardingResult(session, '^ Object new');
+            });
+        });
+        
     });
 
     describe('evaluating an expression and releasing its result automatically', () => {

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -1979,9 +1979,16 @@ export class GciLibrary {
   /**
    * Evaluates `code` for effect, discarding its result.
    *
-   * Appends an explicit `nil` as the final statement so `execute`'s result
-   * OOP is nil — a special object that is never added to the PureExportSet —
-   * instead of retaining `code`'s own result there indefinitely.
+   * Wraps `code` in `[ code ] ensure: [ ^ nil ]` rather than simply
+   * appending `nil` as a final statement (e.g. `[ code ] value. nil`).
+   * Appending is unsafe: a non-local return (`^`) inside `code` exits the
+   * whole doit immediately, skipping that trailing `nil` statement, so
+   * `execute`'s result oop would be `code`'s own result instead of nil --
+   * silently retaining it in the PureExportSet forever, since callers of
+   * this method assume there is nothing to release. `ensure:`'s block runs
+   * regardless of how the protected block exits -- normally, via an
+   * exception, or via a non-local return -- so its own `^ nil` forces the
+   * doit's final result to be nil in every case.
    *
    * @param session - The GemStone session to operate in.
    * @param code - Smalltalk source to evaluate.
@@ -1989,7 +1996,7 @@ export class GciLibrary {
    *   the underlying GCI call fails.
    */
   public executeDiscardingResult(session: unknown, code: string) {
-    this.execute(session, `[ ${code} ] value. nil`);
+    this.execute(session, `[ ${code} ] ensure: [ ^ nil ]`);
   }
 
   /**

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -1,6 +1,6 @@
 import koffi from 'koffi';
 import * as path from 'path';
-import {OOP_ILLEGAL, OOP_NIL, OOP_TRUE} from "./gciConstants";
+import {OOP_FALSE, OOP_ILLEGAL, OOP_NIL, OOP_TRUE} from "./gciConstants";
 import {GciLibraryError} from "./gciLibraryError";
 
 // OopType is uint64_t in C; koffi maps this to BigInt in JS
@@ -1231,8 +1231,8 @@ export class GciLibrary {
     const result = Buffer.alloc(maxResultSize);
     const err: Record<string, unknown> = {};
     const bytesReturned = this._GciTsPerformFetchBytes(
-      session, receiver, selectorStr,
-      args.length > 0 ? args : null, args.length,
+        session, receiver, selectorStr,
+        args.length > 0 ? args : null, args.length,
       result, maxResultSize, err,
     );
     const str = bytesReturned >= 0 ? result.toString('utf8', 0, bytesReturned) : '';
@@ -2018,6 +2018,60 @@ export class GciLibrary {
   }
 
   // ---------------------------------------------------------------------
+  // Message sending
+  // ---------------------------------------------------------------------
+
+  /**
+   * Sends the unary message `selector` to `receiverOop` and returns the OOP
+   * of the result.
+   *
+   * The result OOP is retained in the session's PureExportSet, so the caller
+   * is responsible for releasing it when no longer needed.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param receiverOop - The oop of the message's receiver.
+   * @param selector - The unary selector to send.
+   * @returns The OOP of the result object.
+   * @throws {GciLibraryError} If `selector` cannot be resolved, the sent
+   *   method signals an error, or the underlying GCI call fails.
+   */
+  public perform(session: unknown, receiverOop: bigint, selector: string) {
+    const {result, err} = this.GciTsPerform(session, receiverOop, OOP_ILLEGAL, selector, [], 0, 0);
+
+    this.throwOnIllegalOop(result, err);
+
+    return result;
+  }
+
+  /**
+   * Sends the unary message `selector` to `receiverOop`, passes the
+   * resulting oop to `callback`, and releases that oop afterwards regardless
+   * of whether `callback` returns or throws.
+   *
+   * `callback` must consume `oop` synchronously and must not let it escape
+   * past its own return (e.g. by returning it, or by capturing it in
+   * something that outlives the call): the oop is released the instant
+   * `callback` returns, so any use of it afterwards operates on an already
+   * released oop. Async callbacks are rejected at the type level for this
+   * reason; there is no equivalent check for an oop returned directly.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param receiverOop - The oop of the message's receiver.
+   * @param selector - The unary selector to send.
+   * @param callback - Receives the oop `selector` resolved to on
+   *   `receiverOop`. Must be synchronous and must not let the oop escape its
+   *   own return.
+   * @returns Whatever `callback` returns.
+   * @throws {GciLibraryError} If `selector` cannot be resolved, the sent
+   *   method signals an error, or the underlying GCI call fails.
+   * @throws Whatever `callback` itself throws, unchanged, not necessarily a
+   *   {@link GciLibraryError}.
+   */
+  public performAndRelease<T>(session: unknown, receiverOop: bigint, selector: string, callback: (oop: bigint) => NotPromise<T>) : T {
+    return this.releaseAfterUse(session, this.perform(session, receiverOop, selector), callback);
+  }
+
+  // ---------------------------------------------------------------------
   // Symbol resolution & Utf8 caching
   // ---------------------------------------------------------------------
 
@@ -2474,6 +2528,11 @@ export class GciLibrary {
     return OOP_NIL;
   }
 
+  /** Returns the OOP of GemStone's `false` singleton. */
+  public falseOop() {
+    return OOP_FALSE;
+  }
+
   /** Returns whether `oop` is the OOP of GemStone's `nil` singleton. */
   public isNilOop(oop: bigint) {
     return this.nilOop() === oop;
@@ -2609,6 +2668,5 @@ export class GciLibrary {
 
     return Buffer.concat(chunks).toString('utf8');
   }
-
 }
 

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -2608,6 +2608,16 @@ export class GciLibrary {
    * `GciTsFetchBytes` -- see that method's comment for why
    * `GciTsFetchUtf8Bytes` itself isn't used for the fetch either.
    *
+   * The `encodeAsUTF8` send happens as its own {@link performAndRelease}
+   * call on the already-evaluated result oop, rather than being appended to
+   * `code`'s source (e.g. `[ ${code} ] value encodeAsUTF8`). Appending it to
+   * the source is unsafe: a non-local return (`^`) inside `code` exits the
+   * whole doit immediately, so a trailing `encodeAsUTF8` send would never
+   * run and the raw, un-encoded result would reach {@link fetchUtf8String}
+   * instead. The extra round-trip this costs is a deliberate trade-off for
+   * that correctness, not an oversight -- do not collapse the two sends
+   * back into one to save a round-trip.
+   *
    * @param session - The GemStone session to operate in.
    * @param code - Smalltalk source to evaluate.
    * @returns The evaluated result, decoded as a UTF-8 JS string.
@@ -2618,8 +2628,12 @@ export class GciLibrary {
   public executeAndFetchString(session: unknown, code: string) : string {
     return this.executeAndRelease(
         session,
-        `[ ${code} ] value encodeAsUTF8`,
-        stringOop => this.fetchUtf8String(session, stringOop, GciLibrary.FETCH_STRING_PAGE_SIZE_BYTES));
+        code,
+        resultOop => this.performAndRelease(
+            session,
+            resultOop,
+            'encodeAsUTF8',
+            utf8StringOop => this.fetchUtf8String(session, utf8StringOop, GciLibrary.FETCH_STRING_PAGE_SIZE_BYTES)));
   }
 
   /** The page size, in bytes, used by {@link fetchUtf8String} to page a string's contents out of GemStone. */


### PR DESCRIPTION
## Summary

Supersedes #161

- `executeAndFetchString` sends `encodeAsUTF8` as its own `performAndRelease` call on the evaluated result oop, instead of appending it to the evaluated source (`[ code ] value encodeAsUTF8`).
- `executeDiscardingResult` wraps `code` in `[ code ] ensure: [ ^ nil ]`, instead of appending a trailing `nil` statement (`[ code ] value. nil`).
- Both previously assumed the evaluated source would always run to completion and hand control back at the point right after `code`. A non-local return (`^`) inside `code` breaks that assumption: it exits the whole doit immediately, skipping whatever was appended after it in the source string.

## Why this matters

`executeAndFetchString` is going to back most of the query/eval paths in Jasper, so we don't control what code runs through it. Users can (and do) write workspace snippets with an explicit `^` — a non-local return is completely ordinary Smalltalk. Before this fix:

- `executeAndFetchString` would silently skip the `encodeAsUTF8` send, so unusual string encodings (e.g. a UTF-16 result) would reach `GciTsFetchUtf8Bytes`, which doesn't support that encoding, and come back garbled instead of throwing.
- `executeDiscardingResult` would leak the discarded result's oop into the session's `PureExportSet` forever, since callers assume the discard produces `nil` (never tracked) and never release it.

Both bugs were silent, not crashes, so they'd have been easy to miss without an explicit regression test covering the `^` case.

## Test plan

- [x] `npm run compile`
- [x] `npm test` (142 client test files / 3258 tests, 12 server files / 320 tests, 3 mcp-server files / 95 tests — all passing, including two new regression tests exercising a non-local return in each helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)