### PR TITLE
Repro: perform: NameError vs MessageNotUnderstood

### DIFF
--- a/client/src/__tests__/repro/InternedSelectorRepro.c
+++ b/client/src/__tests__/repro/InternedSelectorRepro.c
@@ -1,0 +1,294 @@
+/*
+ * Standalone C reproduction of a GemStone finding. See README.md (same
+ * directory) for the full write-up -- what we found, why picking a
+ * made-up literal for a "selector cannot be resolved" test is fragile, and
+ * what we verified (and didn't) about how far the effect reaches.
+ *
+ * This file loads libgcits dynamically (dlopen/dlsym) instead of linking
+ * against GemStone's SDK headers, so it builds with nothing but a C compiler
+ * and the shared library itself. Signatures below are transcribed from
+ * gcits.hf / gci.ht (bundled in this repo under docs/3.7/) and cross-checked
+ * against the koffi FFI declarations in ../../gciLibrary.ts.
+ *
+ * Easiest way to run this: from the repo root,
+ *   ./client/src/__tests__/repro/run-c-repro.sh [gemstone-version]
+ * That starts the test stone, compiles this file, and runs it with the
+ * connection details and GEMSTONE_GLOBAL_DIR pulled automatically from
+ * client/.env.test. Works on macOS and Linux.
+ *
+ * To build and run by hand instead:
+ *
+ * Build:
+ *   cc -o gci_repro InternedSelectorRepro.c          # macOS
+ *   cc -o gci_repro InternedSelectorRepro.c -ldl     # Linux
+ *
+ * Run:
+ *   ./gci_repro <path-to-libgcits> <stoneNrs> <gemNrs> <user> <password>
+ *
+ * GEMSTONE_GLOBAL_DIR must be set in the environment first, pointing at the
+ * GemStone installation's `global` directory -- without it, login fails with
+ * "NetLDI service ... not found on node 'localhost'" even though the NetLDI
+ * is actually running (it's how local NRS name resolution finds it).
+ *
+ * Example, using this repo's own test stone (see client/.env.test after
+ * `npm run test:server:start` for the exact values):
+ *   export GEMSTONE_GLOBAL_DIR=.../GemStone64Bit3.6.2-arm64.Darwin/global
+ *   ./gci_repro \
+ *     .../GemStone64Bit3.6.2-arm64.Darwin/lib/libgcits-3.6.2-64.dylib \
+ *     '!tcp@localhost#server!jasper-test-3.6.2-gs64-stone' \
+ *     '!tcp@localhost#netldi:jasper-test-3.6.2-gs64-ldi#task!gemnetobject' \
+ *     DataCurator swordfish
+ *
+ * Each case mints a fresh random tag rather than reusing fixed text: once a
+ * given selector string has been compiled anywhere in a session (even as an
+ * unrelated Symbol literal, not sent as a message), perform: on that exact
+ * text switches from NameError to MessageNotUnderstood for the rest of that
+ * session (see README). Re-running this binary re-rolls the tags, so it
+ * reproduces reliably run after run instead of only reproducing the first
+ * time any given tag is ever used.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+typedef uint64_t OopType;
+typedef void *GciSession;
+typedef int BoolType;
+
+#define GCI_ERR_STR_SIZE 1024
+#define GCI_MAX_ERR_ARGS 10
+
+/* gci.ht:221-259 */
+typedef struct {
+  OopType       category;
+  OopType       context;
+  OopType       exceptionObj;
+  OopType       args[GCI_MAX_ERR_ARGS];
+  int           number;
+  int           argCount;
+  unsigned char fatal;
+  char          message[GCI_ERR_STR_SIZE + 1];
+  char          reason[GCI_ERR_STR_SIZE + 1];
+} GciErrSType;
+
+/* Well-known OOPs, from gcioop.ht (mirrored in ../../gciConstants.ts) */
+#define OOP_ILLEGAL 0x01ULL
+#define OOP_NIL     0x14ULL
+#define OOP_FALSE   0x0cULL
+#define OOP_CLASS_UTF8 154113ULL
+
+/* gcits.hf:72-83 */
+typedef GciSession (*GciTsLoginFn)(
+    const char *stoneNameNrs,
+    const char *hostUserId,
+    const char *hostPassword,
+    BoolType hostPwIsEncrypted,
+    const char *gemServiceNrs,
+    const char *gemstoneUsername,
+    const char *gemstonePassword,
+    unsigned int loginFlags,
+    int haltOnErrNum,
+    BoolType *executedSessionInit, /* out */
+    GciErrSType *err);             /* out */
+
+/* gcits.hf:181-182 */
+typedef BoolType (*GciTsLogoutFn)(GciSession sess, GciErrSType *err);
+
+/* gcits.hf:931-938 */
+typedef OopType (*GciTsExecuteFn)(
+    GciSession sess,
+    const char *sourceStr,
+    OopType sourceOop,
+    OopType contextObject,
+    OopType symbolList,
+    int flags,
+    unsigned short environmentId,
+    GciErrSType *err);
+
+/* gcits.hf:735-743 -- selector == OOP_ILLEGAL and selectorStr used, per the
+ * header comment on this function (the alternative is selectorStr == NULL
+ * and selector used). */
+typedef OopType (*GciTsPerformFn)(
+    GciSession sess,
+    OopType receiver,
+    OopType aSymbol,
+    const char *selectorStr,
+    const OopType *args,
+    int numArgs,
+    int flags,
+    unsigned short environmentId,
+    GciErrSType *err);
+
+/* gcits.hf:978-979 */
+typedef BoolType (*GciTsCommitFn)(GciSession sess, GciErrSType *err);
+
+typedef enum { EXPECT_NAME_ERROR, EXPECT_DNU } Expectation;
+
+/* Appends an 8-char random alnum suffix to `label` into `buf`, so every run
+ * (and every case within a run) sends a selector this stone's sessions have
+ * never seen before -- see the file header for why that matters. */
+static void unique_tag(char *buf, size_t bufSize, const char *label) {
+  static const char alphabet[] = "abcdefghijklmnopqrstuvwxyz0123456789";
+  char suffix[9];
+  int i;
+  for (i = 0; i < 8; i++) {
+    suffix[i] = alphabet[rand() % (sizeof(alphabet) - 1)];
+  }
+  suffix[8] = '\0';
+  snprintf(buf, bufSize, "%s%s", label, suffix);
+}
+
+static int check_perform_error(GciTsPerformFn gciTsPerform, GciSession sess,
+                                const char *label, const char *selector,
+                                Expectation expect) {
+  GciErrSType err;
+  OopType result;
+  int failed, sawNameError, sawDnu, ok;
+
+  memset(&err, 0, sizeof(err));
+  result = gciTsPerform(sess, OOP_FALSE, OOP_ILLEGAL, selector, NULL, 0, 0, 0, &err);
+
+  failed = (result == OOP_ILLEGAL);
+  sawNameError = failed && strstr(err.message, "NameError") != NULL;
+  sawDnu = failed && strstr(err.message, "MessageNotUnderstood") != NULL;
+  ok = failed && ((expect == EXPECT_NAME_ERROR) ? sawNameError : sawDnu);
+
+  printf("[%s] %s\n", ok ? "PASS" : "FAIL", label);
+  printf("      selector: %s\n", selector);
+  printf("      result:   %s\n", failed ? err.message : "(message understood!)");
+
+  return ok;
+}
+
+int main(int argc, char **argv) {
+  const char *libPath, *stoneNrs, *gemNrs, *user, *password;
+  void *lib;
+  GciTsLoginFn gciTsLogin;
+  GciTsExecuteFn gciTsExecute;
+  GciTsPerformFn gciTsPerform;
+  GciTsCommitFn gciTsCommit;
+  GciTsLogoutFn gciTsLogout;
+  GciErrSType loginErr, execErr, commitErr, logoutErr;
+  BoolType executedSessionInit = 0;
+  GciSession sess, otherSess;
+  int allOk = 1;
+  char sel[64], code[128];
+  OopType execResult;
+
+  if (argc != 6) {
+    fprintf(stderr,
+      "usage: %s <path-to-libgcits> <stoneNrs> <gemNrs> <user> <password>\n\n"
+      "GEMSTONE_GLOBAL_DIR must be set in the environment first (the "
+      "installation's `global` directory) -- without it, login fails with "
+      "\"NetLDI service ... not found\" even though it's running.\n\n"
+      "example (this repo's own test stone -- see client/.env.test):\n"
+      "  export GEMSTONE_GLOBAL_DIR=.../GemStone64Bit3.6.2-arm64.Darwin/global\n"
+      "  %s \\\n"
+      "    .../GemStone64Bit3.6.2-arm64.Darwin/lib/libgcits-3.6.2-64.dylib \\\n"
+      "    '!tcp@localhost#server!jasper-test-3.6.2-gs64-stone' \\\n"
+      "    '!tcp@localhost#netldi:jasper-test-3.6.2-gs64-ldi#task!gemnetobject' \\\n"
+      "    DataCurator swordfish\n",
+      argv[0], argv[0]);
+    return 2;
+  }
+  libPath = argv[1];
+  stoneNrs = argv[2];
+  gemNrs = argv[3];
+  user = argv[4];
+  password = argv[5];
+
+  lib = dlopen(libPath, RTLD_NOW);
+  if (!lib) {
+    fprintf(stderr, "dlopen failed: %s\n", dlerror());
+    return 1;
+  }
+
+  gciTsLogin = (GciTsLoginFn) dlsym(lib, "GciTsLogin");
+  gciTsExecute = (GciTsExecuteFn) dlsym(lib, "GciTsExecute");
+  gciTsPerform = (GciTsPerformFn) dlsym(lib, "GciTsPerform");
+  gciTsCommit = (GciTsCommitFn) dlsym(lib, "GciTsCommit");
+  gciTsLogout = (GciTsLogoutFn) dlsym(lib, "GciTsLogout");
+  if (!gciTsLogin || !gciTsExecute || !gciTsPerform || !gciTsCommit || !gciTsLogout) {
+    fprintf(stderr, "dlsym failed to resolve a GCI function: %s\n", dlerror());
+    return 1;
+  }
+
+  /* time(NULL) alone has 1-second resolution -- two runs launched within the
+   * same second would otherwise get the same seed and mint identical tags,
+   * which would silently defeat the point of unique_tag() (see file header). */
+  srand((unsigned) time(NULL) ^ (unsigned) getpid());
+
+  memset(&loginErr, 0, sizeof(loginErr));
+  sess = gciTsLogin(stoneNrs, NULL, NULL, 0, gemNrs, user, password, 0, 0,
+                     &executedSessionInit, &loginErr);
+  if (!sess) {
+    fprintf(stderr, "GciTsLogin failed [%d]: %s\n", loginErr.number, loginErr.message);
+    return 1;
+  }
+
+  /* CASE 1: a selector this session has never seen raises NameError. */
+  unique_tag(sel, sizeof(sel), "gciReproNeverSeen");
+  allOk &= check_perform_error(gciTsPerform, sess,
+      "never-before-seen selector raises NameError", sel, EXPECT_NAME_ERROR);
+
+  /* CASE 2: repeating the exact same failed perform: doesn't change anything
+   * -- a failed lookup by itself does not intern the selector. */
+  unique_tag(sel, sizeof(sel), "gciReproRepeated");
+  allOk &= check_perform_error(gciTsPerform, sess,
+      "repeating the same failed perform: still raises NameError (1st)", sel, EXPECT_NAME_ERROR);
+  allOk &= check_perform_error(gciTsPerform, sess,
+      "repeating the same failed perform: still raises NameError (2nd)", sel, EXPECT_NAME_ERROR);
+
+  /* CASE 3: once the exact selector text is compiled as a bare Symbol
+   * literal -- completely unrelated to perform: or to Boolean -- the same
+   * perform: call now raises MessageNotUnderstood instead. */
+  unique_tag(sel, sizeof(sel), "gciReproLiteral");
+  allOk &= check_perform_error(gciTsPerform, sess,
+      "before the literal appears anywhere: NameError", sel, EXPECT_NAME_ERROR);
+  memset(&execErr, 0, sizeof(execErr));
+  snprintf(code, sizeof(code), "#%s", sel);
+  execResult = gciTsExecute(sess, code, OOP_CLASS_UTF8, OOP_ILLEGAL, OOP_NIL, 0, 0, &execErr);
+  if (execResult == OOP_ILLEGAL) {
+    fprintf(stderr, "unexpected: compiling a bare Symbol literal failed: %s\n", execErr.message);
+    allOk = 0;
+  }
+  allOk &= check_perform_error(gciTsPerform, sess,
+      "after the literal appears once, unrelated to perform: MessageNotUnderstood", sel, EXPECT_DNU);
+
+  /* CASE 4: the effect does not appear to reach other sessions, even across
+   * an explicit commit -- we expected this to be a stone-wide effect (Symbol
+   * creation is documented to bypass normal repository commit semantics so
+   * new symbols are visible everywhere at once) but couldn't reproduce that
+   * here. See the "still not sure" section in README.md. */
+  unique_tag(sel, sizeof(sel), "gciReproCrossSession");
+  memset(&execErr, 0, sizeof(execErr));
+  snprintf(code, sizeof(code), "#%s", sel);
+  gciTsExecute(sess, code, OOP_CLASS_UTF8, OOP_ILLEGAL, OOP_NIL, 0, 0, &execErr);
+  memset(&commitErr, 0, sizeof(commitErr));
+  gciTsCommit(sess, &commitErr);
+
+  otherSess = gciTsLogin(stoneNrs, NULL, NULL, 0, gemNrs, user, password, 0, 0,
+                         &executedSessionInit, &loginErr);
+  if (!otherSess) {
+    fprintf(stderr, "second GciTsLogin failed [%d]: %s\n", loginErr.number, loginErr.message);
+    allOk = 0;
+  } else {
+    allOk &= check_perform_error(gciTsPerform, otherSess,
+        "a brand new session still gets NameError for a selector another "
+        "session just committed", sel, EXPECT_NAME_ERROR);
+    memset(&logoutErr, 0, sizeof(logoutErr));
+    gciTsLogout(otherSess, &logoutErr);
+  }
+
+  memset(&logoutErr, 0, sizeof(logoutErr));
+  gciTsLogout(sess, &logoutErr);
+
+  printf("\n%s\n", allOk ? "ALL CASES MATCHED EXPECTATIONS"
+                         : "SOME CASES DID NOT MATCH EXPECTATIONS");
+  return allOk ? 0 : 1;
+}

