### PR TITLE
Migrate SUnit test runner queries off deprecated bind() executor

### DIFF
--- a/client/src/__tests__/sunitQueries.test.ts
+++ b/client/src/__tests__/sunitQueries.test.ts
@@ -24,7 +24,7 @@ const noErr = {
 function createMockSession(executeFetchData = ''): ActiveSession {
   const mockGci = {
     GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({ data: executeFetchData, err: { ...noErr } })),
+    executeAndFetchString: vi.fn(() => executeFetchData),
     GciTsCallInProgress: vi.fn(() => ({ result: 0 })),
   };
 
@@ -54,8 +54,7 @@ describe('sunitQueries', () => {
     it('emits the per-class test count from the query', () => {
       const session = createMockSession('');
       sunit.discoverTestClasses(session);
-      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
-        .calls[0][1];
+      const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(code).toContain('testSelectors size');
     });
 
@@ -84,8 +83,7 @@ describe('sunitQueries', () => {
     it('executes Smalltalk code that finds TestCase subclasses', () => {
       const session = createMockSession('');
       sunit.discoverTestClasses(session);
-      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
-        .calls[0][1];
+      const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(code).toContain('TestCase');
       expect(code).toContain('isSubclassOf');
     });
@@ -120,7 +118,7 @@ describe('sunitQueries', () => {
       (dict) => {
         const session = createMockSession('');
         sunit.discoverTestMethods(session, 'AnnouncerTest', dict);
-        const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
+        const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock
           .calls[0][1];
         expect(code).toContain(`objectNamed: #'${dict}'`);
         expect(code).toContain("at: #'AnnouncerTest'");
@@ -184,8 +182,7 @@ describe('sunitQueries', () => {
     it('captures live exception class + messageText (no testCase run framework)', () => {
       const session = createMockSession('');
       sunit.runTestMethod(session, 'MyTestCase', 'testBad');
-      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
-        .calls[0][1];
+      const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(code).toContain('on: AbstractException');
       expect(code).toContain('testCase setUp');
       expect(code).toContain('testCase perform:');
@@ -205,7 +202,7 @@ describe('sunitQueries', () => {
       (dict) => {
         const session = createMockSession('passed\t\t1');
         sunit.runTestMethod(session, 'AnnouncerTest', 'testFoo', dict);
-        const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
+        const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock
           .calls[0][1];
         expect(code).toContain(`objectNamed: #'${dict}'`);
         expect(code).toContain("at: #'AnnouncerTest'");
@@ -262,8 +259,7 @@ describe('sunitQueries', () => {
     it('does not send #testCase to failure/error wrappers', () => {
       const session = createMockSession('');
       sunit.runTestClass(session, 'MyTestCase');
-      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
-        .calls[0][1];
+      const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(code).not.toMatch(/testCase\s+class\s+name/);
       expect(code).not.toMatch(/testCase\s+selector/);
     });
@@ -275,8 +271,7 @@ describe('sunitQueries', () => {
     it('captures live exception class + messageText for failures and errors via re-run', () => {
       const session = createMockSession('');
       sunit.runTestClass(session, 'MyTestCase');
-      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
-        .calls[0][1];
+      const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(code).toContain('captureMessage');
       expect(code).toContain('on: AbstractException');
       expect(code).toContain('t setUp');
@@ -297,8 +292,7 @@ describe('sunitQueries', () => {
     it('runs the suite of the dictionary-scoped class, not a bare name', () => {
       const session = createMockSession('');
       sunit.runTestClass(session, 'AnnouncerTest', 'Globals');
-      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
-        .calls[0][1];
+      const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(code).toContain("objectNamed: #'Globals'");
       expect(code).toContain("at: #'AnnouncerTest'");
       expect(code).toContain('suite := cls suite');
@@ -310,8 +304,7 @@ describe('sunitQueries', () => {
     it('falls back to bare-name lookup when no dictionary is given', () => {
       const session = createMockSession('');
       sunit.runTestClass(session, 'MyTestCase');
-      const code = (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
-        .calls[0][1];
+      const code = (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1];
       expect(code).toContain("objectNamed: #'MyTestCase'");
     });
   });
@@ -341,7 +334,7 @@ describe('sunitQueries', () => {
     // running any suite, on every selection path (an explicit list or a wide
     // glob can be just as large as discover-all).
     const lastCode = (session: ActiveSession) =>
-      (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
 
     it.each<[string, (s: ActiveSession) => void]>([
       ['no-args (discover-all)', (s) => sunit.runFailingTests(s)],
@@ -362,9 +355,8 @@ describe('sunitQueries', () => {
   describe('error handling', () => {
     it('throws SunitQueryError on GCI error', () => {
       const session = createMockSession('');
-      (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mockReturnValue({
-        data: '',
-        err: { ...noErr, number: 2101, message: 'TestCase not found' },
+      (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('TestCase not found');
       });
       expect(() => sunit.discoverTestClasses(session)).toThrow('TestCase not found');
     });

--- a/client/src/sunitQueries.ts
+++ b/client/src/sunitQueries.ts
@@ -1,6 +1,7 @@
 import { ActiveSession } from './sessionManager';
-import { executeFetchString, BrowserQueryError } from './browserQueries';
+import { BrowserQueryError } from './browserQueries';
 import { QueryExecutor } from './queries/types';
+import { logQuery, logResult, logError } from './gciLog';
 
 import { discoverTestClasses as sharedDiscoverTestClasses } from './queries/discoverTestClasses';
 import { discoverTestMethods as sharedDiscoverTestMethods } from './queries/discoverTestMethods';
@@ -18,16 +19,43 @@ export type { TestRunResult } from './queries/runTestMethod';
 // reference it in mocks.
 export const SunitQueryError = BrowserQueryError;
 
-function bind(session: ActiveSession): QueryExecutor {
-  return (label, code) => executeFetchString(session, label, code);
+/**
+ * Binds a session to the QueryExecutor shape that shared queries expect,
+ * backed by GciLibrary.executeAndFetchString.
+ *
+ * executeAndFetchString explicitly encodes the evaluated result as UTF-8 in
+ * Smalltalk before paging it out, so results decode correctly regardless of
+ * their original encoding and are not capped at a single fixed-size buffer.
+ */
+function defaultQueryExecutorUsing(session: ActiveSession): QueryExecutor {
+  return (label, code) => {
+    logQuery(session.id, label, code);
+
+    const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
+    if (inProgress !== 0) {
+      const msg = 'Session is busy with another operation. Please wait or use a different session.';
+      logError(session.id, msg);
+      throw new BrowserQueryError(msg);
+    }
+
+    try {
+      const data = session.gci.executeAndFetchString(session.handle, code);
+      logResult(session.id, data);
+      return data;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logError(session.id, msg);
+      throw new BrowserQueryError(msg);
+    }
+  };
 }
 
 export function discoverTestClasses(session: ActiveSession) {
-  return sharedDiscoverTestClasses(bind(session));
+  return sharedDiscoverTestClasses(defaultQueryExecutorUsing(session));
 }
 
 export function discoverTestMethods(session: ActiveSession, className: string, dictName?: string) {
-  return sharedDiscoverTestMethods(bind(session), className, dictName);
+  return sharedDiscoverTestMethods(defaultQueryExecutorUsing(session), className, dictName);
 }
 
 export function runTestMethod(
@@ -36,11 +64,11 @@ export function runTestMethod(
   selector: string,
   dictName?: string,
 ) {
-  return sharedRunTestMethod(bind(session), className, selector, dictName);
+  return sharedRunTestMethod(defaultQueryExecutorUsing(session), className, selector, dictName);
 }
 
 export function runTestClass(session: ActiveSession, className: string, dictName?: string) {
-  return sharedRunTestClass(bind(session), className, dictName);
+  return sharedRunTestClass(defaultQueryExecutorUsing(session), className, dictName);
 }
 
 export function runFailingTests(
@@ -48,9 +76,9 @@ export function runFailingTests(
   classNames?: string[],
   classNamePattern?: string,
 ) {
-  return sharedRunFailingTests(bind(session), classNames, classNamePattern);
+  return sharedRunFailingTests(defaultQueryExecutorUsing(session), classNames, classNamePattern);
 }
 
 export function describeTestFailure(session: ActiveSession, className: string, selector: string) {
-  return sharedDescribeTestFailure(bind(session), className, selector);
+  return sharedDescribeTestFailure(defaultQueryExecutorUsing(session), className, selector);
 }


### PR DESCRIPTION
## Summary
- Migrates the SUnit test runner group (`sunitQueries.ts`: `discoverTestClasses`, `discoverTestMethods`, `runTestMethod`, `runTestClass`, `runFailingTests`, `describeTestFailure`) from the deprecated `bind()`/`executeFetchString` executor to a new local `defaultQueryExecutorUsing()` (mirroring `browserQueries.ts`'s), backed by `GciLibrary.executeAndFetchString`.
- `executeFetchString`'s raw `GciTsExecuteFetchBytes` call mis-decodes non-ASCII results and truncates large ones; `executeAndFetchString` encodes the result as UTF-8 in Smalltalk before paging it out, fixing both.
- Every function in this file is now migrated, so the deprecated `bind()` helper itself is fully unused and removed.

Stacked on top of #201 — merge that one first.

## Manual test plan

1. Open the **Testing** view (flask icon in the Activity Bar) with a GemStone session active. Confirm GemStone SUnit test classes appear as top-level nodes. (`discoverTestClasses`)
2. Expand a test class node. Confirm its test methods appear as children. (`discoverTestMethods`)
3. Click the run (▶) arrow next to a single test method. Confirm it runs and reports pass/fail. (`runTestMethod`)
4. Click the run (▶) arrow next to the class node itself. Confirm all its methods run. (`runTestClass`)

**`runFailingTests` and `describeTestFailure`** have no UI caller at all, only reachable through the MCP tool interface (`list_failing_tests`, `describe_test_failure`). I exercised both live through the MCP socket on the current session's GemStone build and both currently fail, regardless of `classNames` vs `classNamePattern` selection:

```
Error: a CompileError occurred (error 1001), Internal logic error in compiler:
ComStrmSetCursor: new cursor out of range ... expected a right bracket (])
```

This is a pre-existing GemStone compiler defect (affects GemStone 3.6.2 to 3.7.4.3), not a regression from this migration. Bisecting the generated Smalltalk down to a minimal reproduction shows the trigger is erratic (adding or renaming an unrelated temp variable flips it between failing and succeeding), which points to a general compiler byte-code-cursor bug rather than anything specific to this function's shape or content. The compile failure happens before any executor-specific fetch/decode step runs, and `querySunit.smoke.test.ts`'s live-GCI tests for these two functions independently confirm the same failure signature on plain `main` (6 of 13 tests in that file fail with this identical error) with no changes from this branch involved, so it's already latent in the test suite rather than introduced here.

Bottom line: this migration's own change (swapping executors) is not implicated. `runFailingTests`/`describeTestFailure` are already broken on affected GemStone builds independent of this PR. Tracked at [GemStone/grail#76](https://code.gemtalksystems.com/GemStone/grail/-/work_items/76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

