### PR TITLE
Fix flaky GciLibrary selector-error tests

### DIFF
--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -350,10 +350,15 @@ describe('GciLibrary', () => {
       expectOopToBeTrue(result);
     });
 
-    it('throws when the selector cannot be resolved', () => {
+    it('throws when the receiver does not understand the selector', () => {
+      // 'new' is used because it's a well-known selector that GemStone has
+      // always already interned as a Symbol. A made-up selector like 'foo'
+      // only raises NameError the first time any test sends it; once
+      // interned, it raises MessageNotUnderstood instead, so the expected
+      // error flips depending on test run order.
       expectToThrowGciLibraryError(
-        () => gciLibrary.perform(session, gciLibrary.falseOop(), 'foo'),
-        'a NameError occurred (error 2404), foo, There is no Symbol with the specified value',
+        () => gciLibrary.perform(session, gciLibrary.falseOop(), 'new'),
+        "a MessageNotUnderstood occurred (error 2010), a Boolean does not understand  #'new'",
       );
     });
   });
@@ -416,9 +421,14 @@ describe('GciLibrary', () => {
     });
 
     it('throws when sending a message signals an error', () => {
+      // 'new' is used because it's a well-known selector that GemStone has
+      // always already interned as a Symbol. A made-up selector like 'foo'
+      // only raises NameError the first time any test sends it; once
+      // interned, it raises MessageNotUnderstood instead, so the expected
+      // error flips depending on test run order.
       expectToThrowGciLibraryError(
-        () => gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'foo', () => {}),
-        'a NameError occurred (error 2404), foo, There is no Symbol with the specified value',
+        () => gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'new', () => {}),
+        "a MessageNotUnderstood occurred (error 2010), a Boolean does not understand  #'new'",
       );
     });
 

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -351,11 +351,13 @@ describe('GciLibrary', () => {
     });
 
     it('throws when the receiver does not understand the selector', () => {
-      // 'new' is used because it's a well-known selector that GemStone has
-      // always already interned as a Symbol. A made-up selector like 'foo'
-      // only raises NameError the first time any test sends it; once
-      // interned, it raises MessageNotUnderstood instead, so the expected
-      // error flips depending on test run order.
+      // 'new' is used because it's a well-known selector that's always
+      // already a real Symbol. A made-up selector like 'foo' raises
+      // NameError instead, but only until something -- anything, even
+      // unrelated to this test -- compiles that exact text as a Symbol
+      // literal or send in this session; after that it raises
+      // MessageNotUnderstood instead, so a made-up selector's expected
+      // error flips depending on what else ran earlier in the file.
       expectToThrowGciLibraryError(
         () => gciLibrary.perform(session, gciLibrary.falseOop(), 'new'),
         "a MessageNotUnderstood occurred (error 2010), a Boolean does not understand  #'new'",
@@ -421,11 +423,13 @@ describe('GciLibrary', () => {
     });
 
     it('throws when sending a message signals an error', () => {
-      // 'new' is used because it's a well-known selector that GemStone has
-      // always already interned as a Symbol. A made-up selector like 'foo'
-      // only raises NameError the first time any test sends it; once
-      // interned, it raises MessageNotUnderstood instead, so the expected
-      // error flips depending on test run order.
+      // 'new' is used because it's a well-known selector that's always
+      // already a real Symbol. A made-up selector like 'foo' raises
+      // NameError instead, but only until something -- anything, even
+      // unrelated to this test -- compiles that exact text as a Symbol
+      // literal or send in this session; after that it raises
+      // MessageNotUnderstood instead, so a made-up selector's expected
+      // error flips depending on what else ran earlier in the file.
       expectToThrowGciLibraryError(
         () => gciLibrary.performAndRelease(session, gciLibrary.falseOop(), 'new', () => {}),
         "a MessageNotUnderstood occurred (error 2010), a Boolean does not understand  #'new'",


### PR DESCRIPTION
## Summary
- Two tests asserted that sending an unrecognized selector (`'foo'`) to a Boolean raises `NameError`. GemStone only raises `NameError` the first time a given symbol is sent anywhere in the stone; once any test interns it, later sends see `MessageNotUnderstood` instead. Under vitest's randomized test order, whichever test happened to intern `'foo'` first flipped the expected error for tests running after it, causing intermittent CI failures.
- Both tests now use `'new'`, a selector GemStone always has already interned, so they deterministically hit `MessageNotUnderstood` regardless of run order. Added comments explaining the reasoning so future selector choices in this file don't reintroduce the flake.

## Test plan
- [x] `npx vitest run src/__tests__/gciLibrary.test.ts -t "sending"` passes
- [x] Ran the full suite with `VITEST_SEED=1|2|3` to confirm no order-dependent flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)