### PR TITLE
Warn when package-lock.json changes require npm install

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "matteopieroni.refresh-npm-packages"]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,16 +90,19 @@ It **only compiles `client/out` when that directory is missing** — if a build 
 - Run `npm run watch` in another terminal for live reload (then "Developer: Reload Window" in the dev window after edits), or
 - Force a one-off rebuild first: `npm run compile:client` (or `rm -rf client/out` to guarantee a clean recompile).
 
-### Optional local pre-commit hook
+### Optional local git hooks
 
-If you'd like `eslint` and `prettier --check` to run on staged files automatically before each commit, install the [lefthook](https://github.com/evilmartians/lefthook) git hook:
+If you'd like, you can install some optional [lefthook](https://github.com/evilmartians/lefthook) git hooks:
 
 ```sh
 npm run hooks:install    # opt in
 npm run hooks:uninstall  # opt out
 ```
 
-This is entirely optional and not run by `npm install` — CI's `lint` job is the real gate regardless.
+- **pre-commit**: runs `eslint` and `prettier --check` on staged files
+- **post-checkout** / **post-merge** / **post-rewrite**: warns (non-blocking) when the root `package-lock.json` changed, as a reminder to run `npm install`
+
+If you've already installed the hooks, re-run `npm run hooks:install` after pulling changes to `lefthook.yml` to pick up any new/changed hooks.
 
 ## Running integration tests against a custom GemStone instance
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,3 +10,18 @@ pre-commit:
     - name: prettier
       glob: '*.{ts,mts,cts,js,mjs,cjs}'
       run: npx prettier --check {staged_files}
+
+post-checkout:
+  jobs:
+    - name: warn-outdated-packages
+      run: bash scripts/warn-outdated-packages.sh post-checkout {1} {2} {3}
+
+post-merge:
+  jobs:
+    - name: warn-outdated-packages
+      run: bash scripts/warn-outdated-packages.sh post-merge
+
+post-rewrite:
+  jobs:
+    - name: warn-outdated-packages
+      run: bash scripts/warn-outdated-packages.sh post-rewrite

--- a/scripts/warn-outdated-packages.sh
+++ b/scripts/warn-outdated-packages.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Warns (stderr, colored) when a git checkout/merge/rewrite brings in a
+# changed root package-lock.json, so you know to run `npm install`. Prints a
+# plain confirmation to stdout when nothing changed, so the hook job never
+# looks like it silently did nothing. Never blocks or fails the git
+# operation it's hooked into — always exits 0.
+#
+# Usage: bash scripts/warn-outdated-packages.sh <mode> [git-hook-args...]
+#   post-checkout: warn-outdated-packages.sh post-checkout <old> <new> <flag>
+#   post-merge:    warn-outdated-packages.sh post-merge
+#   post-rewrite:  warn-outdated-packages.sh post-rewrite
+
+set -euo pipefail
+
+mode="${1:-}"
+
+case "$mode" in
+    post-checkout)
+        old="${2:-}"
+        new="${3:-}"
+        flag="${4:-}"
+
+        # flag=0 is a file checkout (e.g. `git checkout -- file`), not a
+        # branch switch — nothing relevant to warn about.
+        [ "$flag" = "1" ] || exit 0
+
+        # All-zeros old ref means there was no previous HEAD (fresh clone,
+        # or checking out into an unborn branch) — nothing to compare.
+        case "$old" in
+            0000000000000000000000000000000000000000) exit 0 ;;
+        esac
+        ;;
+    post-merge | post-rewrite)
+        # No refs are passed for these hooks; ORIG_HEAD is git's pointer to
+        # the pre-operation tip. If it doesn't resolve, there's nothing to
+        # diff against.
+        if ! git rev-parse --verify --quiet ORIG_HEAD >/dev/null; then
+            exit 0
+        fi
+        old="ORIG_HEAD"
+        new="HEAD"
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+[ "$old" = "$new" ] && exit 0
+
+# git diff --quiet exits 0 (identical), 1 (differs), or >1 (error, e.g. a
+# bad ref). Capture the code explicitly rather than `if ! cmd`, which would
+# treat an error the same as "differs" and warn spuriously.
+diff_status=0
+git diff --quiet "$old" "$new" -- package-lock.json 2>/dev/null || diff_status=$?
+
+if [ "$diff_status" -eq 1 ]; then
+    # Bold yellow, unless the caller opted out via NO_COLOR (https://no-color.org/).
+    if [ -n "${NO_COLOR:-}" ]; then
+        bold_yellow=""
+        reset=""
+    else
+        bold_yellow=$'\033[1;33m'
+        reset=$'\033[0m'
+    fi
+    printf '%s\n' "${bold_yellow}🚨 WARNING: root package-lock.json changed — run \`npm install\` to sync your dependencies.${reset}" >&2
+else
+    echo "package-lock.json unchanged."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add `post-checkout`, `post-merge`, and `post-rewrite` lefthook hooks (`scripts/warn-outdated-packages.sh`) that print a non-blocking warning when a checkout, merge, or rebase brings in a changed root `package-lock.json` — so you know to run `npm install` before `node_modules` drifts out of sync.
- Recommend the "Refresh NPM Packages" VS Code extension (`.vscode/extensions.json`) as a companion: it pops up a reminder after a branch switch if `package-lock.json` changed.
- Update `CONTRIBUTING.md` to document the new hooks and note that anyone with lefthook already installed needs to re-run `npm run hooks:install` to pick up the new hook types.

## Screenshots

<img width="1332" height="188" alt="image" src="https://github.com/user-attachments/assets/33e1121b-8c90-4f7f-b34a-3b50a88e198c" />

<img width="940" height="242" alt="image" src="https://github.com/user-attachments/assets/8e61553d-61e1-4fe8-81f6-dfa4df7c0adc" />

