### PR TITLE
Migrate method search queries off deprecated bind() executor

### DIFF
--- a/client/src/__tests__/browserQueries.test.ts
+++ b/client/src/__tests__/browserQueries.test.ts
@@ -103,7 +103,7 @@ describe('browserQueries', () => {
       const session = createMockSession('');
       queries.sendersOf(session, 'size', 2);
 
-      const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
+      const mockExec = session.gci.executeAndFetchString as ReturnType<typeof vi.fn>;
       const code = mockExec.mock.calls[0][1] as string;
       expect(code).toContain('environmentId: 2');
     });
@@ -135,7 +135,7 @@ describe('browserQueries', () => {
       const session = createMockSession('');
       queries.implementorsOf(session, 'size');
 
-      const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
+      const mockExec = session.gci.executeAndFetchString as ReturnType<typeof vi.fn>;
       const code = mockExec.mock.calls[0][1] as string;
       expect(code).toContain('asArray');
     });

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -604,11 +604,11 @@ export function getStepPointSelectorRanges(
 }
 
 export function searchMethodSource(session: ActiveSession, term: string, ignoreCase: boolean) {
-  return sharedSearchMethodSource(bind(session), term, ignoreCase);
+  return sharedSearchMethodSource(defaultQueryExecutorUsing(session), term, ignoreCase);
 }
 
 export function sendersOf(session: ActiveSession, selector: string, environmentId: number = 0) {
-  return sharedSendersOf(bind(session), selector, environmentId);
+  return sharedSendersOf(defaultQueryExecutorUsing(session), selector, environmentId);
 }
 
 export function implementorsOf(
@@ -616,7 +616,7 @@ export function implementorsOf(
   selector: string,
   environmentId: number = 0,
 ) {
-  return sharedImplementorsOf(bind(session), selector, environmentId);
+  return sharedImplementorsOf(defaultQueryExecutorUsing(session), selector, environmentId);
 }
 
 export function hierarchyImplementorsOf(
@@ -629,7 +629,7 @@ export function hierarchyImplementorsOf(
   environmentId: number = 0,
 ) {
   return sharedHierarchyImplementorsOf(
-    bind(session),
+    defaultQueryExecutorUsing(session),
     dictIndex,
     className,
     selector,
@@ -644,7 +644,7 @@ export function referencesToObject(
   objectName: string,
   environmentId: number = 0,
 ) {
-  return sharedReferencesToObject(bind(session), objectName, environmentId);
+  return sharedReferencesToObject(defaultQueryExecutorUsing(session), objectName, environmentId);
 }
 
 // ── Write-path queries (mutations) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Migrates the method search group (`searchMethodSource`, `sendersOf`, `implementorsOf`, `hierarchyImplementorsOf`, `referencesToObject`) from the deprecated `bind()`/`executeFetchString` executor to `defaultQueryExecutorUsing()`, backed by `GciLibrary.executeAndFetchString`.
- `executeFetchString`'s raw `GciTsExecuteFetchBytes` call mis-decodes non-ASCII results and truncates large ones; `executeAndFetchString` encodes the result as UTF-8 in Smalltalk before paging it out, fixing both.

Based directly on `main` (first PR in this new stack).

## Manual test plan

1. Open a method's source (double-click it in System Browser's Methods column). Confirm the CodeLens above the method reads "N senders" and "N implementors". Click **"N senders"**. Confirm a quick-pick of senders appears. (`sendersOf`)
2. Click **"N implementors"** on the same CodeLens. Confirm a quick-pick of implementors appears. (`implementorsOf`)
3. In System Browser, find a method with an override arrow (▲ or ▼) in its gutter and click it. Confirm the hierarchy implementors view opens, titled "... — superclass implementors" or "... — subclass overrides". (`hierarchyImplementorsOf`)
4. Run the **"GemStone: Search Method Source"** command from the Command Palette, search for a known string. Confirm a quick-pick of matches appears. (`searchMethodSource`)
5. In System Browser, right-click a class or a symbol dictionary and choose **"Browse References"**. Confirm a "References to ..." result appears. (`referencesToObject`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