--- a/client/src/__tests__/repro/InternedSelectorRepro.test.ts
+++ b/client/src/__tests__/repro/InternedSelectorRepro.test.ts
@@ -8,9 +8,8 @@ import { GCI_LIBRARY_PATH, STONE_NRS, GEM_NRS, GS_USER, GS_PASSWORD } from '../g
 // whole point being demonstrated here is that a selector string only raises
 // NameError the first time this session has seen it become a real Symbol.
 // A fixed literal would only reproduce the "never seen" case once per
-// session, and reusing one across tests that share a session (as
-// useIntegrationTest-based suites do -- see README) makes the result depend
-// on what ran earlier.
+// session -- reusing one across a whole session's lifetime (e.g. multiple
+// tests sharing one login) makes the result depend on what ran earlier.
 function unique(label: string): string {
   return `${label}${Math.random().toString(36).slice(2, 10)}`;
 }

--- a/client/src/__tests__/repro/InternedSelectorRepro.test.ts
+++ b/client/src/__tests__/repro/InternedSelectorRepro.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { GciLibrary } from '../../gciLibrary';
+import { GCI_LIBRARY_PATH, STONE_NRS, GEM_NRS, GS_USER, GS_PASSWORD } from '../gci/gciTestConfig';
+
+// See README.md (same directory) for the full write-up.
+//
+// Each test mints a fresh, never-before-seen selector via unique() -- the
+// whole point being demonstrated here is that a selector string only raises
+// NameError the first time this session has seen it become a real Symbol.
+// A fixed literal would only reproduce the "never seen" case once per
+// session, and reusing one across tests that share a session (as
+// useIntegrationTest-based suites do -- see README) makes the result depend
+// on what ran earlier.
+function unique(label: string): string {
+  return `${label}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+describe('GemStone perform: symbol interning changes the error you get', () => {
+  let gci: GciLibrary;
+  let session: unknown;
+
+  beforeEach(() => {
+    gci = new GciLibrary(GCI_LIBRARY_PATH);
+    const login = gci.GciTsLogin(STONE_NRS, null, null, false, GEM_NRS, GS_USER, GS_PASSWORD, 0, 0);
+    expect(login.session).not.toBeNull();
+    session = login.session;
+  });
+
+  afterEach(() => {
+    if (session) gci.GciTsLogout(session);
+    gci.close();
+  });
+
+  it('raises NameError for a selector that has never been seen before', () => {
+    const selector = unique('gciReproNeverSeen');
+
+    expect(() => gci.perform(session, gci.falseOop(), selector)).toThrow(/NameError/);
+  });
+
+  it('repeating the exact same failed perform still raises NameError, not MessageNotUnderstood', () => {
+    const selector = unique('gciReproRepeatedFailure');
+
+    expect(() => gci.perform(session, gci.falseOop(), selector)).toThrow(/NameError/);
+    expect(() => gci.perform(session, gci.falseOop(), selector)).toThrow(/NameError/);
+  });
+
+  it('raises MessageNotUnderstood once the selector text has appeared as a Symbol literal in unrelated compiled source', () => {
+    const selector = unique('gciReproSymbolLiteral');
+
+    expect(() => gci.perform(session, gci.falseOop(), selector)).toThrow(/NameError/);
+
+    gci.execute(session, `#${selector}`);
+
+    expect(() => gci.perform(session, gci.falseOop(), selector)).toThrow(/MessageNotUnderstood/);
+  });
+
+  it('raises MessageNotUnderstood once the selector text has been sent asSymbol in unrelated compiled source', () => {
+    const selector = unique('gciReproAsSymbolSend');
+
+    expect(() => gci.perform(session, gci.falseOop(), selector)).toThrow(/NameError/);
+
+    gci.execute(session, `'${selector}' asSymbol`);
+
+    expect(() => gci.perform(session, gci.falseOop(), selector)).toThrow(/MessageNotUnderstood/);
+  });
+
+  it('does not carry over to a brand new session, even after an explicit commit', () => {
+    const selector = unique('gciReproCrossSession');
+
+    gci.execute(session, `#${selector}`);
+    gci.GciTsCommit(session);
+
+    const otherLogin = gci.GciTsLogin(
+      STONE_NRS,
+      null,
+      null,
+      false,
+      GEM_NRS,
+      GS_USER,
+      GS_PASSWORD,
+      0,
+      0,
+    );
+    expect(otherLogin.session).not.toBeNull();
+    const otherSession = otherLogin.session;
+
+    try {
+      expect(() => gci.perform(otherSession, gci.falseOop(), selector)).toThrow(/NameError/);
+    } finally {
+      gci.GciTsLogout(otherSession);
+    }
+  });
+});

