### PR TITLE
Clarify that the NetLDI login field accepts a name or a port number

### DIFF
--- a/client/src/loginEditorPanel.ts
+++ b/client/src/loginEditorPanel.ts
@@ -309,8 +309,9 @@ export class LoginEditorPanel {
     <label for="stone">Stone</label>
     <input type="text" id="stone" placeholder="gs64stone">
 
-    <label for="netldi">NetLDI</label>
-    <input type="text" id="netldi" placeholder="gs64ldi">
+    <label for="netldi">NetLDI (name or port)</label>
+    <input type="text" id="netldi" placeholder="gs64ldi or 50377">
+    <div class="hint">Accepts a NetLDI service name (e.g. gs64ldi) or a port number (e.g. 50377), useful for remote stones.</div>
   </div>
 
   <div class="field-group">


### PR DESCRIPTION
## Summary
Clarifies in the login editor UI that the NetLDI field accepts either a NetLDI service name or a port number. An external user asked whether Jasper's login config can accept a NetLDI port number instead of a service name (for connecting to remote stones over SSH port-forwarding). It already does — the value is passed straight into the GCI network resource string (`#netldi:<value>`) as an opaque string — but the UI only hinted at a name-style example.

## Changes

### Before

<img width="1072" height="1492" alt="image" src="https://github.com/user-attachments/assets/10b59f34-2288-4c8c-9d3c-52b474b80d31" />

### After 

<img width="1056" height="1542" alt="image" src="https://github.com/user-attachments/assets/08d2b946-27a8-4f7a-b572-dbbacf1afc8d" />

No parsing/validation change is needed — the value is already treated as an opaque string on login.

Addresses Gitlab#69.