### PR TITLE
Rowan: create a new project on disk

### DIFF
--- a/client/src/__tests__/rowanCreate.test.ts
+++ b/client/src/__tests__/rowanCreate.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createRowanProject } from '../rowanCreate';
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'rowan-create-'));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+// Independent copies of createRowanProject.solo's captured output (3.7.5), so a
+// drift in the module's templates is caught.
+const EXPECTED_PROJECT = [
+  'RwProjectSpecificationV3 {',
+  "\t#specName : 'project',",
+  "\t#projectVersion : '1.0.0',",
+  "\t#projectSpecPath : 'rowan',",
+  "\t#componentsPath : 'rowan/components',",
+  "\t#packagesPath : 'src',",
+  "\t#projectsPath : 'rowan/projects',",
+  "\t#specsPath : 'rowan/specs',",
+  "\t#packageFormat : 'tonel',",
+  "\t#packageConvention : 'RowanHybrid',",
+  "\t#comment : ''",
+  '}',
+].join('\n');
+
+const EXPECTED_CORE = [
+  'RwLoadComponent {',
+  "\t#name : 'Core',",
+  '\t#projectNames : [ ],',
+  '\t#componentNames : [ ],',
+  '\t#packageNames : [ ],',
+  "\t#comment : ''",
+  '}',
+].join('\n');
+
+const EXPECTED_PROPERTIES = [
+  '{ ',
+  "\t#format : 'tonel',",
+  "\t#convention : 'RowanHybrid'",
+  '}',
+  '',
+].join('\n');
+
+function expectedLoadSpec(name: string): string {
+  return [
+    'RwLoadSpecificationV2 {',
+    `\t#projectName : '${name}',`,
+    "\t#projectSpecFile : 'rowan/project.ston',",
+    '\t#componentNames : [',
+    "\t\t'Core'",
+    '\t],',
+    '\t#platformProperties : {',
+    "\t\t'gemstone' : {",
+    "\t\t\t'allusers' : {",
+    "\t\t\t\t#defaultSymbolDictName : 'UserGlobals'",
+    '\t\t\t}',
+    '\t\t}',
+    '\t},',
+    "\t#comment : ''",
+    '}',
+  ].join('\n');
+}
+
+describe('createRowanProject', () => {
+  it('writes the full project layout', () => {
+    const dir = tmp();
+
+    const result = createRowanProject(dir, 'MyApp');
+
+    expect(result).toEqual({ success: true, projectDir: dir });
+    for (const p of [
+      'rowan/project.ston',
+      'rowan/specs/MyApp.ston',
+      'rowan/components/Core.ston',
+      'rowan/projects/README.md',
+      'src/properties.st',
+    ]) {
+      expect(fs.existsSync(path.join(dir, p))).toBe(true);
+    }
+  });
+
+  it('matches the solo tool output byte-for-byte', () => {
+    const dir = tmp();
+    createRowanProject(dir, 'MyApp');
+    const read = (p: string) => fs.readFileSync(path.join(dir, p), 'utf8');
+
+    expect(read('rowan/project.ston')).toBe(EXPECTED_PROJECT);
+    expect(read('rowan/components/Core.ston')).toBe(EXPECTED_CORE);
+    expect(read('src/properties.st')).toBe(EXPECTED_PROPERTIES);
+    expect(read('rowan/specs/MyApp.ston')).toBe(expectedLoadSpec('MyApp'));
+    expect(read('rowan/projects/README.md')).toBe('');
+  });
+
+  it('names the load spec file and #projectName after the project, verbatim', () => {
+    const dir = tmp();
+
+    createRowanProject(dir, 'seaside-app');
+
+    const spec = fs.readFileSync(path.join(dir, 'rowan', 'specs', 'seaside-app.ston'), 'utf8');
+    expect(spec).toContain("#projectName : 'seaside-app',");
+  });
+
+  it('backslash-escapes a single quote in the project name', () => {
+    const dir = tmp();
+
+    createRowanProject(dir, "O'Hara");
+
+    const spec = fs.readFileSync(path.join(dir, 'rowan', 'specs', "O'Hara.ston"), 'utf8');
+    expect(spec).toContain("#projectName : 'O\\'Hara',");
+  });
+
+  it('backslash-escapes a backslash in the project name', () => {
+    const dir = tmp();
+
+    createRowanProject(dir, 'a\\b');
+
+    const spec = fs.readFileSync(path.join(dir, 'rowan', 'specs', 'a\\b.ston'), 'utf8');
+    expect(spec).toContain("#projectName : 'a\\\\b',");
+  });
+
+  it('refuses to overwrite an existing Rowan project', () => {
+    const dir = tmp();
+    createRowanProject(dir, 'MyApp');
+
+    const again = createRowanProject(dir, 'MyApp');
+
+    expect(again.success).toBe(false);
+    expect(again.error).toContain('already a Rowan project');
+  });
+
+  it('gitignores the local .gemstone class mirror', () => {
+    const dir = tmp();
+
+    createRowanProject(dir, 'MyApp');
+
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toContain('.gemstone/');
+  });
+
+  it('appends to an existing .gitignore instead of clobbering it', () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n');
+
+    createRowanProject(dir, 'MyApp');
+
+    const gitignore = fs.readFileSync(path.join(dir, '.gitignore'), 'utf8');
+    expect(gitignore).toContain('node_modules/');
+    expect(gitignore).toContain('.gemstone/');
+  });
+});

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -57,6 +57,7 @@ import {
 } from './rowanTreeProvider';
 import { isRowanProjectRoot } from './rowanProject';
 import { RowanProjectTreeProvider } from './rowanProjectView';
