### PR TITLE
Migrate Python bridge queries off deprecated bind() executor

### DIFF
--- a/client/src/pythonQueries.ts
+++ b/client/src/pythonQueries.ts
@@ -1,6 +1,7 @@
 import { ActiveSession } from './sessionManager';
-import { executeFetchString } from './browserQueries';
+import { BrowserQueryError } from './browserQueries';
 import { QueryExecutor } from './queries/types';
+import { logQuery, logResult, logError } from './gciLog';
 
 import {
   evalPython as sharedEvalPython,
@@ -9,22 +10,49 @@ import {
   compilePython as sharedCompilePython,
 } from './queries/python';
 
-function bind(session: ActiveSession): QueryExecutor {
-  return (label, code) => executeFetchString(session, label, code);
+/**
+ * Binds a session to the QueryExecutor shape that shared queries expect,
+ * backed by GciLibrary.executeAndFetchString.
+ *
+ * executeAndFetchString explicitly encodes the evaluated result as UTF-8 in
+ * Smalltalk before paging it out, so results decode correctly regardless of
+ * their original encoding and are not capped at a single fixed-size buffer.
+ */
+function defaultQueryExecutorUsing(session: ActiveSession): QueryExecutor {
+  return (label, code) => {
+    logQuery(session.id, label, code);
+
+    const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
+    if (inProgress !== 0) {
+      const msg = 'Session is busy with another operation. Please wait or use a different session.';
+      logError(session.id, msg);
+      throw new BrowserQueryError(msg);
+    }
+
+    try {
+      const data = session.gci.executeAndFetchString(session.handle, code);
+      logResult(session.id, data);
+      return data;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logError(session.id, msg);
+      throw new BrowserQueryError(msg);
+    }
+  };
 }
 
 export function evalPython(session: ActiveSession, source: string) {
-  return sharedEvalPython(bind(session), source);
+  return sharedEvalPython(defaultQueryExecutorUsing(session), source);
 }
 
 export function evalPythonInScope(session: ActiveSession, source: string, scopeId: string) {
-  return sharedEvalPythonInScope(bind(session), source, scopeId);
+  return sharedEvalPythonInScope(defaultQueryExecutorUsing(session), source, scopeId);
 }
 
 export function resetPythonScope(session: ActiveSession, scopeId: string) {
-  return sharedResetPythonScope(bind(session), scopeId);
+  return sharedResetPythonScope(defaultQueryExecutorUsing(session), scopeId);
 }
 
 export function compilePython(session: ActiveSession, source: string) {
-  return sharedCompilePython(bind(session), source);
+  return sharedCompilePython(defaultQueryExecutorUsing(session), source);
 }


### PR DESCRIPTION
## Summary
- Migrates the Python bridge group (`pythonQueries.ts`: `evalPython`, `evalPythonInScope`, `resetPythonScope`, `compilePython`) from the deprecated `bind()`/`executeFetchString` executor to a new local `defaultQueryExecutorUsing()` (mirroring `browserQueries.ts`'s and `sunitQueries.ts`'s), backed by `GciLibrary.executeAndFetchString`.
- `executeFetchString`'s raw `GciTsExecuteFetchBytes` call mis-decodes non-ASCII results and truncates large ones; `executeAndFetchString` encodes the result as UTF-8 in Smalltalk before paging it out, fixing both.
- Every function in this file is now migrated, so the deprecated `bind()` helper itself is fully unused and removed. This is the last commit in this stack — `bind()` is now gone from `browserQueries.ts`, `sunitQueries.ts`, and `pythonQueries.ts` everywhere.

Stacked on top of #202 — merge that one first. Needs the Jupyter extension installed (Jasper's Grail kernel registers against the standard `jupyter-notebook` type, not a custom file type).

## Manual test plan

1. Open (or create) a `.ipynb` notebook, add a cell, and pick **"Grail (GemStone Python)"** from the kernel picker in the notebook toolbar. Run the cell (e.g. `2 + 2`). Confirm it evaluates and shows the result. (`evalPythonInScope`)
2. With that notebook as the active editor, run **"GemStone: Reset Grail Notebook Scope"** from the Command Palette. Confirm it completes without error (no visible UI feedback beyond that — it clears the Python-side scope for the next cell run). (`resetPythonScope`)

**⚠️ Step 1 currently fails on affected GemStone builds (3.6.2–3.7.4.3), unrelated to this migration.** I tested `evalPython`, `compilePython` (MCP-only, no UI caller — see below) and the exact Smalltalk `evalPythonInScope` generates (same shared template, driving it directly since it isn't exposed as an MCP tool) live against this session's GemStone build. All three fail identically and deterministically, on any input including a trivial `2 + 2`:

```
Error: a CompileError occurred (error 1001), Internal logic error in compiler:
ComStrmSetCursor: new cursor out of range ... expected a right bracket (])
```

This is the same pre-existing GemStone compiler defect already documented against other functions in this migration (see #201, #202), tracked at [GemStone/grail#76](https://code.gemtalksystems.com/GemStone/grail/-/work_items/76) — not a regression from swapping executors, since the failure is a compile-time error that happens before `defaultQueryExecutorUsing`/`executeAndFetchString` ever runs. Unlike the erratic trigger seen in #202, this one looks deterministic and specific to `buildPythonQuery`'s shared template shape (nested `ifTrue:ifFalse:` wrapping nested `on:do:` blocks) — as confirmation, `resetPythonScope`, the one function in this file that doesn't route through `buildPythonQuery`, compiled and ran cleanly in the same session. So step 1 will currently fail with this compiler error on affected builds; that's expected, not something this PR introduces or can fix. On a GemStone build without this defect (3.7.5+), step 1 should work normally.

**`evalPython` and `compilePython`** additionally have no UI caller at all — only reachable through the MCP tool interface (`eval_python`, `compile_python`). They do have live-GCI smoke-test coverage (`queryPython.smoke.test.ts`), but it exercises the shared `queries/python.ts` implementation directly, bypassing this wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

