### PR TITLE
Open Getting Started walkthrough on first GemStone view reveal

### DIFF
--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -230,7 +230,10 @@ export const window = {
   showErrorMessage: vi.fn(),
   showInformationMessage: vi.fn(),
   showWarningMessage: vi.fn(),
-  createTreeView: vi.fn(() => ({ dispose: () => {} })),
+  createTreeView: vi.fn(() => ({
+    onDidChangeVisibility: new EventEmitter<{ visible: boolean }>().event,
+    dispose: () => {},
+  })),
   registerFileDecorationProvider: vi.fn(() => ({ dispose: () => {} })),
   createOutputChannel: vi.fn(() => ({
     append: vi.fn(),

--- a/client/src/__tests__/extension.test.ts
+++ b/client/src/__tests__/extension.test.ts
@@ -555,3 +555,59 @@ describe('withLoginGuard', () => {
     expect(handler).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('maybeOpenGettingStarted', () => {
+  const SEEN_KEY = 'gemstone.hasSeenGettingStarted';
+
+  function fakeContext(alreadySeen?: boolean) {
+    const store = new Map<string, unknown>();
+    if (alreadySeen !== undefined) store.set(SEEN_KEY, alreadySeen);
+    const context = {
+      globalState: {
+        get: (key: string) => store.get(key),
+        update: (key: string, value: unknown) => {
+          if (value === undefined) store.delete(key);
+          else store.set(key, value);
+          return Promise.resolve();
+        },
+      },
+    } as unknown as vscode.ExtensionContext;
+    return { context, store };
+  }
+
+  const walkthroughOpenings = () =>
+    vi
+      .mocked(vscode.commands.executeCommand)
+      .mock.calls.filter((c) => c[0] === 'workbench.action.openWalkthrough');
+
+  beforeEach(() => {
+    vi.mocked(vscode.commands.executeCommand).mockReset();
+  });
+
+  it('opens the walkthrough the first time the GemStone view is revealed', () => {
+    const { context, store } = fakeContext();
+
+    extension.maybeOpenGettingStarted(context);
+
+    expect(walkthroughOpenings()).toHaveLength(1);
+    expect(store.get(SEEN_KEY)).toBe(true);
+  });
+
+  it('stays out of the way once it has already been shown', () => {
+    const { context } = fakeContext(true);
+
+    extension.maybeOpenGettingStarted(context);
+
+    expect(walkthroughOpenings()).toHaveLength(0);
+  });
+
+  it('opens only once no matter how often the view is revealed', () => {
+    const { context } = fakeContext();
+
+    extension.maybeOpenGettingStarted(context);
+    extension.maybeOpenGettingStarted(context);
+    extension.maybeOpenGettingStarted(context);
+
+    expect(walkthroughOpenings()).toHaveLength(1);
+  });
+});

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -285,12 +285,29 @@ export async function openWorkspaceForSession(
   await openWorkspace();
 }
 
-// Getting Started onboarding. The walkthrough auto-opens once per machine on the
-// first successful connect; this globalState key records that it has been shown.
-// Clear it via the `gemstone.resetGettingStarted` command to make it auto-open
-// again on the next connect.
+// Getting Started onboarding. The walkthrough auto-opens once per machine the
+// first time the GemStone view is revealed; this globalState key records that it
+// has been shown. Clear it via the `gemstone.resetGettingStarted` command to make
+// it auto-open again the next time the view is revealed.
 const GETTING_STARTED_SEEN_KEY = 'gemstone.hasSeenGettingStarted';
 const GETTING_STARTED_WALKTHROUGH_ID = 'gemtalksystems.gemstone-ide#gemstoneGettingStarted';
+
+// Open the Getting Started walkthrough the first time the user reveals the
+// GemStone view. Revealing the view proves intent, and it happens *before* the
+// user connects — so the walkthrough's "how to connect" step arrives when it's
+// actually useful, not after they've already worked it out. Gated by
+// GETTING_STARTED_SEEN_KEY so it fires once per machine; the flag is set before
+// opening so a rapid second reveal can't double-open. Idempotent — safe to call
+// on every visibility change.
+export function maybeOpenGettingStarted(context: vscode.ExtensionContext): void {
+  if (context.globalState.get<boolean>(GETTING_STARTED_SEEN_KEY)) return;
+  void context.globalState.update(GETTING_STARTED_SEEN_KEY, true);
+  void vscode.commands.executeCommand(
+    'workbench.action.openWalkthrough',
+    GETTING_STARTED_WALKTHROUGH_ID,
+    false,
+  );
+}
 
 // How long a connect target stays reserved after a login attempt settles, so
 // clicks queued behind a slow (blocking) login are dropped when they replay.
@@ -564,6 +581,15 @@ export function activate(context: vscode.ExtensionContext) {
     showCollapseAll: false,
   });
   context.subscriptions.push(treeView);
+
+  // Auto-open the Getting Started walkthrough the first time the GemStone view is
+  // revealed (see maybeOpenGettingStarted). Fires once per machine; reset via the
+  // gemstone.resetGettingStarted command.
+  context.subscriptions.push(
+    treeView.onDidChangeVisibility((e) => {
+      if (e.visible) maybeOpenGettingStarted(context);
+    }),
+  );
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
@@ -1058,7 +1084,7 @@ export function activate(context: vscode.ExtensionContext) {
       await context.globalState.update(GETTING_STARTED_SEEN_KEY, undefined);
       const openNow = 'Open Walkthrough Now';
       const choice = await vscode.window.showInformationMessage(
-        'Getting Started reset — the walkthrough will open automatically on your next connect.',
+        'Getting Started reset — the walkthrough will open automatically the next time you open the GemStone view.',
         openNow,
       );
       if (choice === openNow) {
@@ -1265,19 +1291,11 @@ export function activate(context: vscode.ExtensionContext) {
           return;
         }
         // We no longer auto-open a workspace on every connect (it left a dirty,
-        // hot-exit-restored buffer behind). Instead, on the *first* successful
-        // connect, open the Getting Started walkthrough once — a richer, native,
-        // dismissible onboarding card that links to the on-demand workspace. The
-        // workspace stays available afterward via the gemstone.openWorkspace
-        // command and the Logins & Sessions welcome view.
-        if (!context.globalState.get<boolean>(GETTING_STARTED_SEEN_KEY)) {
-          void context.globalState.update(GETTING_STARTED_SEEN_KEY, true);
-          void vscode.commands.executeCommand(
-            'workbench.action.openWalkthrough',
-            GETTING_STARTED_WALKTHROUGH_ID,
-            false,
-          );
-        }
+        // hot-exit-restored buffer behind), nor the Getting Started walkthrough —
+        // that now opens the first time the GemStone view is revealed (see
+        // maybeOpenGettingStarted), so its "how to connect" step arrives before the
+        // user connects rather than after. The workspace stays available via the
+        // gemstone.openWorkspace command and the Logins & Sessions welcome view.
 
         // If this stone lacks Enhanced Inspector support, offer (or auto-run) the
         // install per the gemstone.enhancedInspector.autoInstall setting. Fire and

--- a/resources/walkthrough/reopen.md
+++ b/resources/walkthrough/reopen.md
@@ -11,12 +11,12 @@ back at any time.
 - **Command Palette** (`Cmd/Ctrl + Shift + P`) → **"Welcome: Open Walkthrough..."**
   → **Get Started with GemStone**.
 
-## Make it auto-open again on connect
+## Make it auto-open again
 
-This walkthrough opens automatically **once per machine**, on your first
-successful connect. After that it stays out of your way.
+This walkthrough opens automatically **once per machine**, the first time you
+open the GemStone view. After that it stays out of your way.
 
-To make it auto-open again on your next connect, run:
+To make it auto-open again the next time you open the GemStone view, run:
 
 > **Command Palette → "GemStone: Reset Getting Started"**
 


### PR DESCRIPTION
## Problem

The Getting Started walkthrough's first step teaches the user **how to connect to a stone**, but it previously auto-opened only inside the successful-connect handler (`extension.ts`). By the time it appeared, the user had already worked out connecting on their own — the single most valuable step was delivered too late by construction.

## Change

Move the trigger earlier: open the walkthrough the **first time the GemStone (Logins) view is revealed**, via a `TreeView.onDidChangeVisibility` listener. Revealing the view proves intent *and* happens before connecting, so the "how to connect" step lands when it's actually useful.

- Extracted the open logic into an exported, idempotent `maybeOpenGettingStarted(context)` so repeated visibility events can't double-open.
- The once-per-machine gate (`globalState` key `gemstone.hasSeenGettingStarted`) is **unchanged** — same contract, earlier trigger.
- Removed the auto-open block from the connect handler (workspace-auto-open removal note preserved).
- Updated the `gemstone.resetGettingStarted` message and `resources/walkthrough/reopen.md` copy to describe the new trigger.

## Tests

- New unit tests for `maybeOpenGettingStarted`: opens on first reveal, stays out of the way once shown, opens only once across repeated reveals.
- Enhanced the `vscode` mock's `createTreeView` to expose `onDidChangeVisibility`.
- Full gate green locally: `lint`, `format:check`, `compile`, and `npm test` (client 3261 incl. live-stone integration, server 320, mcp-server 95).

## Reviewer note

Watch the acceptance specs in `acceptance/` — the earlier trigger could make the walkthrough tab pop sooner. `--skip-welcome` only suppresses VS Code's *built-in* welcome, not this walkthrough, so specs may need the globalState key pre-seeded. Confirming CI is the reason this is a branch/PR rather than a direct merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)