### PR TITLE
Fix Display It's non-ASCII printString results

### DIFF
--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -52,7 +52,7 @@ const OOP_NIL = 0x14n;
 
 function makeGci(overrides: Record<string, unknown> = {}) {
   return {
-    GciTsResolveSymbol: vi.fn(() => ({ result: 100n, err: { number: 0 } })),
+    utf8ClassOop: vi.fn(() => 100n),
     GciTsNbExecute: vi.fn((): Record<string, unknown> => ({
       success: true,
       err: { number: 0, message: '' },
@@ -66,11 +66,15 @@ function makeGci(overrides: Record<string, unknown> = {}) {
     })),
     GciTsPerformFetchBytes: vi.fn(() => ({ data: '42', err: { number: 0 } })),
     GciTsExecuteFetchBytes: vi.fn(() => ({ data: '', err: { number: 0 } })),
+    executeAndFetchString: vi.fn(() =>
+      expect.unreachable(
+        'executeAndFetchString mock not configured for this test -- call ' +
+          '(gci.executeAndFetchString as Mock).mockReturnValue(...) before triggering Display It.',
+      ),
+    ),
     GciTsClearStack: vi.fn(),
     GciTsObjExists: vi.fn(() => false),
     GciTsFetchClass: vi.fn(() => ({ result: 0n, err: { number: 0 } })),
-
-    GciTsExecute: vi.fn(() => ({ result: 0n, err: { number: 0 } })),
     ...overrides,
   };
 }
@@ -309,6 +313,8 @@ describe('CodeExecutor', () => {
     });
 
     it('clears diagnostics on successful execution', async () => {
+      (gci.executeAndFetchString as Mock).mockReturnValue('7');
+
       const editor = makeEditor('3 + 4');
       setActiveEditor(editor);
 
@@ -636,10 +642,7 @@ describe('CodeExecutor', () => {
     });
 
     it('selects the inserted result (including leading space)', async () => {
-      (gci.GciTsPerformFetchBytes as Mock).mockReturnValue({
-        data: '42',
-        err: { number: 0 },
-      });
+      (gci.executeAndFetchString as Mock).mockReturnValue('42');
 
       const userCode = '3 + 4';
       const sel = new vscode.Selection(
@@ -662,10 +665,7 @@ describe('CodeExecutor', () => {
     });
 
     it('selection spans exactly the inserted text so backspace removes it cleanly', async () => {
-      (gci.GciTsPerformFetchBytes as Mock).mockReturnValue({
-        data: "'hello'",
-        err: { number: 0 },
-      });
+      (gci.executeAndFetchString as Mock).mockReturnValue("'hello'");
 
       const userCode = "'hi'";
       const editor = makeMutableEditor(userCode);
@@ -681,10 +681,7 @@ describe('CodeExecutor', () => {
     });
 
     it('places selection correctly when user code is on a non-first line', async () => {
-      (gci.GciTsPerformFetchBytes as Mock).mockReturnValue({
-        data: '7',
-        err: { number: 0 },
-      });
+      (gci.executeAndFetchString as Mock).mockReturnValue('7');
 
       const text = 'line0\n3 + 4\nline2';
       const sel = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 5));
@@ -739,10 +736,7 @@ describe('CodeExecutor', () => {
     });
 
     it('applies the result decoration to the inserted result range', async () => {
-      (gci.GciTsPerformFetchBytes as Mock).mockReturnValue({
-        data: '42',
-        err: { number: 0 },
-      });
+      (gci.executeAndFetchString as Mock).mockReturnValue('42');
 
       const userCode = '3 + 4';
       const editor = makeMutableEditor(userCode);
@@ -771,10 +765,7 @@ describe('CodeExecutor', () => {
 
   describe('displayIt overlay mode', () => {
     function mockResult(value: string): void {
-      (gci.GciTsPerformFetchBytes as Mock).mockReturnValue({
-        data: value,
-        err: { number: 0 },
-      });
+      (gci.executeAndFetchString as Mock).mockReturnValue(value);
     }
 
     /** The decoration options passed to the last after-content setDecorations call. */
@@ -1045,10 +1036,7 @@ describe('CodeExecutor', () => {
       describe(`${mode} mode`, () => {
         beforeEach(() => {
           setDisplayItMode(mode);
-          (gci.GciTsPerformFetchBytes as Mock).mockReturnValue({
-            data: '42',
-            err: { number: 0 },
-          });
+          (gci.executeAndFetchString as Mock).mockReturnValue('42');
         });
 
         it('executes the whole current line when the selection is empty', async () => {
@@ -1264,16 +1252,15 @@ describe('CodeExecutor', () => {
       );
     });
 
-    it('does not set gemstone.executing when resolveOopClassString fails (executeIt)', async () => {
-      (gci.GciTsResolveSymbol as Mock).mockReturnValue({
-        result: 0n,
-        err: { number: 4242, message: 'cannot resolve String' },
+    it('does not set gemstone.executing when the Utf8 class oop cannot be resolved (executeIt)', async () => {
+      (gci.utf8ClassOop as Mock).mockImplementation(() => {
+        throw new Error('cannot resolve Utf8');
       });
 
       const editor = makeEditor('3 + 4');
       setActiveEditor(editor);
 
-      await executor.executeIt();
+      await expect(executor.executeIt()).rejects.toThrow('cannot resolve Utf8');
 
       const setCalls = vi
         .mocked(vscode.commands.executeCommand)
@@ -1281,19 +1268,20 @@ describe('CodeExecutor', () => {
       expect(setCalls.some(([, , value]) => value === true)).toBe(false);
     });
 
-    it('does not set gemstone.executing when resolveOopClassString fails (inspectIt)', async () => {
-      (gci.GciTsResolveSymbol as Mock).mockReturnValue({
-        result: 0n,
-        err: { number: 4242, message: 'cannot resolve String' },
+    it('does not set gemstone.executing when the Utf8 class oop cannot be resolved (inspectIt)', async () => {
+      (gci.utf8ClassOop as Mock).mockImplementation(() => {
+        throw new Error('cannot resolve Utf8');
       });
 
       const editor = makeEditor('3 + 4');
       setActiveEditor(editor);
 
       const inspectorProvider = { addRoot: vi.fn(), findRootByLabel: vi.fn() };
-      await executor.inspectIt(
-        inspectorProvider as unknown as import('../inspectorTreeProvider').InspectorTreeProvider,
-      );
+      await expect(
+        executor.inspectIt(
+          inspectorProvider as unknown as import('../inspectorTreeProvider').InspectorTreeProvider,
+        ),
+      ).rejects.toThrow('cannot resolve Utf8');
 
       const setCalls = vi
         .mocked(vscode.commands.executeCommand)

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -77,7 +77,6 @@ function toBigInt(value: number | bigint): bigint {
 
 export class CodeExecutor {
   private executing = new Set<number>();
-  private oopClassStringCache = new Map<unknown, bigint>();
   private diagnostics: vscode.DiagnosticCollection;
   private statusBarItem: vscode.StatusBarItem;
   // Most recent Display It result (full text), used by the Copy/Expand hover
@@ -160,8 +159,7 @@ export class CodeExecutor {
       return;
     }
 
-    const oopClassString = this.resolveOopClassString(session);
-    if (oopClassString === undefined) return;
+    const oopClassString = this.resolveUtf8ClassOopUsing(session);
 
     const label = mode === 'display' ? 'Display It' : mode === 'debug' ? 'Debug It' : 'Execute It';
     logQuery(session.id, label, code);
@@ -513,20 +511,8 @@ export class CodeExecutor {
     }
   }
 
-  private resolveOopClassString(session: ActiveSession): bigint | undefined {
-    let oop = this.oopClassStringCache.get(session.handle);
-    if (oop !== undefined) return oop;
-
-    const { result, err } = session.gci.GciTsResolveSymbol(session.handle, 'String', OOP_NIL);
-    if (err.number !== 0) {
-      vscode.window.showErrorMessage(
-        `Failed to resolve String class: ${err.message || `error ${err.number}`}`,
-      );
-      return undefined;
-    }
-    oop = result;
-    this.oopClassStringCache.set(session.handle, oop);
-    return oop;
+  private resolveUtf8ClassOopUsing(session: ActiveSession): bigint {
+    return session.gci.utf8ClassOop(session.handle);
   }
 
   /**
@@ -688,18 +674,10 @@ export class CodeExecutor {
   private async fetchResultString(session: ActiveSession): Promise<string> {
     const resultOop = await this.fetchResultOop(session);
 
-    const { data, err: fetchErr } = session.gci.GciTsPerformFetchBytes(
+    return session.gci.executeAndFetchString(
       session.handle,
-      resultOop,
-      'printString',
-      [],
-      MAX_RESULT_SIZE,
+      `(Object objectForOop: ${resultOop}) printString`,
     );
-    if (fetchErr.number !== 0) {
-      throw new Error(fetchErr.message || `printString error ${fetchErr.number}`);
-    }
-
-    return data;
   }
 
   // ── Inspect ──────────────────────────────────────────
@@ -761,8 +739,7 @@ export class CodeExecutor {
     label: string,
     inspectorProvider: InspectorTreeProvider,
   ): Promise<void> {
-    const oopClassString = this.resolveOopClassString(session);
-    if (oopClassString === undefined) return;
+    const oopClassString = this.resolveUtf8ClassOopUsing(session);
 
     logQuery(session.id, 'Inspect It', code);
 


### PR DESCRIPTION
## Summary

- Typing a non-ASCII literal into Execute It/Display It/Debug It (e.g. `UserGlobals at: #'A—B' put: 42`) stored it **corrupted** in GemStone: the old source-encoding resolution (`resolveOopClassString`, using GemStone's `String` class) treated each byte of the literal's UTF-8 encoding as its own raw character, so the em dash's 3-byte sequence became 3 separate garbage characters in the actual stored object.
- This was invisible from Display It itself: rendering the result went through an equally old raw-byte fetch (`GciTsPerformFetchBytes`) that shipped those same corrupted bytes back out essentially unencoded, which happened to UTF-8-decode into the original em dash on the client — two independent bugs canceling out by coincidence. `main` renders `#'A—B'` correctly in Display It today; this isn't a visible regression fix.
- The corruption only surfaces once you read that same data through anything that fetches correctly, e.g. this repo's already-UTF8-fixed dictionary/globals browser queries — there it shows as three garbage characters instead of the intended em dash.
- Fixes both halves together: `resolveUtf8ClassOopUsing` now resolves the true `Utf8` class for compiling source (so the literal is stored correctly), and `fetchResultString` now fetches via `executeAndFetchString` (UTF-8-safe) instead of the raw byte fetch. Display It's own rendering is unchanged; the underlying data is now genuinely correct instead of accidentally-appearing-correct.
- Depends on #175: `resolveUtf8ClassOopUsing` now lets a resolution failure propagate instead of swallowing it into a `bigint | undefined`, which is only safe because that PR made sure command failures actually surface instead of vanishing.

## Test plan

- [ ] Display It on `UserGlobals at: #'A—B' put: 42.` then `UserGlobals keys` — still renders the em dash correctly (no visible change vs. before)
- [ ] Open the Globals Browser on the same global — confirm it now *also* shows the em dash correctly (on unpatched `main`, this would show 3 garbage characters instead, diverging from what Display It showed)
- [ ] Display It on plain ASCII (`3 + 4`, `'hello'`, `nil`) — no regression
- [ ] Display It on a large result (e.g. `(1 to: 50000) asArray`) — completes without hanging (note: the old 64KB cap is gone; a large result may now take longer / show more than before, that's expected)
- [ ] `npm run lint && npm run format:check && npm run compile && npm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)