### PR TITLE
Drop remaining `any` from test mocks (phase 6)

### DIFF
--- a/client/src/__tests__/breakpointManager.test.ts
+++ b/client/src/__tests__/breakpointManager.test.ts
@@ -175,7 +175,7 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('file:///test.tpz');
-      const results = manager.setBreakpointsForSource(session, uri as any, [1]);
+      const results = manager.setBreakpointsForSource(session, uri, [1]);
       expect(results).toHaveLength(1);
       expect(results[0].verified).toBe(false);
     });
@@ -187,7 +187,7 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A');
-      const results = manager.setBreakpointsForSource(session, uri as any, [1, 2]);
+      const results = manager.setBreakpointsForSource(session, uri, [1, 2]);
 
       expect(results).toHaveLength(2);
       expect(results[0]).toEqual({ stepPoint: 1, actualLine: 1, verified: true });
@@ -200,7 +200,7 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A');
-      const results = manager.setBreakpointsForSource(session, uri as any, []);
+      const results = manager.setBreakpointsForSource(session, uri, []);
 
       expect(results).toHaveLength(0);
       expect(mockClearAllBreaks).toHaveBeenCalledTimes(1);
@@ -212,7 +212,7 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/at%3A');
-      const results = manager.setBreakpointsForSource(session, uri as any, [1]);
+      const results = manager.setBreakpointsForSource(session, uri, [1]);
 
       expect(results).toHaveLength(1);
       expect(results[0].verified).toBe(false);
@@ -226,7 +226,7 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/foo');
-      const results = manager.setBreakpointsForSource(session, uri as any, [1]);
+      const results = manager.setBreakpointsForSource(session, uri, [1]);
 
       expect(results).toHaveLength(1);
       expect(results[0].verified).toBe(false);
@@ -239,7 +239,7 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('gemstone://1/Globals/Array/class/creation/new');
-      manager.setBreakpointsForSource(session, uri as any, [1]);
+      manager.setBreakpointsForSource(session, uri, [1]);
 
       expect(mockGetMethodSource).toHaveBeenCalledWith(
         expect.anything(), 'Array', true, 'new', 0,
@@ -253,7 +253,7 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/foo?env=2');
-      manager.setBreakpointsForSource(session, uri as any, [1]);
+      manager.setBreakpointsForSource(session, uri, [1]);
 
       expect(mockGetMethodSource).toHaveBeenCalledWith(
         expect.anything(), 'Array', false, 'foo', 2,
@@ -269,17 +269,17 @@ describe('BreakpointManager', () => {
       const manager = new BreakpointManager(makeSessionManager(true));
       const session = makeSessionManager(true).getSelectedSession()!;
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/foo');
-      manager.setBreakpointsForSource(session, uri as any, [1]);
+      manager.setBreakpointsForSource(session, uri, [1]);
 
       // Verify tracked (indirectly: clearing and re-setting should not fail)
       manager.clearAllForSession(1);
 
       // After clearing, the internal map should be empty for this session
       // We can verify by calling invalidateForUri which checks the map
-      manager.invalidateForUri(uri as any);
+      manager.invalidateForUri(uri);
       // getMethodSource should NOT be called again since tracking was cleared
       mockGetMethodSource.mockReset();
-      manager.invalidateForUri(uri as any);
+      manager.invalidateForUri(uri);
       expect(mockGetMethodSource).not.toHaveBeenCalled();
     });
   });

--- a/client/src/__tests__/databaseManager.test.ts
+++ b/client/src/__tests__/databaseManager.test.ts
@@ -16,6 +16,8 @@ import {
 } from '../wslFs';
 import { DatabaseManager } from '../databaseManager';
 import { GemStoneDatabase } from '../sysadminTypes';
+import { SysadminStorage } from '../sysadminStorage';
+import { ProcessManager } from '../processManager';
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -41,18 +43,18 @@ function makeManager(overrides?: {
     getAvailableExtents: vi.fn(() => ['extent0']),
     getGemstonePath: vi.fn(() => '/gs'),
     ...overrides?.storage,
-  } as any;
+  } as unknown as SysadminStorage;
   const processManager = {
     isStoneRunning: vi.fn(() => false),
     ...overrides?.processManager,
-  } as any;
+  } as unknown as ProcessManager;
   return new DatabaseManager(storage, processManager);
 }
 
 /** Pick the QuickPick item at `index` (preserving object identity). */
 function pickItem(index: number): void {
   vi.mocked(vscode.window.showQuickPick).mockImplementation(
-    async (items: any) => (await items)[index],
+    async (items) => (await items)[index] as vscode.QuickPickItem,
   );
 }
 
@@ -61,14 +63,14 @@ describe('DatabaseManager.replaceExtent', () => {
     vi.clearAllMocks();
     vi.mocked(wslExistsSync).mockReturnValue(true);
     vi.mocked(wslReaddirSync).mockReturnValue(['extent0.dbf', 'tranlog1.dbf', 'README.txt']);
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Replace' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Replace' as unknown as vscode.MessageItem);
   });
 
   it('copies a browsed extent into extent0.dbf and records its basename', async () => {
     pickItem(0); // the "Browse for extent file…" item is always first
     vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
       vscode.Uri.file('/seed/mydata.dbf'),
-    ] as any);
+    ]);
 
     const ok = await makeManager().replaceExtent(makeDb());
 
@@ -87,7 +89,7 @@ describe('DatabaseManager.replaceExtent', () => {
   it('still copies a vendor extent from the product bin directory', async () => {
     // items = [browse, separator, extent0] → last item is the vendor extent.
     vi.mocked(vscode.window.showQuickPick).mockImplementation(
-      async (items: any) => { const r = await items; return r[r.length - 1]; },
+      async (items) => { const r = await items; return r[r.length - 1]; },
     );
 
     const ok = await makeManager().replaceExtent(makeDb());
@@ -103,7 +105,7 @@ describe('DatabaseManager.replaceExtent', () => {
     pickItem(0);
     vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
       vscode.Uri.file('/seed/mydata.dbf'),
-    ] as any);
+    ]);
 
     const ok = await makeManager({ storage: { getAvailableExtents: vi.fn(() => []) } })
       .replaceExtent(makeDb());
@@ -124,7 +126,7 @@ describe('DatabaseManager.replaceExtent', () => {
 
   it('does nothing when the browse dialog is cancelled', async () => {
     pickItem(0);
-    vi.mocked(vscode.window.showOpenDialog).mockResolvedValue(undefined as any);
+    vi.mocked(vscode.window.showOpenDialog).mockResolvedValue(undefined);
 
     const ok = await makeManager().replaceExtent(makeDb());
 
@@ -137,7 +139,7 @@ describe('DatabaseManager.replaceExtent', () => {
     pickItem(0);
     vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
       vscode.Uri.file('/seed/gone.dbf'),
-    ] as any);
+    ]);
     vi.mocked(wslExistsSync).mockReturnValue(false);
 
     const ok = await makeManager().replaceExtent(makeDb());
@@ -152,8 +154,8 @@ describe('DatabaseManager.replaceExtent', () => {
     pickItem(0);
     vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
       vscode.Uri.file('/seed/mydata.dbf'),
-    ] as any);
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined as any);
+    ]);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined);
 
     const ok = await makeManager().replaceExtent(makeDb());
 
@@ -170,14 +172,14 @@ describe('DatabaseManager.replaceExtent (copy helper choice)', () => {
     vi.clearAllMocks();
     vi.mocked(wslExistsSync).mockReturnValue(true);
     vi.mocked(wslReaddirSync).mockReturnValue(['extent0.dbf']);
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Replace' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Replace' as unknown as vscode.MessageItem);
   });
 
   it('uses wslImportFileSync, not wslCopyFileSync', async () => {
     pickItem(0);
     vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
       vscode.Uri.file('/seed/mydata.dbf'),
-    ] as any);
+    ]);
 
     await makeManager().replaceExtent(makeDb());
 

--- a/client/src/__tests__/extension.test.ts
+++ b/client/src/__tests__/extension.test.ts
@@ -35,6 +35,11 @@ import * as queries from '../browserQueries';
 import { InFlightGuard } from '../inFlightGuard';
 import { DEFAULT_LOGIN } from '../loginTypes';
 
