### PR TITLE
Give the Versions view terminal the same PATH as the database terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 ### Fixed
 
 - **The walkthrough's (and Logins view's) "Add a Login" button now works.** It was wired to `gemstone.login` — the command that connects a *selected* login — so clicking it from a static button (which passes no login) threw and did nothing. It now opens the new-login editor via `gemstone.addLogin`.
+- **The Versions view's "Open Terminal" button now puts `$GEMSTONE/bin` on `PATH`.** It set `GEMSTONE` but not `PATH` (nor the dynamic-library/man paths), so tools like `topaz` weren't found — unlike the Databases view's terminal, which set them correctly. Both terminals (and the internal process listing) now share one version-environment builder, so `$GEMSTONE/bin` binaries are runnable from either and the two can't drift apart again.
 
 ### Security
 

--- a/client/src/__tests__/processManager.test.ts
+++ b/client/src/__tests__/processManager.test.ts
@@ -629,17 +629,33 @@ describe('ProcessManager', () => {
       expect(terminal.show).toHaveBeenCalled();
     });
 
-    it('sets only GEMSTONE and GEMSTONE_GLOBAL_DIR, not the full stone environment', () => {
+    it('puts the version bin on PATH so its tools run, without any stone-specific vars', () => {
+      setPlatform('darwin');
       const manager = new ProcessManager(makeStorage('/gs/3.7.4'));
 
       manager.openVersionTerminal('3.7.4');
 
       const options = vi.mocked(vscode.window.createTerminal).mock
         .calls[0][0] as vscode.TerminalOptions;
-      expect(options.env).toEqual({
-        GEMSTONE: '/gs/3.7.4',
-        GEMSTONE_GLOBAL_DIR: '/home/user/gemstone',
-      });
+      expect(options.env?.PATH).toContain('/gs/3.7.4/bin');
+      expect(options.env?.GEMSTONE).toBe('/gs/3.7.4');
+      expect(options.env?.GEMSTONE_GLOBAL_DIR).toBe('/home/user/gemstone');
+      expect(options.env?.DYLD_LIBRARY_PATH).toBe('/gs/3.7.4/lib');
+      // Still not tied to a particular stone.
+      expect(options.env?.GEMSTONE_SYS_CONF).toBeUndefined();
+      expect(options.env?.GEMSTONE_NRS_ALL).toBeUndefined();
+    });
+
+    it('uses LD_LIBRARY_PATH (not DYLD_LIBRARY_PATH) on Linux', () => {
+      setPlatform('linux');
+      const manager = new ProcessManager(makeStorage('/gs/3.7.4'));
+
+      manager.openVersionTerminal('3.7.4');
+
+      const options = vi.mocked(vscode.window.createTerminal).mock
+        .calls[0][0] as vscode.TerminalOptions;
+      expect(options.env?.LD_LIBRARY_PATH).toBe('/gs/3.7.4/lib');
+      expect(options.env?.DYLD_LIBRARY_PATH).toBeUndefined();
     });
 
     it('refuses when the requested version has not been extracted', () => {
@@ -654,6 +670,7 @@ describe('ProcessManager', () => {
     });
 
     it('under WSL launches a bash shell that cds and exports the version paths', () => {
+      setPlatform('win32');
       vi.mocked(wslBridge.needsWsl).mockReturnValue(true);
       const storage = {
         ...rawStorage(),
@@ -672,6 +689,29 @@ describe('ProcessManager', () => {
       expect(sent).toContain("cd '/mnt/c/gs/3.7.4'");
       expect(sent).toContain("export GEMSTONE='/mnt/c/gs/3.7.4'");
       expect(sent).toContain("export GEMSTONE_GLOBAL_DIR='/mnt/c/gemstone'");
+      expect(sent).toContain("export PATH='/mnt/c/gs/3.7.4/bin:");
+      expect(sent).toContain("export LD_LIBRARY_PATH='/mnt/c/gs/3.7.4/lib'");
+    });
+  });
+
+  describe('openTerminal (database)', () => {
+    beforeEach(() => {
+      vi.mocked(vscode.window.createTerminal).mockClear();
+      vi.mocked(wslBridge.needsWsl).mockReturnValue(false);
+    });
+
+    it('sets PATH to the version bin alongside the stone-specific environment', () => {
+      setPlatform('darwin');
+      const manager = new ProcessManager(makeStorage('/gs/3.7.4'));
+
+      manager.openTerminal(makeDatabase());
+
+      const options = vi.mocked(vscode.window.createTerminal).mock
+        .calls[0][0] as vscode.TerminalOptions;
+      expect(options.env?.PATH).toContain('/gs/3.7.4/bin');
+      expect(options.env?.DYLD_LIBRARY_PATH).toBe('/gs/3.7.4/lib');
+      expect(options.env?.GEMSTONE_SYS_CONF).toBe('/home/user/gemstone/db-1/conf');
+      expect(options.env?.GEMSTONE_NRS_ALL).toContain('#netldi:gs64ldi');
     });
   });
 

--- a/client/src/processManager.ts
+++ b/client/src/processManager.ts
@@ -119,16 +119,7 @@ export class ProcessManager {
     try {
       const gsPath = gslistPath.replace(/\/bin\/gslist$/, '');
       const rootPath = needsWsl() ? this.storage.getWslRootPath() : this.storage.getRootPath();
-      const env: Record<string, string> = {
-        GEMSTONE: gsPath,
-        PATH: `${gsPath}/bin:/usr/local/bin:/usr/bin:/bin`,
-        GEMSTONE_GLOBAL_DIR: rootPath,
-      };
-      if (process.platform === 'darwin') {
-        env.DYLD_LIBRARY_PATH = `${gsPath}/lib`;
-      } else {
-        env.LD_LIBRARY_PATH = `${gsPath}/lib`;
-      }
+      const env = this.versionEnvironment(gsPath, rootPath);
       const output = wslExecSync(`"${gslistPath}" -cvl`, env);
       this.cachedProcesses = parseGslist(output);
     } catch {
@@ -213,21 +204,18 @@ export class ProcessManager {
     return undefined;
   }
 
-  private getEnvironment(db: GemStoneDatabase): Record<string, string> {
-    const gsPath = needsWsl()
-      ? this.storage.getWslGemstonePath(db.config.version)
-      : this.storage.getGemstonePath(db.config.version);
-    if (!gsPath)
-      throw new Error(`GemStone ${db.config.version} not found. Please extract it first.`);
-    const dbPath = needsWsl() ? windowsPathToWsl(db.path) : db.path;
-    const rootPath = needsWsl() ? this.storage.getWslRootPath() : this.storage.getRootPath();
+  /**
+   * Environment for a GemStone version's product directory: the product dir,
+   * the global dir, and the PATH / dynamic-library / man paths its binaries
+   * need. Shared by the version terminal, the per-database environment, and
+   * process listing so the three cannot drift — a version terminal that omitted
+   * PATH could not find binaries in `$GEMSTONE/bin`. Callers layer any
+   * stone-specific vars (GEMSTONE_SYS_CONF, GEMSTONE_LOG, …) on top.
+   */
+  private versionEnvironment(gsPath: string, rootPath: string): Record<string, string> {
     const env: Record<string, string> = {
       GEMSTONE: gsPath,
-      GEMSTONE_SYS_CONF: `${dbPath}/conf`,
       GEMSTONE_GLOBAL_DIR: rootPath,
-      GEMSTONE_LOG: `${dbPath}/log/${db.config.stoneName}.log`,
-      GEMSTONE_EXE_CONF: `${dbPath}/conf`,
-      GEMSTONE_NRS_ALL: `#netldi:${db.config.ldiName}#dir:${dbPath}#log:${dbPath}/log/%N_%P.log`,
       PATH: `${gsPath}/bin:/usr/local/bin:/usr/bin:/bin`,
     };
     if (process.platform === 'darwin') {
@@ -237,6 +225,23 @@ export class ProcessManager {
     }
     env.MANPATH = `${gsPath}/doc`;
     return env;
+  }
+
+  private getEnvironment(db: GemStoneDatabase): Record<string, string> {
+    const gsPath = needsWsl()
+      ? this.storage.getWslGemstonePath(db.config.version)
+      : this.storage.getGemstonePath(db.config.version);
+    if (!gsPath)
+      throw new Error(`GemStone ${db.config.version} not found. Please extract it first.`);
+    const dbPath = needsWsl() ? windowsPathToWsl(db.path) : db.path;
+    const rootPath = needsWsl() ? this.storage.getWslRootPath() : this.storage.getRootPath();
+    return {
+      ...this.versionEnvironment(gsPath, rootPath),
+      GEMSTONE_SYS_CONF: `${dbPath}/conf`,
+      GEMSTONE_LOG: `${dbPath}/log/${db.config.stoneName}.log`,
+      GEMSTONE_EXE_CONF: `${dbPath}/conf`,
+      GEMSTONE_NRS_ALL: `#netldi:${db.config.ldiName}#dir:${dbPath}#log:${dbPath}/log/%N_%P.log`,
+    };
   }
 
   /** Start a stone */
@@ -388,10 +393,10 @@ export class ProcessManager {
   }
 
   /**
-   * Open a terminal in a version's product directory. Unlike a database
-   * terminal, this configures only GEMSTONE (the version's product directory)
-   * and GEMSTONE_GLOBAL_DIR (the root path) — nothing that ties it to a
-   * particular stone.
+   * Open a terminal in a version's product directory, with PATH (and the
+   * dynamic-library / man paths) set so `$GEMSTONE/bin` tools are runnable —
+   * the same version environment the database terminal gets, minus the
+   * stone-specific vars, so nothing ties it to a particular stone.
    */
   openVersionTerminal(version: string): void {
     const gsPath = needsWsl()
@@ -399,10 +404,7 @@ export class ProcessManager {
       : this.storage.getGemstonePath(version);
     if (!gsPath) throw new Error(`GemStone ${version} not found. Please extract it first.`);
     const rootPath = needsWsl() ? this.storage.getWslRootPath() : this.storage.getRootPath();
-    const env: Record<string, string> = {
-      GEMSTONE: gsPath,
-      GEMSTONE_GLOBAL_DIR: rootPath,
-    };
+    const env = this.versionEnvironment(gsPath, rootPath);
     if (needsWsl()) {
       const envExports = Object.entries(env)
         .map(([k, v]) => `export ${k}='${v}'`)


### PR DESCRIPTION
## Problem

The **Versions** view's inline **Open Terminal** button opened a terminal with `GEMSTONE` set but **not `PATH`** (nor the dynamic-library / man paths). So `$GEMSTONE/bin` tools like `topaz` weren't found. The **Databases** view's terminal set `PATH` correctly, so the two behaved differently.

## Cause

The database terminal builds its environment via `getEnvironment()`, which sets `PATH`, the platform library path, and `MANPATH`. `openVersionTerminal` instead built its own minimal env (`GEMSTONE` + `GEMSTONE_GLOBAL_DIR` only). The `PATH`/library construction was duplicated across `getEnvironment`, `refreshProcesses`, and *missing* from `openVersionTerminal` — which is exactly how they drifted.

## Fix

Extract one `versionEnvironment(gsPath, rootPath)` helper — `GEMSTONE`, `GEMSTONE_GLOBAL_DIR`, `PATH` (`$GEMSTONE/bin:…`), `DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH`, and `MANPATH` — and use it from:

- the **version terminal** (`openVersionTerminal`) — the fix the user asked for,
- the **database environment** (`getEnvironment`), which now layers its stone-specific vars (`GEMSTONE_SYS_CONF`, `GEMSTONE_LOG`, `GEMSTONE_NRS_ALL`, …) on top, and
- **process listing** (`refreshProcesses`).

Both terminals now make `$GEMSTONE/bin` binaries runnable, and the shared builder means they can't drift apart again. The version terminal still omits the stone-specific vars, so it stays untied to any particular stone.

## Tests

`processManager.test.ts`: the version terminal now puts `$GEMSTONE/bin` on `PATH` (with the right lib path per platform, and still no stone-specific vars), the WSL path exports `PATH`/`LD_LIBRARY_PATH`, and a new database-terminal test guards that `PATH` and the stone-specific vars coexist. Full gate green (client 3323, server 322, mcp 95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)