### PR TITLE
[1/5] Migrate debugger step-point queries off deprecated bind() executor

### DIFF
--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -582,7 +582,14 @@ export function getSourceOffsets(
   environmentId: number = 0,
   dict?: number | string,
 ): number[] {
-  return sharedGetSourceOffsets(bind(session), className, isMeta, selector, environmentId, dict);
+  return sharedGetSourceOffsets(
+    defaultQueryExecutorUsing(session),
+    className,
+    isMeta,
+    selector,
+    environmentId,
+    dict,
+  );
 }
 
 export function getStepPointSelectorRanges(
@@ -594,7 +601,7 @@ export function getStepPointSelectorRanges(
   dict?: number | string,
 ) {
   return sharedGetStepPointSelectorRanges(
-    bind(session),
+    defaultQueryExecutorUsing(session),
     className,
     isMeta,
     selector,
@@ -792,7 +799,7 @@ export function setBreakAtStepPoint(
   dict?: number | string,
 ): string {
   return sharedSetBreakAtStepPoint(
-    bind(session),
+    defaultQueryExecutorUsing(session),
     className,
     isMeta,
     selector,
@@ -812,7 +819,7 @@ export function clearBreakAtStepPoint(
   dict?: number | string,
 ): string {
   return sharedClearBreakAtStepPoint(
-    bind(session),
+    defaultQueryExecutorUsing(session),
     className,
     isMeta,
     selector,
@@ -830,5 +837,12 @@ export function clearAllBreaks(
   environmentId: number = 0,
   dict?: number | string,
 ): string {
-  return sharedClearAllBreaks(bind(session), className, isMeta, selector, environmentId, dict);
+  return sharedClearAllBreaks(
+    defaultQueryExecutorUsing(session),
+    className,
+    isMeta,
+    selector,
+    environmentId,
+    dict,
+  );
 }


### PR DESCRIPTION
## Summary
- Migrates the debugger step-points group (`getSourceOffsets`, `getStepPointSelectorRanges`, `setBreakAtStepPoint`, `clearBreakAtStepPoint`, `clearAllBreaks`) from the deprecated `bind()`/`executeFetchString` executor to `defaultQueryExecutorUsing()`, backed by `GciLibrary.executeAndFetchString`.
- `executeFetchString`'s raw `GciTsExecuteFetchBytes` call mis-decodes non-ASCII results and truncates large ones; `executeAndFetchString` encodes the result as UTF-8 in Smalltalk before paging it out, fixing both.

## Manual test plan

1. Open a method's source (`gemstone://.../method/...`, e.g. double-click it in System Browser). Click in the gutter on a line inside the method body. Confirm a red breakpoint dot appears. (`setBreakAtStepPoint`, `getSourceOffsets`)
2. Click that same gutter dot again to remove it. Confirm it disappears. (`clearBreakAtStepPoint`, `clearAllBreaks`)
3. Right-click inside a keyword message send in that method and choose **"Toggle Selector Breakpoint"**. Confirm a breakpoint marker appears at that selector. (`getStepPointSelectorRanges`, `setBreakAtStepPoint`)
4. Toggle the same selector breakpoint again to remove it. (`clearBreakAtStepPoint`)
5. With a breakpoint set (gutter or selector), trigger execution that reaches this method (e.g. Execute It something that calls it) and confirm it actually stops there — this is the real end-to-end check that the step-point mapping is correct, not just that a UI marker appeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
