### PR TITLE
Recognize a local product directory placed in the versions folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 ### Fixed
 
 - **The walkthrough's (and Logins view's) "Add a Login" button now works.** It was wired to `gemstone.login` — the command that connects a *selected* login — so clicking it from a static button (which passes no login) threw and did nothing. It now opens the new-login editor via `gemstone.addLogin`.
+- **A locally-built GemStone product tree placed directly in the versions folder is now recognized.** The Versions view only listed versions that were either symlinked local builds or on the download catalog, so a real product directory copied into `~/Documents/GemStone` (e.g. a private 4.0 build) was silently dropped — yet **Register Local Version** refused it with "already exists," leaving no way to surface it. Such directories now appear as extracted, ready-to-use versions (so you can create databases from them); and if you do run Register Local Version on one already in place, it reports that it's already present instead of erroring.
 
 ### Security
 

--- a/client/src/__tests__/localVersion.test.ts
+++ b/client/src/__tests__/localVersion.test.ts
@@ -241,6 +241,25 @@ describe('VersionItem (local version)', () => {
     expect(item.description).toContain('bundled');
     expect(item.tooltip).toContain('bundled');
   });
+
+  it('renders a hand-placed product directory as extracted and ready to use', () => {
+    const version: GemStoneVersion = {
+      version: '4.0.0',
+      fileName: '',
+      url: '',
+      size: 0,
+      date: '2026-07-01',
+      downloaded: false,
+      extracted: true,
+      buildDescription: 'private 4.0 build',
+    };
+
+    const item = new VersionItem(version);
+
+    // ServerExtracted context is what offers Create Database / Delete Extracted.
+    expect(item.contextValue).toBe('gemstoneVersionServerExtracted');
+    expect((item.iconPath as vscode.ThemeIcon).id).toBe('check');
+  });
 });
 
 // ── VersionManager.fetchAvailableVersions (local inclusion) ──
@@ -376,6 +395,58 @@ describe('VersionManager.fetchAvailableVersions', () => {
     expect(versions[0].version).toBe('3.5.0');
     expect(versions[0].local).toBe(true);
   });
+
+  itUnlessWin32(
+    'includes a locally-built product directory the download catalog does not list',
+    async () => {
+      const storage = new SysadminStorage();
+      const manager = new VersionManager(storage);
+      const suffix = storage.getPlatformSuffix();
+
+      // A real product directory (not a symlink) dropped straight into rootPath
+      // for a version the catalog has never heard of — e.g. a private 4.0 build.
+      const versionDir = path.join(tmpDir, `GemStone64Bit4.0.0${suffix}`);
+      fs.mkdirSync(versionDir);
+      writeVersionTxt(
+        versionDir,
+        'GemStone/S 64 Bit\n4.0.0 Build: 2026-07-01T10:00:00-07:00 abcdef\nprivate 4.0 build',
+      );
+
+      vi.spyOn(manager as unknown as FetchUrlHost, 'fetchUrl').mockResolvedValue('');
+
+      const versions = await manager.fetchAvailableVersions();
+
+      expect(versions).toHaveLength(1);
+      expect(versions[0].version).toBe('4.0.0');
+      expect(versions[0].extracted).toBe(true);
+      expect(versions[0].local).toBeFalsy(); // a real dir, not a symlink — not "(local)"
+      expect(versions[0].date).toBe('2026-07-01');
+    },
+  );
+
+  itUnlessWin32(
+    'lists a catalog version present as a real directory only once, marked extracted',
+    async () => {
+      const storage = new SysadminStorage();
+      const manager = new VersionManager(storage);
+      const suffix = storage.getPlatformSuffix();
+      const platformKey = storage.getPlatformKey();
+      const ext = storage.getDownloadExtension();
+
+      const versionDir = path.join(tmpDir, `GemStone64Bit3.7.4${suffix}`);
+      fs.mkdirSync(versionDir);
+      writeVersionTxt(versionDir, 'GemStone/S 64 Bit\n3.7.4 Build: 2026-01-01T10:00:00-07:00 abc');
+
+      const html = `<a href="GemStone64Bit3.7.4-${platformKey}.${ext}">file</a>  01-Jan-2026 12:00  200000000`;
+      vi.spyOn(manager as unknown as FetchUrlHost, 'fetchUrl').mockResolvedValue(html);
+
+      const versions = await manager.fetchAvailableVersions();
+
+      const matching = versions.filter((v) => v.version === '3.7.4');
+      expect(matching).toHaveLength(1);
+      expect(matching[0].extracted).toBe(true);
+    },
+  );
 });
 
 // ── GCI library auto-detection ───────────────────────────────

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2990,6 +2990,20 @@ export function activate(context: vscode.ExtensionContext) {
       const linkName = `GemStone64Bit${info.version}${suffix}`;
       const linkPath = path.join(sysadminStorage.getRootPath(), linkName);
       if (wslExistsSync(linkPath)) {
+        // Something already occupies the target location. If it's already a
+        // valid GemStone product tree — a real directory the user dropped in,
+        // or a prior symlink — there's nothing to do: it's recognized on its
+        // own, so report success rather than failing to create a symlink over
+        // it.
+        if (SysadminStorage.readVersionTxt(linkPath)) {
+          sysadminStorage.invalidateExtractedCache();
+          appendSysadmin(`Local version already present: ${info.version} → ${linkPath}`);
+          vscode.window.showInformationMessage(
+            `GemStone ${info.version} is already present in ${sysadminStorage.getRootPath()}.`,
+          );
+          void versionProvider.loadVersions();
+          return;
+        }
         vscode.window.showErrorMessage(
           `Version ${info.version} already exists in ${sysadminStorage.getRootPath()}.`,
         );

--- a/client/src/versionManager.ts
+++ b/client/src/versionManager.ts
@@ -64,12 +64,14 @@ export class VersionManager {
       });
     }
 
