### PR TITLE
Tighten linter: enable type-aware rules (incl. no-floating-promises)

### DIFF
--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -566,7 +566,7 @@ function createMockDiagnosticCollection() {
     get: vi.fn((uri: { toString(): string }) => store.get(uri.toString())),
     forEach: vi.fn((callback: (uri: Uri, diagnostics: unknown[], collection: unknown) => void) => {
       store.forEach((_diags, uriStr) => {
-        callback(Uri.parse(uriStr), _diags as unknown[], undefined);
+        callback(Uri.parse(uriStr), _diags, undefined);
       });
     }),
     clear: vi.fn(() => store.clear()),

--- a/client/src/__tests__/claudeCodeUserMcpConfig.test.ts
+++ b/client/src/__tests__/claudeCodeUserMcpConfig.test.ts
@@ -46,7 +46,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
     expect(result.updated).toBe(true);
     expect(result.skipped).toBeUndefined();
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers.jasper).toEqual(desiredEntry('/ext', '/tmp/socket.sock'));
   });
 
@@ -74,7 +74,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
 
     expect(result.updated).toBe(true);
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers.jasper.args[0]).toContain('NEW-ext');
   });
 
@@ -90,7 +90,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
     writeClaudeCodeUserMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers['claude-context']).toEqual({ command: 'other' });
     expect(written.mcpServers.jasper).toBeDefined();
   });
@@ -106,7 +106,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
     writeClaudeCodeUserMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.userID).toBe('abc-123');
     expect(written.projects['/some/path'].history).toEqual(['a', 'b']);
   });
@@ -122,7 +122,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
 
     expect(result.updated).toBe(true);
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers.gemstone).toBeUndefined();
     expect(written.mcpServers.jasper).toEqual(desiredEntry('/ext', '/tmp/socket.sock'));
   });
@@ -137,7 +137,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
     writeClaudeCodeUserMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers.gemstone).toEqual(foreignGemstoneEntry);
     expect(written.mcpServers.jasper).toBeDefined();
   });
