### PR TITLE
Migrate method mutations queries off deprecated bind() executor

### DIFF
--- a/client/src/__tests__/browserQueries.test.ts
+++ b/client/src/__tests__/browserQueries.test.ts
@@ -52,7 +52,7 @@ describe('browserQueries', () => {
       queries.compileMethod(session, 'Array', false, 'test', 'foo\n  ^ 42');
 
       const mockPerform = session.gci.GciTsPerform as ReturnType<typeof vi.fn>;
-      const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
+      const mockExec = session.gci.executeAndFetchString as ReturnType<typeof vi.fn>;
       expect(mockPerform).not.toHaveBeenCalled();
       expect(mockExec).toHaveBeenCalledTimes(1);
       const code = mockExec.mock.calls[0][1] as string;
@@ -63,7 +63,7 @@ describe('browserQueries', () => {
     it('branches on isMeta inside the Smalltalk, not via a GCI perform', () => {
       const session = createMockSession('ok');
       queries.compileMethod(session, 'Array', true, 'test', 'foo');
-      const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
+      const mockExec = session.gci.executeAndFetchString as ReturnType<typeof vi.fn>;
       const code = mockExec.mock.calls[0][1] as string;
       expect(code).toContain('target := base class');
     });

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -671,7 +671,7 @@ export function compileMethod(
   dict?: number | string,
 ): string {
   return sharedCompileMethod(
-    bind(session),
+    defaultQueryExecutorUsing(session),
     className,
     isMeta,
     category,
@@ -709,7 +709,7 @@ export function copyMethodToClass(
   dict?: number | string,
 ): string {
   return sharedCopyMethodToClass(
-    bind(session),
+    defaultQueryExecutorUsing(session),
     sourceClass,
     targetClass,
     isMeta,
@@ -726,7 +726,7 @@ export function deleteMethod(
   selector: string,
   dict?: number | string,
 ): string {
-  return sharedDeleteMethod(bind(session), className, isMeta, selector, dict);
+  return sharedDeleteMethod(defaultQueryExecutorUsing(session), className, isMeta, selector, dict);
 }
 
 export function recategorizeMethod(
@@ -737,7 +737,14 @@ export function recategorizeMethod(
   newCategory: string,
   dict?: number | string,
 ): string {
-  return sharedRecategorizeMethod(bind(session), className, isMeta, selector, newCategory, dict);
+  return sharedRecategorizeMethod(
+    defaultQueryExecutorUsing(session),
+    className,
+    isMeta,
+    selector,
+    newCategory,
+    dict,
+  );
 }
 
 export function renameCategory(
@@ -748,7 +755,14 @@ export function renameCategory(
   newCategory: string,
   dict?: number | string,
 ): string {
-  return sharedRenameCategory(bind(session), className, isMeta, oldCategory, newCategory, dict);
+  return sharedRenameCategory(
+    defaultQueryExecutorUsing(session),
+    className,
+    isMeta,
+    oldCategory,
+    newCategory,
+    dict,
+  );
 }
 
 export function deleteClass(


### PR DESCRIPTION
## Summary
- Migrates the method mutations group (`compileMethod`, `copyMethodToClass`, `deleteMethod`, `recategorizeMethod`, `renameCategory`) from the deprecated `bind()`/`executeFetchString` executor to `defaultQueryExecutorUsing()`, backed by `GciLibrary.executeAndFetchString`.
- `executeFetchString`'s raw `GciTsExecuteFetchBytes` call mis-decodes non-ASCII results and truncates large ones; `executeAndFetchString` encodes the result as UTF-8 in Smalltalk before paging it out, fixing both.
- `bind()` is deliberately **not** removed in this commit even though every other function in `browserQueries.ts` is now migrated — the Rowan project group (next in this stack) still calls it, and gets removed there instead once it's truly the last user.

Stacked on top of #199 — merge that one first.

## Manual test plan

Uses one method throughout, in this order, so nothing needs to be re-found or re-selected between steps.

1. In System Browser, open a method's source, edit it, and save (Cmd+S). Confirm the "Compiled method" confirmation and the new source persists. (`compileMethod`)
2. Right-click that method and choose **"Move to Category…"**, picking a different existing category. Confirm it moves. (`recategorizeMethod`)
3. Right-click the category it just moved into (in the Method Categories column) and choose **"Rename Category…"**. Confirm the rename applies. (`renameCategory`)
4. Right-click the method and choose **"Copy to Class…"**, picking a different class in the same dictionary. Confirm it now exists in both classes. (`copyMethodToClass`)
5. Right-click the method and choose **"Delete Method"** — last, since it's destructive. Confirm it's removed after the confirmation prompt. (`deleteMethod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