+    const catalogVersions = new Set<string>();
     let match;
     while ((match = regex.exec(html)) !== null) {
       const fileName = match[1];
       const version = match[2];
       const date = match[3];
       const size = parseInt(match[4], 10);
+      catalogVersions.add(version);
       const isDownloaded = downloaded.has(version) && downloaded.get(version) === size;
       const extractedKind = extractedMap.get(version);
       versions.push({
@@ -82,6 +84,30 @@ export class VersionManager {
         extracted: extractedKind === false, // dir, not symlink
         clientExtracted: clientExtracted.has(version),
         bundled: bundled.has(version),
+      });
+    }
+
+    // A locally-built product directory copied straight into rootPath (a real
+    // directory, not a symlink) for a version the download catalog doesn't list
+    // — e.g. a private 4.0 build. Symlinked local builds are handled by the
+    // "local versions first" loop above, and catalog versions (downloaded or
+    // extracted) by the loop just above; this surfaces the remaining case as a
+    // present, extracted version so it shows in the list and can create
+    // databases, instead of being silently dropped.
+    for (const info of extractedInfos) {
+      if (info.isLocal) continue;
+      if (catalogVersions.has(info.version)) continue;
+      const gsPath = this.storage.getGemstonePath(info.version);
+      const txt = gsPath ? SysadminStorage.readVersionTxt(gsPath) : undefined;
+      versions.push({
+        version: info.version,
+        fileName: '',
+        url: '',
+        size: 0,
+        date: txt?.date ?? '',
+        downloaded: false,
+        extracted: true,
+        buildDescription: txt?.description,
       });
     }
 


### PR DESCRIPTION
## Problem

A user built GemStone 4.0 locally and copied the product tree straight into `~/Documents/GemStone` next to the other versions. Jasper then:

- **didn't show it** in the Versions view, and
- **refused to add it** via *Register Local Version* — *"already exists"* — because a directory already occupied the symlink target.

So it was present enough to block registration, but never surfaced.

## Cause

`VersionManager.fetchAvailableVersions` built the list from only two sources: symlinked local builds (`isLocal`) and versions on the download catalog. A **real product directory that isn't on the catalog** is neither (`isLocal === false`, not a released version), so it was silently dropped. `registerLocalVersion` then hit the occupied symlink target and errored.

## Fix

- **`fetchAvailableVersions`** now also lists real product directories that aren't on the catalog, as **extracted / ready-to-use** versions (`local: false`) — so they appear and can create databases. Symlinked local builds and catalog versions are unchanged; a catalog version that happens to be present as a real directory is still listed once (marked extracted), not duplicated.
- **`registerLocalVersion`** now treats an already-present valid product tree as success — *"GemStone X is already present"* — instead of an error, so "adding" one that's already in place is a harmless no-op.

Net: dropping a built product tree into the versions folder is recognized automatically, and the manual register path no longer complains about it.

## Tests

`localVersion.test.ts`: `fetchAvailableVersions` surfaces a non-catalog real directory (extracted, not `local`), and de-dups a catalog version that's present as a real directory; `VersionItem` renders such a directory with the `ServerExtracted` context (offering Create Database / Delete Extracted). Full gate green (client 3324, server 322, mcp 95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)