@@ -168,7 +168,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
 
     expect(result.updated).toBe(true);
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.projects['/Users/me/Grail'].mcpServers.gemstone).toBeUndefined();
     expect(written.projects['/Users/me/Grail'].mcpServers['other-mcp']).toEqual({
       command: 'keep-me',
@@ -191,7 +191,7 @@ describe('writeClaudeCodeUserMcpConfig', () => {
     writeClaudeCodeUserMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.projects['/Users/me/Grail'].mcpServers.gemstone).toEqual(foreignGemstoneEntry);
   });
 

--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -79,7 +79,7 @@ function makeSession(gci = makeGci()): ActiveSession {
   return {
     id: 1,
     gci: gci as unknown as ActiveSession['gci'],
-    handle: {} as unknown,
+    handle: {},
     login: { label: 'Test', gs_user: 'DataCurator' },
     stoneVersion: '3.7.2',
   } as ActiveSession;
@@ -690,7 +690,7 @@ describe('CodeExecutor', () => {
       const sel = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 5));
       const editor = makeMutableEditor(text, sel);
       // Real VSCode's getText(selection) returns only the selected substring
-      editor.document.getText = vi.fn(() => '3 + 4') as unknown as typeof editor.document.getText;
+      editor.document.getText = vi.fn(() => '3 + 4');
       setActiveEditor(editor);
 
       await executor.displayIt();
@@ -995,7 +995,7 @@ describe('CodeExecutor', () => {
       const sel = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 5));
       const editor = makeMutableEditor(text, sel);
       // Real VSCode's getText(selection) returns only the selected substring
-      editor.document.getText = vi.fn(() => '3 + 4') as unknown as typeof editor.document.getText;
+      editor.document.getText = vi.fn(() => '3 + 4');
       setActiveEditor(editor);
 
       await executor.displayIt();
@@ -1480,7 +1480,7 @@ describe('CodeExecutor', () => {
 
     it('starts debugging and focuses the Run and Debug view when the user clicks Debug', async () => {
       vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Debug' as never);
-      vi.mocked(vscode.debug.startDebugging).mockResolvedValue(true as never);
+      vi.mocked(vscode.debug.startDebugging).mockResolvedValue(true);
       setup();
 
       await executor.executeIt();
@@ -1498,7 +1498,7 @@ describe('CodeExecutor', () => {
     });
 
     it('does not reveal the view or start debugging, and clears the stack, when the dialog is dismissed', async () => {
-      vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined as never);
+      vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined);
       setup();
 
       await executor.executeIt();

--- a/client/src/__tests__/commentBrowser.test.ts
+++ b/client/src/__tests__/commentBrowser.test.ts
@@ -68,7 +68,7 @@ describe('CommentBrowser', () => {
     vi.mocked(queries.getClassComment).mockReturnValue('the class comment');
     vi.mocked(queries.setClassComment).mockReturnValue('ok');
     vi.mocked(queries.canClassBeWritten).mockReturnValue(true);
-    vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as never);
+    vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
   });
 
   afterEach(resetPanels);
@@ -261,7 +261,7 @@ describe('CommentBrowser', () => {
     });
 
     it('saves the outgoing class edits when the user chooses Save, then loads the new class', async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Save' as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Save');
       vi.mocked(queries.getClassComment).mockReturnValue('invoice comment');
 
       await CommentBrowser.showOrUpdate(
@@ -284,7 +284,7 @@ describe('CommentBrowser', () => {
     });
 
     it("discards the edits and loads the new class when the user chooses Don't Save", async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue("Don't Save" as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue("Don't Save");
 
       await CommentBrowser.showOrUpdate(
         session,
@@ -301,7 +301,7 @@ describe('CommentBrowser', () => {
     });
 
     it('keeps the current class and does not refill when the prompt is cancelled', async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
 
       await CommentBrowser.showOrUpdate(
         session,

--- a/client/src/__tests__/databaseManager.test.ts
+++ b/client/src/__tests__/databaseManager.test.ts
@@ -53,9 +53,7 @@ function makeManager(overrides?: {
 
 /** Pick the QuickPick item at `index` (preserving object identity). */
 function pickItem(index: number): void {
-  vi.mocked(vscode.window.showQuickPick).mockImplementation(
-    async (items) => (await items)[index] as vscode.QuickPickItem,
-  );
+  vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items) => (await items)[index]);
 }
 
 describe('DatabaseManager.replaceExtent', () => {

--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -551,7 +551,7 @@ describe('debugQueries', () => {
         login: { label: 'T' } as GemStoneLogin,
         stoneVersion: '3.6.2',
         gci: gci as unknown as ActiveSession['gci'],
-      } as ActiveSession;
+      };
     }
 
     it('getNamedInstVarOops fetches absolute OOPs starting at index 1', () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -183,12 +183,11 @@ const ERROR_MSG = 'a UndefinedObject does not understand #foo';
 // Identify it by its themed base `backgroundColor` (unique to this decoration).
 const stepPointDecorationOptions = vi
   .mocked(vscode.window.createTextEditorDecorationType)
-  .mock.calls.map((c) => c[0] as vscode.DecorationRenderOptions)
+  .mock.calls.map((c) => c[0])
   .find(
     (opts) =>
       opts?.backgroundColor instanceof vscode.ThemeColor &&
-      (opts.backgroundColor as vscode.ThemeColor).id ===
-        'editor.focusedStackFrameHighlightBackground',
+      opts.backgroundColor.id === 'editor.focusedStackFrameHighlightBackground',
   );
 
 // Snapshot every debugQueries mock's factory implementation at module load —
@@ -212,7 +211,7 @@ function restoreDebugDefaults(): void {
     // mockReset() also flushes any leftover *Once override queued by a test that
     // didn't consume it; then re-install the captured factory implementation.
     fn.mockReset();
-    if (impl) fn.mockImplementation(impl as unknown as (...args: never[]) => never);
+    if (impl) fn.mockImplementation(impl);
   }
 }
 
@@ -229,7 +228,7 @@ function makeSession(): ActiveSession {
     stoneVersion: '3.7.2',
     enhancedInspectorAvailable: true,
     gci: { GciTsClearStack: vi.fn() } as unknown as ActiveSession['gci'],
-  } as ActiveSession;
+  };
 }
 
 /** The most recently created webview panel mock. */
@@ -641,7 +640,7 @@ describe('DebuggerPanel', () => {
   });
 
   it('disposeForSession disposes every panel created for the session', () => {
-    const s = { ...makeSession(), id: 4242 } as ActiveSession;
+    const s = { ...makeSession(), id: 4242 };
     DebuggerPanel.create(s, GS_PROCESS, ERROR_MSG);
     DebuggerPanel.create(s, 0x456n, 'another error');
     const results = vi.mocked(vscode.window.createWebviewPanel).mock.results;
@@ -718,7 +717,7 @@ describe('DebuggerPanel', () => {
       sendReady(panel); // fetches + caches the stack
       sendMessage(panel, { command: 'copyStack' });
 
-      const text = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0] as string;
+      const text = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0];
       // Header, error, then the short numbered stack ([1]..[5]) …
       expect(text.startsWith('Jasper Debugger stack dump')).toBe(true);
       expect(text).toContain('GemStone error: a UndefinedObject does not understand #foo');
@@ -832,7 +831,7 @@ describe('DebuggerPanel', () => {
       sendReady(panel);
       sendMessage(panel, { command: 'copyStack' });
 
-      const text = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0] as string;
+      const text = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0];
       expect(text).toContain('Receiver:\n    self = a JasperDebugDemo   {100}');
       expect(text).toContain('Instance variables:\n    total = 42   {84}');
       expect(text).toContain('Arguments & Temps:\n    each = 7   {14}');
@@ -899,7 +898,7 @@ describe('DebuggerPanel', () => {
       const panel = lastPanel();
       sendReady(panel);
       sendMessage(panel, { command: 'copyStack' });
-      const copied = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0] as string;
+      const copied = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0];
       sendMessage(panel, { command: 'dumpStackToFile' });
       await tick();
       const dumped = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
@@ -933,7 +932,7 @@ describe('DebuggerPanel', () => {
       sendReady(panel);
       sendMessage(panel, { command: 'copyStack' });
 
-      const text = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0] as string;
+      const text = vi.mocked(vscode.env.clipboard.writeText).mock.calls[0][0];
       // Short stack + per-frame headings still render; just no variable groups.
       expect(text).toContain('[1] [] in JasperDebugDemo>>#finish  @2 line 12');
       expect(text).not.toContain('Receiver:'); // no rows → no groups, no crash
@@ -1451,9 +1450,8 @@ describe('DebuggerPanel', () => {
       };
       // Route getEditorLayout to our sample; everything else returns undefined.
       // mockImplementation persists past clearAllMocks, so restore it in finally.
-      vi.mocked(vscode.commands.executeCommand).mockImplementation(
-        (cmd: string) =>
-          Promise.resolve(cmd === 'vscode.getEditorLayout' ? layout : undefined) as never,
+      vi.mocked(vscode.commands.executeCommand).mockImplementation((cmd: string) =>
+        Promise.resolve(cmd === 'vscode.getEditorLayout' ? layout : undefined),
       );
       try {
         const panel = openPanelWithStack();
@@ -1496,7 +1494,7 @@ describe('DebuggerPanel', () => {
           return Promise.resolve();
         },
         keys: () => Array.from(store.keys()),
-      } as unknown as vscode.Memento;
+      };
     }
 
     it('reaps a debugger source tab a prior session left open, then re-arms the set', () => {
@@ -1561,7 +1559,7 @@ describe('DebuggerPanel', () => {
       closePanel(panel);
 
       // …and dropped on a clean dispose, so the next launch has nothing to reap.
-      expect((memento.get(ORPHAN_KEY) as string[] | undefined) ?? []).not.toContain(uri);
+      expect(memento.get(ORPHAN_KEY) ?? []).not.toContain(uri);
     });
 
     // ── Double-click-to-edit inline values (#5 Phase 2) ───────────────────
@@ -4068,7 +4066,7 @@ describe('DebuggerPanel', () => {
 
     it('opens nothing when the inheritance-chain QuickPick is cancelled', async () => {
       vi.mocked(debug.getReceiverClassChain).mockReturnValueOnce(CHAIN);
-      vi.mocked(vscode.window.showQuickPick).mockResolvedValueOnce(undefined as never);
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValueOnce(undefined);
       const panel = openPanel();
       vi.mocked(vscode.workspace.openTextDocument).mockClear();
       sendMessage(panel, { command: 'implementInReceiver', level: 2 });

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -655,7 +655,7 @@ describe('DebuggerView.init — progress indicator (#9)', () => {
     try {
       const { refs } = setupIdle();
 
-      (refs.evalInput as HTMLInputElement).value = '3 + 4';
+      refs.evalInput.value = '3 + 4';
       refs.evalInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       vi.advanceTimersByTime(500);
 

--- a/client/src/__tests__/enhancedInspectorColumns.test.ts
+++ b/client/src/__tests__/enhancedInspectorColumns.test.ts
@@ -63,7 +63,7 @@ function buildColumnDom(col: Column): HTMLElement {
   root.className = 'column';
   root.dataset.colId = String(col.id);
   root.scrollIntoView = () => {}; // jsdom has no real scrollIntoView
-  col.el = { root } as Column['el'];
+  col.el = { root };
   return root;
 }
 

--- a/client/src/__tests__/enhancedInspectorPerfTracker.test.ts
+++ b/client/src/__tests__/enhancedInspectorPerfTracker.test.ts
@@ -114,14 +114,14 @@ describe('wrapWithEnhancedInspectorPerfProxy', () => {
   it('counts a round-trip method when enabled', () => {
     enhancedInspectorPerfTracker.setEnabled(true);
     const proxy = wrapWithEnhancedInspectorPerfProxy(makeFakeGci());
-    proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    proxy.GciTsExecuteFetchBytes({}, null, -1, 0n, 0n, 0n, 1024);
     expect(enhancedInspectorPerfTracker.count).toBe(1);
     expect(enhancedInspectorPerfTracker.methodCounts.get('GciTsExecuteFetchBytes')).toBe(1);
   });
 
   it('does not count a round-trip method when disabled', () => {
     const proxy = wrapWithEnhancedInspectorPerfProxy(makeFakeGci());
-    proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    proxy.GciTsExecuteFetchBytes({}, null, -1, 0n, 0n, 0n, 1024);
     expect(enhancedInspectorPerfTracker.count).toBe(0);
   });
 
@@ -137,14 +137,14 @@ describe('wrapWithEnhancedInspectorPerfProxy', () => {
   it('does not count GciTsCallInProgress', () => {
     enhancedInspectorPerfTracker.setEnabled(true);
     const proxy = wrapWithEnhancedInspectorPerfProxy(makeFakeGci());
-    proxy.GciTsCallInProgress({} as never);
+    proxy.GciTsCallInProgress({});
     expect(enhancedInspectorPerfTracker.count).toBe(0);
   });
 
   it('passes the return value through unchanged', () => {
     enhancedInspectorPerfTracker.setEnabled(true);
     const proxy = wrapWithEnhancedInspectorPerfProxy(makeFakeGci());
-    const result = proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    const result = proxy.GciTsExecuteFetchBytes({}, null, -1, 0n, 0n, 0n, 1024);
     expect(result.data).toBe('ok');
   });
 
@@ -152,7 +152,7 @@ describe('wrapWithEnhancedInspectorPerfProxy', () => {
     enhancedInspectorPerfTracker.setEnabled(true);
     const fake = makeFakeGci();
     const proxy = wrapWithEnhancedInspectorPerfProxy(fake);
-    proxy.GciTsExecuteFetchBytes({} as never, null, -1, 0n, 0n, 0n, 1024);
+    proxy.GciTsExecuteFetchBytes({}, null, -1, 0n, 0n, 0n, 1024);
     expect(fake.GciTsExecuteFetchBytes).toHaveBeenCalledOnce();
   });
 });

--- a/client/src/__tests__/executeFetchStringWithLimit.test.ts
+++ b/client/src/__tests__/executeFetchStringWithLimit.test.ts
@@ -23,7 +23,7 @@ function makeSession(gciOverrides: Record<string, unknown> = {}): ActiveSession 
     gci: gci as unknown as ActiveSession['gci'],
     login: {} as ActiveSession['login'],
     stoneVersion: '3.7.2',
-  } as ActiveSession;
+  };
 }
 
 describe('executeFetchStringWithLimit', () => {

--- a/client/src/__tests__/explorerOpenEditorsLabel.test.ts
+++ b/client/src/__tests__/explorerOpenEditorsLabel.test.ts
@@ -13,7 +13,7 @@ function methodUri(over: Partial<ParsedUri> = {}): ParsedUri {
     selector: 'at:',
     environmentId: 0,
     ...over,
-  } as ParsedUri;
+  };
 }
 
 describe('classifyGemstoneUri', () => {

--- a/client/src/__tests__/exportManager.test.ts
+++ b/client/src/__tests__/exportManager.test.ts
@@ -212,7 +212,7 @@ function createMockSession(overrides?: Partial<GemStoneLogin>): ActiveSession {
       ...overrides,
     },
     stoneVersion: '3.7.2',
-  } as ActiveSession;
+  };
 }
 
 function defaultImage() {

--- a/client/src/__tests__/extentBackupManager.test.ts
+++ b/client/src/__tests__/extentBackupManager.test.ts
@@ -85,7 +85,7 @@ describe('runOnlineExtentBackup', () => {
 
     await runOnlineExtentBackup(deps);
 
-    const message = vi.mocked(vscode.window.showInformationMessage).mock.calls[0][0] as string;
+    const message = vi.mocked(vscode.window.showInformationMessage).mock.calls[0][0];
     expect(message).toContain('written to');
     expect(message).toContain('transaction logs');
   });
@@ -135,7 +135,7 @@ describe('runOnlineExtentBackup', () => {
 
     expect(ok).toBe(false);
     expect(deps.copyFile).toHaveBeenCalled();
-    const error = vi.mocked(vscode.window.showErrorMessage).mock.calls[0][0] as string;
+    const error = vi.mocked(vscode.window.showErrorMessage).mock.calls[0][0];
     expect(error).toContain('NOT usable');
   });
 
@@ -176,7 +176,7 @@ function fakeSession(stone: string): ActiveSession {
   return { login: { stone } } as unknown as ActiveSession;
 }
 function sessionRow(session: ActiveSession): GemStoneSessionItem {
-  return { activeSession: session } as unknown as GemStoneSessionItem;
+  return { activeSession: session };
 }
 function runningStoneRow(stoneName: string): DatabaseNode {
   return { kind: 'stone', db: { config: { stoneName } }, running: true } as unknown as DatabaseNode;

--- a/client/src/__tests__/gciLibrary.test.ts
+++ b/client/src/__tests__/gciLibrary.test.ts
@@ -924,7 +924,7 @@ describe('GciLibrary', () => {
     });
 
     it('cleans up the snapshot key when the callback succeeds', () => {
-      let snapshotNameToRemove;
+      let snapshotNameToRemove: string;
 
       gciLibrary.didPureExportSetGrow(session, (snapshotName) => {
         snapshotNameToRemove = snapshotName;

--- a/client/src/__tests__/gciLog.test.ts
+++ b/client/src/__tests__/gciLog.test.ts
@@ -16,7 +16,7 @@ import {
 /** The lines appended to the singleton channel, in order. */
 function loggedLines(): string[] {
   const channel = getGciLog();
-  return vi.mocked(channel.appendLine).mock.calls.map((c) => c[0] as string);
+  return vi.mocked(channel.appendLine).mock.calls.map((c) => c[0]);
 }
 
 describe('gciLog', () => {

--- a/client/src/__tests__/gemstoneDebugSession.test.ts
+++ b/client/src/__tests__/gemstoneDebugSession.test.ts
@@ -105,7 +105,7 @@ function createTestSession(breakpointManager?: BreakpointManager) {
     sent.push({
       type: 'response',
       command: resp.command,
-      body: resp.body as Record<string, unknown>,
+      body: resp.body,
       success: resp.success,
       message: resp.message,
     });

--- a/client/src/__tests__/listFilter.test.ts
+++ b/client/src/__tests__/listFilter.test.ts
@@ -155,7 +155,7 @@ describe('ListFilter', () => {
       filter.applyFilter();
 
       expect(filter.matchedItems).toHaveLength(1);
-      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Array');
+      expect(filter.matchedItems[0].dataset.value).toBe('Array');
     });
 
     it('adds a match-highlight span for the matched portion', () => {
@@ -459,10 +459,7 @@ describe('ListFilter', () => {
       getListFilterClass().refreshFilterOf(list);
 
       expect(filter.matchedItems).toHaveLength(2);
-      expect(filter.matchedItems.map((el) => (el as HTMLElement).dataset.value)).toEqual([
-        'Array',
-        'Barrage',
-      ]);
+      expect(filter.matchedItems.map((el) => el.dataset.value)).toEqual(['Array', 'Barrage']);
     });
 
     it('picks up a changed query when called after searchBox value changes', () => {
@@ -476,7 +473,7 @@ describe('ListFilter', () => {
       getListFilterClass().refreshFilterOf(list);
 
       expect(filter.matchedItems).toHaveLength(1);
-      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Bag');
+      expect(filter.matchedItems[0].dataset.value).toBe('Bag');
     });
 
     it('re-applies the active filter against new children after list repopulation', () => {
@@ -494,10 +491,7 @@ describe('ListFilter', () => {
       getListFilterClass().refreshFilterOf(list);
 
       expect(filter.matchedItems).toHaveLength(2);
-      expect(filter.matchedItems.map((el) => (el as HTMLElement).dataset.value)).toEqual([
-        'Array',
-        'Barrage',
-      ]);
+      expect(filter.matchedItems.map((el) => el.dataset.value)).toEqual(['Array', 'Barrage']);
     });
 
     it('does nothing when no filter is associated with the list element', () => {
@@ -536,7 +530,7 @@ describe('ListFilter', () => {
       getListFilterClass().refreshFilterOf(list);
 
       expect(filter.matchedItems).toHaveLength(1);
-      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Array');
+      expect(filter.matchedItems[0].dataset.value).toBe('Array');
     });
   });
 
@@ -559,7 +553,7 @@ describe('ListFilter', () => {
       filter.applyFilter();
 
       expect(filter.matchedItems).toHaveLength(1);
-      expect((filter.matchedItems[0] as HTMLElement).dataset.value).toBe('Array');
+      expect(filter.matchedItems[0].dataset.value).toBe('Array');
     });
   });
 

--- a/client/src/__tests__/loginEditorPanel.test.ts
+++ b/client/src/__tests__/loginEditorPanel.test.ts
@@ -58,8 +58,8 @@ describe('LoginEditorPanel', () => {
   });
 
   describe('show', () => {
-    it('creates a new webview panel for a new login', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('creates a new webview panel for a new login', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       expect(window.createWebviewPanel).toHaveBeenCalledWith(
         'gemstoneLoginEditor',
         'New GemStone Login',
@@ -68,9 +68,9 @@ describe('LoginEditorPanel', () => {
       );
     });
 
-    it('creates a panel titled with login description when editing', () => {
+    it('creates a panel titled with login description when editing', async () => {
       const login = makeLogin({ gs_user: 'Admin', stone: 'prod', gem_host: 'db.example.com' });
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
       expect(window.createWebviewPanel).toHaveBeenCalledWith(
         'gemstoneLoginEditor',
         'Edit: Admin on prod (db.example.com)',
@@ -79,26 +79,36 @@ describe('LoginEditorPanel', () => {
       );
     });
 
-    it('reuses existing panel on subsequent calls', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('reuses existing panel on subsequent calls', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const firstCallCount = window.createWebviewPanel.mock.calls.length;
 
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin({ label: 'Second' }));
+      await LoginEditorPanel.show(
+        storage,
+        secretsArg,
+        treeProvider,
+        makeLogin({ label: 'Second' }),
+      );
       expect(window.createWebviewPanel.mock.calls.length).toBe(firstCallCount);
     });
 
-    it('reveals existing panel on subsequent calls', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('reveals existing panel on subsequent calls', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
 
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, makeLogin({ label: 'Second' }));
+      await LoginEditorPanel.show(
+        storage,
+        secretsArg,
+        treeProvider,
+        makeLogin({ label: 'Second' }),
+      );
       expect(panel.reveal).toHaveBeenCalled();
     });
   });
 
   describe('webview HTML', () => {
-    it('sets webview html with form fields', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('sets webview html with form fields', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
@@ -113,8 +123,8 @@ describe('LoginEditorPanel', () => {
       expect(html).toContain('id="host_password"');
     });
 
-    it('includes Content-Security-Policy with nonce', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('includes Content-Security-Policy with nonce', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
@@ -122,8 +132,8 @@ describe('LoginEditorPanel', () => {
       expect(html).toMatch(/nonce-[a-f0-9]{32}/);
     });
 
-    it('includes save and cancel buttons', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('includes save and cancel buttons', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
@@ -133,8 +143,8 @@ describe('LoginEditorPanel', () => {
   });
 
   describe('message handling', () => {
-    it('sends loadData message after creating panel', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('sends loadData message after creating panel', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadData',
@@ -144,9 +154,9 @@ describe('LoginEditorPanel', () => {
       });
     });
 
-    it('sends existing login data when editing', () => {
+    it('sends existing login data when editing', async () => {
       const login = makeLogin({ label: 'Server', gem_host: 'myhost' });
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, login);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadData',
@@ -158,52 +168,52 @@ describe('LoginEditorPanel', () => {
   });
 
   describe('version dropdown', () => {
-    it('includes extracted versions in loadData message', () => {
+    it('includes extracted versions in loadData message', async () => {
       const sysadmin = makeSysadminStorage(['3.7.4', '3.6.4']);
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.7.4', '3.6.4'] }),
       );
     });
 
-    it('includes versions from gciLibraries config', () => {
+    it('includes versions from gciLibraries config', async () => {
       __setConfig('gemstone', 'gciLibraries', { '3.5.0': '/path/to/lib' });
       const sysadmin = makeSysadminStorage([]);
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.5.0'] }),
       );
     });
 
-    it('deduplicates versions from both sources', () => {
+    it('deduplicates versions from both sources', async () => {
       __setConfig('gemstone', 'gciLibraries', { '3.7.4': '/path/to/lib' });
       const sysadmin = makeSysadminStorage(['3.7.4']);
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.7.4'] }),
       );
     });
 
-    it('sorts versions newest first', () => {
+    it('sorts versions newest first', async () => {
       __setConfig('gemstone', 'gciLibraries', { '3.5.0': '/path/a' });
       const sysadmin = makeSysadminStorage(['3.6.4', '3.7.4']);
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ versions: ['3.7.4', '3.6.4', '3.5.0'] }),
       );
     });
 
-    it('includes GCI versions bundled with the extension on Windows', () => {
+    it('includes GCI versions bundled with the extension on Windows', async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       (bundledWindowsClientVersions as Mock).mockReturnValue(['3.6.2']);
       try {
         const sysadmin = makeSysadminStorage([]);
-        LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+        await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
         const panel = window.createWebviewPanel.mock.results[0].value;
         expect(panel.webview.postMessage).toHaveBeenCalledWith(
           expect.objectContaining({ versions: ['3.6.2'] }),
@@ -213,14 +223,14 @@ describe('LoginEditorPanel', () => {
       }
     });
 
-    it('omits bundled versions when the arch cannot load them (e.g. ARM64)', () => {
+    it('omits bundled versions when the arch cannot load them (e.g. ARM64)', async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       (bundledWindowsClientVersions as Mock).mockReturnValue(['3.6.2']);
       (bundledGciArchSupported as Mock).mockReturnValue(false);
       try {
         const sysadmin = makeSysadminStorage([]);
-        LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+        await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
         const panel = window.createWebviewPanel.mock.results[0].value;
         expect(panel.webview.postMessage).toHaveBeenCalledWith(
           expect.objectContaining({ versions: [] }),
@@ -230,15 +240,15 @@ describe('LoginEditorPanel', () => {
       }
     });
 
-    it('renders a select element for the version field', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('renders a select element for the version field', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.html).toContain('<select id="version">');
     });
 
-    it('defaults new login version to the highest available version', () => {
+    it('defaults new login version to the highest available version', async () => {
       const sysadmin = makeSysadminStorage(['3.6.4', '3.7.4']);
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -247,9 +257,9 @@ describe('LoginEditorPanel', () => {
       );
     });
 
-    it('defaults to empty version when no versions are available', () => {
+    it('defaults to empty version when no versions are available', async () => {
       const sysadmin = makeSysadminStorage([]);
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, undefined, sysadmin);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -258,10 +268,10 @@ describe('LoginEditorPanel', () => {
       );
     });
 
-    it('preserves version from existing login rather than defaulting', () => {
+    it('preserves version from existing login rather than defaulting', async () => {
       const sysadmin = makeSysadminStorage(['3.7.4', '3.6.4']);
       const login = makeLogin({ version: '3.6.4' });
-      LoginEditorPanel.show(storage, secretsArg, treeProvider, login, sysadmin);
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider, login, sysadmin);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -272,8 +282,8 @@ describe('LoginEditorPanel', () => {
   });
 
   describe('OS keychain option', () => {
-    it('renders a "Store password in OS keychain" checkbox in the HTML', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('renders a "Store password in OS keychain" checkbox in the HTML', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
 
@@ -281,8 +291,8 @@ describe('LoginEditorPanel', () => {
       expect(html).toContain('Store password in OS keychain');
     });
 
-    it('renders a hint about leaving the password blank to be prompted', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('renders a hint about leaving the password blank to be prompted', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.html).toContain('Leave password blank to be prompted on each login');
     });
@@ -321,8 +331,8 @@ describe('LoginEditorPanel', () => {
   });
 
   describe('class sync option', () => {
-    it('renders a "Sync classes to local files" checkbox in the HTML', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('renders a "Sync classes to local files" checkbox in the HTML', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       const html = panel.webview.html;
       expect(html).toContain('id="sync_classes"');
@@ -331,8 +341,8 @@ describe('LoginEditorPanel', () => {
   });
 
   describe('read-only view', () => {
-    it('renders the read-only banner element in the HTML', () => {
-      LoginEditorPanel.show(storage, secretsArg, treeProvider);
+    it('renders the read-only banner element in the HTML', async () => {
+      await LoginEditorPanel.show(storage, secretsArg, treeProvider);
       const panel = window.createWebviewPanel.mock.results[0].value;
       expect(panel.webview.html).toContain('id="readOnlyBanner"');
     });

--- a/client/src/__tests__/mcpSocketServer.test.ts
+++ b/client/src/__tests__/mcpSocketServer.test.ts
@@ -121,7 +121,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
     expect(writeCall).toBeDefined();
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers[MCP_SERVER_NAME].command).toBe('node');
     expect(written.mcpServers[MCP_SERVER_NAME].args).toContain('--proxy-socket');
     expect(written.mcpServers[MCP_SERVER_NAME].args).toContain('/tmp/socket.sock');
@@ -147,7 +147,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
     writeClaudeDesktopMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers.filesystem).toEqual({ command: 'mcp-fs' });
     expect(written.mcpServers.notion).toEqual({ command: 'mcp-notion' });
     expect(written.mcpServers[MCP_SERVER_NAME]).toBeDefined();
@@ -164,7 +164,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
     writeClaudeDesktopMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.globalShortcut).toBe('Ctrl+Space');
   });
 
@@ -201,7 +201,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
     expect(writeCall).toBeDefined();
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers[MCP_SERVER_NAME].args).toContain('/tmp/NEW.sock');
   });
 
@@ -215,7 +215,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
     writeClaudeDesktopMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers.gemstone).toBeUndefined();
     expect(written.mcpServers[MCP_SERVER_NAME]).toBeDefined();
   });
@@ -230,7 +230,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
     writeClaudeDesktopMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers.gemstone).toEqual(foreignGemstoneEntry);
     expect(written.mcpServers[MCP_SERVER_NAME]).toBeDefined();
   });
@@ -249,7 +249,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
     writeClaudeDesktopMcpConfig('/ext', '/tmp/socket.sock');
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers['gemstone-abcdef0123']).toBeUndefined();
     expect(written.mcpServers['gemstone-fedcba9876']).toBeUndefined();
     expect(written.mcpServers[MCP_SERVER_NAME]).toBeDefined();
@@ -293,7 +293,7 @@ describe('writeClaudeDesktopMcpConfig', () => {
     expect(() => writeClaudeDesktopMcpConfig('/ext', '/tmp/socket.sock')).not.toThrow();
 
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    const written = JSON.parse(writeCall![1] as string);
+    const written = JSON.parse(writeCall[1] as string);
     expect(written.mcpServers[MCP_SERVER_NAME]).toBeDefined();
   });
 });

--- a/client/src/__tests__/rowanRepos.test.ts
+++ b/client/src/__tests__/rowanRepos.test.ts
@@ -12,7 +12,7 @@ function fakeMemento(): vscode.Memento {
       store.set(key, value);
     },
     keys: () => [...store.keys()],
-  } as vscode.Memento;
+  };
 }
 
 describe('RowanRepoRegistry', () => {

--- a/client/src/__tests__/rowanTreeProvider.test.ts
+++ b/client/src/__tests__/rowanTreeProvider.test.ts
@@ -38,7 +38,7 @@ function fakeMemento(): vscode.Memento {
       store.set(key, value);
     },
     keys: () => [...store.keys()],
-  } as vscode.Memento;
+  };
 }
 
 // A real directory on disk, holding a Rowan load spec when asked — the
@@ -316,7 +316,7 @@ describe('RowanTreeProvider', () => {
       const items = sectionChildren(provider, 'loaded');
 
       expect((items[0] as RowanLoadedProjectItem).label).toBe('Seaside');
-      const group = items[1] as RowanBuiltinGroupItem;
+      const group = items[1];
       expect(group).toBeInstanceOf(RowanBuiltinGroupItem);
       expect(group.description).toBe('2');
       const builtins = provider.getChildren(group) as RowanLoadedProjectItem[];

--- a/client/src/__tests__/seasideServer.test.ts
+++ b/client/src/__tests__/seasideServer.test.ts
@@ -44,7 +44,7 @@ function servesHelloWorld() {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     text: async () => '<body>Hello World from Seaside</body>',
-  }) as unknown as typeof fetch;
+  });
 }
 
 describe('Seaside server lifecycle', () => {

--- a/client/src/__tests__/sessionManager.test.ts
+++ b/client/src/__tests__/sessionManager.test.ts
@@ -145,7 +145,7 @@ describe('SessionManager', () => {
     manager.login({ ...DEFAULT_LOGIN, label: 'Test' }, '/mock/lib');
 
     const installCall = executeFetchBytes.mock.calls.find(
-      (c) => typeof c[1] === 'string' && (c[1] as string).includes('JasperTranscriptSink'),
+      (c) => typeof c[1] === 'string' && c[1].includes('JasperTranscriptSink'),
     );
     expect(installCall).toBeDefined();
     expect(installCall![1]).toContain('TranscriptStream_SessionStream');

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -1254,9 +1254,11 @@ describe('SystemBrowser', () => {
       vi.mocked(queries.getDictionaryNames).mockReturnValue(['UserGlobals', 'Globals', 'NewDict']);
       vi.mocked(mockPanel.webview.postMessage).mockClear();
 
-      await messageHandler({ command: 'ctxAddDictionary' });
+      messageHandler({ command: 'ctxAddDictionary' });
 
-      expect(queries.addDictionary).toHaveBeenCalledWith(session, 'NewDict');
+      await vi.waitFor(() =>
+        expect(queries.addDictionary).toHaveBeenCalledWith(session, 'NewDict'),
+      );
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadDictionaries',
         items: ['UserGlobals', 'Globals', 'NewDict'],
@@ -1267,15 +1269,16 @@ describe('SystemBrowser', () => {
       vi.mocked(window.showInputBox).mockResolvedValue('NewDict');
       vi.mocked(queries.getDictionaryNames).mockReturnValue(['UserGlobals', 'Globals', 'NewDict']);
 
-      await messageHandler({ command: 'ctxAddDictionary' });
+      messageHandler({ command: 'ctxAddDictionary' });
 
-      expect(exportManager.scheduleRefresh).toHaveBeenCalled();
+      await vi.waitFor(() => expect(exportManager.scheduleRefresh).toHaveBeenCalled());
       expect(fs.mkdirSync).not.toHaveBeenCalled();
     });
 
     it('does nothing when user cancels add dictionary', async () => {
       vi.mocked(window.showInputBox).mockResolvedValue(undefined);
-      await messageHandler({ command: 'ctxAddDictionary' });
+      messageHandler({ command: 'ctxAddDictionary' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(queries.addDictionary).not.toHaveBeenCalled();
     });
 
@@ -1331,9 +1334,9 @@ describe('SystemBrowser', () => {
       vi.mocked(queries.getDictionaryNames).mockReturnValue(['Globals']);
       vi.mocked(mockPanel.webview.postMessage).mockClear();
 
-      await messageHandler({ command: 'ctxRemoveDictionary' });
+      messageHandler({ command: 'ctxRemoveDictionary' });
 
-      expect(queries.removeDictionary).toHaveBeenCalledWith(session, 1);
+      await vi.waitFor(() => expect(queries.removeDictionary).toHaveBeenCalledWith(session, 1));
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
         command: 'loadDictionaries',
         items: ['Globals'],
@@ -1348,7 +1351,8 @@ describe('SystemBrowser', () => {
       messageHandler({ command: 'selectDictionary', index: 1 });
       vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
 
-      await messageHandler({ command: 'ctxRemoveDictionary' });
+      messageHandler({ command: 'ctxRemoveDictionary' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(queries.removeDictionary).not.toHaveBeenCalled();
     });
@@ -1359,9 +1363,9 @@ describe('SystemBrowser', () => {
       vi.mocked(queries.getDictionaryNames).mockReturnValue(['Globals']);
       vi.mocked(fs.existsSync).mockReturnValue(true);
 
-      await messageHandler({ command: 'ctxRemoveDictionary' });
+      messageHandler({ command: 'ctxRemoveDictionary' });
 
-      expect(exportManager.scheduleRefresh).toHaveBeenCalled();
+      await vi.waitFor(() => expect(exportManager.scheduleRefresh).toHaveBeenCalled());
       expect(fs.rmSync).not.toHaveBeenCalled();
     });
 
@@ -1441,9 +1445,9 @@ describe('SystemBrowser', () => {
     it('deletes class after confirmation', async () => {
       vi.mocked(window.showWarningMessage).mockResolvedValue('Delete');
 
-      await messageHandler({ command: 'ctxDeleteClass' });
+      messageHandler({ command: 'ctxDeleteClass' });
 
-      expect(queries.deleteClass).toHaveBeenCalledWith(session, 1, 'Array');
+      await vi.waitFor(() => expect(queries.deleteClass).toHaveBeenCalledWith(session, 1, 'Array'));
       // The class's mirror file + persisted hash are dropped.
       expect(exportManager.removeClassFile).toHaveBeenCalledWith(
         session,
@@ -1462,16 +1466,19 @@ describe('SystemBrowser', () => {
 
     it('does not delete class when user cancels', async () => {
       vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
-      await messageHandler({ command: 'ctxDeleteClass' });
+      messageHandler({ command: 'ctxDeleteClass' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(queries.deleteClass).not.toHaveBeenCalled();
     });
 
     it('moves class to another dictionary', async () => {
       vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Globals', index: 2 });
 
-      await messageHandler({ command: 'ctxMoveClass' });
+      messageHandler({ command: 'ctxMoveClass' });
 
-      expect(queries.moveClass).toHaveBeenCalledWith(session, 1, 2, 'Array');
+      await vi.waitFor(() =>
+        expect(queries.moveClass).toHaveBeenCalledWith(session, 1, 2, 'Array'),
+      );
     });
 
     it('delegates run tests to command', () => {
@@ -1504,9 +1511,11 @@ describe('SystemBrowser', () => {
       vi.mocked(queries.fileOutClass).mockReturnValue('! Array file-out');
       vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/Array.gs'));
 
-      await messageHandler({ command: 'ctxFileOutClass' });
+      messageHandler({ command: 'ctxFileOutClass' });
 
-      expect(queries.fileOutClass).toHaveBeenCalledWith(session, 'Array', 1);
+      await vi.waitFor(() =>
+        expect(queries.fileOutClass).toHaveBeenCalledWith(session, 'Array', 1),
+      );
       expect(fs.writeFileSync).toHaveBeenCalledWith('/out/Array.gs', '! Array file-out', 'utf8');
     });
 
@@ -1514,8 +1523,9 @@ describe('SystemBrowser', () => {
       messageHandler({ command: 'selectClass', name: 'AccountTestCase' });
       vi.mocked(window.showSaveDialog).mockResolvedValue(undefined);
 
-      await messageHandler({ command: 'ctxFileOutClass' });
+      messageHandler({ command: 'ctxFileOutClass' });
 
+      await vi.waitFor(() => expect(window.showSaveDialog).toHaveBeenCalled());
       const opts = vi.mocked(window.showSaveDialog).mock.calls[0][0]!;
       expect((opts.defaultUri as { fsPath: string }).fsPath).toContain('Account.gs');
     });
@@ -1524,7 +1534,8 @@ describe('SystemBrowser', () => {
       messageHandler({ command: 'selectClass', name: 'Array' });
       vi.mocked(window.showSaveDialog).mockResolvedValue(undefined);
 
-      await messageHandler({ command: 'ctxFileOutClass' });
+      messageHandler({ command: 'ctxFileOutClass' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
@@ -1540,9 +1551,15 @@ describe('SystemBrowser', () => {
       );
       vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs'));
 
-      await messageHandler({ command: 'ctxFileOutDictionaryMany' });
+      messageHandler({ command: 'ctxFileOutDictionaryMany' });
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith('/out/Object.gs', '! Object file-out', 'utf8');
+      await vi.waitFor(() =>
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          '/out/Object.gs',
+          '! Object file-out',
+          'utf8',
+        ),
+      );
       expect(fs.writeFileSync).toHaveBeenCalledWith('/out/Animal.gs', '! Animal file-out', 'utf8');
       expect(fs.writeFileSync).toHaveBeenCalledWith('/out/Dog.gs', '! Dog file-out', 'utf8');
       const loader = vi
@@ -1560,8 +1577,15 @@ describe('SystemBrowser', () => {
       vi.mocked(queries.fileOutClass).mockImplementation((_s, className) => `! ${className}`);
       vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs'));
 
-      await messageHandler({ command: 'ctxFileOutDictionaryMany' });
+      messageHandler({ command: 'ctxFileOutDictionaryMany' });
 
+      await vi.waitFor(() =>
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          '/out/UserGlobals.gs',
+          expect.anything(),
+          'utf8',
+        ),
+      );
       const loader = vi
         .mocked(fs.writeFileSync)
         .mock.calls.find((c) => c[0] === '/out/UserGlobals.gs')![1] as string;
@@ -1576,9 +1600,9 @@ describe('SystemBrowser', () => {
       vi.mocked(queries.getDictionaryClassFileOutOrder).mockReturnValue([]);
       vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs'));
 
-      await messageHandler({ command: 'ctxFileOutDictionaryMany' });
+      messageHandler({ command: 'ctxFileOutDictionaryMany' });
 
-      expect(window.showWarningMessage).toHaveBeenCalled();
+      await vi.waitFor(() => expect(window.showWarningMessage).toHaveBeenCalled());
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
   });
@@ -1598,21 +1622,24 @@ describe('SystemBrowser', () => {
     it('renames method category', async () => {
       vi.mocked(window.showInputBox).mockResolvedValue('Getters');
 
-      await messageHandler({ command: 'ctxRenameCategory' });
+      messageHandler({ command: 'ctxRenameCategory' });
 
-      expect(queries.renameCategory).toHaveBeenCalledWith(
-        session,
-        'Array',
-        false,
-        'Accessing',
-        'Getters',
-        1,
+      await vi.waitFor(() =>
+        expect(queries.renameCategory).toHaveBeenCalledWith(
+          session,
+          'Array',
+          false,
+          'Accessing',
+          'Getters',
+          1,
+        ),
       );
     });
 
     it('does not rename when user cancels', async () => {
       vi.mocked(window.showInputBox).mockResolvedValue(undefined);
-      await messageHandler({ command: 'ctxRenameCategory' });
+      messageHandler({ command: 'ctxRenameCategory' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(queries.renameCategory).not.toHaveBeenCalled();
     });
 
@@ -1659,9 +1686,11 @@ describe('SystemBrowser', () => {
     it('deletes method after confirmation', async () => {
       vi.mocked(window.showWarningMessage).mockResolvedValue('Delete');
 
-      await messageHandler({ command: 'ctxDeleteMethod' });
+      messageHandler({ command: 'ctxDeleteMethod' });
 
-      expect(queries.deleteMethod).toHaveBeenCalledWith(session, 'Array', false, 'name', 1);
+      await vi.waitFor(() =>
+        expect(queries.deleteMethod).toHaveBeenCalledWith(session, 'Array', false, 'name', 1),
+      );
       // The class's mirror file is re-filed-out to reflect the removed method.
       expect(exportManager.syncClass).toHaveBeenCalledWith(session, 'UserGlobals', 'Array');
     });
@@ -1670,10 +1699,12 @@ describe('SystemBrowser', () => {
       vi.mocked(window.showWarningMessage).mockResolvedValue('Delete');
       vi.mocked(mockPanel.webview.postMessage).mockClear();
 
-      await messageHandler({ command: 'ctxDeleteMethod' });
+      messageHandler({ command: 'ctxDeleteMethod' });
 
-      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ command: 'loadMethodCategories' }),
+      await vi.waitFor(() =>
+        expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ command: 'loadMethodCategories' }),
+        ),
       );
       expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ command: 'loadMethods' }),
@@ -1682,7 +1713,8 @@ describe('SystemBrowser', () => {
 
     it('does not delete method when user cancels', async () => {
       vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
-      await messageHandler({ command: 'ctxDeleteMethod' });
+      messageHandler({ command: 'ctxDeleteMethod' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(queries.deleteMethod).not.toHaveBeenCalled();
     });
 
@@ -1694,15 +1726,17 @@ describe('SystemBrowser', () => {
       ]);
       vi.mocked(window.showQuickPick).mockResolvedValue('Printing');
 
-      await messageHandler({ command: 'ctxMoveToCategory' });
+      messageHandler({ command: 'ctxMoveToCategory' });
 
-      expect(queries.recategorizeMethod).toHaveBeenCalledWith(
-        session,
-        'Array',
-        false,
-        'name',
-        'Printing',
-        1,
+      await vi.waitFor(() =>
+        expect(queries.recategorizeMethod).toHaveBeenCalledWith(
+          session,
+          'Array',
+          false,
+          'name',
+          'Printing',
+          1,
+        ),
       );
     });
 

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -752,7 +752,7 @@ describe('SystemBrowser', () => {
             return new Promise<void>((r) => {
               releaseGroup = r;
             });
-          return undefined as unknown as Thenable<unknown>;
+          return undefined;
         });
         try {
           // First click starts opening the diff and blocks awaiting the new group.
@@ -1327,7 +1327,7 @@ describe('SystemBrowser', () => {
 
     it('removes dictionary after confirmation', async () => {
       messageHandler({ command: 'selectDictionary', index: 1 });
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Remove' as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Remove');
       vi.mocked(queries.getDictionaryNames).mockReturnValue(['Globals']);
       vi.mocked(mockPanel.webview.postMessage).mockClear();
 
@@ -1346,7 +1346,7 @@ describe('SystemBrowser', () => {
 
     it('does not remove dictionary when user cancels', async () => {
       messageHandler({ command: 'selectDictionary', index: 1 });
-      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
 
       await messageHandler({ command: 'ctxRemoveDictionary' });
 
@@ -1355,7 +1355,7 @@ describe('SystemBrowser', () => {
 
     it('reconciles the mirror via a debounced refresh when removing a dictionary', async () => {
       messageHandler({ command: 'selectDictionary', index: 1 });
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Remove' as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Remove');
       vi.mocked(queries.getDictionaryNames).mockReturnValue(['Globals']);
       vi.mocked(fs.existsSync).mockReturnValue(true);
 
@@ -1439,7 +1439,7 @@ describe('SystemBrowser', () => {
     });
 
     it('deletes class after confirmation', async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Delete' as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Delete');
 
       await messageHandler({ command: 'ctxDeleteClass' });
 
@@ -1461,13 +1461,13 @@ describe('SystemBrowser', () => {
     });
 
     it('does not delete class when user cancels', async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
       await messageHandler({ command: 'ctxDeleteClass' });
       expect(queries.deleteClass).not.toHaveBeenCalled();
     });
 
     it('moves class to another dictionary', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Globals', index: 2 } as never);
+      vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Globals', index: 2 });
 
       await messageHandler({ command: 'ctxMoveClass' });
 
@@ -1502,7 +1502,7 @@ describe('SystemBrowser', () => {
     it('writes the selected class file-out to the chosen path', async () => {
       messageHandler({ command: 'selectClass', name: 'Array' });
       vi.mocked(queries.fileOutClass).mockReturnValue('! Array file-out');
-      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/Array.gs') as never);
+      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/Array.gs'));
 
       await messageHandler({ command: 'ctxFileOutClass' });
 
@@ -1512,7 +1512,7 @@ describe('SystemBrowser', () => {
 
     it('defaults a test class file name to its subject', async () => {
       messageHandler({ command: 'selectClass', name: 'AccountTestCase' });
-      vi.mocked(window.showSaveDialog).mockResolvedValue(undefined as never);
+      vi.mocked(window.showSaveDialog).mockResolvedValue(undefined);
 
       await messageHandler({ command: 'ctxFileOutClass' });
 
@@ -1522,7 +1522,7 @@ describe('SystemBrowser', () => {
 
     it('does not write a class file-out when the save dialog is cancelled', async () => {
       messageHandler({ command: 'selectClass', name: 'Array' });
-      vi.mocked(window.showSaveDialog).mockResolvedValue(undefined as never);
+      vi.mocked(window.showSaveDialog).mockResolvedValue(undefined);
 
       await messageHandler({ command: 'ctxFileOutClass' });
 
@@ -1538,7 +1538,7 @@ describe('SystemBrowser', () => {
       vi.mocked(queries.fileOutClass).mockImplementation(
         (_s, className) => `! ${className} file-out`,
       );
-      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs') as never);
+      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs'));
 
       await messageHandler({ command: 'ctxFileOutDictionaryMany' });
 
@@ -1558,7 +1558,7 @@ describe('SystemBrowser', () => {
         'Dog',
       ]);
       vi.mocked(queries.fileOutClass).mockImplementation((_s, className) => `! ${className}`);
-      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs') as never);
+      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs'));
 
       await messageHandler({ command: 'ctxFileOutDictionaryMany' });
 
@@ -1574,7 +1574,7 @@ describe('SystemBrowser', () => {
 
     it('warns and writes nothing when a dictionary has no classes', async () => {
       vi.mocked(queries.getDictionaryClassFileOutOrder).mockReturnValue([]);
-      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs') as never);
+      vi.mocked(window.showSaveDialog).mockResolvedValue(Uri.file('/out/UserGlobals.gs'));
 
       await messageHandler({ command: 'ctxFileOutDictionaryMany' });
 
@@ -1657,7 +1657,7 @@ describe('SystemBrowser', () => {
     });
 
     it('deletes method after confirmation', async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Delete' as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Delete');
 
       await messageHandler({ command: 'ctxDeleteMethod' });
 
@@ -1667,7 +1667,7 @@ describe('SystemBrowser', () => {
     });
 
     it('refreshes method list after deletion', async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Delete' as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Delete');
       vi.mocked(mockPanel.webview.postMessage).mockClear();
 
       await messageHandler({ command: 'ctxDeleteMethod' });
@@ -1681,7 +1681,7 @@ describe('SystemBrowser', () => {
     });
 
     it('does not delete method when user cancels', async () => {
-      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as never);
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined);
       await messageHandler({ command: 'ctxDeleteMethod' });
       expect(queries.deleteMethod).not.toHaveBeenCalled();
     });
@@ -1692,7 +1692,7 @@ describe('SystemBrowser', () => {
         'Comparing',
         'Printing',
       ]);
-      vi.mocked(window.showQuickPick).mockResolvedValue('Printing' as never);
+      vi.mocked(window.showQuickPick).mockResolvedValue('Printing');
 
       await messageHandler({ command: 'ctxMoveToCategory' });
 
@@ -1853,7 +1853,7 @@ describe('SystemBrowser', () => {
     });
 
     it('moves the class to the chosen category', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue('Collections' as never);
+      vi.mocked(window.showQuickPick).mockResolvedValue('Collections');
 
       messageHandler({ command: 'ctxMoveClassToCategory' });
       await flush();
@@ -1866,7 +1866,7 @@ describe('SystemBrowser', () => {
     });
 
     it('offers the real class categories, excluding the "all classes" pseudo-entry', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue(undefined as never);
+      vi.mocked(window.showQuickPick).mockResolvedValue(undefined);
 
       messageHandler({ command: 'ctxMoveClassToCategory' });
       await flush();
@@ -1876,7 +1876,7 @@ describe('SystemBrowser', () => {
     });
 
     it('does nothing to the category when the quick pick is cancelled', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue(undefined as never);
+      vi.mocked(window.showQuickPick).mockResolvedValue(undefined);
 
       messageHandler({ command: 'ctxMoveClassToCategory' });
       await flush();
@@ -1886,7 +1886,7 @@ describe('SystemBrowser', () => {
 
     it('copies the selected method to the chosen class, preserving side and environment', async () => {
       vi.mocked(queries.getClassNames).mockReturnValue(['Array', 'Bag', 'Set']);
-      vi.mocked(window.showQuickPick).mockResolvedValue('Set' as never);
+      vi.mocked(window.showQuickPick).mockResolvedValue('Set');
 
       messageHandler({ command: 'ctxCopyMethodToClass' });
       await flush();
@@ -1906,7 +1906,7 @@ describe('SystemBrowser', () => {
 
     it('excludes the source class from the copy targets', async () => {
       vi.mocked(queries.getClassNames).mockReturnValue(['Array', 'Bag', 'Set']);
-      vi.mocked(window.showQuickPick).mockResolvedValue(undefined as never);
+      vi.mocked(window.showQuickPick).mockResolvedValue(undefined);
 
       messageHandler({ command: 'ctxCopyMethodToClass' });
       await flush();

--- a/client/src/__tests__/transcriptSink.test.ts
+++ b/client/src/__tests__/transcriptSink.test.ts
@@ -36,7 +36,7 @@ function forwarderError(overrides: Partial<GciError> = {}): GciError {
     message: 'clientForwarderSend',
     reason: '',
     ...overrides,
-  } as GciError;
+  };
 }
 
 function makeGci(overrides: Record<string, unknown> = {}) {

--- a/client/src/__tests__/tutorialNotebook.test.ts
+++ b/client/src/__tests__/tutorialNotebook.test.ts
@@ -141,7 +141,7 @@ describe('tutorial notebook', () => {
       await openTutorialNotebook();
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
-      const msg = vi.mocked(vscode.window.showErrorMessage).mock.calls[0][0] as string;
+      const msg = vi.mocked(vscode.window.showErrorMessage).mock.calls[0][0];
       expect(msg).toContain('tutorial notebook');
       expect(vscode.window.showNotebookDocument).not.toHaveBeenCalled();
     });

--- a/client/src/claudeCodeUserMcpConfig.ts
+++ b/client/src/claudeCodeUserMcpConfig.ts
@@ -45,7 +45,7 @@ function readUserConfig(configPath: string): ClaudeCodeUserConfig {
   } catch {
     // Don't clobber a corrupt file with our own contents — let Claude Code
     // recreate it on next launch and skip this activation's write.
-    return { __unreadable__: true } as ClaudeCodeUserConfig;
+    return { __unreadable__: true };
   }
 }
 
@@ -83,7 +83,7 @@ export function writeClaudeCodeUserMcpConfig(
     env: {},
   };
 
-  const mcpServers = (settings.mcpServers ?? {}) as Record<string, unknown>;
+  const mcpServers = settings.mcpServers ?? {};
   let dirty = false;
   if (JSON.stringify(mcpServers[MCP_SERVER_NAME]) !== JSON.stringify(desired)) {
     mcpServers[MCP_SERVER_NAME] = desired;
@@ -98,7 +98,7 @@ export function writeClaudeCodeUserMcpConfig(
 
   if (settings.projects) {
     for (const proj of Object.values(settings.projects)) {
-      const projMcp = proj?.mcpServers as Record<string, unknown> | undefined;
+      const projMcp = proj?.mcpServers;
       if (!projMcp) {
         continue;
       }

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -675,7 +675,7 @@ export class CodeExecutor {
     );
     if (resultErr.number !== 0) {
       const msg = resultErr.message || `GemStone error ${resultErr.number}`;
-      const context = toBigInt(resultErr.context as unknown as number | bigint);
+      const context = toBigInt(resultErr.context);
       if (context !== OOP_NIL && context !== 0n) {
         this.validateContextOop(session, context);
         throw new DebuggableError(msg, context);

--- a/client/src/commands/__tests__/findMethodInClass.test.ts
+++ b/client/src/commands/__tests__/findMethodInClass.test.ts
@@ -75,7 +75,7 @@ function createSequencedSession(methodPayload = methodListPayload): ActiveSessio
 
 function lastQuickPick(): QuickPickHandle {
   const results = vi.mocked(vscode.window.createQuickPick).mock.results;
-  return results[results.length - 1].value as unknown as QuickPickHandle;
+  return results[results.length - 1].value;
 }
 
 // Kicks off the command, waits for the class picker to appear, and hands back

--- a/client/src/debuggerPanel.ts
+++ b/client/src/debuggerPanel.ts
@@ -3142,6 +3142,7 @@ export class DebuggerPanel {
       this.pendingDnuMethodUri = undefined;
       this.pendingDnuSelector = undefined;
       this.dnuInfo = undefined; // the method now exists
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: needs investigation before deciding void vs .catch; the sibling override branch below uses void, but confirm finishDnuMethod can't reject outside runNb's internal handling first
       this.finishDnuMethod(selector);
       return;
     }

--- a/client/src/enhancedInspectorPerfTracker.ts
+++ b/client/src/enhancedInspectorPerfTracker.ts
@@ -174,5 +174,5 @@ export function wrapWithEnhancedInspectorPerfProxy(gci: GciLibrary): GciLibrary 
         ? (val as (...args: unknown[]) => unknown).bind(target)
         : val;
     },
-  }) as GciLibrary;
+  });
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -552,6 +552,7 @@ export function activate(context: vscode.ExtensionContext) {
     clientOptions,
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
   client.start();
 
   // ── Login Management ─────────────────────────────────────
@@ -1013,6 +1014,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     vscode.commands.registerCommand('gemstone.addLogin', () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       LoginEditorPanel.show(storage, context.secrets, treeProvider, undefined, sysadminStorage);
     }),
 
@@ -1020,6 +1022,7 @@ export function activate(context: vscode.ExtensionContext) {
       // A connected login opens read-only so its config can still be viewed;
       // the settings are only consumed at login, so editing a live one is
       // disabled (log out first) to avoid disturbing the session's tree row.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       LoginEditorPanel.show(
         storage,
         context.secrets,
@@ -1053,6 +1056,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand('gemstone.duplicateLogin', (item: GemStoneLoginItem) => {
       const copy = { ...item.login, label: '' };
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       LoginEditorPanel.show(storage, context.secrets, treeProvider, copy, sysadminStorage);
     }),
 
@@ -1211,6 +1215,7 @@ export function activate(context: vscode.ExtensionContext) {
               if (gciPath) {
                 await storage.setGciLibraryPath(login.version, gciPath);
               }
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
               versionProvider.loadVersions();
             } catch (e) {
               vscode.window.showErrorMessage(
@@ -1284,6 +1289,7 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage(
             `Connected to ${login.stone} (${session.stoneVersion}) on ${login.gem_host} as ${login.gs_user}`,
           );
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
           exportManager.exportSession(session, true);
         } catch (e: unknown) {
           const msg = e instanceof Error ? e.message : String(e);
@@ -1727,6 +1733,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     vscode.commands.registerCommand('gemstone.copyDisplayItResult', () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       codeExecutor.copyLastResult();
     }),
 
@@ -1739,6 +1746,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     vscode.commands.registerCommand('gemstone.expandDisplayResultInPlace', () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       codeExecutor.expandResultInPlace();
     }),
 
@@ -2171,6 +2179,7 @@ export function activate(context: vscode.ExtensionContext) {
   // will re-probe — giving the user a recovery path without reloading.
   if (isWindows()) {
     vscode.commands.executeCommand('setContext', 'gemstone.isWindows', true);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
     (async () => {
       let wslInfo = await getWslInfoAsync();
       if (!wslInfo.available) {
@@ -2754,6 +2763,7 @@ export function activate(context: vscode.ExtensionContext) {
         const wslInfo = await getWslInfoAsync();
         vscode.commands.executeCommand('setContext', 'gemstone.wslAvailable', wslInfo.available);
       }
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       versionProvider.loadVersions();
     }),
 
@@ -2770,6 +2780,7 @@ export function activate(context: vscode.ExtensionContext) {
         },
       );
       vscode.window.showInformationMessage(`GemStone ${version.version} downloaded.`);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       versionProvider.loadVersions();
     }),
 
@@ -2781,6 +2792,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
       if (confirmed !== 'Delete') return;
       await versionManager.deleteDownload(item.version);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       versionProvider.loadVersions();
     }),
 
@@ -2795,6 +2807,7 @@ export function activate(context: vscode.ExtensionContext) {
         },
       );
       vscode.window.showInformationMessage(`GemStone ${item.version.version} extracted.`);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       versionProvider.loadVersions();
     }),
 
@@ -2806,6 +2819,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
       if (confirmed !== 'Delete') return;
       await versionManager.deleteExtracted(item.version);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       versionProvider.loadVersions();
     }),
 
@@ -2839,6 +2853,7 @@ export function activate(context: vscode.ExtensionContext) {
       vscode.window.showInformationMessage(
         `Registered local GemStone ${info.version} (${info.description || 'local build'}).`,
       );
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       versionProvider.loadVersions();
     }),
 
@@ -2852,6 +2867,7 @@ export function activate(context: vscode.ExtensionContext) {
         );
         if (confirmed !== 'Unregister') return;
         await versionManager.deleteExtracted(item.version);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
         versionProvider.loadVersions();
       },
     ),
@@ -2887,6 +2903,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage(
           `Windows client install failed: ${e instanceof Error ? e.message : e}`,
         );
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
         versionProvider.loadVersions();
         return;
       }
@@ -2896,6 +2913,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (gciPath) {
         await storage.setGciLibraryPath(version, gciPath);
       }
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       versionProvider.loadVersions();
       vscode.window.showInformationMessage(
         `Windows client for GemStone ${version} is ready.${gciPath ? ' GCI library registered.' : ''}`,
@@ -2919,6 +2937,7 @@ export function activate(context: vscode.ExtensionContext) {
         );
         if (confirmed !== 'Delete') return;
         await versionManager.deleteWindowsClientExtracted(item.version);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
         versionProvider.loadVersions();
       },
     ),
@@ -3087,6 +3106,7 @@ export function activate(context: vscode.ExtensionContext) {
           }
         }
       }
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       LoginEditorPanel.show(storage, context.secrets, treeProvider, login, sysadminStorage);
     }),
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1599,7 +1599,7 @@ export function activate(context: vscode.ExtensionContext) {
               title: `Unloading ${projectName}…`,
               cancellable: false,
             },
-            () => Promise.resolve(queries.unloadRowanProject(sys, projectName!)),
+            () => Promise.resolve(queries.unloadRowanProject(sys, projectName)),
           );
         } finally {
           try {
@@ -2067,7 +2067,7 @@ export function activate(context: vscode.ExtensionContext) {
             title: `Fetching hierarchy for ${className}...`,
             cancellable: false,
           },
-          () => Promise.resolve(queries.getClassHierarchy(session, className!)),
+          () => Promise.resolve(queries.getClassHierarchy(session, className)),
         );
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -3272,7 +3272,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         db =
           db ??
-          sysadminStorage.getDatabases().find((d) => d.config.stoneName === session!.login.stone);
+          sysadminStorage.getDatabases().find((d) => d.config.stoneName === session.login.stone);
         if (!db) {
           vscode.window.showErrorMessage(
             `Full logical restore currently requires a database created through Jasper's Databases ` +
@@ -3308,7 +3308,7 @@ export function activate(context: vscode.ExtensionContext) {
           backupFile,
           hasFileControl: () =>
             hasFileControlPrivilege((label, code) =>
-              queries.executeFetchString(session!, label, code),
+              queries.executeFetchString(session, label, code),
             ),
           closeCurrentSession: async () => {
             sessionManager.logout(sessionId);

--- a/client/src/gemstoneDebugSession.ts
+++ b/client/src/gemstoneDebugSession.ts
@@ -298,7 +298,7 @@ export class GemStoneDebugSession extends DebugSession {
               const side = uriInfo.isMeta ? 'class' : 'instance';
               frameName = `${baseClass}${uriInfo.isMeta ? ' class' : ''}>>#${uriInfo.selector}`;
               sourcePath =
-                `gemstone://${this.session!.id}` +
+                `gemstone://${this.session.id}` +
                 `/${encodeURIComponent(uriInfo.dictName)}` +
                 `/${encodeURIComponent(baseClass)}` +
                 `/${side}` +
@@ -463,7 +463,7 @@ export class GemStoneDebugSession extends DebugSession {
 
   private getReceiverVariables(receiverOop: bigint): Variable[] {
     if (!this.session || receiverOop === OOP_NIL || receiverOop === 0n) {
-      return [{ name: 'self', value: 'nil', variablesReference: 0 } as Variable];
+      return [{ name: 'self', value: 'nil', variablesReference: 0 }];
     }
 
     const vars: Variable[] = [];
@@ -514,7 +514,7 @@ export class GemStoneDebugSession extends DebugSession {
 
   private makeVariable(name: string, oop: bigint): Variable {
     if (!this.session) {
-      return { name, value: '<no session>', variablesReference: 0 } as Variable;
+      return { name, value: '<no session>', variablesReference: 0 };
     }
 
     const value = debug.getObjectPrintString(this.session, oop, MAX_PRINT_STRING);

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -426,7 +426,7 @@ class ExplorerController {
   private currentMethodSelector(): string | undefined {
     const selection = this.views?.method.selection;
     if (!selection) return this.state.selectedSelector;
-    const item = selection.find((n) => n instanceof MethodItem) as MethodItem | undefined;
+    const item = selection.find((n) => n instanceof MethodItem);
     return item?.info.selector;
   }
 
@@ -437,13 +437,13 @@ class ExplorerController {
   private providerFor(viewId: string): RefreshableProvider<unknown> {
     switch (viewId) {
       case VIEW_DICTS:
-        return this.dictProvider as RefreshableProvider<unknown>;
+        return this.dictProvider;
       case VIEW_CATEGORIES:
-        return this.categoryProvider as RefreshableProvider<unknown>;
+        return this.categoryProvider;
       case VIEW_CLASSES:
-        return this.classProvider as RefreshableProvider<unknown>;
+        return this.classProvider;
       default:
-        return this.methodProvider as RefreshableProvider<unknown>;
+        return this.methodProvider;
     }
   }
 
@@ -536,8 +536,7 @@ class ExplorerController {
     const session = this.session();
     const { dictName, dictIndex, className } = this.state;
     // Remember the method row currently selected so it can be re-revealed.
-    const selectedMethod = this.views?.method.selection.find((n) => n instanceof MethodItem) as
-      MethodItem | undefined;
+    const selectedMethod = this.views?.method.selection.find((n) => n instanceof MethodItem);
     const revealMethod = selectedMethod
       ? { selector: selectedMethod.info.selector, isMeta: selectedMethod.isMeta }
       : undefined;
@@ -1329,7 +1328,7 @@ class ExplorerController {
     if (this.state.className === className && this.state.dictName === dictName) {
       if (revealMethod) {
         const info = this.selectorsFor(revealMethod.isMeta, ALL_METHODS_CATEGORY).find(
-          (i) => i.selector === revealMethod!.selector,
+          (i) => i.selector === revealMethod.selector,
         );
         if (info) {
           try {
@@ -1815,7 +1814,7 @@ class MethodDragAndDrop implements vscode.TreeDragAndDropController<MethodNode> 
   constructor(private readonly ctl: ExplorerController) {}
 
   handleDrag(source: readonly MethodNode[], dataTransfer: vscode.DataTransfer): void {
-    const item = source.find((n) => n instanceof MethodItem) as MethodItem | undefined;
+    const item = source.find((n) => n instanceof MethodItem);
     const payload = item && this.ctl.dragPayload(item);
     if (payload) dataTransfer.set(METHOD_MIME, new vscode.DataTransferItem(payload));
   }

--- a/client/src/mcpSettings.ts
+++ b/client/src/mcpSettings.ts
@@ -22,7 +22,7 @@ interface ConfigLike {
 export type GetConfiguration = (section: string) => ConfigLike;
 
 const defaultGetConfiguration: GetConfiguration = (section) =>
-  vscode.workspace.getConfiguration(section) as unknown as ConfigLike;
+  vscode.workspace.getConfiguration(section);
 
 /** True when the user set this key at any scope (not merely the contributed default). */
 function isExplicitlySet<T>(config: ConfigLike, key: string): boolean {

--- a/client/src/mcpSocketServer.ts
+++ b/client/src/mcpSocketServer.ts
@@ -361,7 +361,7 @@ export function writeClaudeDesktopMcpConfig(extensionPath: string, socketPath: s
     args: [proxyScriptPath(extensionPath), '--proxy-socket', socketPath],
   };
 
-  const mcpServers = (settings.mcpServers ?? {}) as Record<string, unknown>;
+  const mcpServers = settings.mcpServers ?? {};
   let dirty = false;
   if (JSON.stringify(mcpServers[MCP_SERVER_NAME]) !== JSON.stringify(desired)) {
     mcpServers[MCP_SERVER_NAME] = desired;

--- a/client/src/restoreManager.ts
+++ b/client/src/restoreManager.ts
@@ -227,7 +227,7 @@ export async function runLogicalRestore(deps: LogicalRestoreDeps): Promise<boole
     await deps.startStone();
 
     step('restoring from the backup…');
-    const needsCommit = await runRestoreCall(await login(), backupFile!);
+    const needsCommit = await runRestoreCall(await login(), backupFile);
 
     if (needsCommit) {
       step('finalizing the restore…');

--- a/client/src/sharedMemoryTreeProvider.ts
+++ b/client/src/sharedMemoryTreeProvider.ts
@@ -339,6 +339,7 @@ export class OsConfigTreeProvider implements vscode.TreeDataProvider<OsConfigNod
       if (this._cache) return this._cache;
 
       // Return a loading indicator immediately, then fetch async and refresh.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       this._loadConfig();
       return [{ kind: 'loading' }];
     }

--- a/client/src/sunitTestController.ts
+++ b/client/src/sunitTestController.ts
@@ -125,7 +125,7 @@ export class SunitTestController implements vscode.Disposable {
       exclude: [],
       profile: undefined,
       preserveFocus: false,
-    } as vscode.TestRunRequest);
+    });
     await this.runClassTests(session, run, classItem, className, dictName);
     run.end();
   }

--- a/client/src/systemBrowser.ts
+++ b/client/src/systemBrowser.ts
@@ -504,7 +504,7 @@ export class SystemBrowser {
 
     // Update dictionary if changed
     if (this.state.selectedDictIndex !== dictIndex) {
-      this.handleSelectDictionary(dictIndex);
+      this.handleSelectDictionary(dictIndex).catch((e) => this.postError(e));
       this.panel.webview.postMessage({
         command: 'selectDictionaryItem',
         index: dictIndex,
@@ -604,7 +604,9 @@ export class SystemBrowser {
           this.handleReady();
           break;
         case 'selectDictionary':
-          this.handleSelectDictionary(message.index as number, false, true);
+          this.handleSelectDictionary(message.index as number, false, true).catch((e) =>
+            this.postError(e),
+          );
           break;
         case 'selectCategory':
           this.handleSelectCategory(message.name as string);
@@ -984,7 +986,7 @@ export class SystemBrowser {
     const className = this.state.selectedClass;
     if (!className) return;
 
-    this.openClassFile(className, selector, this.state.isMeta);
+    this.openClassFile(className, selector, this.state.isMeta).catch((e) => this.postError(e));
   }
 
   // Open a side-by-side diff of a session override against the persistent base
@@ -1138,7 +1140,7 @@ export class SystemBrowser {
     });
     this.postMethods(this.state.methods, selector);
 
-    if (openFile) this.openClassFile(className, selector, isMeta);
+    if (openFile) this.openClassFile(className, selector, isMeta).catch((e) => this.postError(e));
   }
 
   /**
@@ -1159,7 +1161,7 @@ export class SystemBrowser {
     this.panel.reveal(undefined, true);
 
     if (this.state.selectedDictIndex !== dictIndex) {
-      this.handleSelectDictionary(dictIndex);
+      this.handleSelectDictionary(dictIndex).catch((e) => this.postError(e));
       this.panel.webview.postMessage({ command: 'selectDictionaryItem', index: dictIndex });
     }
 
@@ -1210,7 +1212,7 @@ export class SystemBrowser {
     // Restore previous selections when the items still exist after refresh
     if (!prev.selectedDictIndex || prev.selectedDictIndex > this.state.dictionaries.length) return;
 
-    this.handleSelectDictionary(prev.selectedDictIndex);
+    this.handleSelectDictionary(prev.selectedDictIndex).catch((e) => this.postError(e));
     this.panel.webview.postMessage({
       command: 'selectDictionaryItem',
       index: prev.selectedDictIndex,

--- a/client/src/versionTreeProvider.ts
+++ b/client/src/versionTreeProvider.ts
@@ -129,6 +129,7 @@ export class VersionTreeProvider implements vscode.TreeDataProvider<VersionItem>
       // keeps `loaded` true so the refresh() below does not re-trigger us into
       // an endless reload/error-dialog loop. Explicit user actions (the refresh
       // command, post-download, etc.) call loadVersions() directly to re-fetch.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME: unhandled floating promise; needs investigation to decide await vs. void vs. .catch before this rule is enabled repo-wide
       this.loadVersions();
       return [];
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,29 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended, // non-type-checked only — no `projectService`/type-aware rules for now
   {
+    // Type-aware linting, scoped to `**/*.ts` (the files covered by a workspace
+    // tsconfig.json — client/server/mcp-server/acceptance). `projectService`
+    // finds the nearest tsconfig per file rather than needing an explicit list.
+    // Enabling type-aware rules individually rather than the full
+    // `recommendedTypeChecked` set, which surfaces ~2k pre-existing findings
+    // across the codebase that need separate triage (see
+    // playground/research/jasper-eslint-type-aware-rules.md for the full breakdown).
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          // vitest.config.ts files aren't included in any tsconfig's `include`,
+          // so type-aware linting can't otherwise parse them.
+          allowDefaultProject: ['vitest.config.ts', '*/vitest.config.ts'],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+    },
+  },
+  {
     // Catches stale `eslint-disable` comments that no longer suppress anything.
     linterOptions: { reportUnusedDisableDirectives: 'error' },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-unnecessary-type-assertion': 'error',
       '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default tseslint.config(
     },
     rules: {
       '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/await-thenable': 'error',
     },
   },
   {

--- a/mcp-server/src/__tests__/mcpSession.test.ts
+++ b/mcp-server/src/__tests__/mcpSession.test.ts
@@ -52,7 +52,10 @@ function makeConfig(overrides: Partial<McpSessionConfig> = {}): McpSessionConfig
 
 function createMockGci() {
   return {
-    GciTsLogin: vi.fn(() => ({ session: {} as unknown, err: { ...noErr } })),
+    GciTsLogin: vi.fn((): { session: unknown; err: typeof noErr } => ({
+      session: {},
+      err: { ...noErr },
+    })),
     GciTsLogout: vi.fn(() => ({ err: { ...noErr } })),
     GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
     GciTsExecuteFetchBytes: vi.fn(() => ({ data: 'result', bytesReturned: 6, err: { ...noErr } })),
@@ -66,7 +69,7 @@ describe('McpSession', () => {
     mockGci = createMockGci();
     vi.mocked(GciLibrary).mockImplementation(function (this: unknown) {
       return mockGci as unknown as GciLibrary;
-    } as unknown as new (...args: ConstructorParameters<typeof GciLibrary>) => GciLibrary);
+    });
   });
 
   describe('constructor', () => {

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -11,16 +11,13 @@ import {
   MethodNode,
   MethodBodyNode,
   MessagePatternNode,
-  UnaryPatternNode,
   BinaryPatternNode,
   KeywordPatternNode,
   StatementNode,
   ReturnNode,
-  AssignmentNode,
   ExpressionNode,
   PrimaryNode,
   VariableNode,
-  PathNode,
   BlockNode,
   SelectionBlockNode,
   ParenExpressionNode,
@@ -32,12 +29,9 @@ import {
   KeywordPartNode,
   LiteralNode,
   NumberLiteralNode,
-  StringLiteralNode,
   SymbolLiteralNode,
-  CharacterLiteralNode,
   ArrayLiteralNode,
   ByteArrayLiteralNode,
-  SpecialLiteralNode,
   ArrayItemNode,
   PragmaNode,
   UnaryPragmaNode,
@@ -116,7 +110,7 @@ export class Parser {
         kind: 'UnaryPattern',
         selector: id.text,
         range: this.rangeFrom(start),
-      } as UnaryPatternNode;
+      };
     }
 
     this.addError('Expected method pattern');
@@ -124,7 +118,7 @@ export class Parser {
       kind: 'UnaryPattern',
       selector: 'unknown',
       range: this.rangeFrom(start),
-    } as UnaryPatternNode;
+    };
   }
 
   private parseBinaryPattern(start: SourcePosition): BinaryPatternNode {
@@ -173,7 +167,7 @@ export class Parser {
     if (this.check(TokenType.Identifier)) {
       const text = this.peek().text;
       if (text === 'protected' || text === 'unprotected') {
-        protection = text as 'protected' | 'unprotected';
+        protection = text;
         this.advance();
       }
     }
@@ -381,7 +375,7 @@ export class Parser {
           variable,
           value,
           range: this.rangeFrom(start),
-        } as AssignmentNode;
+        };
       }
     }
 
@@ -469,7 +463,7 @@ export class Parser {
       selector: selector.text,
       envSpecifier,
       range: this.rangeFrom(start),
-    } as UnaryMessageNode;
+    };
   }
 
   private parseBinaryMessageNode(): BinaryMessageNode {
@@ -489,7 +483,7 @@ export class Parser {
       argument,
       envSpecifier,
       range: this.rangeFrom(start),
-    } as BinaryMessageNode;
+    };
   }
 
   private parseKeywordMessage(): KeywordMessageNode | null {
@@ -565,7 +559,7 @@ export class Parser {
         kind: 'SymbolLiteral',
         value: '#',
         range: this.rangeFrom(start),
-      } as SymbolLiteralNode;
+      };
     }
 
     // Block: [...]
@@ -599,7 +593,7 @@ export class Parser {
           kind: 'NumberLiteral',
           value: '-' + num.text,
           range: this.rangeFrom(start),
-        } as NumberLiteralNode;
+        };
       }
     }
 
@@ -621,7 +615,7 @@ export class Parser {
       kind: 'Variable',
       name: token.text,
       range: this.rangeFrom(start),
-    } as VariableNode;
+    };
   }
 
   private parseIdentifierOrPath(): PrimaryNode {
@@ -663,7 +657,7 @@ export class Parser {
             kind: 'Path',
             segments,
             range: this.rangeFrom(start),
-          } as PathNode;
+          };
         }
       }
     }
@@ -672,7 +666,7 @@ export class Parser {
       kind: 'Variable',
       name: id.text,
       range: this.rangeFrom(start),
-    } as VariableNode;
+    };
   }
 
   private parseBlock(): BlockNode {
@@ -804,7 +798,7 @@ export class Parser {
           kind: 'NumberLiteral',
           value: '-' + num.text,
           range: this.rangeFrom(start),
-        } as NumberLiteralNode;
+        };
       }
     }
 
@@ -820,7 +814,7 @@ export class Parser {
         kind: 'SymbolLiteral',
         value: text,
         range: this.rangeFrom(start),
-      } as SymbolLiteralNode;
+      };
     }
 
     if (this.check(TokenType.Keyword)) {
@@ -833,10 +827,10 @@ export class Parser {
         kind: 'SymbolLiteral',
         value: text,
         range: this.rangeFrom(start),
-      } as SymbolLiteralNode;
+      };
     }
 
-    return this.parseLiteral() as ArrayItemNode;
+    return this.parseLiteral();
   }
 
   private parseByteArrayLiteral(): ByteArrayLiteralNode {
@@ -893,7 +887,7 @@ export class Parser {
           kind: 'NumberLiteral',
           value: token.text,
           range: this.rangeFrom(start),
-        } as NumberLiteralNode;
+        };
 
       case TokenType.String:
         this.advance();
@@ -901,7 +895,7 @@ export class Parser {
           kind: 'StringLiteral',
           value: token.text,
           range: this.rangeFrom(start),
-        } as StringLiteralNode;
+        };
 
       case TokenType.Symbol:
         return this.parseSymbolLiteral();
@@ -912,7 +906,7 @@ export class Parser {
           kind: 'CharacterLiteral',
           value: token.text,
           range: this.rangeFrom(start),
-        } as CharacterLiteralNode;
+        };
 
       case TokenType.SpecialLiteral:
         this.advance();
@@ -920,7 +914,7 @@ export class Parser {
           kind: 'SpecialLiteral',
           value: token.text as 'true' | 'false' | 'nil' | '_remoteNil',
           range: this.rangeFrom(start),
-        } as SpecialLiteralNode;
+        };
 
       case TokenType.HashLeftParen:
         return this.parseArrayLiteral();
@@ -935,7 +929,7 @@ export class Parser {
           kind: 'NumberLiteral',
           value: '0',
           range: this.rangeFrom(start),
-        } as NumberLiteralNode;
+        };
     }
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -84,14 +84,14 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 
 connection.onInitialized(async () => {
   if (hasConfigurationCapability) {
-    connection.client.register(DidChangeConfigurationNotification.type, {
+    await connection.client.register(DidChangeConfigurationNotification.type, {
       section: 'gemstoneSmalltalk',
     });
     await updateFormatterSettings();
   }
 
   // Register file watchers for Smalltalk files
-  connection.client.register(DidChangeWatchedFilesNotification.type, {
+  await connection.client.register(DidChangeWatchedFilesNotification.type, {
     watchers: SMALLTALK_EXTENSIONS.map((ext) => ({
       globPattern: `**/*${ext}`,
     })),
@@ -169,7 +169,7 @@ documents.onDidChangeContent((change) => {
     change.document.getText(),
     format,
   );
-  connection.sendDiagnostics({
+  void connection.sendDiagnostics({
     uri: parsed.uri,
     diagnostics: toDiagnostics(parsed.errors),
   });
@@ -180,7 +180,7 @@ documents.onDidChangeContent((change) => {
 
 documents.onDidClose((event) => {
   documentManager.remove(event.document.uri);
-  connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+  void connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
 });
 
 // ── File watcher ────────────────────────────────────────────

--- a/server/src/services/documentSymbols.ts
+++ b/server/src/services/documentSymbols.ts
@@ -1,12 +1,5 @@
 import { DocumentSymbol, SymbolKind } from 'vscode-languageserver';
-import {
-  MethodNode,
-  BlockNode,
-  StatementNode,
-  ExpressionNode,
-  PrimaryNode,
-  MessageNode,
-} from '../parser/ast';
+import { MethodNode, StatementNode, ExpressionNode, PrimaryNode, MessageNode } from '../parser/ast';
 import { SourceRange } from '../lexer/tokens';
 import { TopazRegion } from '../topaz/topazParser';
 
@@ -115,7 +108,7 @@ function collectFromMessage(msg: MessageNode, symbols: DocumentSymbol[], off: nu
 
 function collectFromPrimary(primary: PrimaryNode, symbols: DocumentSymbol[], off: number): void {
   if (primary.kind === 'Block') {
-    const block = primary as BlockNode;
+    const block = primary;
     const blockSymbol: DocumentSymbol = {
       name:
         block.parameters.length > 0

--- a/server/src/services/folding.ts
+++ b/server/src/services/folding.ts
@@ -1,14 +1,7 @@
 import { FoldingRange, FoldingRangeKind } from 'vscode-languageserver';
 import { ParsedDocument } from '../utils/documentManager';
 import { TokenType } from '../lexer/tokens';
-import {
-  MethodNode,
-  BlockNode,
-  StatementNode,
-  ExpressionNode,
-  PrimaryNode,
-  MessageNode,
-} from '../parser/ast';
+import { MethodNode, StatementNode, ExpressionNode, PrimaryNode, MessageNode } from '../parser/ast';
 
 export function getFoldingRanges(doc: ParsedDocument): FoldingRange[] {
   const ranges: FoldingRange[] = [];
@@ -132,7 +125,7 @@ function walkMessageForFolds(msg: MessageNode, ranges: FoldingRange[], off: numb
 
 function walkPrimaryForFolds(primary: PrimaryNode, ranges: FoldingRange[], off: number): void {
   if (primary.kind === 'Block') {
-    const block = primary as BlockNode;
+    const block = primary;
     const startLine = block.range.start.line + off;
     const endLine = block.range.end.line + off;
     if (endLine > startLine) {

--- a/server/src/services/formatting.ts
+++ b/server/src/services/formatting.ts
@@ -337,7 +337,7 @@ function formatKeywordMessage(
   const allBlockArgs = blocks.every((b) => b !== null);
 
   if (allBlockArgs && msg.parts.length >= 2) {
-    const blockList = blocks as BlockNode[];
+    const blockList = blocks;
 
     // Tier 1: All blocks are trivial (empty or single variable/literal)
     // → keep everything on one line

--- a/server/src/services/semanticTokens.ts
+++ b/server/src/services/semanticTokens.ts
@@ -8,8 +8,6 @@ import {
   BlockNode,
   LiteralNode,
   VariableNode,
-  KeywordMessageNode,
-  BinaryMessageNode,
   SelectionBlockNode,
 } from '../parser/ast';
 import { ScopeAnalyzer, ScopeNode } from '../utils/scopeAnalyzer';
@@ -199,9 +197,9 @@ export function collectSemanticTokens(
       if (selectorToken) {
         pushFromToken(selectorToken, 7);
       }
-      walkExpression((msg as BinaryMessageNode).argument);
+      walkExpression(msg.argument);
     } else if (msg.kind === 'KeywordMessage') {
-      const kwMsg = msg as KeywordMessageNode;
+      const kwMsg = msg;
       for (const part of kwMsg.parts) {
         const docPartRange = toDocRange(part.range);
         for (const token of tokens) {
@@ -221,10 +219,10 @@ export function collectSemanticTokens(
         walkVariable(primary);
         break;
       case 'Block':
-        walkBlock(primary as BlockNode);
+        walkBlock(primary);
         break;
       case 'SelectionBlock':
-        walkSelectionBlock(primary as SelectionBlockNode);
+        walkSelectionBlock(primary);
         break;
       case 'ParenExpression':
         walkStatement(primary.expression);
@@ -238,7 +236,7 @@ export function collectSemanticTokens(
       default:
         // Literal
         if (isLiteral(primary.kind)) {
-          walkLiteral(primary as LiteralNode);
+          walkLiteral(primary);
         }
         break;
     }

--- a/server/src/utils/scopeAnalyzer.ts
+++ b/server/src/utils/scopeAnalyzer.ts
@@ -152,7 +152,7 @@ export class ScopeAnalyzer {
   private walkPrimary(primary: PrimaryNode, scope: ScopeNode): void {
     switch (primary.kind) {
       case 'Block':
-        this.walkBlock(primary as BlockNode, scope);
+        this.walkBlock(primary, scope);
         break;
       case 'SelectionBlock':
         // Selection block has a parameter and predicate


### PR DESCRIPTION
## Summary

Incrementally tightens the ESLint config by enabling type-aware lint rules and fixing (or deliberately deferring) the pre-existing findings each one surfaces. Enabling `projectService` type-aware linting exposes ~2k findings across the codebase; rather than turn on the full `recommendedTypeChecked` set at once, this branch enables individual high-value rules step by step.

Rules enabled in this branch:

- **`no-unnecessary-type-assertion`** — bulk-fixable; removes redundant `as T` casts.
- **`await-thenable`** — flags `await` on non-thenables.
- **`no-floating-promises`** — flags promise-returning calls that are neither awaited nor handled. Genuine correctness signal (unhandled rejections can crash the host or silently swallow errors).

## `no-floating-promises` — what was fixed vs. deferred

The rule surfaced 62 pre-existing findings. Handled as follows:

**Genuinely fixed:**
- **Login editor tests** (25) — the tests called the async `LoginEditorPanel.show` without awaiting and asserted on the same tick; made them `async` + `await` so they wait for the panel work and surface rejections.
- **LSP server** (4) — `await`ed the two `client.register` capability requests; `void`ed the two `sendDiagnostics` notification sends (deliberate fire-and-forget).
- **System browser** (6) — routed six fire-and-forget navigation calls through `.catch(postError)`, matching the file's existing convention and surfacing errors that were previously dropped.

**Deferred with scoped `eslint-disable` + FIXME (27):** the remaining call sites (`extension.ts` command handlers, the two tree providers, one debugger branch) are all currently fire-and-forget. Deciding the correct handling — `await` vs. `void` vs. `.catch` — requires per-site investigation and, in a couple of cases (`client.start()`, `exportSession` inside a login `try/catch`), involves real behavior questions. Each is annotated with a single-line disable carrying a `-- FIXME` reason so the rule can be enabled now to prevent *future* floating promises, and the existing ones retired incrementally.

## Why enable now

The goal is to get the rule on the books so new code can't introduce unhandled promises, without blocking on a full audit of every pre-existing site.

## Testing

- `npm run lint` — clean (rule enabled, exit 0)
- `npm run format:check` — clean
- `npm run compile` — clean
- server + client test suites pass for the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
