### PR TITLE
Sync ESLint ignores with .gitignore via @eslint/compat

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,19 +3,17 @@ import tseslint from 'typescript-eslint';
 import globals from 'globals';
 import eslintComments from '@eslint-community/eslint-plugin-eslint-comments';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import gitignore from 'eslint-config-flat-gitignore';
 
 export default tseslint.config(
+  // Keep lint ignores in sync with every `.gitignore` in the repo, instead of
+  // a hand-maintained duplicate list that drifts (e.g. missed `.vscode-test/`
+  // choking the parser on a downloaded test binary).
+  gitignore({ recursive: true }),
   {
-    ignores: [
-      '**/out/**',
-      '**/node_modules/**',
-      '**/*.d.ts',
-      '**/*.vsix',
-      'resources/**',
-      '.gemstone/**',
-      'client/tmp/**',
-      'acceptance/test-results/**',
-    ],
+    // Tracked files that are intentionally excluded from lint, not from git —
+    // no `.gitignore` equivalent, so these stay explicit.
+    ignores: ['**/*.d.ts', 'resources/**'],
   },
   // `eslint .` only auto-targets extensions it has a language for by default;
   // this makes the intent explicit and future-proofs against config drift.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.28.1",
         "eslint": "^10.0.0",
+        "eslint-config-flat-gitignore": "^2.3.0",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^16.0.0",
         "lefthook": "^2.1.10",
@@ -991,6 +992,27 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40 || 9 || 10"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/config-array": {
@@ -4517,6 +4539,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-flat-gitignore": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-flat-gitignore/-/eslint-config-flat-gitignore-2.3.0.tgz",
+      "integrity": "sha512-bg4ZLGgoARg1naWfsINUUb/52Ksw/K22K+T16D38Y8v+/sGwwIYrGvH/JBjOin+RQtxxC9tzNNiy4shnGtGyyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/compat": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "eslint": "^9.5.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-config-prettier": {

--- a/package.json
+++ b/package.json
@@ -2047,6 +2047,7 @@
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.28.1",
     "eslint": "^10.0.0",
+    "eslint-config-flat-gitignore": "^2.3.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^16.0.0",
     "lefthook": "^2.1.10",


### PR DESCRIPTION
## Summary
- Replace the hand-maintained ESLint `ignores` array with `eslint-config-flat-gitignore`'s `recursive: true` mode, which walks the repo and picks up every `.gitignore` automatically — so lint ignores can't drift from what's actually gitignored.
- Concrete motivation: a missed `.vscode-test/` entry previously choked the ESLint parser on a downloaded VS Code test binary. Recursive discovery avoids that class of miss structurally, including catching `docs/enhancedInspectorSupport/.gitignore`, which a hand-maintained list would be easy to overlook.
- Keeps `**/*.d.ts` and `resources/**` as explicit lint-only ignores, since they're tracked files with no gitignore equivalent.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run compile` passes
- [x] Verified `.gemstone/` and `.vscode-test/` are correctly ignored by lint
- [x] Verified `.gitignore` negation (e.g. `!.claude/hooks/`) is still honored, so those files remain linted