### PR TITLE
Fix transitive dependency vulnerabilities flagged by Dependabot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ## [Unreleased]
 
+### Security
+
+- **Patched three transitive dependency vulnerabilities flagged by Dependabot.** Added root `overrides` pinning `fast-uri` to `^3.1.4` (host-confusion, high — pulled in via the MCP SDK's `ajv`), `js-yaml` to `^4.3.0` (quadratic-CPU merge keys, high — dev-only, via `@vscode/vsce`), and `@hono/node-server` to `^2.0.5` (`serve-static` path traversal on Windows, moderate — via the MCP SDK; the vulnerable path is unreachable since Jasper's MCP server uses the SSE transport, not the hono-based Streamable-HTTP transport). `npm audit` now reports zero vulnerabilities, guarded by a new `dependencyVulnFloors` test so a lockfile refresh can't silently regress below the patched floors.
+
 ## [1.8.8] - 2026-07-21
 
 Maintenance release — no user-facing changes. Internal refactoring (migrating the shared query layer onto `defaultQueryExecutorUsing`, plus dead-code removal), developer-tooling tweaks (`dev:fresh`, ESLint ignore sync), and transitive dependency (lockfile) updates including `hono` and `linkify-it`.

--- a/client/src/__tests__/dependencyVulnFloors.test.ts
+++ b/client/src/__tests__/dependencyVulnFloors.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Regression guard for the transitive dependency vulnerabilities Dependabot flagged
+// on the default branch (see https://github.com/GemTalk/Jasper/security/dependabot).
+//
+// None of these are direct dependencies — they are pulled in transitively (fast-uri and
+// @hono/node-server via @modelcontextprotocol/sdk, js-yaml via @vscode/vsce's secretlint),
+// so the only way to pin them to a patched version is the root package.json `overrides`
+// block. A plain `npm install` will happily resolve a fresh, still-vulnerable minor if the
+// override is ever removed, and nothing else in the suite would notice — hence this test.
+//
+// It asserts two things:
+//   1. root package.json still declares the overrides (a clear failure if one is deleted), and
+//   2. every copy of each package the lockfile resolves sits at or above the patched floor
+//      (so `npm ci` — what CI installs — can never regress to a flagged version).
+//
+// Notes on the specific advisories, so future maintainers know what these floors buy:
+//   - fast-uri >= 3.1.4        GHSA-4c8g-83qw-93j6 + GHSA-v2hh-gcrm-f6hx (host confusion, high)
+//   - @hono/node-server >= 2.0.5  GHSA-frvp-7c67-39w9 (serve-static path traversal, moderate).
+//       The MCP SDK still declares ^1.19.9, so this override forces a major bump past the
+//       SDK's declared range; `npm ls` reports it as "invalid", which is expected and benign.
+//       We use SSEServerTransport (raw Node res), not the SDK's hono-based Streamable-HTTP
+//       transport, so the vulnerable serve-static path is unreachable regardless — the bump
+//       is defence-in-depth plus a clean Dependabot dashboard.
+//   - js-yaml >= 4.3.0         GHSA-52cp-r559-cp3m (quadratic CPU via merge keys, high). Dev-
+//       only (packaging tool), never shipped, but kept patched so the dashboard stays clean.
+//
+// __dirname here is client/src/__tests__, so the repo root is three levels up.
+describe('transitive dependency vulnerability floors', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const lock = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package-lock.json'), 'utf8'));
+
+  // Patched floor for each flagged package. Keep in sync with the overrides in package.json.
+  const FLOORS: Record<string, string> = {
+    'fast-uri': '3.1.4',
+    '@hono/node-server': '2.0.5',
+    'js-yaml': '4.3.0',
+  };
+
+  // Numeric-tuple >= compare, prerelease stripped. Our floors are plain releases, so this is
+  // sufficient and avoids depending on an undeclared transitive `semver`.
+  function gte(version: string, floor: string): boolean {
+    const parse = (v: string) =>
+      v
+        .split('-')[0]
+        .split('.')
+        .map((n) => parseInt(n, 10) || 0);
+    const a = parse(version);
+    const b = parse(floor);
+    for (let i = 0; i < 3; i++) {
+      const av = a[i] ?? 0;
+      const bv = b[i] ?? 0;
+      if (av !== bv) return av > bv;
+    }
+    return true;
+  }
+
+  // Every resolved copy of `name` in the lockfile. The installed package name is the path
+  // segment after the final "node_modules/" in each lockfile key (handles nesting/dedupe).
+  function resolvedVersions(name: string): string[] {
+    const marker = 'node_modules/';
+    const out: string[] = [];
+    for (const [key, entry] of Object.entries<{ version?: string }>(lock.packages)) {
+      if (!entry || typeof entry.version !== 'string') continue;
+      const idx = key.lastIndexOf(marker);
+      if (idx === -1) continue;
+      if (key.slice(idx + marker.length) === name) out.push(entry.version);
+    }
+    return out;
+  }
+
+  it.each(Object.entries(FLOORS))(
+    'declares an override pinning %s to at least %s',
+    (name, floor) => {
+      const override = pkg.overrides?.[name];
+      expect(override, `package.json overrides.${name} is missing`).toBeDefined();
+      // Override is a range like "^2.0.5"; strip the leading range operator for the floor check.
+      const overrideFloor = String(override).replace(/^[\^~>=]*/, '');
+      expect(gte(overrideFloor, floor)).toBe(true);
+    },
+  );
+
+  it.each(Object.entries(FLOORS))(
+    'resolves every copy of %s at or above the patched floor %s',
+    (name, floor) => {
+      const versions = resolvedVersions(name);
+      expect(versions.length, `${name} not found in package-lock.json`).toBeGreaterThan(0);
+      for (const v of versions) {
+        expect(gte(v, floor), `${name}@${v} is below the patched floor ${floor}`).toBe(true);
+      }
+    },
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1133,12 +1133,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -5914,9 +5914,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -2064,5 +2064,10 @@
   "dependencies": {
     "@vscode/debugadapter": "^1.68.0",
     "koffi": "^2.15.1"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.4",
+    "@hono/node-server": "^2.0.5",
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
## What

Adds root `package.json` `overrides` pinning the three transitively-pulled packages Dependabot flagged, and a regression-guard test so a future lockfile refresh can't silently regress below the patched floors.

| Package | Floor | Severity | Advisory | Pulled in via |
|---|---|---|---|---|
| `fast-uri` | `^3.1.4` | high | GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx (host confusion) | `@modelcontextprotocol/sdk` → `ajv` |
| `js-yaml` | `^4.3.0` | high | GHSA-52cp-r559-cp3m (quadratic CPU via merge keys) | `@vscode/vsce` → secretlint (dev-only) |
| `@hono/node-server` | `^2.0.5` | moderate | GHSA-frvp-7c67-39w9 (`serve-static` path traversal on Windows) | `@modelcontextprotocol/sdk` |

`npm audit` now reports **0 vulnerabilities**; `npm ci` reproduces the patched tree.

## Notes

- **`fast-uri` was already bumped on `main` by Dependabot #196** (a plain lockfile bump — it stays within `ajv`'s range). Keeping it in `overrides` here is redundant with that but adds durable regression protection, and lets a single guard test cover all three. The lockfile change in this PR is therefore only `js-yaml` and `@hono/node-server`.
- **`@hono/node-server` is the one Dependabot can't fix on its own:** the MCP SDK still declares `^1.19.9`, so the patched `2.x` is a *major* bump outside the SDK's declared range. The override forces it; `npm ls` reports the resolved copy as `invalid`, which is expected and benign. The vulnerable `serve-static` path is unreachable regardless — Jasper's MCP server uses `SSEServerTransport` (raw Node `res`), not the hono-based Streamable-HTTP transport — so this is defence-in-depth plus a clean Dependabot dashboard.
- **`js-yaml`** is dev-only (packaging tooling), never shipped, but kept patched so the dashboard stays clean.

## Testing

- `npm audit` → 0 vulnerabilities; `npm ci` reproduces the tree.
- New `dependencyVulnFloors` test asserts the overrides exist and every resolved copy of each package sits at/above its patched floor.
- Full suite green: client 3296, server 322, mcp-server 95; `npm run lint`, `format:check`, `compile` all pass.
- MCP server compiles and all 95 tests pass against `@hono/node-server` 2.x.
- Lockfile diff is limited to exactly the security-relevant packages — no collateral transitive bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)