### PR TITLE
Migrate Rowan project queries off deprecated bind() executor

### DIFF
--- a/client/src/__tests__/rowanQueries.test.ts
+++ b/client/src/__tests__/rowanQueries.test.ts
@@ -4,7 +4,7 @@ import { getGemCacheKB } from '../queries/rowan/getGemCacheKB';
 import { exportRowanProject } from '../queries/rowan/exportRowanProject';
 import { findRowanClassOwners } from '../queries/rowan/findRowanClassOwners';
 import { listAllRowanClasses } from '../queries/rowan/listAllRowanClasses';
-import { loadRowanProject } from '../queries/rowan/loadRowanProject';
+import { buildLoadRowanProjectCode, parseRowanLoadResult } from '../queries/rowan/loadRowanProject';
 import { diffRowanProject, formatRowanDiff } from '../queries/rowan/diffRowanProject';
 import { unloadRowanProject } from '../queries/rowan/unloadRowanProject';
 import type { QueryExecutor } from '../queries/types';
@@ -75,25 +75,20 @@ describe('findRowanClassOwners', () => {
   });
 });
 
-describe('loadRowanProject', () => {
+describe('parseRowanLoadResult', () => {
   it('reports the loaded project name on OK', () => {
-    const result = loadRowanProject(executor('OK\tLoadMe'), '/p/rowan/specs/LoadMe.ston', '/p');
-
-    expect(result).toEqual({ success: true, detail: 'LoadMe' });
+    expect(parseRowanLoadResult('OK\tLoadMe')).toEqual({ success: true, detail: 'LoadMe' });
   });
 
-  it('reports the error and aborts on ERR', () => {
-    const result = loadRowanProject(executor('ERR\tbad spec'), '/p/x.ston', '/p');
-
-    expect(result).toEqual({ success: false, detail: 'bad spec' });
+  it('reports the error message on ERR', () => {
+    expect(parseRowanLoadResult('ERR\tbad spec')).toEqual({ success: false, detail: 'bad spec' });
   });
+});
 
+describe('buildLoadRowanProjectCode', () => {
   it('loads via projectFromUrl:diskUrl: and commits', () => {
-    const execute = executor('');
+    const code = buildLoadRowanProjectCode('/p/specs/LoadMe.ston', '/p');
 
-    loadRowanProject(execute, '/p/specs/LoadMe.ston', '/p');
-
-    const code = execute.mock.calls[0][1];
     expect(code).toContain("projectFromUrl: 'file:/p/specs/LoadMe.ston' diskUrl: 'file:/p'");
     expect(code).toContain('System commitTransaction');
     expect(code).toContain('System abortTransaction');

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -43,7 +43,6 @@ import { exportRowanProject as sharedExportRowanProject } from './queries/rowan/
 import { findRowanClassOwners as sharedFindRowanClassOwners } from './queries/rowan/findRowanClassOwners';
 import { listAllRowanClasses as sharedListAllRowanClasses } from './queries/rowan/listAllRowanClasses';
 import {
-  loadRowanProject as sharedLoadRowanProject,
   buildLoadRowanProjectCode,
   parseRowanLoadResult,
   RowanLoadResult,
@@ -311,17 +310,6 @@ export function sessionNeedsCommit(session: ActiveSession): boolean | undefined 
 }
 
 /**
- * Binds a session to the QueryExecutor shape that shared queries expect.
- *
- * @deprecated Backed by executeFetchString's raw GciTsExecuteFetchBytes
- * call, which is prone to mis-decoding non-ASCII results and truncating
- * large ones. Being replaced by {@link defaultQueryExecutorUsing} one call-site group at a time.
- */
-function bind(session: ActiveSession): QueryExecutor {
-  return (label, code) => executeFetchString(session, label, code);
-}
-
-/**
  * Binds a session to the QueryExecutor shape that shared queries expect,
  * backed by GciLibrary.executeAndFetchString.
  *
@@ -361,27 +349,23 @@ export function getDictionaryNames(session: ActiveSession): string[] {
 // ── Rowan browser queries ─────────────────────────────────────────────────
 
 export function getGemCacheKB(session: ActiveSession) {
-  return sharedGetGemCacheKB(bind(session));
+  return sharedGetGemCacheKB(defaultQueryExecutorUsing(session));
 }
 
 export function listRowanProjects(session: ActiveSession) {
-  return sharedListRowanProjects(bind(session));
+  return sharedListRowanProjects(defaultQueryExecutorUsing(session));
 }
 
 export function exportRowanProject(session: ActiveSession, projectName: string, targetDir: string) {
-  return sharedExportRowanProject(bind(session), projectName, targetDir);
+  return sharedExportRowanProject(defaultQueryExecutorUsing(session), projectName, targetDir);
 }
 
 export function findRowanClassOwners(session: ActiveSession, className: string) {
-  return sharedFindRowanClassOwners(bind(session), className);
+  return sharedFindRowanClassOwners(defaultQueryExecutorUsing(session), className);
 }
 
 export function listAllRowanClasses(session: ActiveSession) {
-  return sharedListAllRowanClasses(bind(session));
-}
-
-export function loadRowanProject(session: ActiveSession, specPath: string, diskPath: string) {
-  return sharedLoadRowanProject(bind(session), specPath, diskPath);
+  return sharedListAllRowanClasses(defaultQueryExecutorUsing(session));
 }
 
 // Non-blocking load for the extension: same Smalltalk, run via
@@ -403,11 +387,11 @@ export async function loadRowanProjectNb(
 }
 
 export function diffRowanProject(session: ActiveSession, projectName: string) {
-  return sharedDiffRowanProject(bind(session), projectName);
+  return sharedDiffRowanProject(defaultQueryExecutorUsing(session), projectName);
 }
 
 export function unloadRowanProject(session: ActiveSession, projectName: string) {
-  return sharedUnloadRowanProject(bind(session), projectName);
+  return sharedUnloadRowanProject(defaultQueryExecutorUsing(session), projectName);
 }
 
 export function getClassNames(session: ActiveSession, dict: number | string): string[] {

--- a/client/src/queries/rowan/loadRowanProject.ts
+++ b/client/src/queries/rowan/loadRowanProject.ts
@@ -1,4 +1,3 @@
-import { QueryExecutor } from '../types';
 import { escapeString } from '../util';
 
 export interface RowanLoadResult {
@@ -17,10 +16,11 @@ export interface RowanLoadResult {
 // Must run on a SystemUser session: loading mutates Rowan's system-owned
 // registry (objectSecurityPolicyId 1), which DataCurator cannot write.
 //
-// The Smalltalk builder and result parser are exported separately so the
-// extension can run this long operation over the NON-BLOCKING execute path
-// (executeFetchStringNb) — project loads can take minutes, and the synchronous
-// call would freeze the extension host for the duration.
+// The builder and result parser are exported separately (rather than composed
+// into one function here) because the extension runs this long operation over
+// the NON-BLOCKING execute path (executeFetchStringNb, see
+// browserQueries.ts's loadRowanProjectNb) — project loads can take minutes,
+// and a synchronous call would freeze the extension host for the duration.
 export function buildLoadRowanProjectCode(specPath: string, diskPath: string): string {
   return `| r sep resolved name |
 sep := String with: Character tab.
@@ -39,16 +39,4 @@ export function parseRowanLoadResult(raw: string): RowanLoadResult {
   const status = tab === -1 ? raw.trim() : raw.slice(0, tab);
   const detail = tab === -1 ? '' : raw.slice(tab + 1).trim();
   return { success: status === 'OK', detail };
-}
-
-export function loadRowanProject(
-  execute: QueryExecutor,
-  specPath: string,
-  diskPath: string,
-): RowanLoadResult {
-  const raw = execute(
-    `loadRowanProject(${specPath})`,
-    buildLoadRowanProjectCode(specPath, diskPath),
-  );
-  return parseRowanLoadResult(raw);
 }


### PR DESCRIPTION
## Summary
- Removes a dead export (`loadRowanProject`, the synchronous wrapper) instead of migrating it — zero production callers anywhere in `client/`, `server/`, or `mcp-server/`. The only production Rowan-load path is `loadRowanProjectNb` (the non-blocking one, for minutes-long loads), which never calls this wrapper. Also removes the now-unreachable composed function of the same name in `queries/rowan/loadRowanProject.ts`, keeping `buildLoadRowanProjectCode`/`parseRowanLoadResult` (still used by `loadRowanProjectNb`) and their test coverage, exercised directly instead of through the deleted composition.
- Migrates the rest of the Rowan project group (`getGemCacheKB`, `listRowanProjects`, `exportRowanProject`, `findRowanClassOwners`, `listAllRowanClasses`, `diffRowanProject`, `unloadRowanProject`) from the deprecated `bind()`/`executeFetchString` executor to `defaultQueryExecutorUsing()`, backed by `GciLibrary.executeAndFetchString`.
- `executeFetchString`'s raw `GciTsExecuteFetchBytes` call mis-decodes non-ASCII results and truncates large ones; `executeAndFetchString` encodes the result as UTF-8 in Smalltalk before paging it out, fixing both.
- This is the last group in `browserQueries.ts` still calling `bind()` in this stack, so the deprecated helper itself is now fully removed from that file.

Stacked on top of #200 — merge that one first.

## Manual test plan

All steps go through Jasper's own UI (no shell scripts), reusing one Rowan-enabled database and one loaded project throughout.

1. **Create a Rowan-enabled database.** Open the **Databases** view (GemStone activity bar) → **"Create Database"**. Pick a GemStone version that ships Rowan (3.6.4+ or any 3.7.x, e.g. `3.7.5`). For "Select base extent", choose `extent0.rowan3` (or `extent0.rowan`) instead of the plain `extent0`. Accept the default stone/NetLDI names. Start it, then log in (e.g. as `DataCurator`).
2. **Add a Rowan repository.** In the **Rowan** view's title bar, click **"Add Rowan Repository…"** → **"Clone from Git URL…"** → enter `https://github.com/srbaker/seaside-rowan.git` (small, known-good).
3. **Load it into the session.** Under the Rowan view's "Repositories" section, hover the new repo row and click its **"Load into Image"** icon. Confirm it now appears under "Loaded Projects". (`listRowanProjects`; `getGemCacheKB` runs automatically here too, as a pre-flight check — no separate action needed)
4. Run **"GemStone: Search Rowan Classes"** from the Command Palette. Confirm a quick-pick of all Rowan-loaded classes appears, including some from Seaside. Pick one and note its name. (`listAllRowanClasses`)
5. Run **"GemStone: Find Class's Rowan Package"** from the Command Palette, entering the class name from step 4. Confirm it reports the owning package. (`findRowanClassOwners`)
6. Right-click the loaded project and choose **"Open Diff Against Disk"**. Confirm a diff document opens. (`diffRowanProject`)
7. Right-click the loaded project and choose **"Export Copy…"**, picking a folder. Confirm it exports and offers to reveal the folder. (`exportRowanProject`)
8. Right-click the loaded project and choose **"Unload Rowan Project…"** — last, since it's destructive. Confirm it disappears from "Loaded Projects" after confirming. (`unloadRowanProject`)

**Expected errors on the `seaside-rowan` fixture, confirmed unrelated to this migration:** this project was only ever built to demo *loading* — per a team member, "everything is slightly broken because it only worked to get Seaside in for the demo."
- Step 6 (`diffRowanProject`) may throw `a MessageNotUnderstood occurred (error 2010), a UndefinedObject does not understand #'do:'`. Cause: the query's Smalltalk doesn't guard against `patchesForProjectNamed:` returning `nil`. Tracked at [GemStone/grail#77](https://code.gemtalksystems.com/GemStone/grail/-/work_items/77).
- Step 8 (`unloadRowanProject`) may throw `a Error occurred (error 2008), reason:rtErrSubclassResponsibility, ... Selector: #'argumentCount'`. This one's Smalltalk *is* wrapped in `on: Error do: [...]`, but this particular GemStone-level error isn't catchable through ordinary exception handling, so the guard doesn't help. Tracked at [GemStone/grail#78](https://code.gemtalksystems.com/GemStone/grail/-/work_items/78).

Both confirm the underlying `executeAndFetchString` migration works correctly — the errors surface only after real Smalltalk execution completes, deep in Rowan's own tooling reacting to this fixture's structure. Not something to chase as part of this PR; if a clean end-to-end diff/unload example is needed, use a different, more complete Rowan project as the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

