### PR TITLE
Finish dropping `any` from mcpZodErrorMap.ts and gemstoneDebugSession.ts (phase 7)

### DIFF
--- a/client/src/gemstoneDebugSession.ts
+++ b/client/src/gemstoneDebugSession.ts
@@ -11,6 +11,7 @@ import {
   Variable,
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
+import type * as vscode from 'vscode';
 import { SessionManager, ActiveSession } from './sessionManager';
 import { OOP_NIL } from './gciConstants';
 import * as debug from './debugQueries';
@@ -156,17 +157,20 @@ export class GemStoneDebugSession extends DebugSession {
     // Try to resolve from source path (gemstone:// URI) if available
     if (args.source.path && this.breakpointManager) {
       try {
-        const uri = { scheme: 'gemstone', path: '', authority: '', query: '', fragment: '', fsPath: '', toString: () => args.source.path!, with: () => uri as any, toJSON: () => ({}) } as any;
         // Parse the path as a URI
         const parsed = args.source.path.match(/^gemstone:\/\/(\d+)(\/[^?]*?)(?:\?(.*))?$/);
         if (parsed) {
+          // A partial, hand-built Uri: breakpointManager only reads scheme/path/query
+          // (parseMethodUri) and toString() (tracking key). The path is kept *encoded*
+          // on purpose — parseMethodUri decodeURIComponent's it — so a real
+          // vscode.Uri.parse (which decodes .path) would double-decode. Cast honestly.
           const actualUri = {
             scheme: 'gemstone',
             authority: parsed[1],
             path: parsed[2],
             query: parsed[3] || '',
             toString: () => args.source.path!,
-          } as any;
+          } as unknown as vscode.Uri;
           const results = this.breakpointManager.setBreakpointsForSource(
             this.session, actualUri, requestedLines,
           );

--- a/client/src/mcpZodErrorMap.ts
+++ b/client/src/mcpZodErrorMap.ts
@@ -80,10 +80,13 @@ export function applyErrorMapToShape<T extends z.ZodRawShape>(shape: T): T {
 // `any[]` opts out of that check, matching the runtime reality that we
 // inspect the args dynamically and forward them through.
 export function withMcpErrorMap(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- McpServer.tool is overloaded; see the "Why `any[]` rather than `unknown[]`" note above
   server: { tool: (...args: any[]) => any },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- return shape mirrors the overloaded server.tool; see note above
 ): { tool: (...args: any[]) => any } {
   const original = server.tool.bind(server);
   return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- forwards the overloaded server.tool args dynamically; see note above
     tool(...args: any[]) {
       // server.tool overloads:
       //   (name, cb)


### PR DESCRIPTION
## What & why

This continues the phased work of **preparing to enable ESLint in Jasper**. Phase 6 (#164) dropped `any` from mocks in 8 test files but deferred `mcpZodErrorMap.ts` and `gemstoneDebugSession.ts` since they needed a judgment call rather than the mechanical mock recipe. This phase handles those two remaining files.

## Changes

* `mcpZodErrorMap.ts`: `withMcpErrorMap` wraps McpServer's 4-way-overloaded `tool` method, forwarding args dynamically. `unknown[]` is contravariantly narrower than those overloads, so it can't accept the real McpServer, and modeling the overload union would hard-code the SDK's internal generics. Keep `any[]` and add scoped `eslint-disable` comments pointing at the existing justification block, per the repo's policy for rules that genuinely can't be satisfied.
* `gemstoneDebugSession.ts`: delete the dead `uri` object in `setBreakpointsRequest` (it was only referenced by its own `with` closure and never passed anywhere), removing two `any` casts outright. For the `actualUri` actually handed to `breakpointManager`, replace `as any` with `as unknown as vscode.Uri` via a type-only vscode import — an honest cast that preserves the exact runtime shape. Add a comment noting the path is kept encoded on purpose (`parseMethodUri` decodeURIComponent's it) so it isn't "fixed" to `vscode.Uri.parse`, which decodes `.path` and would double-decode.

All changes are pure cleanup with no behavior change.

## Verification

* `npm run lint`, `npm run compile`, and `npm test` pass locally.