+import { createRowanProject } from './rowanCreate';
 import { RowanDecorationProvider } from './rowanDecorations';
 import { findMethodInClass } from './commands/findMethodInClass';
 import { loadClassPickItems } from './commands/classPicker';
@@ -2512,6 +2513,29 @@ export function activate(context: vscode.ExtensionContext) {
     rowanProjectProvider.refresh();
     rowanProjectView.description = rowanProjectProvider.projectName();
   };
+  // Resolve a GemStone install that can run the Rowan solo scripts: prefer the
+  // connected session's version, else the first extracted version that ships the
+  // tooling. $GEMSTONE is the sysadmin path, or two dirs up from the GCI library
+  // (…/lib/libgci → install root).
+  // Open a freshly-created project's load-spec manifest with the project name
+  // selected, so the user names it there (the name is metadata, not the folder).
+  const openRowanManifestAtName = async (projectRoot: string, specName: string) => {
+    const manifest = path.join(projectRoot, 'rowan', 'specs', `${specName}.ston`);
+    let doc: vscode.TextDocument;
+    try {
+      doc = await vscode.workspace.openTextDocument(vscode.Uri.file(manifest));
+    } catch {
+      return;
+    }
+    const m = /(#projectName\s*:\s*')([^']*)'/.exec(doc.getText());
+    const selection = m
+      ? new vscode.Range(
+          doc.positionAt(m.index + m[1].length),
+          doc.positionAt(m.index + m[1].length + m[2].length),
+        )
+      : undefined;
+    await vscode.window.showTextDocument(doc, selection ? { selection } : {});
+  };
   // Recognize when the open workspace root is itself a Rowan project — gates the
   // Explorer section's visibility. Passive: no effect when it isn't one.
   const refreshRowanWorkspaceContext = () => {
@@ -2542,6 +2566,95 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand('gemstone.rowanRefreshView', () => {
       rowanProvider.refresh();
+    }),
+
+    vscode.commands.registerCommand('gemstone.rowanNewProject', async () => {
+      const name = (
+        await vscode.window.showInputBox({
+          prompt: 'New Rowan project name',
+          placeHolder: 'MyProject',
+          ignoreFocusOut: true,
+          // The name becomes a folder, so only reject what breaks a folder name —
+          // the project's own name lives in the Rowan metadata, and Rowan itself
+          // accepts hyphens, dots, etc.
+          validateInput: (v) => {
+            const t = v.trim();
+            if (!t) return 'Enter a project name.';
+            if (/[\\/]/.test(t) || t === '.' || t === '..')
+              return 'Avoid /, \\, ".", and ".." — this becomes a folder name.';
+            return undefined;
+          },
+        })
+      )?.trim();
+      if (!name) return;
+
+      const openFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const picked = await vscode.window.showOpenDialog({
+        canSelectFolders: true,
+        canSelectFiles: false,
+        canSelectMany: false,
+        openLabel: 'Create Project Here',
+        title: `Choose where to create "${name}"`,
+        defaultUri: openFolder ? vscode.Uri.file(openFolder) : undefined,
+      });
+      if (!picked || picked.length === 0) return;
+      const dest = path.join(picked[0].fsPath, name);
+      if (fs.existsSync(dest)) {
+        vscode.window.showErrorMessage(`"${dest}" already exists.`);
+        return;
+      }
+      try {
+        fs.mkdirSync(dest, { recursive: true });
+      } catch (e: unknown) {
+        vscode.window.showErrorMessage(
+          `Could not create the folder: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        return;
+      }
+
+      const result = createRowanProject(dest, name);
+      if (!result.success) {
+        vscode.window.showErrorMessage(`Could not create the project: ${result.error}`);
+        return;
+      }
+      const choice = await vscode.window.showInformationMessage(
+        `Created Rowan project "${name}".`,
+        'Open Project',
+      );
+      if (choice === 'Open Project' && result.projectDir) {
+        await vscode.commands.executeCommand(
+          'vscode.openFolder',
+          vscode.Uri.file(result.projectDir),
+        );
+      }
+    }),
+
+    vscode.commands.registerCommand('gemstone.rowanInitHere', async () => {
+      const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (!folder) {
+        vscode.window.showErrorMessage(
+          'Open a folder first — this turns the open folder into a Rowan project.',
+        );
+        return;
+      }
+      if (isRowanProjectRoot(folder)) {
+        vscode.window.showInformationMessage('This folder is already a Rowan project.');
+        return;
+      }
+      // The open folder IS the project's containing folder; its name becomes the
+      // load spec's file name. The project's own name is metadata the user edits
+      // in the manifest we open right afterward.
+      const name = path.basename(folder);
+
+      const result = createRowanProject(folder, name);
+      if (!result.success) {
+        vscode.window.showErrorMessage(`Could not create the project: ${result.error}`);
+        return;
+      }
+      refreshRowanWorkspaceContext();
+      rowanProvider.refresh();
+      refreshRowanProjectView();
+      await openRowanManifestAtName(folder, name);
     }),
 
     vscode.commands.registerCommand('gemstone.rowanAddRepo', async () => {

--- a/client/src/rowanCreate.ts
+++ b/client/src/rowanCreate.ts
@@ -1,0 +1,123 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Create a Rowan project by writing its files directly — no solo gem, no
+// GemStone install required. The output matches createRowanProject.solo's
+// default layout byte-for-byte (tonel, RowanHybrid, a Core load component,
+// packages under src/), minus the `git init` it does (version control is the
+// user's / VS Code's job). Templates use tabs; the .ston files have no trailing
+// newline, properties.st ends with one — matching the shipped tool.
+
+const PROJECT_STON = [
+  'RwProjectSpecificationV3 {',
+  "\t#specName : 'project',",
+  "\t#projectVersion : '1.0.0',",
+  "\t#projectSpecPath : 'rowan',",
+  "\t#componentsPath : 'rowan/components',",
+  "\t#packagesPath : 'src',",
+  "\t#projectsPath : 'rowan/projects',",
+  "\t#specsPath : 'rowan/specs',",
+  "\t#packageFormat : 'tonel',",
+  "\t#packageConvention : 'RowanHybrid',",
+  "\t#comment : ''",
+  '}',
+].join('\n');
+
+const CORE_COMPONENT_STON = [
+  'RwLoadComponent {',
+  "\t#name : 'Core',",
+  '\t#projectNames : [ ],',
+  '\t#componentNames : [ ],',
+  '\t#packageNames : [ ],',
+  "\t#comment : ''",
+  '}',
+].join('\n');
+
+const PROPERTIES_ST = ['{ ', "\t#format : 'tonel',", "\t#convention : 'RowanHybrid'", '}', ''].join(
+  '\n',
+);
+
+// STON single-quoted string escaping, matching GemStone's STONWriter: a
+// backslash escapes a literal backslash and a literal quote (not Smalltalk-style
+// quote doubling). Escape the backslash first so an escaped quote isn't
+// re-escaped.
+function escapeStonString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function loadSpecSton(projectName: string): string {
+  return [
+    'RwLoadSpecificationV2 {',
+    `\t#projectName : '${escapeStonString(projectName)}',`,
+    "\t#projectSpecFile : 'rowan/project.ston',",
+    '\t#componentNames : [',
+    "\t\t'Core'",
+    '\t],',
+    '\t#platformProperties : {',
+    "\t\t'gemstone' : {",
+    "\t\t\t'allusers' : {",
+    "\t\t\t\t#defaultSymbolDictName : 'UserGlobals'",
+    '\t\t\t}',
+    '\t\t}',
+    '\t},',
+    "\t#comment : ''",
+    '}',
+  ].join('\n');
+}
+
+// Ensure the project ignores Jasper's local class mirror (.gemstone/) — it's
+// per-user/stone, generated, and can get large. Appends to an existing
+// .gitignore rather than clobbering it.
+function ensureGitignore(projectDir: string): void {
+  const gitignorePath = path.join(projectDir, '.gitignore');
+  const entry = '.gemstone/';
+  let existing = '';
+  try {
+    existing = fs.readFileSync(gitignorePath, 'utf8');
+  } catch {
+    /* no .gitignore yet */
+  }
+  if (existing.split(/\r?\n/).some((line) => line.trim() === entry)) return;
+  const header = "# Jasper's local read-only class mirror of a connected stone (per user/stone).";
+  const content =
+    existing.trim().length > 0
+      ? `${existing.replace(/\n*$/, '')}\n\n${header}\n${entry}\n`
+      : `${header}\n${entry}\n`;
+  fs.writeFileSync(gitignorePath, content);
+}
+
+export interface CreateRowanProjectResult {
+  success: boolean;
+  // Absolute path to the project directory (the one passed in).
+  projectDir?: string;
+  error?: string;
+}
+
+// Scaffold a Rowan project into `projectDir` (which must already exist). The
+// load spec is named after `projectName` (its file and its #projectName). Writes
+// files only. Refuses if the directory is already a Rowan project.
+export function createRowanProject(
+  projectDir: string,
+  projectName: string,
+): CreateRowanProjectResult {
+  const rowan = path.join(projectDir, 'rowan');
+  if (fs.existsSync(path.join(rowan, 'project.ston'))) {
+    return { success: false, error: `"${projectDir}" is already a Rowan project.` };
+  }
+  try {
+    fs.mkdirSync(path.join(rowan, 'specs'), { recursive: true });
+    fs.mkdirSync(path.join(rowan, 'components'), { recursive: true });
+    fs.mkdirSync(path.join(rowan, 'projects'), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, 'src'), { recursive: true });
+
+    fs.writeFileSync(path.join(rowan, 'project.ston'), PROJECT_STON);
+    fs.writeFileSync(path.join(rowan, 'specs', `${projectName}.ston`), loadSpecSton(projectName));
+    fs.writeFileSync(path.join(rowan, 'components', 'Core.ston'), CORE_COMPONENT_STON);
+    fs.writeFileSync(path.join(rowan, 'projects', 'README.md'), '');
+    fs.writeFileSync(path.join(projectDir, 'src', 'properties.st'), PROPERTIES_ST);
+    ensureGitignore(projectDir);
+    return { success: true, projectDir };
+  } catch (e: unknown) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -438,7 +438,18 @@
       },
       {
         "view": "gemstoneRowan",
-        "contents": "Not connected."
+        "contents": "Not connected.",
+        "when": "gemstone.workspaceIsRowanProject"
+      },
+      {
+        "view": "gemstoneRowan",
+        "contents": "This folder isn't a Rowan project.\n[Create Rowan Project](command:gemstone.rowanInitHere)",
+        "when": "!gemstone.workspaceIsRowanProject && workspaceFolderCount != 0"
+      },
+      {
+        "view": "gemstoneRowan",
+        "contents": "Open a folder to work with Rowan.\n[New Rowan Project…](command:gemstone.rowanNewProject)",
+        "when": "workspaceFolderCount == 0"
       },
       {
         "view": "gemstoneInspector",
@@ -816,6 +827,17 @@
         "title": "Refresh Rowan View",
         "category": "GemStone",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "gemstone.rowanNewProject",
+        "title": "New Rowan Project…",
+        "category": "GemStone",
+        "icon": "$(new-folder)"
+      },
+      {
+        "command": "gemstone.rowanInitHere",
+        "title": "Create Rowan Project",
+        "category": "GemStone"
       },
       {
         "command": "gemstone.rowanFindClassPackage",
@@ -1458,6 +1480,11 @@
         {
           "command": "gemstone.openWalkthrough",
           "when": "view == gemstoneVersions",
+          "group": "navigation@0"
+        },
+        {
+          "command": "gemstone.rowanNewProject",
+          "when": "view == gemstoneRowan",
           "group": "navigation@0"
         },
         {


### PR DESCRIPTION
Add **New Rowan Project** — scaffold a Rowan project on disk without a running
stone or a GemStone install. Builds on the workspace-project recognition from
#179: create a project here, and Jasper immediately frames the workspace around
it.

## What changes
- **`createRowanProject`** (`rowanCreate.ts`) writes the project files directly:
  `rowan/project.ston`, a load spec named after the project, a `Core`
  component, and `src/properties.st`. The layout matches the RowanV3 solo tool's
  default output byte-for-byte — same tonel/RowanHybrid conventions — but needs
  no solo gem and no GemStone install.
- A new project gets a `.gitignore` entry for Jasper's local `.gemstone` class
  mirror (generated, per-user, potentially large); an existing `.gitignore` is
  appended to, never clobbered.
- Refuses to scaffold into a directory that is already a Rowan project, and
  doesn't over-restrict project names.
- Commands: **New Rowan Project…** (name → pick a location → generate → open the
  folder) and **Create Rowan Project** (turn the currently open folder into one,
  offered via the Rowan view's welcome content when the folder isn't yet a
  project).

## Notes
- Creation is pure file generation — no stone required for the new behavior.
- Stacks on #179; open once that merges.
