### PR TITLE
Add STON syntax highlighting for .ston files

### DIFF
--- a/client/src/__tests__/stonGrammar.test.ts
+++ b/client/src/__tests__/stonGrammar.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as oniguruma from 'vscode-oniguruma';
+import { Registry, parseRawGrammar, INITIAL, type IGrammar } from 'vscode-textmate';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const onigWasmPath = path.join(
+  repoRoot,
+  'node_modules',
+  'vscode-oniguruma',
+  'release',
+  'onig.wasm',
+);
+const grammarPath = path.join(repoRoot, 'syntaxes', 'ston.tmLanguage.json');
+
+function readJson(rel: string): unknown {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, rel), 'utf8'));
+}
+
+// ── The contribution wiring must be intact ──────────────────
+
+describe('STON language contribution', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+
+  it('registers the .ston extension with a valid language configuration', () => {
+    const lang = pkg.contributes.languages.find((l: { id: string }) => l.id === 'ston');
+
+    expect(lang).toBeDefined();
+    expect(lang.extensions).toContain('.ston');
+    expect(fs.existsSync(path.join(repoRoot, lang.configuration))).toBe(true);
+    expect(() => readJson(lang.configuration)).not.toThrow();
+  });
+
+  it('registers a grammar whose scopeName matches its TextMate file', () => {
+    const grammar = pkg.contributes.grammars.find(
+      (g: { language: string }) => g.language === 'ston',
+    );
+
+    expect(grammar).toBeDefined();
+    expect(grammar.scopeName).toBe('source.ston');
+    const tm = readJson(grammar.path) as { scopeName: string };
+    expect(tm.scopeName).toBe(grammar.scopeName);
+  });
+});
+
+// ── The grammar must actually tokenize STON correctly ───────
+
+describe('STON grammar tokenization', () => {
+  let grammar: IGrammar;
+
+  beforeAll(async () => {
+    const wasm = fs.readFileSync(onigWasmPath);
+    await oniguruma.loadWASM(wasm);
+    const registry = new Registry({
+      onigLib: Promise.resolve({
+        createOnigScanner: (patterns) => new oniguruma.OnigScanner(patterns),
+        createOnigString: (s) => new oniguruma.OnigString(s),
+      }),
+      loadGrammar: async (scope) =>
+        scope === 'source.ston'
+          ? parseRawGrammar(fs.readFileSync(grammarPath, 'utf8'), grammarPath)
+          : null,
+    });
+    const loaded = await registry.loadGrammar('source.ston');
+    if (!loaded) throw new Error('failed to load the source.ston grammar');
+    grammar = loaded;
+  });
+
+  /** The scopes assigned to the first token whose text is exactly `token`. */
+  function scopesOf(line: string, token: string): string[] {
+    const { tokens } = grammar.tokenizeLine(line, INITIAL);
+    for (const t of tokens) {
+      if (line.slice(t.startIndex, t.endIndex) === token) return t.scopes;
+    }
+    throw new Error(`token ${JSON.stringify(token)} not found in ${JSON.stringify(line)}`);
+  }
+
+  it('marks a class-tagged object name as a type', () => {
+    expect(scopesOf('Point { #x: 1 }', 'Point')).toContain('entity.name.type.class.ston');
+  });
+
+  it('marks a symbol used as a map key as a tag', () => {
+    expect(scopesOf('#name: 1', '#name')).toContain('entity.name.tag.ston');
+  });
+
+  it('marks a bare symbol as a symbol constant', () => {
+    expect(scopesOf('[ #foo ]', '#foo')).toContain('constant.other.symbol.ston');
+  });
+
+  it('keeps hyphens, dots and slashes inside a bare symbol', () => {
+    expect(scopesOf('[ #Rowan-Core ]', '#Rowan-Core')).toContain('constant.other.symbol.ston');
+    expect(scopesOf('[ #rowan/src ]', '#rowan/src')).toContain('constant.other.symbol.ston');
+  });
+
+  it('marks a single-quoted string', () => {
+    expect(scopesOf("'hello'", 'hello')).toContain('string.quoted.single.ston');
+  });
+
+  it('escapes an embedded quote with a backslash rather than ending the string', () => {
+    const line = "'Rowan\\'s project'";
+
+    expect(scopesOf(line, "\\'")).toContain('constant.character.escape.ston');
+    expect(scopesOf(line, 's project')).toContain('string.quoted.single.ston');
+  });
+
+  it('marks other backslash escapes inside a string', () => {
+    expect(scopesOf("'a\\nb'", '\\n')).toContain('constant.character.escape.ston');
+    expect(scopesOf("'a\\\\b'", '\\\\')).toContain('constant.character.escape.ston');
+  });
+
+  it('marks true/false/nil as language constants', () => {
+    expect(scopesOf('true', 'true')).toContain('constant.language.ston');
+    expect(scopesOf('nil', 'nil')).toContain('constant.language.ston');
+  });
+
+  it('marks a character literal', () => {
+    expect(scopesOf('$a', '$a')).toContain('constant.character.ston');
+  });
+
+  it('marks an object reference', () => {
+    expect(scopesOf('@3', '@3')).toContain('constant.other.reference.ston');
+  });
+
+  it('marks plain and radix numbers', () => {
+    expect(scopesOf('42', '42')).toContain('constant.numeric.ston');
+    expect(scopesOf('16rFF', '16rFF')).toContain('constant.numeric.radix.ston');
+  });
+
+  it('marks the key/value colon as punctuation', () => {
+    expect(scopesOf('#x: 1', ':')).toContain('punctuation.separator.key-value.ston');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,9 @@
         "ovsx": "^0.10.5",
         "prettier": "^3.9.5",
         "typescript": "^5.7.2",
-        "typescript-eslint": "^8.20.0"
+        "typescript-eslint": "^8.20.0",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2"
       },
       "engines": {
         "node": ">=22.15.1",
@@ -9559,6 +9561,20 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+      "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+      "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,16 @@
           "text/x-gemstone-smalltalk"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "ston",
+        "aliases": [
+          "STON"
+        ],
+        "extensions": [
+          ".ston"
+        ],
+        "configuration": "./ston.language-configuration.json"
       }
     ],
     "grammars": [
@@ -99,6 +109,11 @@
         "language": "gemstone-smalltalk",
         "scopeName": "source.gemstone-smalltalk",
         "path": "./syntaxes/gemstone-smalltalk.tmLanguage.json"
+      },
+      {
+        "language": "ston",
+        "scopeName": "source.ston",
+        "path": "./syntaxes/ston.tmLanguage.json"
       }
     ],
     "configuration": [
@@ -2001,7 +2016,9 @@
     "ovsx": "^0.10.5",
     "prettier": "^3.9.5",
     "typescript": "^5.7.2",
-    "typescript-eslint": "^8.20.0"
+    "typescript-eslint": "^8.20.0",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   },
   "dependencies": {
     "@vscode/debugadapter": "^1.68.0",

--- a/ston.language-configuration.json
+++ b/ston.language-configuration.json
@@ -1,0 +1,27 @@
+{
+  "comments": {},
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "'", "close": "'", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["'", "'"]
+  ],
+  "folding": {
+    "markers": {
+      "start": "\\{",
+      "end": "\\}"
+    }
+  },
+  "indentationRules": {
+    "increaseIndentPattern": "[\\[{]\\s*$",
+    "decreaseIndentPattern": "^\\s*[\\]}]"
+  }
+}

--- a/syntaxes/ston.tmLanguage.json
+++ b/syntaxes/ston.tmLanguage.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "STON",
+  "scopeName": "source.ston",
+  "patterns": [{ "include": "#value" }],
+  "repository": {
+    "value": {
+      "patterns": [
+        { "include": "#class-name" },
+        { "include": "#symbol-key" },
+        { "include": "#symbol" },
+        { "include": "#string" },
+        { "include": "#constant" },
+        { "include": "#character" },
+        { "include": "#reference" },
+        { "include": "#number" },
+        { "include": "#punctuation" }
+      ]
+    },
+    "class-name": {
+      "comment": "A class-tagged object or association value: ClassName { ... } / ClassName [ ... ]",
+      "match": "([A-Z]\\w*)\\s*(?=[\\[{])",
+      "captures": {
+        "1": { "name": "entity.name.type.class.ston" }
+      }
+    },
+    "symbol-key": {
+      "comment": "A symbol used as a map key (before a colon). A bare symbol may hold any simple-symbol character (letters, digits, - _ . /); anything else is quoted and, like a string, uses backslash escapes.",
+      "match": "(#[A-Za-z0-9_./-]+|#'(?:\\\\.|[^'\\\\])*')\\s*(?=:)",
+      "captures": {
+        "1": { "name": "entity.name.tag.ston" }
+      }
+    },
+    "symbol": {
+      "name": "constant.other.symbol.ston",
+      "match": "#[A-Za-z0-9_./-]+|#'(?:\\\\.|[^'\\\\])*'"
+    },
+    "string": {
+      "comment": "STON strings use backslash escapes (\\' \\\" \\\\ \\/ \\b \\f \\n \\r \\uXXXX), matching GemStone's STONWriter — not Smalltalk-style doubled quotes.",
+      "name": "string.quoted.single.ston",
+      "begin": "'",
+      "end": "'",
+      "applyEndPatternLast": true,
+      "patterns": [
+        {
+          "name": "constant.character.escape.ston",
+          "match": "\\\\(?:u[0-9A-Fa-f]{4}|['\\\"btnfr/\\\\])"
+        }
+      ]
+    },
+    "constant": {
+      "name": "constant.language.ston",
+      "match": "\\b(true|false|nil)\\b"
+    },
+    "character": {
+      "name": "constant.character.ston",
+      "match": "\\$(?:\\\\.|.)"
+    },
+    "reference": {
+      "comment": "STON object reference, e.g. @3",
+      "name": "constant.other.reference.ston",
+      "match": "@\\d+"
+    },
+    "number": {
+      "patterns": [
+        {
+          "comment": "radix integer, e.g. 16rFF",
+          "name": "constant.numeric.radix.ston",
+          "match": "(?<!\\w)\\d+r[0-9A-Za-z]+"
+        },
+        {
+          "comment": "integer / float / exponent, optionally negative",
+          "name": "constant.numeric.ston",
+          "match": "(?<!\\w)-?\\d+(?:\\.\\d+)?(?:[eE][-+]?\\d+)?"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        { "name": "punctuation.separator.key-value.ston", "match": ":" },
+        { "name": "punctuation.separator.comma.ston", "match": "," },
+        { "name": "punctuation.section.map.ston", "match": "[{}]" },
+        { "name": "punctuation.section.array.ston", "match": "[\\[\\]]" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
A TextMate grammar (`source.ston`) and language configuration for STON (Smalltalk Object Notation), registered in the extension manifest, so `.ston` files get highlighting, bracket matching, and folding.

The grammar follows **GemStone's STON dialect**, as defined by its `STONWriter` (in the RowanV3 STON package) rather than the original STON paper — the two differ:

- **Strings and quoted symbols use backslash escapes** (`\'`, `\"`, `\\`, `\b \f \n \r \t`, `\uXXXX`), not Smalltalk-style doubled quotes. So an embedded quote (`'Rowan\'s project'`) is highlighted as one string instead of terminating early.
- **Bare symbols may contain `-` `_` `.` `/`** alongside letters and digits (`#Rowan-Core`, `#rowan/src`), matching `STONWriter>>isSimpleSymbolChar:`.

Tested with vscode-textmate: registration integrity (the grammar/config files resolve and the scopeName matches) plus tokenization of every construct — class tags, symbol keys and symbols (including hyphens and slashes), strings and their backslash escapes, true/false/nil, character literals, object references, plain and radix numbers, and key/value punctuation.