+/** Replace the mocked `tabGroups.all`, keeping the cast in one place. */
+function setTabs(groups: { tabs: vscode.Tab[] }[]): void {
+  (vscode.window.tabGroups as unknown as { all: { tabs: vscode.Tab[] }[] }).all = groups;
+}
+
 describe('openTextEditorOn', () => {
   const uri = vscode.Uri.parse('gemstone://1/SymbolDictionary/Array/instance/accessing/at:');
 
@@ -101,14 +106,14 @@ describe('closeTextEditorOn', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    (vscode.window.tabGroups as any).all = [];
+    setTabs([]);
     vi.mocked(vscode.window.tabGroups.close).mockReset();
     vi.mocked(vscode.window.showErrorMessage).mockReset();
     vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
   });
 
   it('does nothing when no tabs are opened for the given uri', async () => {
-    (vscode.window.tabGroups as any).all = [{ tabs: [] }];
+    setTabs([{ tabs: [] }]);
 
     await extension.closeTextEditorOn(targetUri);
 
@@ -118,7 +123,7 @@ describe('closeTextEditorOn', () => {
 
   it('closes one matching opened tab (happy path)', async () => {
     const tab = makeTextTab(targetUri);
-    (vscode.window.tabGroups as any).all = [{ tabs: [tab] }];
+    setTabs([{ tabs: [tab] }]);
     vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
 
     await extension.closeTextEditorOn(targetUri);
@@ -131,7 +136,7 @@ describe('closeTextEditorOn', () => {
   it('logs error when closing one matching opened tab fails', async () => {
     const tab = makeTextTab(targetUri);
     const error = new Error('close failed');
-    (vscode.window.tabGroups as any).all = [{ tabs: [tab] }];
+    setTabs([{ tabs: [tab] }]);
     vi.mocked(vscode.window.tabGroups.close).mockRejectedValue(error);
 
     await extension.closeTextEditorOn(targetUri);
@@ -147,7 +152,7 @@ describe('closeTextEditorOn', () => {
   it('closes both tabs when more than one matching tab is opened (happy path)', async () => {
     const tab1 = makeTextTab(targetUri);
     const tab2 = makeTextTab(targetUri);
-    (vscode.window.tabGroups as any).all = [{ tabs: [tab1, tab2] }];
+    setTabs([{ tabs: [tab1, tab2] }]);
     vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
 
     await extension.closeTextEditorOn(targetUri);
@@ -162,7 +167,7 @@ describe('closeTextEditorOn', () => {
     const tab1 = makeTextTab(targetUri);
     const tab2 = makeTextTab(targetUri);
     const error = new Error('first close failed');
-    (vscode.window.tabGroups as any).all = [{ tabs: [tab1, tab2] }];
+    setTabs([{ tabs: [tab1, tab2] }]);
     vi.mocked(vscode.window.tabGroups.close)
       .mockRejectedValueOnce(error)
       .mockResolvedValueOnce(undefined as never);
@@ -183,7 +188,7 @@ describe('closeTextEditorOn', () => {
     const matching = makeTextTab(targetUri);
     const different = makeTextTab(otherUri);
     const notText = { input: { uri: targetUri } } as unknown as vscode.Tab;
-    (vscode.window.tabGroups as any).all = [{ tabs: [matching, different, notText] }];
+    setTabs([{ tabs: [matching, different, notText] }]);
     vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
 
     await extension.closeTextEditorOn(targetUri);
@@ -203,7 +208,7 @@ describe('handleMethodCompiled', () => {
     vi.mocked(vscode.window.showTextDocument).mockReset();
     vi.mocked(vscode.window.tabGroups.close).mockReset();
     vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
-    (vscode.window.tabGroups as any).all = [];
+    setTabs([]);
   });
 
   it('opens the new uri and closes the previous tab when the previous URI is a template', async () => {
@@ -211,7 +216,7 @@ describe('handleMethodCompiled', () => {
     vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
     vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as vscode.TextEditor);
     const previousTab = { input: new vscode.TabInputText(previousUri) } as unknown as vscode.Tab;
-    (vscode.window.tabGroups as any).all = [{ tabs: [previousTab] }];
+    setTabs([{ tabs: [previousTab] }]);
     vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
 
     await extension.handleMethodCompiled({ uri, previousUri, previousUriIsTemplate: true });
@@ -223,7 +228,7 @@ describe('handleMethodCompiled', () => {
   });
 
   it('does nothing when uri equals previousUri (selector unchanged)', async () => {
-    (vscode.window.tabGroups as any).all = [];
+    setTabs([]);
 
     await extension.handleMethodCompiled({ uri, previousUri: uri, previousUriIsTemplate: false });
 
@@ -236,7 +241,7 @@ describe('handleMethodCompiled', () => {
     vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
     vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as vscode.TextEditor);
     const previousTab = { input: new vscode.TabInputText(previousUri) } as unknown as vscode.Tab;
-    (vscode.window.tabGroups as any).all = [{ tabs: [previousTab] }];
+    setTabs([{ tabs: [previousTab] }]);
 
     await extension.handleMethodCompiled({ uri, previousUri, previousUriIsTemplate: false });
 
@@ -255,7 +260,7 @@ describe('handleClassDefinitionCompiled', () => {
     vi.mocked(vscode.window.showTextDocument).mockReset();
     vi.mocked(vscode.window.tabGroups.close).mockReset();
     vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
-    (vscode.window.tabGroups as any).all = [];
+    setTabs([]);
   });
 
   it('opens the definition uri when uri differs from previousUri', async () => {
@@ -279,7 +284,7 @@ describe('handleClassDefinitionCompiled', () => {
     vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(document);
     vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as vscode.TextEditor);
     const previousTab = { input: new vscode.TabInputText(previousUri) } as unknown as vscode.Tab;
-    (vscode.window.tabGroups as any).all = [{ tabs: [previousTab] }];
+    setTabs([{ tabs: [previousTab] }]);
     vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(undefined as never);
 
     await extension.handleClassDefinitionCompiled({ uri, previousUri, previousUriIsTemplate: true });
@@ -356,7 +361,7 @@ describe('confirmLogoutWithUncommittedChanges', () => {
   });
 
   it('commits then proceeds when the user chooses to commit before logging out', async () => {
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Commit & Logout' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Commit & Logout' as unknown as vscode.MessageItem);
     const commit = vi.fn(() => ({ success: true, err: { number: 0, message: '' } }));
 
     const decision = await extension.confirmLogoutWithUncommittedChanges(3, true, commit);
@@ -366,7 +371,7 @@ describe('confirmLogoutWithUncommittedChanges', () => {
   });
 
   it('cancels the logout when the requested commit fails', async () => {
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Commit & Logout' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Commit & Logout' as unknown as vscode.MessageItem);
     const commit = vi.fn(() => ({ success: false, err: { number: 4001, message: 'no privilege' } }));
 
     const decision = await extension.confirmLogoutWithUncommittedChanges(3, true, commit);
@@ -376,7 +381,7 @@ describe('confirmLogoutWithUncommittedChanges', () => {
   });
 
   it('proceeds without committing when the user chooses to log out anyway', async () => {
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Logout Anyway' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Logout Anyway' as unknown as vscode.MessageItem);
     const commit = vi.fn();
 
     const decision = await extension.confirmLogoutWithUncommittedChanges(3, true, commit);
@@ -396,7 +401,7 @@ describe('confirmLogoutWithUncommittedChanges', () => {
   });
 
   it('still prompts when the commit state could not be determined', async () => {
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Logout Anyway' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Logout Anyway' as unknown as vscode.MessageItem);
     const commit = vi.fn();
 
     const decision = await extension.confirmLogoutWithUncommittedChanges(3, undefined, commit);

--- a/client/src/__tests__/gemstoneCodeLensProvider.test.ts
+++ b/client/src/__tests__/gemstoneCodeLensProvider.test.ts
@@ -8,6 +8,7 @@ vi.mock('../browserQueries', () => ({
 }));
 
 import { Uri } from 'vscode';
+import type { TextDocument, CodeLens } from 'vscode';
 import { GemStoneCodeLensProvider } from '../gemstoneCodeLensProvider';
 import { SessionManager, ActiveSession } from '../sessionManager';
 import * as queries from '../browserQueries';
@@ -32,7 +33,8 @@ function createMockSession(): ActiveSession {
   };
 }
 
-function createMockDocument(text: string, scheme = 'file') {
+/** Build a partial TextDocument mock, confining the one unavoidable cast here. */
+function createMockDocument(text: string, scheme = 'file'): TextDocument {
   return {
     uri: scheme === 'gemstone'
       ? Uri.parse('gemstone://1/UserGlobals/MyClass/instance/accessing/name')
@@ -41,7 +43,7 @@ function createMockDocument(text: string, scheme = 'file') {
     languageId: scheme === 'gemstone' ? 'gemstone-smalltalk' : 'gemstone-topaz',
     lineAt: vi.fn(),
     lineCount: text.split('\n').length,
-  };
+  } as unknown as TextDocument;
 }
 
 describe('GemStoneCodeLensProvider', () => {
@@ -61,7 +63,7 @@ describe('GemStoneCodeLensProvider', () => {
 
   // The count is computed off the resolve path (so a spinner can paint first),
   // so resolving twice with the deferred work flushed in between yields the count.
-  function resolveCount(lens: any): any {
+  function resolveCount(lens: CodeLens): CodeLens {
     provider.resolveCodeLens(lens);   // first resolve → spinner + schedules the lookup
     vi.runAllTimers();                // run the deferred sendersOf/implementorsOf
     return provider.resolveCodeLens(lens); // re-resolve → cache hit → the count
@@ -83,19 +85,19 @@ method: MyClass
 name: aString
   name := aString
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       expect(lenses).toHaveLength(4); // 2 methods × 2 lenses
     });
 
     it('returns a senders+implementors lens pair for gemstone:// method URIs', () => {
       const doc = createMockDocument('name\n  ^ name', 'gemstone');
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       expect(lenses).toHaveLength(2); // 1 method × 2 lenses
     });
 
     it('returns no lenses for empty files', () => {
       const doc = createMockDocument('');
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       expect(lenses).toHaveLength(0);
     });
 
@@ -103,7 +105,7 @@ name: aString
       const doc = createMockDocument(`run
 true
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       expect(lenses).toHaveLength(0);
     });
   });
@@ -118,7 +120,7 @@ true
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       const loading = provider.resolveCodeLens(lenses[0]); // before the deferred lookup runs
 
       expect(loading.command?.title).toContain('$(loading~spin)');
@@ -135,7 +137,7 @@ foo
 foo
   ^ 42
 %`);
-      const lens = provider.provideCodeLenses(doc as any)[0];
+      const lens = provider.provideCodeLenses(doc)[0];
 
       expect(provider.resolveCodeLens(lens).command?.title).toContain('$(loading~spin)');
       vi.runAllTimers(); // the deferred lookup runs and caches the count
@@ -147,7 +149,7 @@ foo
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       expect(lenses).toHaveLength(2);
 
       // Both lenses report no session — neither computes a count when
@@ -174,7 +176,7 @@ foo
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       const sendersLens = resolveCount(lenses[0]);
 
       expect(sendersLens.command?.title).toBe('2 senders');
@@ -200,7 +202,7 @@ foo
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       const implementorsLens = resolveCount(lenses[1]);
 
       expect(implementorsLens.command?.title).toBe('1 implementor');
@@ -224,7 +226,7 @@ foo
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       resolveCount(lenses[0]); // senders lens
 
       expect(queries.sendersOf).toHaveBeenCalled();
@@ -241,7 +243,7 @@ foo
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       resolveCount(lenses[1]); // implementors lens
 
       expect(queries.implementorsOf).toHaveBeenCalled();
@@ -263,7 +265,7 @@ foo
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       expect(resolveCount(lenses[0]).command?.title).toBe('1 sender');
       expect(resolveCount(lenses[1]).command?.title).toBe('1 implementor');
     });
@@ -280,11 +282,11 @@ foo
 foo
   ^ 42
 %`);
-      const lenses = provider.provideCodeLenses(doc as any);
+      const lenses = provider.provideCodeLenses(doc);
       expect(resolveCount(lenses[0]).command?.title).toBe('3 senders');
       // Re-provide + re-resolve (fresh lens objects, as VS Code does on a refresh):
       // the count comes from cache, so no second server lookup.
-      const again = provider.provideCodeLenses(doc as any);
+      const again = provider.provideCodeLenses(doc);
       expect(provider.resolveCodeLens(again[0]).command?.title).toBe('3 senders');
       expect(queries.sendersOf as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
     });
@@ -297,7 +299,7 @@ foo
 foo
   ^ 42
 %`);
-      provider.resolveCodeLens(provider.provideCodeLenses(doc as any)[0]); // schedules the lookup
+      provider.resolveCodeLens(provider.provideCodeLenses(doc)[0]); // schedules the lookup
 
       provider.dispose();
       vi.runAllTimers();              // a still-pending timer would fire here
@@ -314,9 +316,9 @@ foo
 foo
   ^ 42
 %`);
-      resolveCount(provider.provideCodeLenses(doc as any)[0]);
+      resolveCount(provider.provideCodeLenses(doc)[0]);
       provider.refresh();
-      resolveCount(provider.provideCodeLenses(doc as any)[0]);
+      resolveCount(provider.provideCodeLenses(doc)[0]);
       expect(queries.sendersOf as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(2);
     });
   });

--- a/client/src/__tests__/loginEditorPanel.test.ts
+++ b/client/src/__tests__/loginEditorPanel.test.ts
@@ -7,6 +7,7 @@ vi.mock('../bundledGci', () => ({
   bundledGciArchSupported: vi.fn(() => true),
 }));
 
+import type * as vscode from 'vscode';
 import { window, __resetConfig, __setConfig } from '../__mocks__/vscode';
 import { LoginEditorPanel } from '../loginEditorPanel';
 import { bundledWindowsClientVersions, bundledGciArchSupported } from '../bundledGci';
@@ -23,7 +24,7 @@ function makeSysadminStorage(extractedVersions: string[] = []): SysadminStorage 
   return {
     getExtractedVersions: vi.fn(() => extractedVersions),
     getExtractedWindowsClientVersions: vi.fn(() => []),
-  } as any;
+  } as unknown as SysadminStorage;
 }
 
 function makeSecrets() {
@@ -39,14 +40,18 @@ describe('LoginEditorPanel', () => {
   let storage: LoginStorage;
   let treeProvider: LoginTreeProvider;
   let secrets: ReturnType<typeof makeSecrets>;
+  // `secrets` keeps its mock type so tests can assert on `.get`/`.store`/`.delete`;
+  // this is the same mock, cast once for handing to `show()`.
+  let secretsArg: vscode.SecretStorage;
 
   beforeEach(() => {
     __resetConfig();
     storage = new LoginStorage();
     treeProvider = new LoginTreeProvider(storage);
     secrets = makeSecrets();
+    secretsArg = secrets as unknown as vscode.SecretStorage;
     // Reset the static currentPanel between tests
-    (LoginEditorPanel as any).currentPanel = undefined;
+    (LoginEditorPanel as unknown as { currentPanel: unknown }).currentPanel = undefined;
     vi.clearAllMocks();
     (bundledWindowsClientVersions as Mock).mockReturnValue([]);
     (bundledGciArchSupported as Mock).mockReturnValue(true);
@@ -54,7 +59,7 @@ describe('LoginEditorPanel', () => {
 
   describe('show', () => {
     it('creates a new webview panel for a new login', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
       expect(window.createWebviewPanel).toHaveBeenCalledWith(
         'gemstoneLoginEditor',
         'New GemStone Login',
@@ -65,7 +70,7 @@ describe('LoginEditorPanel', () => {
 
     it('creates a panel titled with login description when editing', () => {
       const login = makeLogin({ gs_user: 'Admin', stone: 'prod', gem_host: 'db.example.com' });
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, login);
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
       expect(window.createWebviewPanel).toHaveBeenCalledWith(
         'gemstoneLoginEditor',
         'Edit: Admin on prod (db.example.com)',
@@ -75,26 +80,26 @@ describe('LoginEditorPanel', () => {
     });
 
     it('reuses existing panel on subsequent calls', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const firstCallCount = (window.createWebviewPanel as any).mock.calls.length;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const firstCallCount = window.createWebviewPanel.mock.calls.length;
 
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, makeLogin({ label: 'Second' }));
-      expect((window.createWebviewPanel as any).mock.calls.length).toBe(firstCallCount);
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin({ label: 'Second' }));
+      expect(window.createWebviewPanel.mock.calls.length).toBe(firstCallCount);
     });
 
     it('reveals existing panel on subsequent calls', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
 
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, makeLogin({ label: 'Second' }));
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin({ label: 'Second' }));
       expect(panel.reveal).toHaveBeenCalled();
     });
   });
 
   describe('webview HTML', () => {
     it('sets webview html with form fields', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
       expect(html).toContain('GemStone Login Parameters');
@@ -109,8 +114,8 @@ describe('LoginEditorPanel', () => {
     });
 
     it('includes Content-Security-Policy with nonce', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
       expect(html).toContain('Content-Security-Policy');
@@ -118,8 +123,8 @@ describe('LoginEditorPanel', () => {
     });
 
     it('includes save and cancel buttons', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
       expect(html).toContain('id="saveBtn"');
@@ -130,8 +135,8 @@ describe('LoginEditorPanel', () => {
 
   describe('message handling', () => {
     it('sends loadData message after creating panel', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadData',
         data: expect.objectContaining({ label: '' }),
@@ -142,8 +147,8 @@ describe('LoginEditorPanel', () => {
 
     it('sends existing login data when editing', () => {
       const login = makeLogin({ label: 'Server', gem_host: 'myhost' });
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, login);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadData',
         data: expect.objectContaining({ label: 'Server', gem_host: 'myhost' }),
@@ -156,8 +161,8 @@ describe('LoginEditorPanel', () => {
   describe('version dropdown', () => {
     it('includes extracted versions in loadData message', () => {
       const sysadmin = makeSysadminStorage(['3.7.4', '3.6.4']);
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.7.4', '3.6.4'] }),
       );
@@ -166,8 +171,8 @@ describe('LoginEditorPanel', () => {
     it('includes versions from gciLibraries config', () => {
       __setConfig('gemstone', 'gciLibraries', { '3.5.0': '/path/to/lib' });
       const sysadmin = makeSysadminStorage([]);
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.5.0'] }),
       );
@@ -176,8 +181,8 @@ describe('LoginEditorPanel', () => {
     it('deduplicates versions from both sources', () => {
       __setConfig('gemstone', 'gciLibraries', { '3.7.4': '/path/to/lib' });
       const sysadmin = makeSysadminStorage(['3.7.4']);
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.7.4'] }),
       );
@@ -186,8 +191,8 @@ describe('LoginEditorPanel', () => {
     it('sorts versions newest first', () => {
       __setConfig('gemstone', 'gciLibraries', { '3.5.0': '/path/a' });
       const sysadmin = makeSysadminStorage(['3.6.4', '3.7.4']);
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.7.4', '3.6.4', '3.5.0'] }),
       );
@@ -199,8 +204,8 @@ describe('LoginEditorPanel', () => {
       (bundledWindowsClientVersions as Mock).mockReturnValue(['3.6.2']);
       try {
         const sysadmin = makeSysadminStorage([]);
-        LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-        const panel = (window.createWebviewPanel as any).mock.results[0].value;
+        LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+        const panel = window.createWebviewPanel.mock.results[0].value;
         expect(panel.webview.postMessage).toHaveBeenCalledWith(
           expect.objectContaining({ versions: ['3.6.2'] }),
         );
@@ -216,8 +221,8 @@ describe('LoginEditorPanel', () => {
       (bundledGciArchSupported as Mock).mockReturnValue(false);
       try {
         const sysadmin = makeSysadminStorage([]);
-        LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-        const panel = (window.createWebviewPanel as any).mock.results[0].value;
+        LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+        const panel = window.createWebviewPanel.mock.results[0].value;
         expect(panel.webview.postMessage).toHaveBeenCalledWith(
           expect.objectContaining({ versions: [] }),
         );
@@ -227,15 +232,15 @@ describe('LoginEditorPanel', () => {
     });
 
     it('renders a select element for the version field', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.html).toContain('<select id="version">');
     });
 
     it('defaults new login version to the highest available version', () => {
       const sysadmin = makeSysadminStorage(['3.6.4', '3.7.4']);
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ version: '3.7.4' }),
@@ -245,8 +250,8 @@ describe('LoginEditorPanel', () => {
 
     it('defaults to empty version when no versions are available', () => {
       const sysadmin = makeSysadminStorage([]);
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, undefined, sysadmin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ version: '' }),
@@ -257,8 +262,8 @@ describe('LoginEditorPanel', () => {
     it('preserves version from existing login rather than defaulting', () => {
       const sysadmin = makeSysadminStorage(['3.7.4', '3.6.4']);
       const login = makeLogin({ version: '3.6.4' });
-      LoginEditorPanel.show(storage, secrets as any, treeProvider, login, sysadmin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider, login, sysadmin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ version: '3.6.4' }),
@@ -269,8 +274,8 @@ describe('LoginEditorPanel', () => {
 
   describe('OS keychain option', () => {
     it('renders a "Store password in OS keychain" checkbox in the HTML', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
       expect(html).toContain('id="password_in_keychain"');
@@ -278,8 +283,8 @@ describe('LoginEditorPanel', () => {
     });
 
     it('renders a hint about leaving the password blank to be prompted', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.html).toContain('Leave password blank to be prompted on each login');
     });
 
@@ -293,22 +298,22 @@ describe('LoginEditorPanel', () => {
         password_in_keychain: true,
       });
 
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, login);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
 
       expect(secrets.get).toHaveBeenCalledWith(
         'jasper-gemstone-login:DataCurator@localhost/gs64stone',
       );
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
-      const loadCall = (panel.webview.postMessage as any).mock.calls.find(
-        (c: any[]) => c[0]?.command === 'loadData',
+      const panel = window.createWebviewPanel.mock.results[0].value;
+      const loadCall = panel.webview.postMessage.mock.calls.find(
+        (c: unknown[]) => (c[0] as { command?: string })?.command === 'loadData',
       );
-      expect(loadCall?.[0].data.gs_password).toBe('kc-secret');
+      expect((loadCall?.[0] as { data: { gs_password: string } }).data.gs_password).toBe('kc-secret');
     });
 
     it('does not call SecretStorage when editing a non-keychain login', async () => {
       const login = makeLogin({ gs_password: 'plain' });
 
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, login);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
 
       expect(secrets.get).not.toHaveBeenCalled();
     });
@@ -316,8 +321,8 @@ describe('LoginEditorPanel', () => {
 
   describe('class sync option', () => {
     it('renders a "Sync classes to local files" checkbox in the HTML', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
       expect(html).toContain('id="sync_classes"');
       expect(html).toContain('Sync classes to local files');
@@ -326,22 +331,22 @@ describe('LoginEditorPanel', () => {
 
   describe('read-only view', () => {
     it('renders the read-only banner element in the HTML', () => {
-      LoginEditorPanel.show(storage, secrets as any, treeProvider);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.html).toContain('id="readOnlyBanner"');
     });
 
     it('marks the load data read-only when opened read-only', async () => {
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, makeLogin(), undefined, true);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin(), undefined, true);
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ command: 'loadData', readOnly: true }),
       );
     });
 
     it('is not read-only by default', async () => {
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, makeLogin());
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin());
+      const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ command: 'loadData', readOnly: false }),
       );
@@ -349,7 +354,7 @@ describe('LoginEditorPanel', () => {
 
     it('titles the panel "View:" when read-only', async () => {
       const login = makeLogin({ gs_user: 'Admin', stone: 'prod', gem_host: 'db' });
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, login, undefined, true);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, login, undefined, true);
       expect(window.createWebviewPanel).toHaveBeenCalledWith(
         'gemstoneLoginEditor',
         'View: Admin on prod (db)',
@@ -359,11 +364,11 @@ describe('LoginEditorPanel', () => {
     });
 
     it('switches an open panel to read-only when reused for a connected login', async () => {
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, makeLogin({ label: 'A' }));
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
-      (panel.webview.postMessage as any).mockClear();
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin({ label: 'A' }));
+      const panel = window.createWebviewPanel.mock.results[0].value;
+      panel.webview.postMessage.mockClear();
 
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, makeLogin({ label: 'A' }), undefined, true);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin({ label: 'A' }), undefined, true);
 
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ command: 'loadData', readOnly: true }),
@@ -372,9 +377,9 @@ describe('LoginEditorPanel', () => {
 
     it('ignores a save message while read-only', async () => {
       const saveSpy = vi.spyOn(storage, 'saveLogin').mockResolvedValue();
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, makeLogin(), undefined, true);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
-      const handler = (panel.webview.onDidReceiveMessage as any).mock.calls[0][0];
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin(), undefined, true);
+      const panel = window.createWebviewPanel.mock.results[0].value;
+      const handler = panel.webview.onDidReceiveMessage.mock.calls[0][0];
 
       await handler({ command: 'save', data: makeLogin({ stone: 'edited' }), originalLabel: 'Test' });
 
@@ -387,9 +392,9 @@ describe('LoginEditorPanel', () => {
       existingLogin: GemStoneLogin | undefined,
       saveData: Partial<GemStoneLogin> & { password_in_keychain?: boolean; sync_classes?: boolean },
     ) {
-      await LoginEditorPanel.show(storage, secrets as any, treeProvider, existingLogin);
-      const panel = (window.createWebviewPanel as any).mock.results[0].value;
-      const handler = (panel.webview.onDidReceiveMessage as any).mock.calls[0][0];
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, existingLogin);
+      const panel = window.createWebviewPanel.mock.results[0].value;
+      const handler = panel.webview.onDidReceiveMessage.mock.calls[0][0];
       const data = { ...makeLogin(), ...saveData };
       await handler({ command: 'save', data, originalLabel: existingLogin?.label ?? null });
     }

--- a/client/src/__tests__/processManager.test.ts
+++ b/client/src/__tests__/processManager.test.ts
@@ -19,10 +19,11 @@ vi.mock('../wslBridge', async () => {
 });
 
 import * as vscode from 'vscode';
-import { spawn } from 'child_process';
+import { spawn, type SpawnOptions } from 'child_process';
 import { ProcessManager, parseGslist, classifyPidOwnership, versionsMatch } from '../processManager';
 import { GemStoneDatabase, GemStoneProcess } from '../sysadminTypes';
 import * as wslBridge from '../wslBridge';
+import { SysadminStorage } from '../sysadminStorage';
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -40,12 +41,16 @@ function makeDatabase(overrides: Partial<GemStoneDatabase> = {}): GemStoneDataba
   };
 }
 
-function makeStorage(gsPath = '/gs/3.7.4') {
+function rawStorage(gsPath = '/gs/3.7.4') {
   return {
     getRootPath: vi.fn(() => '/home/user/gemstone'),
     getGemstonePath: vi.fn(() => gsPath),
     getExtractedVersions: vi.fn(() => ['3.7.4']),
   };
+}
+
+function makeStorage(gsPath = '/gs/3.7.4'): SysadminStorage {
+  return rawStorage(gsPath) as unknown as SysadminStorage;
 }
 
 /** Create a mock ChildProcess that emits 'close' with the given exit code. */
@@ -74,6 +79,11 @@ function makeChildProcess(exitCode = 0) {
     },
   };
   return proc;
+}
+
+/** Point the mocked spawn() at a fake ChildProcess, keeping the cast in one place. */
+function mockSpawnReturn(proc: ReturnType<typeof makeChildProcess>) {
+  vi.mocked(spawn).mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
 }
 
 function setPlatform(platform: string) {
@@ -120,10 +130,10 @@ describe('ProcessManager', () => {
     it('on Linux wraps spawn in bash with ulimit -n 1024', async () => {
       setPlatform('linux');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const storage = makeStorage('/gs/3.7.4');
-      const manager = new ProcessManager(storage as any);
+      const manager = new ProcessManager(storage);
       const db = makeDatabase();
 
       const promise = manager.startStone(db);
@@ -143,10 +153,10 @@ describe('ProcessManager', () => {
     it('on Linux passes the stone arguments after the exec sentinel', async () => {
       setPlatform('linux');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const storage = makeStorage('/gs/3.7.4');
-      const manager = new ProcessManager(storage as any);
+      const manager = new ProcessManager(storage);
       const db = makeDatabase();
 
       const promise = manager.startStone(db);
@@ -162,10 +172,10 @@ describe('ProcessManager', () => {
     it('on macOS spawns the binary directly without a shell wrapper', async () => {
       setPlatform('darwin');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const storage = makeStorage('/gs/3.7.4');
-      const manager = new ProcessManager(storage as any);
+      const manager = new ProcessManager(storage);
       const db = makeDatabase();
 
       const promise = manager.startStone(db);
@@ -181,32 +191,32 @@ describe('ProcessManager', () => {
     it('on Linux the env is passed as the spawn options env', async () => {
       setPlatform('linux');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const storage = makeStorage('/gs/3.7.4');
-      const manager = new ProcessManager(storage as any);
+      const manager = new ProcessManager(storage);
       const promise = manager.startStone(makeDatabase());
       proc.finish();
       await promise;
 
-      const [, , opts] = vi.mocked(spawn).mock.calls[0];
-      expect((opts as any).env).toBeDefined();
-      expect((opts as any).env.GEMSTONE).toBe('/gs/3.7.4');
+      const [, , opts] = vi.mocked(spawn).mock.calls[0] as [string, string[], SpawnOptions];
+      expect(opts.env).toBeDefined();
+      expect(opts.env?.GEMSTONE).toBe('/gs/3.7.4');
     });
 
     it('on Linux sets LD_LIBRARY_PATH (not DYLD_LIBRARY_PATH) in env', async () => {
       setPlatform('linux');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const storage = makeStorage('/gs/3.7.4');
-      const manager = new ProcessManager(storage as any);
+      const manager = new ProcessManager(storage);
       const promise = manager.startStone(makeDatabase());
       proc.finish();
       await promise;
 
-      const [, , opts] = vi.mocked(spawn).mock.calls[0];
-      const env = (opts as any).env;
+      const [, , opts] = vi.mocked(spawn).mock.calls[0] as [string, string[], SpawnOptions];
+      const env = opts.env as NodeJS.ProcessEnv;
       expect(env.LD_LIBRARY_PATH).toContain('/gs/3.7.4/lib');
       expect(env.DYLD_LIBRARY_PATH).toBeUndefined();
     });
@@ -214,16 +224,16 @@ describe('ProcessManager', () => {
     it('on macOS sets DYLD_LIBRARY_PATH (not LD_LIBRARY_PATH) in env', async () => {
       setPlatform('darwin');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const storage = makeStorage('/gs/3.7.4');
-      const manager = new ProcessManager(storage as any);
+      const manager = new ProcessManager(storage);
       const promise = manager.startStone(makeDatabase());
       proc.finish();
       await promise;
 
-      const [, , opts] = vi.mocked(spawn).mock.calls[0];
-      const env = (opts as any).env;
+      const [, , opts] = vi.mocked(spawn).mock.calls[0] as [string, string[], SpawnOptions];
+      const env = opts.env as NodeJS.ProcessEnv;
       expect(env.DYLD_LIBRARY_PATH).toContain('/gs/3.7.4/lib');
       expect(env.LD_LIBRARY_PATH).toBeUndefined();
     });
@@ -231,9 +241,9 @@ describe('ProcessManager', () => {
     it('rejects when the process exits with a non-zero code', async () => {
       setPlatform('linux');
       const proc = makeChildProcess(1);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const promise = manager.startStone(makeDatabase());
       proc.finish();
 
@@ -342,7 +352,7 @@ describe('ProcessManager', () => {
     function managerWith(output: string) {
       vi.mocked(wslBridge.wslExecSync).mockReturnValue(output);
       const storage = makeStorage('/gs/3.7.5');
-      const manager = new ProcessManager(storage as any);
+      const manager = new ProcessManager(storage);
       manager.refreshProcesses();
       return manager;
     }
@@ -372,9 +382,9 @@ describe('ProcessManager', () => {
     it('on Linux also wraps startnetldi in the bash ulimit shell', async () => {
       setPlatform('linux');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const promise = manager.startNetldi(makeDatabase());
       proc.finish();
       await promise;
@@ -387,9 +397,9 @@ describe('ProcessManager', () => {
     it('on macOS spawns startnetldi directly', async () => {
       setPlatform('darwin');
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const promise = manager.startNetldi(makeDatabase());
       proc.finish();
       await promise;
@@ -450,7 +460,7 @@ describe('ProcessManager', () => {
 
     it('returns safe=true and the expected lock path when the PID is gone', () => {
       vi.mocked(wslBridge.wslExecSync).mockReturnValue('GONE');
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const report = manager.inspectStaleLock(staleStone());
       expect(report.safe).toBe(true);
       expect(report.lockPath).toBe('/home/user/gemstone/locks/gs64stone..LCK');
@@ -459,7 +469,7 @@ describe('ProcessManager', () => {
 
     it('refuses when the recorded PID is still a running stoned', () => {
       vi.mocked(wslBridge.wslExecSync).mockReturnValue('/gs/sys/stoned -l /log gs64stone');
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const report = manager.inspectStaleLock(staleStone());
       expect(report.safe).toBe(false);
       expect(report.reason).toMatch(/still a running GemStone server/);
@@ -468,7 +478,7 @@ describe('ProcessManager', () => {
     it('marks safe=true when the PID has been reused by an unrelated process', () => {
       // This is the exact scenario from the user's bug: PID 4106 is now ssh-agent.
       vi.mocked(wslBridge.wslExecSync).mockReturnValue('/usr/bin/ssh-agent');
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const report = manager.inspectStaleLock(staleStone());
       expect(report.safe).toBe(true);
       expect(report.currentPidOwner).toBe('/usr/bin/ssh-agent');
@@ -479,7 +489,7 @@ describe('ProcessManager', () => {
       vi.mocked(wslBridge.wslExecSync).mockImplementation(() => {
         throw new Error('ps: not found');
       });
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const report = manager.inspectStaleLock(staleStone());
       expect(report.safe).toBe(false);
       expect(report.reason).toMatch(/Could not check PID/);
@@ -489,10 +499,10 @@ describe('ProcessManager', () => {
       vi.mocked(wslBridge.needsWsl).mockReturnValue(true);
       vi.mocked(wslBridge.wslExecSync).mockReturnValue('GONE');
       const storage = {
-        ...makeStorage(),
+        ...rawStorage(),
         getWslRootPath: vi.fn(() => '/mnt/c/gemstone'),
-      };
-      const manager = new ProcessManager(storage as any);
+      } as unknown as SysadminStorage;
+      const manager = new ProcessManager(storage);
       const report = manager.inspectStaleLock(staleStone());
       expect(report.lockPath).toBe('/mnt/c/gemstone/locks/gs64stone..LCK');
     });
@@ -505,7 +515,7 @@ describe('ProcessManager', () => {
 
     it('shells out an rm -f for the lock path and reports success', () => {
       vi.mocked(wslBridge.wslExecSync).mockReturnValue('');
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const ok = manager.deleteStaleLock('/home/user/gemstone/locks/gs64stone..LCK');
       expect(ok).toBe(true);
       const cmd = vi.mocked(wslBridge.wslExecSync).mock.calls[0][0];
@@ -517,7 +527,7 @@ describe('ProcessManager', () => {
       vi.mocked(wslBridge.wslExecSync).mockImplementation(() => {
         throw new Error('rm: permission denied');
       });
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const ok = manager.deleteStaleLock('/home/user/gemstone/locks/gs64stone..LCK');
       expect(ok).toBe(false);
     });
@@ -530,7 +540,7 @@ describe('ProcessManager', () => {
     });
 
     it('reports success without signalling anything when the stone is not running', async () => {
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       vi.spyOn(manager, 'refreshProcesses').mockReturnValue([]);
 
       const result = await manager.forceKillStone(makeDatabase(), { graceMs: 0 });
@@ -541,7 +551,7 @@ describe('ProcessManager', () => {
     });
 
     it('refuses to kill a PID that now belongs to an unrelated process', async () => {
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       vi.spyOn(manager, 'refreshProcesses').mockReturnValue([staleStone()]);
       vi.mocked(wslBridge.wslExecSync).mockReturnValueOnce('/usr/bin/ssh-agent');
 
@@ -554,7 +564,7 @@ describe('ProcessManager', () => {
     });
 
     it('SIGTERMs a running stone, clears its lock, and reports recovery', async () => {
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       vi.spyOn(manager, 'refreshProcesses').mockReturnValue([staleStone()]);
       vi.mocked(wslBridge.wslExecSync)
         .mockReturnValueOnce('/gs/sys/stoned -l /log gs64stone')
@@ -573,7 +583,7 @@ describe('ProcessManager', () => {
     });
 
     it('escalates to SIGKILL when SIGTERM does not stop the stone', async () => {
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       vi.spyOn(manager, 'refreshProcesses').mockReturnValue([staleStone()]);
       vi.mocked(wslBridge.wslExecSync)
         .mockReturnValueOnce('/gs/sys/stoned -l /log gs64stone')
@@ -600,7 +610,7 @@ describe('ProcessManager', () => {
     });
 
     it('opens a terminal rooted at the version product directory', () => {
-      const manager = new ProcessManager(makeStorage('/gs/3.7.4') as any);
+      const manager = new ProcessManager(makeStorage('/gs/3.7.4'));
 
       manager.openVersionTerminal('3.7.4');
 
@@ -612,11 +622,11 @@ describe('ProcessManager', () => {
     });
 
     it('sets only GEMSTONE and GEMSTONE_GLOBAL_DIR, not the full stone environment', () => {
-      const manager = new ProcessManager(makeStorage('/gs/3.7.4') as any);
+      const manager = new ProcessManager(makeStorage('/gs/3.7.4'));
 
       manager.openVersionTerminal('3.7.4');
 
-      const options = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as any;
+      const options = vi.mocked(vscode.window.createTerminal).mock.calls[0][0] as vscode.TerminalOptions;
       expect(options.env).toEqual({
         GEMSTONE: '/gs/3.7.4',
         GEMSTONE_GLOBAL_DIR: '/home/user/gemstone',
@@ -624,8 +634,11 @@ describe('ProcessManager', () => {
     });
 
     it('refuses when the requested version has not been extracted', () => {
-      const storage = { ...makeStorage(), getGemstonePath: vi.fn(() => undefined) };
-      const manager = new ProcessManager(storage as any);
+      const storage = {
+        ...rawStorage(),
+        getGemstonePath: vi.fn(() => undefined),
+      } as unknown as SysadminStorage;
+      const manager = new ProcessManager(storage);
 
       expect(() => manager.openVersionTerminal('9.9.9')).toThrow(/not found/);
       expect(vscode.window.createTerminal).not.toHaveBeenCalled();
@@ -634,11 +647,11 @@ describe('ProcessManager', () => {
     it('under WSL launches a bash shell that cds and exports the version paths', () => {
       vi.mocked(wslBridge.needsWsl).mockReturnValue(true);
       const storage = {
-        ...makeStorage(),
+        ...rawStorage(),
         getWslGemstonePath: vi.fn(() => '/mnt/c/gs/3.7.4'),
         getWslRootPath: vi.fn(() => '/mnt/c/gemstone'),
-      };
-      const manager = new ProcessManager(storage as any);
+      } as unknown as SysadminStorage;
+      const manager = new ProcessManager(storage);
 
       manager.openVersionTerminal('3.7.4');
 
@@ -665,9 +678,9 @@ describe('ProcessManager', () => {
 
     it('raises an existing 50 MB cache to 500 MB on start', async () => {
       const { db, confFile } = dbWithGemConf('GEM_TEMPOBJ_CACHE_SIZE = 50000;');
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const promise = manager.startNetldi(db);
       proc.finish();
@@ -679,9 +692,9 @@ describe('ProcessManager', () => {
 
     it('adds the cache setting when the conf lacks it', async () => {
       const { db, confFile } = dbWithGemConf(null);
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const promise = manager.startNetldi(db);
       proc.finish();
@@ -692,9 +705,9 @@ describe('ProcessManager', () => {
 
     it('leaves an already-adequate cache untouched', async () => {
       const { db, confFile } = dbWithGemConf('GEM_TEMPOBJ_CACHE_SIZE = 2000000;');
-      const manager = new ProcessManager(makeStorage() as any);
+      const manager = new ProcessManager(makeStorage());
       const proc = makeChildProcess(0);
-      vi.mocked(spawn).mockReturnValue(proc as any);
+      mockSpawnReturn(proc);
 
       const promise = manager.startNetldi(db);
       proc.finish();

--- a/client/src/__tests__/quickSetup.test.ts
+++ b/client/src/__tests__/quickSetup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 vi.mock('fs');
@@ -9,18 +9,33 @@ import * as vscode from 'vscode';
 import { exec } from 'child_process';
 import { runQuickSetup, QuickSetupDeps } from '../quickSetup';
 import { GemStoneVersion } from '../sysadminTypes';
+import { SysadminStorage } from '../sysadminStorage';
+import { VersionManager } from '../versionManager';
+import { DatabaseManager } from '../databaseManager';
+import { ProcessManager } from '../processManager';
+import { LoginStorage } from '../loginStorage';
 
 // ── Helpers ────────────────────────────────────────────────
 
 const SHMMAX_1GB = 1073741824;
 const SHMALL_1GB = 262144;
 
+type VersionPickItem = vscode.QuickPickItem & { version: GemStoneVersion };
+
+// `showQuickPick` is overloaded; production passes an array of custom
+// `{ label, description, version }` items, but `vi.mocked` types the mock via
+// the (last) `QuickPickItem` overload. Narrow to that shape once so mock
+// return values type-check without `any`.
+const mockShowQuickPick = vi.mocked(vscode.window.showQuickPick) as unknown as
+  Mock<(items: readonly VersionPickItem[], options?: vscode.QuickPickOptions) => Promise<VersionPickItem | undefined>>;
+
 function mockSharedMemory(shmmax: number, shmall: number): void {
   const output = process.platform === 'linux'
     ? `kernel.shmmax = ${shmmax}\nkernel.shmall = ${shmall}\n`
     : `kern.sysv.shmmax: ${shmmax}\nkern.sysv.shmall: ${shmall}\n`;
-  vi.mocked(exec as any).mockImplementation((_cmd: any, _opts: any, cb: any) => {
-    cb(null, output, '');
+  vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+    cb?.(null, output, '');
+    return {} as ReturnType<typeof exec>;
   });
 }
 
@@ -52,29 +67,29 @@ function makeDeps(overrides?: Partial<QuickSetupDeps>): QuickSetupDeps {
       getAvailableExtents: vi.fn(() => ['extent0']),
       getPlatformSuffix: vi.fn(() => '-arm64.Darwin'),
       getWindowsClientGciPath: vi.fn(() => undefined),
-    } as any,
+    } as unknown as SysadminStorage,
     versionManager: {
       fetchAvailableVersions: vi.fn(async () => [makeVersion()]),
       download: vi.fn(async () => {}),
       extract: vi.fn(async () => {}),
       downloadAndExtractWindowsClient: vi.fn(async () => {}),
-    } as any,
+    } as unknown as VersionManager,
     databaseManager: {
       createDatabaseDirect: vi.fn(async () => ({
         dirName: 'db-1',
         path: '/root/db-1',
         config: { version: '3.7.4', stoneName: 'gs64stone', ldiName: 'gs64ldi', baseExtent: 'extent0.dbf' },
       })),
-    } as any,
+    } as unknown as DatabaseManager,
     processManager: {
       startStone: vi.fn(async () => 'started'),
       startNetldi: vi.fn(async () => 'started'),
       refreshProcesses: vi.fn(),
-    } as any,
+    } as unknown as ProcessManager,
     loginStorage: {
       saveLogin: vi.fn(async () => {}),
       setGciLibraryPath: vi.fn(async () => {}),
-    } as any,
+    } as unknown as LoginStorage,
     refreshAdminViews: vi.fn(),
     refreshVersions: vi.fn(),
     refreshLogins: vi.fn(),
@@ -96,8 +111,8 @@ describe('runQuickSetup', () => {
     originalPlatform = process.platform;
     setPlatform('darwin');
     mockSharedMemory(SHMMAX_1GB, SHMALL_1GB);
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version: makeVersion() } as any);
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version: makeVersion() });
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined);
     vi.mocked(fs.existsSync).mockReturnValue(true);
   });
 
@@ -114,7 +129,7 @@ describe('runQuickSetup', () => {
   it('skips shared memory check on Windows', async () => {
     setPlatform('win32');
     const deps = makeDeps();
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version: makeVersion({ extracted: true }) } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version: makeVersion({ extracted: true }) });
     await runQuickSetup(deps);
     expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
     expect(deps.loginStorage.saveLogin).toHaveBeenCalled();
@@ -122,7 +137,7 @@ describe('runQuickSetup', () => {
 
   it('warns when shared memory is too low', async () => {
     mockSharedMemorySmall();
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined as any); // cancelled
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined); // cancelled
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
@@ -137,9 +152,9 @@ describe('runQuickSetup', () => {
 
   it('proceeds when shared memory is low and user clicks Skip', async () => {
     mockSharedMemorySmall();
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Skip' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Skip' as unknown as vscode.MessageItem);
     const deps = makeDeps();
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version: makeVersion({ extracted: true }) } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version: makeVersion({ extracted: true }) });
     await runQuickSetup(deps);
     expect(deps.loginStorage.saveLogin).toHaveBeenCalled();
   });
@@ -148,32 +163,33 @@ describe('runQuickSetup', () => {
     // First call: memory is low → user clicks "Run Setup Script"
     // Second call (after terminal closes): memory is now OK → proceeds
     let callCount = 0;
-    vi.mocked(exec as any).mockImplementation((_cmd: any, _opts: any, cb: any) => {
+    vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
       callCount++;
       if (callCount <= 1) {
         // First check: memory too small
         const output = process.platform === 'linux'
           ? 'kernel.shmmax = 4194304\nkernel.shmall = 1024\n'
           : 'kern.sysv.shmmax: 4194304\nkern.sysv.shmall: 1024\n';
-        cb(null, output, '');
+        cb?.(null, output, '');
       } else {
         // After script ran: memory is now configured
         const output = process.platform === 'linux'
           ? `kernel.shmmax = ${SHMMAX_1GB}\nkernel.shmall = ${SHMALL_1GB}\n`
           : `kern.sysv.shmmax: ${SHMMAX_1GB}\nkern.sysv.shmall: ${SHMALL_1GB}\n`;
-        cb(null, output, '');
+        cb?.(null, output, '');
       }
+      return {} as ReturnType<typeof exec>;
     });
-    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Run Setup Script' as any);
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Run Setup Script' as unknown as vscode.MessageItem);
 
     // Simulate terminal close when onDidCloseTerminal is registered
-    vi.mocked(vscode.window.onDidCloseTerminal).mockImplementation((handler: any) => {
-      setTimeout(() => handler({ name: 'GemStone: Shared Memory Setup' }), 0);
+    vi.mocked(vscode.window.onDidCloseTerminal).mockImplementation((handler) => {
+      setTimeout(() => handler({ name: 'GemStone: Shared Memory Setup' } as unknown as vscode.Terminal), 0);
       return { dispose: vi.fn() };
     });
 
     const deps = makeDeps();
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version: makeVersion({ extracted: true }) } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version: makeVersion({ extracted: true }) });
     await runQuickSetup(deps);
 
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('gemstone.runSetSharedMemory');
@@ -184,7 +200,7 @@ describe('runQuickSetup', () => {
   // ── Version selection ─────────────────────────────────────
 
   it('returns early if version picker is cancelled', async () => {
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined as any);
+    mockShowQuickPick.mockResolvedValue(undefined);
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.versionManager.download).not.toHaveBeenCalled();
@@ -192,7 +208,7 @@ describe('runQuickSetup', () => {
 
   it('shows error if no versions are available', async () => {
     const deps = makeDeps({
-      versionManager: { fetchAvailableVersions: vi.fn(async () => []), download: vi.fn(), extract: vi.fn() } as any,
+      versionManager: { fetchAvailableVersions: vi.fn(async () => []), download: vi.fn(), extract: vi.fn() } as unknown as VersionManager,
     });
     await runQuickSetup(deps);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('No GemStone versions'));
@@ -202,7 +218,7 @@ describe('runQuickSetup', () => {
 
   it('downloads and extracts when version is not yet available', async () => {
     const version = makeVersion({ downloaded: false, extracted: false });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.versionManager.download).toHaveBeenCalled();
@@ -211,7 +227,7 @@ describe('runQuickSetup', () => {
 
   it('skips download when version is already downloaded', async () => {
     const version = makeVersion({ downloaded: true, extracted: false });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.versionManager.download).not.toHaveBeenCalled();
@@ -220,7 +236,7 @@ describe('runQuickSetup', () => {
 
   it('skips download and extract when version is already extracted', async () => {
     const version = makeVersion({ downloaded: true, extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.versionManager.download).not.toHaveBeenCalled();
@@ -229,13 +245,13 @@ describe('runQuickSetup', () => {
 
   it('stops if download fails', async () => {
     const version = makeVersion();
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps({
       versionManager: {
         fetchAvailableVersions: vi.fn(async () => [version]),
         download: vi.fn(async () => { throw new Error('network error'); }),
         extract: vi.fn(),
-      } as any,
+      } as unknown as VersionManager,
     });
     await runQuickSetup(deps);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('network error'));
@@ -244,13 +260,13 @@ describe('runQuickSetup', () => {
 
   it('stops if extraction fails', async () => {
     const version = makeVersion({ downloaded: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps({
       versionManager: {
         fetchAvailableVersions: vi.fn(async () => [version]),
         download: vi.fn(),
         extract: vi.fn(async () => { throw new Error('disk full'); }),
-      } as any,
+      } as unknown as VersionManager,
     });
     await runQuickSetup(deps);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('disk full'));
@@ -261,7 +277,7 @@ describe('runQuickSetup', () => {
 
   it('creates database with default names', async () => {
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.databaseManager.createDatabaseDirect).toHaveBeenCalledWith(
@@ -271,7 +287,7 @@ describe('runQuickSetup', () => {
 
   it('starts stone and NetLDI after creating database', async () => {
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.processManager.startStone).toHaveBeenCalled();
@@ -280,13 +296,13 @@ describe('runQuickSetup', () => {
 
   it('stops if stone start fails', async () => {
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps({
       processManager: {
         startStone: vi.fn(async () => { throw new Error('stone failed'); }),
         startNetldi: vi.fn(),
         refreshProcesses: vi.fn(),
-      } as any,
+      } as unknown as ProcessManager,
     });
     await runQuickSetup(deps);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('stone failed'));
@@ -297,7 +313,7 @@ describe('runQuickSetup', () => {
 
   it('saves a login with correct defaults', async () => {
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.loginStorage.saveLogin).toHaveBeenCalledWith(expect.objectContaining({
@@ -313,7 +329,7 @@ describe('runQuickSetup', () => {
   it('sets GCI library path on non-Windows platforms', async () => {
     setPlatform('darwin');
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.loginStorage.setGciLibraryPath).toHaveBeenCalledWith(
@@ -326,7 +342,7 @@ describe('runQuickSetup', () => {
 
   it('refreshes all views and shows success message', async () => {
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.refreshAdminViews).toHaveBeenCalled();
@@ -341,9 +357,9 @@ describe('runQuickSetup', () => {
   it('installs Windows client and sets GCI library on Windows', async () => {
     setPlatform('win32');
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
-    vi.mocked(deps.sysadminStorage.getWindowsClientGciPath as any).mockReturnValue('/native/lib/libgcits-3.7.4-64.dll');
+    vi.mocked(deps.sysadminStorage.getWindowsClientGciPath).mockReturnValue('/native/lib/libgcits-3.7.4-64.dll');
     await runQuickSetup(deps);
     expect(deps.versionManager.downloadAndExtractWindowsClient).toHaveBeenCalled();
     expect(deps.loginStorage.setGciLibraryPath).toHaveBeenCalledWith(
@@ -355,14 +371,14 @@ describe('runQuickSetup', () => {
   it('continues setup even if Windows client install fails', async () => {
     setPlatform('win32');
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps({
       versionManager: {
         fetchAvailableVersions: vi.fn(async () => [version]),
         download: vi.fn(async () => {}),
         extract: vi.fn(async () => {}),
         downloadAndExtractWindowsClient: vi.fn(async () => { throw new Error('network error'); }),
-      } as any,
+      } as unknown as VersionManager,
     });
     await runQuickSetup(deps);
     // Should still complete setup despite Windows client install failure
@@ -375,7 +391,7 @@ describe('runQuickSetup', () => {
   it('does not install Windows client on non-Windows platforms', async () => {
     setPlatform('darwin');
     const version = makeVersion({ extracted: true });
-    vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: '3.7.4', version } as any);
+    mockShowQuickPick.mockResolvedValue({ label: '3.7.4', version });
     const deps = makeDeps();
     await runQuickSetup(deps);
     expect(deps.versionManager.downloadAndExtractWindowsClient).not.toHaveBeenCalled();

--- a/client/src/__tests__/wslBridgeNetwork.test.ts
+++ b/client/src/__tests__/wslBridgeNetwork.test.ts
@@ -11,7 +11,7 @@ vi.mock('child_process', () => ({
 }));
 
 import * as fs from 'fs';
-import { exec } from 'child_process';
+import { exec, type ChildProcess } from 'child_process';
 import {
   parseWslConfigForMirrored,
   parseWslCoreVersion,
@@ -32,28 +32,31 @@ function setPlatform(platform: string) {
 
 /** Make exec call its callback with the given stdout. */
 function mockExec(stdout: string) {
-  vi.mocked(exec as any).mockImplementation((_cmd: any, _opts: any, cb: any) => {
-    cb(null, stdout, '');
+  vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+    cb?.(null, stdout, '');
+    return {} as ChildProcess;
   });
 }
 
 function mockExecError() {
-  vi.mocked(exec as any).mockImplementation((_cmd: any, _opts: any, cb: any) => {
-    cb(new Error('fail'), '', '');
+  vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+    cb?.(new Error('fail'), '', '');
+    return {} as ChildProcess;
   });
 }
 
 /** Route stdout per command substring — useful when refreshWslNetworkInfo
  *  fans out into multiple exec calls (hostname + version). */
 function mockExecByCommand(table: Array<{ match: RegExp; stdout?: string; error?: boolean }>) {
-  vi.mocked(exec as any).mockImplementation((cmd: any, _opts: any, cb: any) => {
+  vi.mocked(exec).mockImplementation((cmd, _opts, cb) => {
     for (const row of table) {
       if (row.match.test(String(cmd))) {
-        if (row.error) { cb(new Error('fail'), '', ''); return; }
-        cb(null, row.stdout ?? '', ''); return;
+        if (row.error) { cb?.(new Error('fail'), '', ''); return {} as ChildProcess; }
+        cb?.(null, row.stdout ?? '', ''); return {} as ChildProcess;
       }
     }
-    cb(new Error('no match'), '', '');
+    cb?.(new Error('no match'), '', '');
+    return {} as ChildProcess;
   });
 }
 
@@ -178,7 +181,7 @@ describe('refreshWslNetworkInfo', () => {
 
   it('on Windows with mirrored config skips the IP probe but still checks WSL core version', async () => {
     setPlatform('win32');
-    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nnetworkingMode=mirrored\n' as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nnetworkingMode=mirrored\n');
     mockExecByCommand([
       { match: /--version/, stdout: 'WSL version: 2.0.9.0\n' },
     ]);
@@ -188,13 +191,13 @@ describe('refreshWslNetworkInfo', () => {
       wslCoreVersion: '2.0.9.0', supportsMirrored: true,
     });
     // IP probe (hostname -I) should NOT run when mirrored is true.
-    const calls = vi.mocked(exec as any).mock.calls;
-    expect(calls.some((c: any[]) => /hostname -I/.test(String(c[0])))).toBe(false);
+    const calls = vi.mocked(exec).mock.calls;
+    expect(calls.some((c) => /hostname -I/.test(String(c[0])))).toBe(false);
   });
 
   it('on Windows without mirrored config probes both IP and core version', async () => {
     setPlatform('win32');
-    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\n' as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\n');
     mockExecByCommand([
       { match: /hostname -I/, stdout: '172.29.240.2\n' },
       { match: /--version/, stdout: 'WSL version: 2.0.9.0\n' },
@@ -208,7 +211,7 @@ describe('refreshWslNetworkInfo', () => {
 
   it('on older WSL where --version errors, reports supportsMirrored=false', async () => {
     setPlatform('win32');
-    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\n' as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\n');
     mockExecByCommand([
       { match: /hostname -I/, stdout: '10.0.0.5\n' },
       { match: /--version/, error: true },
@@ -233,7 +236,7 @@ describe('refreshWslNetworkInfo', () => {
 
   it('leaves netldiHost undefined when mirrored is false and IP probe fails', async () => {
     setPlatform('win32');
-    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\n' as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\n');
     mockExecError();
     const info = await refreshWslNetworkInfo();
     expect(info.netldiHost).toBeUndefined();
@@ -242,7 +245,7 @@ describe('refreshWslNetworkInfo', () => {
 
   it('caches the last result for getWslNetworkInfoCached', async () => {
     setPlatform('win32');
-    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nnetworkingMode=mirrored\n' as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nnetworkingMode=mirrored\n');
     mockExecByCommand([
       { match: /--version/, stdout: 'WSL version: 2.0.9.0\n' },
     ]);
@@ -255,7 +258,7 @@ describe('refreshWslNetworkInfo', () => {
 
   it('invalidateWslNetworkCache resets the cache', async () => {
     setPlatform('win32');
-    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nnetworkingMode=mirrored\n' as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('[wsl2]\nnetworkingMode=mirrored\n');
     mockExecByCommand([
       { match: /--version/, stdout: 'WSL version: 2.0.9.0\n' },
     ]);


### PR DESCRIPTION
## What & why

This continues the phased work of **preparing to enable ESLint in Jasper**. Following the phase-5 mock cleanup in #160, this phase drops `any` from mocks in 8 more test files, so that turning the `no-explicit-any` rule from `warn` to `error` later stays a small, low-noise change instead of a wall of errors.

## Changes

* Drop `any` from mocks across 8 test files: `processManager`, `quickSetup`, `loginEditorPanel`, `breakpointManager`, `databaseManager`, `extension`, `gemstoneCodeLensProvider`, `wslBridgeNetwork` — one commit per file, typing mock factories/helpers directly and using precise `as unknown as T` casts only where genuine overload friction exists (e.g. `child_process.exec`, `showWarningMessage`'s `MessageItem` overload).

All changes are pure cleanup with no behavior change.

`npm run lint` now reports 8 remaining warnings (down from 87 at the start of this phase), confined to `mcpZodErrorMap.ts` and `gemstoneDebugSession.ts`, which need a judgment call rather than the mechanical mock recipe and are being handled separately.

## Verification

* `npm run lint`, `npm run compile`, and `npm test` pass locally.