### PR TITLE
Migrate executeFetchString onto executeAndFetchString

### DIFF
--- a/client/src/__tests__/browserQueries.test.ts
+++ b/client/src/__tests__/browserQueries.test.ts
@@ -10,29 +10,11 @@ import { ActiveSession } from '../sessionManager';
 import { GemStoneLogin } from '../loginTypes';
 import * as queries from '../browserQueries';
 
-const noErr = {
-  number: 0,
-  message: '',
-  context: 0n,
-  category: 0,
-  fatal: false,
-  argCount: 0,
-  exceptionObj: 0n,
-  args: [],
-};
-
 function createMockSession(executeFetchData = ''): ActiveSession {
   const mockGci = {
-    GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
-    GciTsPerform: vi.fn(() => ({ result: 2000n, err: { ...noErr } })),
-    GciTsNewString: vi.fn(() => ({ result: 3000n, err: { ...noErr } })),
-    GciTsNewSymbol: vi.fn(() => ({ result: 4000n, err: { ...noErr } })),
-    GciTsCompileMethod: vi.fn(() => ({ result: 5000n, err: { ...noErr } })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({ data: executeFetchData, err: { ...noErr } })),
-    GciTsPerformFetchBytes: vi.fn(() => ({ data: '', err: { ...noErr } })),
     executeAndFetchString: vi.fn(() => executeFetchData),
     GciTsCallInProgress: vi.fn(() => ({ result: 0 })),
-    GciTsClearStack: vi.fn(),
+    GciTsPerform: vi.fn(),
   };
 
   return {
@@ -364,8 +346,10 @@ describe('browserQueries', () => {
 
     it('asks the image via System needsCommit', () => {
       const session = createMockSession('false');
+
       queries.sessionNeedsCommit(session);
-      const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
+
+      const mockExec = session.gci.executeAndFetchString as ReturnType<typeof vi.fn>;
       expect(mockExec.mock.calls[0][1]).toContain('System needsCommit');
     });
   });

--- a/client/src/__tests__/enhancedInspectorAvailability.test.ts
+++ b/client/src/__tests__/enhancedInspectorAvailability.test.ts
@@ -11,21 +11,9 @@ import { GemStoneLogin } from '../loginTypes';
 import * as queries from '../browserQueries';
 import { refreshEnhancedInspectorAvailable } from '../enhancedInspectorAvailability';
 
-const noErr = {
-  number: 0,
-  message: '',
-  context: 0n,
-  category: 0,
-  fatal: false,
-  argCount: 0,
-  exceptionObj: 0n,
-  args: [],
-};
-
 function createMockSession(executeFetchData = '', stoneVersion = '3.7.5'): ActiveSession {
   const mockGci = {
-    GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({ data: executeFetchData, err: { ...noErr } })),
+    executeAndFetchString: vi.fn(() => executeFetchData),
     GciTsCallInProgress: vi.fn(() => ({ result: 0 })),
   };
 
@@ -61,17 +49,19 @@ describe('checkEnhancedInspectorAvailable', () => {
 
   it('returns false when GCI returns an error', () => {
     const session = createMockSession('');
-    (session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: '',
-      err: { ...noErr, number: 2010, message: 'GCI error' },
+    (session.gci.executeAndFetchString as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('GCI error');
     });
+
     expect(queries.checkEnhancedInspectorAvailable(session)).toBe(false);
   });
 
   it('emitted Smalltalk references GtRemotePhlowViewedObject', () => {
     const session = createMockSession('true');
+
     queries.checkEnhancedInspectorAvailable(session);
-    const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
+
+    const mockExec = session.gci.executeAndFetchString as ReturnType<typeof vi.fn>;
     const code = mockExec.mock.calls[0][1] as string;
     expect(code).toContain('GtRemotePhlowViewedObject');
   });
@@ -110,6 +100,6 @@ describe('refreshEnhancedInspectorAvailable', () => {
 
     refreshEnhancedInspectorAvailable(session);
 
-    expect(session.gci.GciTsExecuteFetchBytes).not.toHaveBeenCalled();
+    expect(session.gci.executeAndFetchString).not.toHaveBeenCalled();
   });
 });

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -317,7 +317,7 @@ export function sessionNeedsCommit(session: ActiveSession): boolean | undefined 
  * Smalltalk before paging it out, so results decode correctly regardless of
  * their original encoding and are not capped at a single fixed-size buffer.
  */
-function defaultQueryExecutorUsing(session: ActiveSession): QueryExecutor {
+export function defaultQueryExecutorUsing(session: ActiveSession): QueryExecutor {
   return (label, code) => {
     logQuery(session.id, label, code);
 

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -1,6 +1,6 @@
 import { ActiveSession } from './sessionManager';
 import { OOP_NIL, OOP_ILLEGAL } from './gciConstants';
-import { logQuery, logResult, logError, logGciCall, logGciResult } from './gciLog';
+import { logQuery, logResult, logError } from './gciLog';
 import { runNbCall } from './nbRunner';
 
 import { QueryExecutor } from './queries/types';
@@ -122,6 +122,11 @@ function resolveClassUtf8(session: ActiveSession): bigint {
   return oop;
 }
 
+// Evaluates `code` and fetches its result as a UTF-8 string via
+// GciLibrary.executeAndFetchString, which explicitly encodes the evaluated
+// result as UTF-8 in Smalltalk before paging it out, so results decode
+// correctly regardless of their original encoding and are not capped at a
+// single fixed-size buffer.
 export function executeFetchString(session: ActiveSession, label: string, code: string): string {
   logQuery(session.id, label, code);
 
@@ -133,47 +138,15 @@ export function executeFetchString(session: ActiveSession, label: string, code: 
     throw new BrowserQueryError(msg);
   }
 
-  const oopClassUtf8 = resolveClassUtf8(session);
-
-  logGciCall(session.id, 'GciTsExecuteFetchBytes', {
-    sourceStr: code,
-    sourceSize: -1,
-    sourceOop: oopClassUtf8,
-    contextObject: OOP_ILLEGAL,
-    symbolList: OOP_NIL,
-    maxResultSize: MAX_RESULT,
-  });
-
-  const { bytesReturned, data, err } = session.gci.GciTsExecuteFetchBytes(
-    session.handle,
-    code,
-    -1,
-    oopClassUtf8,
-    OOP_ILLEGAL,
-    OOP_NIL,
-    MAX_RESULT,
-  );
-
-  logGciResult(session.id, 'GciTsExecuteFetchBytes', {
-    bytesReturned,
-    data,
-    'err.number': err.number,
-    'err.category': err.category,
-    'err.context': err.context,
-    'err.exceptionObj': err.exceptionObj,
-    'err.args': err.args,
-    'err.message': err.message,
-    'err.reason': err.reason,
-    'err.fatal': err.fatal,
-  });
-
-  if (err.number !== 0) {
-    const msg = err.message || `GCI error ${err.number}`;
+  try {
+    const result = session.gci.executeAndFetchString(session.handle, code);
+    logResult(session.id, result);
+    return result;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
     logError(session.id, msg);
-    throw new BrowserQueryError(msg, err.number);
+    throw new BrowserQueryError(msg);
   }
-  logResult(session.id, data);
-  return data;
 }
 
 // Non-blocking variant of executeFetchString for LONG-RUNNING queries (e.g. a
@@ -228,10 +201,12 @@ export async function executeFetchStringNb(
   return data;
 }
 
-// Like executeFetchString but with a caller-chosen result-buffer size. The
-// class-sync transport (see client/src/sync/) moves multi-MB chunks well above
-// the default 256 KB cap, slicing on code-point boundaries so the UTF-8 decode
-// here is always lossless. Result data is not logged — chunks can be megabytes.
+// Like executeFetchString but with a caller-chosen result-buffer size instead
+// of executeAndFetchString's own paging. The class-sync transport (see
+// client/src/sync/) moves multi-MB chunks well above the 256 KB size used
+// elsewhere in this file, slicing on code-point boundaries so the UTF-8
+// decode here is always lossless. Result data is not logged — chunks can be
+// megabytes.
 export function executeFetchStringWithLimit(
   session: ActiveSession,
   label: string,
@@ -310,34 +285,18 @@ export function sessionNeedsCommit(session: ActiveSession): boolean | undefined 
 }
 
 /**
- * Binds a session to the QueryExecutor shape that shared queries expect,
- * backed by GciLibrary.executeAndFetchString.
+ * Binds a session to the {@link QueryExecutor} shape shared queries expect,
+ * backed by {@link executeFetchString}. This is the shared entry point used
+ * across browserQueries, pythonQueries, and sunitQueries.
  *
- * executeAndFetchString explicitly encodes the evaluated result as UTF-8 in
- * Smalltalk before paging it out, so results decode correctly regardless of
- * their original encoding and are not capped at a single fixed-size buffer.
+ * @param activeSession - The active GCI session to execute against.
+ * @returns A {@link QueryExecutor} that runs `code` in `session` and returns
+ * its String result.
+ * @throws {@link BrowserQueryError} if the session is busy, the code fails to
+ * compile or execute, or the result cannot be resolved to a String.
  */
-export function defaultQueryExecutorUsing(session: ActiveSession): QueryExecutor {
-  return (label, code) => {
-    logQuery(session.id, label, code);
-
-    const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
-    if (inProgress !== 0) {
-      const msg = 'Session is busy with another operation. Please wait or use a different session.';
-      logError(session.id, msg);
-      throw new BrowserQueryError(msg);
-    }
-
-    try {
-      const data = session.gci.executeAndFetchString(session.handle, code);
-      logResult(session.id, data);
-      return data;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      logError(session.id, msg);
-      throw new BrowserQueryError(msg);
-    }
-  };
+export function defaultQueryExecutorUsing(activeSession: ActiveSession): QueryExecutor {
+  return (label, code) => executeFetchString(activeSession, label, code);
 }
 
 // ── Read-only queries (thin delegates to client/src/queries/) ─────────────

--- a/client/src/enhancedInspectorInstall.ts
+++ b/client/src/enhancedInspectorInstall.ts
@@ -181,9 +181,9 @@ export async function installEnhancedInspectorSupport(
         // variant decodes correctly in both String and Unicode16 modes
         // (UTF-8 decode of the all-ASCII files is the identity).
         //
-        // Must end in a byte object (String): executeFetchString fetches the
-        // result via GciTsExecuteFetchBytes, and a non-byte result (e.g. the
-        // boolean `true`) raises ArgumentTypeError 2103 ("not a byte object").
+        // Must end in a String: executeFetchString sends #encodeAsUTF8 to the
+        // result before fetching it, and a non-String result (e.g. the
+        // boolean `true`) raises an error attempting that send.
         `GsFileIn fromPath: ${gsStringLiteral(serverPath(file))} on: #serverUtf8File to: nil. 'ok'`,
       );
       filedIn.push(file);

--- a/client/src/pythonQueries.ts
+++ b/client/src/pythonQueries.ts
@@ -1,7 +1,5 @@
 import { ActiveSession } from './sessionManager';
-import { BrowserQueryError } from './browserQueries';
-import { QueryExecutor } from './queries/types';
-import { logQuery, logResult, logError } from './gciLog';
+import { defaultQueryExecutorUsing } from './browserQueries';
 
 import {
   evalPython as sharedEvalPython,
@@ -9,37 +7,6 @@ import {
   resetPythonScope as sharedResetPythonScope,
   compilePython as sharedCompilePython,
 } from './queries/python';
-
-/**
- * Binds a session to the QueryExecutor shape that shared queries expect,
- * backed by GciLibrary.executeAndFetchString.
- *
- * executeAndFetchString explicitly encodes the evaluated result as UTF-8 in
- * Smalltalk before paging it out, so results decode correctly regardless of
- * their original encoding and are not capped at a single fixed-size buffer.
- */
-function defaultQueryExecutorUsing(session: ActiveSession): QueryExecutor {
-  return (label, code) => {
-    logQuery(session.id, label, code);
-
-    const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
-    if (inProgress !== 0) {
-      const msg = 'Session is busy with another operation. Please wait or use a different session.';
-      logError(session.id, msg);
-      throw new BrowserQueryError(msg);
-    }
-
-    try {
-      const data = session.gci.executeAndFetchString(session.handle, code);
-      logResult(session.id, data);
-      return data;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      logError(session.id, msg);
-      throw new BrowserQueryError(msg);
-    }
-  };
-}
 
 export function evalPython(session: ActiveSession, source: string) {
   return sharedEvalPython(defaultQueryExecutorUsing(session), source);

--- a/client/src/sunitQueries.ts
+++ b/client/src/sunitQueries.ts
@@ -1,7 +1,5 @@
 import { ActiveSession } from './sessionManager';
-import { BrowserQueryError } from './browserQueries';
-import { QueryExecutor } from './queries/types';
-import { logQuery, logResult, logError } from './gciLog';
+import { BrowserQueryError, defaultQueryExecutorUsing } from './browserQueries';
 
 import { discoverTestClasses as sharedDiscoverTestClasses } from './queries/discoverTestClasses';
 import { discoverTestMethods as sharedDiscoverTestMethods } from './queries/discoverTestMethods';
@@ -18,37 +16,6 @@ export type { TestRunResult } from './queries/runTestMethod';
 // Backward compatibility alias — no callers catch this by class, but tests
 // reference it in mocks.
 export const SunitQueryError = BrowserQueryError;
-
-/**
- * Binds a session to the QueryExecutor shape that shared queries expect,
- * backed by GciLibrary.executeAndFetchString.
- *
- * executeAndFetchString explicitly encodes the evaluated result as UTF-8 in
- * Smalltalk before paging it out, so results decode correctly regardless of
- * their original encoding and are not capped at a single fixed-size buffer.
- */
-function defaultQueryExecutorUsing(session: ActiveSession): QueryExecutor {
-  return (label, code) => {
-    logQuery(session.id, label, code);
-
-    const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
-    if (inProgress !== 0) {
-      const msg = 'Session is busy with another operation. Please wait or use a different session.';
-      logError(session.id, msg);
-      throw new BrowserQueryError(msg);
-    }
-
-    try {
-      const data = session.gci.executeAndFetchString(session.handle, code);
-      logResult(session.id, data);
-      return data;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      logError(session.id, msg);
-      throw new BrowserQueryError(msg);
-    }
-  };
-}
 
 export function discoverTestClasses(session: ActiveSession) {
   return sharedDiscoverTestClasses(defaultQueryExecutorUsing(session));


### PR DESCRIPTION
## Summary
- Deduplicate `defaultQueryExecutorUsing` across `pythonQueries.ts`/`sunitQueries.ts` by exporting the one in `browserQueries.ts` and importing it instead.
- Migrate `executeFetchString` itself onto `GciLibrary.executeAndFetchString`, the last query-layer function still calling `GciTsExecuteFetchBytes` directly, so it decodes results correctly regardless of encoding and isn't capped at a fixed 256 KB buffer, matching the Python/SUnit executor migrations before it.
- Update the two test files whose mocks still stubbed `GciTsExecuteFetchBytes`, and correct comments left describing mechanics that moved or no longer apply.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile`
- [x] `npm test` (server, client, mcp-server — 3738 tests, live stone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)