--- a/client/src/__tests__/repro/README.md
+++ b/client/src/__tests__/repro/README.md
@@ -1,12 +1,4 @@
-# perform: NameError vs. MessageNotUnderstood: a session-scoped gotcha
-
-While building Jasper (our VS Code extension for GemStone Smalltalk), a pair
-of our own unit tests turned out to be flaky in a way that traces back to a
-GemStone `perform:` behavior we hadn't seen documented. We wanted to write up
-what we found and share it, in case it's useful for your team, and in case
-you can shed light on the parts we're still unsure about.
-
-## The symptom
+# perform: NameError vs. MessageNotUnderstood depends on compile history
 
 `GciTsPerform` (`perform:` on a receiver, called with a selector string) can
 fail two different ways for what looks like the same input:
@@ -21,11 +13,18 @@ a MessageNotUnderstood occurred (error 2010), a Boolean does not
 understand  #'fooBar'
 ```
 
-We originally wrote a test asserting the first message for a made-up
-selector (`'foo'`) sent to `false`. It passed reliably in isolation, but
-started failing intermittently once we introduced randomized test ordering
-(vitest's `sequence.shuffle`) — the same assertion sometimes got the second
-message instead.
+Which one you get isn't about the receiver or the selector text in
+isolation — it depends on whether that exact selector text has ever been
+compiled as a Symbol before, in that session. That's easy to miss, since
+nothing about the call site changes between the two outcomes. We ran into
+this while building Jasper (our VS Code extension for GemStone Smalltalk):
+a pair of our own unit tests picked an arbitrary "made-up" selector expecting
+`NameError` every time, and started failing intermittently once we
+introduced randomized test ordering — the same assertion sometimes got
+`MessageNotUnderstood` instead, depending on what had run earlier in the same
+session. We wanted to isolate and write up the underlying mechanism, in case
+it's useful for your team, and in case you can shed light on the parts we're
+still unsure about.
 
 ## The trigger
 
@@ -37,29 +36,28 @@ doesn't have a method for this selector," just by two different routes:
 | The selector text has never become a real Symbol in this session | `NameError` (error 2404) |
 | The selector text already is a Symbol, but the receiver has no method for it | `MessageNotUnderstood` (error 2010) |
 
-The part that made our test flaky: **a selector text becomes a Symbol the
-moment it's compiled anywhere as a Symbol literal or message send — it does
-not need to be sent successfully, and it does not need to involve
-`perform:` at all.** We verified two independent ways to trigger it:
+The key mechanism: **a selector text becomes a Symbol the moment it's
+compiled anywhere as a Symbol literal or message send — it does not need to
+be sent successfully, and it does not need to involve `perform:` at all.**
+We verified two independent ways to trigger it:
 
 - Compiling a bare literal, e.g. evaluating `#fooBar` as a doit.
 - Sending `asSymbol` to a matching string, e.g. `'fooBar' asSymbol`.
 
