### PR TITLE
Await Display/Execute/Debug/Inspect It

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1696,16 +1696,16 @@ export function activate(context: vscode.ExtensionContext) {
       sunitTestController.refresh();
     }),
 
-    vscode.commands.registerCommand('gemstone.displayIt', () => {
-      codeExecutor.displayIt();
+    vscode.commands.registerCommand('gemstone.displayIt', async () => {
+      await codeExecutor.displayIt();
     }),
 
-    vscode.commands.registerCommand('gemstone.executeIt', () => {
-      codeExecutor.executeIt();
+    vscode.commands.registerCommand('gemstone.executeIt', async () => {
+      await codeExecutor.executeIt();
     }),
 
-    vscode.commands.registerCommand('gemstone.debugIt', () => {
-      codeExecutor.debugIt();
+    vscode.commands.registerCommand('gemstone.debugIt', async () => {
+      await codeExecutor.debugIt();
     }),
 
     vscode.commands.registerCommand('gemstone.copyDisplayItResult', () => {
@@ -1724,8 +1724,8 @@ export function activate(context: vscode.ExtensionContext) {
       codeExecutor.expandResultInPlace();
     }),
 
-    vscode.commands.registerCommand('gemstone.inspectIt', () => {
-      codeExecutor.inspectIt(inspectorProvider);
+    vscode.commands.registerCommand('gemstone.inspectIt', async () => {
+      await codeExecutor.inspectIt(inspectorProvider);
     }),
 
     vscode.commands.registerCommand('gemstone.showTranscript', () => {


### PR DESCRIPTION
## Summary

- The `gemstone.displayIt`/`.executeIt`/`.debugIt`/`.inspectIt` command handlers called into `CodeExecutor` without awaiting or returning the promise. Since these are async methods, any error inside them (an unresolved class oop, a failed GCI call, etc.) rejected silently — nothing shown to the user, just a discarded unhandled rejection logged only to the Extension Host console.
- The callbacks are now `async` and `await` the call, so VS Code's own command-execution error handling sees the rejection and surfaces it. Verified locally: forcing an error now shows a VS Code error notification instead of failing silently.

## Test plan

- [ ] Force an error inside `execute()`/`executeAndInspect()` (e.g. temporarily throw in `resolveOopClassString`) and confirm Display/Execute/Debug/Inspect It show a VS Code error notification instead of failing silently
- [ ] Normal Display It / Execute It / Debug It / Inspect It still work with no regressions
- [ ] `npm run lint && npm run format:check && npm run compile && npm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)