-Once either of those has happened once, in that session, `perform:` on that
-exact text stops raising `NameError` and raises `MessageNotUnderstood`
-instead — permanently, for the rest of that session. We also checked that a
+Once either of those has happened, in that session, `perform:` on that exact
+text stops raising `NameError` and raises `MessageNotUnderstood` instead —
+permanently, for the rest of that session. We also checked that a
 *repeated, identical, failed* `perform:` call does **not** do this on its
 own: sending the same never-seen selector twice raises `NameError` both
 times. Interning only happens through compilation, never through a failed
 lookup.
 
-In our test suite this bit us because a shared GCI session (one login per
-test file, reused across all its tests) meant whichever test happened to run
-first, under a shuffled order, decided whether a later test's `'foo'`
-selector was still "never seen." The fix on our end was simple — assert
-`MessageNotUnderstood` against a selector we know is already a real Symbol
-(e.g. `'new'`) rather than trying to prove a negative about one that isn't —
-but we wanted to isolate the underlying mechanism, since it surprised us.
+The practical implication: any code that branches on `perform:` failing with
+`NameError` specifically (as opposed to any failure) is implicitly making a
+claim about that selector's entire compile history in the current session,
+not just about the current call — and any long-lived session that compiles a
+wide variety of source over its lifetime (a REPL, a worker process, a test
+suite reusing one login) makes that claim progressively less safe to rely on.
 
 ## Things we're still not sure about
 
@@ -87,11 +85,22 @@ hypothesis, not a diagnosis.
 
 | Version | Reproduces? |
 |---|---|
+| 3.6.1 | Yes |
 | 3.6.2 | Yes |
+| 3.6.3 | Yes |
+| 3.6.4 | Yes |
+| 3.6.5 | Yes |
+| 3.6.6 | Yes |
+| 3.6.8 | Yes |
+| 3.7.2 | Yes |
+| 3.7.4.3 | Untested |
+| 3.7.5 | Yes |
 
-We only had a 3.6.2 test stone on hand when isolating this; we haven't yet
-checked whether it holds across the rest of the release matrix we test
-Jasper against.
+Checked against every GemStone version we had a local test stone for. 3.7.4.3
+is untested only because a local environment issue (unrelated to GemStone
+itself — a machine-specific shared-memory cleanup problem) got in the way
+mid-sweep; every other version in the matrix, oldest to newest, reproduces
+identically.
 
 ## Reproducing this
 

--- a/client/src/__tests__/repro/README.md
+++ b/client/src/__tests__/repro/README.md
@@ -1,0 +1,140 @@
+# perform: NameError vs. MessageNotUnderstood: a session-scoped gotcha
+
+While building Jasper (our VS Code extension for GemStone Smalltalk), a pair
+of our own unit tests turned out to be flaky in a way that traces back to a
+GemStone `perform:` behavior we hadn't seen documented. We wanted to write up
+what we found and share it, in case it's useful for your team, and in case
+you can shed light on the parts we're still unsure about.
+
+## The symptom
+
+`GciTsPerform` (`perform:` on a receiver, called with a selector string) can
+fail two different ways for what looks like the same input:
+
+```
+a NameError occurred (error 2404), fooBar, There is no Symbol with the
+specified value
+```
+
+```
+a MessageNotUnderstood occurred (error 2010), a Boolean does not
+understand  #'fooBar'
+```
+
+We originally wrote a test asserting the first message for a made-up
+selector (`'foo'`) sent to `false`. It passed reliably in isolation, but
+started failing intermittently once we introduced randomized test ordering
+(vitest's `sequence.shuffle`) — the same assertion sometimes got the second
+message instead.
+
+## The trigger
+
+The two errors aren't about the *receiver* at all — both mean "this receiver
+doesn't have a method for this selector," just by two different routes:
+
+| Condition | Result |
+|---|---|
+| The selector text has never become a real Symbol in this session | `NameError` (error 2404) |
+| The selector text already is a Symbol, but the receiver has no method for it | `MessageNotUnderstood` (error 2010) |
+
+The part that made our test flaky: **a selector text becomes a Symbol the
+moment it's compiled anywhere as a Symbol literal or message send — it does
+not need to be sent successfully, and it does not need to involve
+`perform:` at all.** We verified two independent ways to trigger it:
+
+- Compiling a bare literal, e.g. evaluating `#fooBar` as a doit.
+- Sending `asSymbol` to a matching string, e.g. `'fooBar' asSymbol`.
+
+Once either of those has happened once, in that session, `perform:` on that
+exact text stops raising `NameError` and raises `MessageNotUnderstood`
+instead — permanently, for the rest of that session. We also checked that a
+*repeated, identical, failed* `perform:` call does **not** do this on its
+own: sending the same never-seen selector twice raises `NameError` both
+times. Interning only happens through compilation, never through a failed
+lookup.
+
+In our test suite this bit us because a shared GCI session (one login per
+test file, reused across all its tests) meant whichever test happened to run
+first, under a shuffled order, decided whether a later test's `'foo'`
+selector was still "never seen." The fix on our end was simple — assert
+`MessageNotUnderstood` against a selector we know is already a real Symbol
+(e.g. `'new'`) rather than trying to prove a negative about one that isn't —
+but we wanted to isolate the underlying mechanism, since it surprised us.
+
+## Things we're still not sure about
+
+We don't have access to GemStone's source, so this comes from observing
+behavior rather than reading an implementation — please take it as a
+hypothesis, not a diagnosis.
+
+- We initially assumed this was a stone-wide effect: Symbol creation is
+  documented elsewhere as bypassing normal repository commit semantics, so
+  we expected a newly-interned selector to be visible to any session
+  immediately. We tested this directly — compiling the literal in one
+  session, explicitly committing, then checking from a brand new session —
+  and could **not** reproduce cross-session visibility. The effect appears
+  scoped to the session that did the compiling, at least under the
+  conditions we tried. We don't know if that's because it genuinely doesn't
+  reach the shared SymbolTable the way we assumed, or because there's some
+  additional step (an explicit `Symbol` filed into a `SymbolDictionary`,
+  perhaps) needed to make it durable.
+- We don't know the exact scope of "session" here either — whether it's tied
+  to the login, the underlying gem process, or something else — since our
+  test setup always tears the session down at the point we'd want to probe
+  that boundary further.
+
+## Versions we checked
+
+| Version | Reproduces? |
+|---|---|
+| 3.6.2 | Yes |
+
+We only had a 3.6.2 test stone on hand when isolating this; we haven't yet
+checked whether it holds across the rest of the release matrix we test
+Jasper against.
+
+## Reproducing this
+
+We put together two versions of the same repro: a TypeScript/Vitest test,
+and a standalone C program. Use whichever's more convenient.
+
+### TypeScript (Vitest)
+
+```sh
+npm install                    # once, from the repo root
+npm run test:server:start      # starts a local test stone
+npm run test:gci -- src/__tests__/repro/InternedSelectorRepro.test.ts
+```
+
+To check a specific GemStone version:
+
+```sh
+npm run test:server:stop
+npm run test:server:start -- 3.7.5
+npm run test:gci -- src/__tests__/repro/InternedSelectorRepro.test.ts
+```
+
+### C
+
+This script starts the stone, compiles, and runs the repro in one step:
+
+```sh
+./client/src/__tests__/repro/run-c-repro.sh          # from the repo root
+./client/src/__tests__/repro/run-c-repro.sh 3.7.5    # or a specific version
+```
+
+If you'd rather build and run it by hand, the instructions are at the top of
+`InternedSelectorRepro.c`.
+
+## Files in this folder
+
+- **`InternedSelectorRepro.test.ts`** — the Vitest version.
+- **`InternedSelectorRepro.c`** — a standalone C version, meant to be easy to
+  hand off. Loads `libgcits` dynamically (`dlopen`/`dlsym`), so it builds
+  with just a C compiler — no SDK headers needed.
+- **`run-c-repro.sh`** — one-command build-and-run for the C version.
+
+---
+
+Thanks for taking a look. Happy to run more tests or share anything else
+that would help.

--- a/client/src/__tests__/repro/run-c-repro.sh
+++ b/client/src/__tests__/repro/run-c-repro.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Starts this repo's GemStone test stone, then compiles and runs
+# InternedSelectorRepro.c against it.
+#
+# Usage:
+#   ./run-c-repro.sh [gemstone-version]
+#
+# gemstone-version is optional and forwarded to `npm run test:server:start`
+# (defaults to the oldest tracked release -- see gs-test-server.sh). Example:
+#   ./run-c-repro.sh 3.7.5
+#
+# Works on macOS and Linux (the two platforms client/bin/gs-test-server.sh
+# supports). Leaves the test stone running afterward -- this repo's other
+# tests expect one to already be up, so this script doesn't tear it down.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLIENT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+VERSION="${1:-}"
+
+echo "==> Starting test stone${VERSION:+ (version $VERSION)}..."
+declare -a start_args=()
+if [[ -n "$VERSION" ]]; then
+  start_args=(-- "$VERSION")
+fi
+(cd "$CLIENT_DIR" && npm run test:server:start "${start_args[@]}")
+
+ENV_FILE="$CLIENT_DIR/.env.test"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "error: $ENV_FILE not found after test:server:start" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +a
+
+: "${VITE_GEMSTONE_GCI_LIBRARY_PATH:?missing from $ENV_FILE}"
+: "${VITE_GEMSTONE_STONE_NRS:?missing from $ENV_FILE}"
+: "${VITE_GEMSTONE_GEM_NRS:?missing from $ENV_FILE}"
+: "${VITE_GEMSTONE_USER:?missing from $ENV_FILE}"
+: "${VITE_GEMSTONE_PASSWORD:?missing from $ENV_FILE}"
+: "${VITE_GEMSTONE_GLOBAL_DIR:?missing from $ENV_FILE}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+BIN="$WORK_DIR/gci_repro"
+
+# dlopen/dlsym live in libSystem on macOS (no separate libdl, and `-ldl` fails
+# to link there); glibc needs `-ldl` explicitly.
+EXTRA_LIBS=()
+if [[ "$(uname -s)" == "Linux" ]]; then
+  EXTRA_LIBS=(-ldl)
+fi
+
+echo "==> Compiling InternedSelectorRepro.c..."
+cc -o "$BIN" "$SCRIPT_DIR/InternedSelectorRepro.c" "${EXTRA_LIBS[@]}"
+
+echo "==> Running repro against the live stone..."
+echo
+GEMSTONE_GLOBAL_DIR="$VITE_GEMSTONE_GLOBAL_DIR" \
+  "$BIN" \
+  "$VITE_GEMSTONE_GCI_LIBRARY_PATH" \
+  "$VITE_GEMSTONE_STONE_NRS" \
+  "$VITE_GEMSTONE_GEM_NRS" \
+  "$VITE_GEMSTONE_USER" \
+  "$VITE_GEMSTONE_PASSWORD"

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -48,9 +48,10 @@ class SeededSequencer extends BaseSequencer {
 // double-count):
 //   - 'default' : the default suite (unit tests + the automatic GCI test that
 //              uses useIntegrationTest). This is what `npm test` runs.
-//   - 'gci'  : the on-demand GCI suite (src/__tests__/gci/**). It shows up in the
-//              panel and can be run interactively, but is deliberately kept OUT
-//              of `npm test` (the "test" script pins --project default). Run it with
+//   - 'gci'  : the on-demand GCI suite (src/__tests__/gci/** and
+//              src/__tests__/repro/**). It shows up in the panel and can be
+//              run interactively, but is deliberately kept OUT of `npm test`
+//              (the "test" script pins --project default). Run it with
 //              `npm run test:gci` (which pins --project gci).
 export default defineConfig({
   test: {
@@ -68,7 +69,7 @@ export default defineConfig({
         test: {
           name: 'default',
           include: ['src/**/__tests__/**/*.test.ts'],
-          exclude: ['src/__tests__/gci/**'],
+          exclude: ['src/__tests__/gci/**', 'src/__tests__/repro/**'],
           setupFiles: [
             'src/__tests__/vitest.windowSetup.cjs',
             'src/__tests__/vitest.uriSetup.ts',
@@ -83,7 +84,7 @@ export default defineConfig({
       {
         test: {
           name: 'gci',
-          include: ['src/__tests__/gci/**/*.test.ts'],
+          include: ['src/__tests__/gci/**/*.test.ts', 'src/__tests__/repro/**/*.test.ts'],
           maxConcurrency: 5,
           fileParallelism: false,
           sequence: {


### PR DESCRIPTION
## Summary
- While tracking down the two flaky `GciLibrary` tests fixed in #169, we found the underlying GemStone behavior worth writing up separately: `perform:` raises `NameError` for a selector that's never been compiled as a Symbol in that session, but `MessageNotUnderstood` once it has, even if the thing that interned it had nothing to do with sending that message (a bare `#literal` or an `asSymbol` send is enough).
- Follows the same write-up format as the earlier non-ASCII compiler finding (`npapagna/non-ascii-source-cursor-finding-repro`): a `README.md` with the symptom/trigger/open-questions, a Vitest reproduction, and a standalone C program for easy hand-off. Also extends `client/src/__tests__/repro/**` into the `gci` vitest project (on-demand, not part of `npm test`), matching that branch's config change.
- We verified this is scoped to the session that did the compiling — it does **not** appear to reach other sessions, even across an explicit commit, which surprised us; see the "still not sure" section in the README.
- Checked against every locally-available GemStone release, 3.6.1 through 3.7.5 — reproduces identically across all of them (3.7.4.3 untested; a machine-local shared-memory issue blocked that one stone mid-sweep, unrelated to GemStone itself).

## Test plan
- [x] `npm run test:gci -- src/__tests__/repro/InternedSelectorRepro.test.ts` passes (5/5), repeatedly, across shuffled seeds
- [x] `./client/src/__tests__/repro/run-c-repro.sh [version]` builds and runs cleanly against 3.6.1, 3.6.2, 3.6.3, 3.6.4, 3.6.5, 3.6.6, 3.6.8, 3.7.2, and 3.7.5 — all cases pass on each
- [x] `npm run lint && npm run format:check && npm run compile && npm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)