### PR TITLE
Remove GCI query/result dev logging

### DIFF
--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -3,8 +3,6 @@ import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 
 vi.mock('../gciLog', () => ({
-  logQuery: vi.fn(),
-  logResult: vi.fn(),
   logError: vi.fn(),
   logInfo: vi.fn(),
 }));

--- a/client/src/__tests__/gciLog.test.ts
+++ b/client/src/__tests__/gciLog.test.ts
@@ -3,15 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('vscode', () => import('../__mocks__/vscode'));
 
 import { window } from 'vscode';
-import {
-  getGciLog,
-  logQuery,
-  logResult,
-  logError,
-  logInfo,
-  logGciCall,
-  _resetGciLogForTests,
-} from '../gciLog';
+import { getGciLog, logError, logInfo, _resetGciLogForTests } from '../gciLog';
 
 /** The lines appended to the singleton channel, in order. */
 function loggedLines(): string[] {
@@ -38,8 +30,10 @@ describe('gciLog', () => {
   });
 
   it('prefixes each entry with the current wall-clock time', () => {
-    logQuery(1, 'Display It', '3 + 4');
-    expect(loggedLines()[0]).toBe('[14:03:09.087] [Session 1] Display It');
+    logError(1, 'a MessageNotUnderstood occurred');
+    expect(loggedLines()[0]).toBe(
+      '[14:03:09.087] [Session 1] ERROR: a MessageNotUnderstood occurred',
+    );
   });
 
   it('pads the timestamp components to a stable width', () => {
@@ -48,61 +42,9 @@ describe('gciLog', () => {
     expect(loggedLines()[0]).toBe('[09:05:03.007] boot');
   });
 
-  it('reports the time spent between a query and its result', () => {
-    logQuery(1, 'Display It', '(Delay forSeconds: 1) wait');
-    vi.advanceTimersByTime(1234);
-    logResult(1, '42');
-
-    const resultLine = loggedLines().find((l) => l.includes('→'))!;
-    expect(resultLine).toContain('(1234 ms)');
-    expect(resultLine).toContain('→ 42');
-  });
-
-  it('reports the time spent when a call ends in an error', () => {
-    logQuery(1, 'Execute It', 'nil foo');
-    vi.advanceTimersByTime(50);
-    logError(1, 'a MessageNotUnderstood occurred');
-
-    const errorLine = loggedLines().find((l) => l.includes('ERROR'))!;
-    expect(errorLine).toContain('(50 ms)');
-    expect(errorLine).toContain('ERROR: a MessageNotUnderstood occurred');
-  });
-
-  it('omits a duration for an error that was not preceded by a query', () => {
+  it('formats an error line with the session id and message', () => {
     logError(7, 'standalone failure');
 
-    const errorLine = loggedLines()[0];
-    expect(errorLine).not.toMatch(/\(\d+ ms\)/);
-    expect(errorLine).toBe('[14:03:09.087] [Session 7] ERROR: standalone failure');
-  });
-
-  it('measures each session independently when calls interleave', () => {
-    logQuery(1, 'A', 'a');
-    vi.advanceTimersByTime(10);
-    logQuery(2, 'B', 'b');
-    vi.advanceTimersByTime(5); // session 1 now at 15ms, session 2 at 5ms
-    logResult(1, 'x');
-    logResult(2, 'y');
-
-    const lines = loggedLines();
-    expect(lines.find((l) => l.includes('→ x'))).toContain('(15 ms)');
-    expect(lines.find((l) => l.includes('→ y'))).toContain('(5 ms)');
-  });
-
-  it('does not attribute a duration to a second result once the start is consumed', () => {
-    logQuery(1, 'A', 'a');
-    logResult(1, 'first');
-    logResult(1, 'second');
-
-    const results = loggedLines().filter((l) => l.includes('→'));
-    expect(results[0]).toMatch(/\(\d+ ms\)/);
-    expect(results[1]).not.toMatch(/\(\d+ ms\)/);
-  });
-
-  it('timestamps a lower-level GCI call line', () => {
-    logGciCall(1, 'GciTsExecuteFetchBytes', { sourceSize: -1 });
-    expect(loggedLines()[0]).toBe(
-      '[14:03:09.087] [Session 1] GCI: GciTsExecuteFetchBytes(sourceSize: -1)',
-    );
+    expect(loggedLines()[0]).toBe('[14:03:09.087] [Session 7] ERROR: standalone failure');
   });
 });

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -1,6 +1,6 @@
 import { ActiveSession } from './sessionManager';
-import { OOP_NIL, OOP_ILLEGAL } from './gciConstants';
-import { logQuery, logResult, logError } from './gciLog';
+import { OOP_ILLEGAL, OOP_NIL } from './gciConstants';
+import { logError } from './gciLog';
 import { runNbCall } from './nbRunner';
 
 import { QueryExecutor } from './queries/types';
@@ -11,8 +11,8 @@ import { getBaseMethodSource as sharedGetBaseMethodSource } from './queries/getB
 import { getDictionaryNames as sharedGetDictionaryNames } from './queries/getDictionaryNames';
 import { getClassNames as sharedGetClassNames } from './queries/getClassNames';
 import {
-  getClassesWithCategory as sharedGetClassesWithCategory,
   ClassCategoryEntry,
+  getClassesWithCategory as sharedGetClassesWithCategory,
 } from './queries/getClassesWithCategory';
 import { getDictionaryClassFileOutOrder as sharedGetDictionaryClassFileOutOrder } from './queries/getDictionaryClassFileOutOrder';
 import { getDictionaryEntries as sharedGetDictionaryEntries } from './queries/getDictionaryEntries';
@@ -50,11 +50,11 @@ import {
 import { diffRowanProject as sharedDiffRowanProject } from './queries/rowan/diffRowanProject';
 import { unloadRowanProject as sharedUnloadRowanProject } from './queries/rowan/unloadRowanProject';
 import {
+  hierarchyImplementorsOf as sharedHierarchyImplementorsOf,
+  implementorsOf as sharedImplementorsOf,
+  referencesToObject as sharedReferencesToObject,
   searchMethodSource as sharedSearchMethodSource,
   sendersOf as sharedSendersOf,
-  implementorsOf as sharedImplementorsOf,
-  hierarchyImplementorsOf as sharedHierarchyImplementorsOf,
-  referencesToObject as sharedReferencesToObject,
 } from './queries/methodSearch';
 
 // Write-path shared queries.
@@ -128,8 +128,6 @@ function resolveClassUtf8(session: ActiveSession): bigint {
 // correctly regardless of their original encoding and are not capped at a
 // single fixed-size buffer.
 export function executeFetchString(session: ActiveSession, label: string, code: string): string {
-  logQuery(session.id, label, code);
-
   // Check if session is busy with an async operation (e.g., Display It)
   const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
   if (inProgress !== 0) {
@@ -139,9 +137,7 @@ export function executeFetchString(session: ActiveSession, label: string, code: 
   }
 
   try {
-    const result = session.gci.executeAndFetchString(session.handle, code);
-    logResult(session.id, result);
-    return result;
+    return session.gci.executeAndFetchString(session.handle, code);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     logError(session.id, msg);
@@ -164,8 +160,6 @@ export async function executeFetchStringNb(
   progressTitle?: string,
   suppressNotification = false,
 ): Promise<string> {
-  logQuery(session.id, label, code);
-
   const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
   if (inProgress !== 0) {
     const msg = 'Session is busy with another operation. Please wait or use a different session.';
@@ -197,7 +191,6 @@ export async function executeFetchStringNb(
     { title: progressTitle ?? `GemStone: ${label}…`, suppressNotification },
   );
 
-  logResult(session.id, data);
   return data;
 }
 
@@ -213,8 +206,6 @@ export function executeFetchStringWithLimit(
   code: string,
   maxBytes: number,
 ): string {
-  logQuery(session.id, label, code);
-
   const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
   if (inProgress !== 0) {
     const msg = 'Session is busy with another operation. Please wait or use a different session.';

--- a/client/src/codeExecutor.ts
+++ b/client/src/codeExecutor.ts
@@ -7,7 +7,7 @@ import {
   GCI_PERFORM_FLAG_SINGLE_STEP,
   GCI_PERFORM_FLAG_INTERPRETED,
 } from './gciConstants';
-import { logQuery, logResult, logError, logInfo } from './gciLog';
+import { logError, logInfo } from './gciLog';
 import { InspectorTreeProvider } from './inspectorTreeProvider';
 import { routeInspect } from './inspectRouter';
 import { DebuggerPanel } from './debuggerPanel';
@@ -161,9 +161,6 @@ export class CodeExecutor {
 
     const oopClassString = this.resolveUtf8ClassOopUsing(session);
 
-    const label = mode === 'display' ? 'Display It' : mode === 'debug' ? 'Debug It' : 'Execute It';
-    logQuery(session.id, label, code);
-
     // Dim the selected code while executing
     const execRange = new vscode.Range(selection.start, selection.end);
     editor.setDecorations(executingDecorationType, [execRange]);
@@ -201,7 +198,6 @@ export class CodeExecutor {
 
       const resultString = await this.pollForResult(session);
 
-      logResult(session.id, resultString);
       this.diagnostics.delete(editor.document.uri);
 
       if (displayResult) {
@@ -741,8 +737,6 @@ export class CodeExecutor {
   ): Promise<void> {
     const oopClassString = this.resolveUtf8ClassOopUsing(session);
 
-    logQuery(session.id, 'Inspect It', code);
-
     // Dim the selected code in the active editor while executing
     const editor = vscode.window.activeTextEditor;
     if (editor) {
@@ -772,7 +766,6 @@ export class CodeExecutor {
 
       const oop = await this.pollForResultOop(session);
 
-      logResult(session.id, `OOP ${oop}`);
       routeInspect(session, oop, label, inspectorProvider);
     } catch (e: unknown) {
       if (e instanceof NbCancelledError) return;

--- a/client/src/gciLog.ts
+++ b/client/src/gciLog.ts
@@ -2,12 +2,6 @@ import * as vscode from 'vscode';
 
 let channel: vscode.OutputChannel | undefined;
 
-// Wall-clock start (ms) of the most recent logged query per session, so the
-// paired result/error line can report how long the call took. GCI allows only
-// one call in progress per session, so a single pending start per session is
-// exact. Cleared when consumed by logResult/logError.
-const callStart = new Map<number, number>();
-
 export function getGciLog(): vscode.OutputChannel {
   if (!channel) {
     channel = vscode.window.createOutputChannel('GemStone GCI');
@@ -22,71 +16,10 @@ function stamp(): string {
   return `[${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}]`;
 }
 
-/**
- * Time since this session's last logQuery, formatted as `(N ms) ` with a
- * trailing space, then clear the pending start. Empty string when nothing is
- * pending (e.g. a standalone error not preceded by a query), so no misleading
- * duration is shown.
- */
-function elapsed(sessionId: number): string {
-  const start = callStart.get(sessionId);
-  if (start === undefined) return '';
-  callStart.delete(sessionId);
-  return `(${Date.now() - start} ms) `;
-}
-
-export function logQuery(sessionId: number, label: string, code: string): void {
-  const log = getGciLog();
-  callStart.set(sessionId, Date.now());
-  log.appendLine(`${stamp()} [Session ${sessionId}] ${label}`);
-  log.appendLine(code);
-  log.appendLine('');
-}
-
-export function logResult(sessionId: number, result: string): void {
-  const log = getGciLog();
-  const preview = result.length > 500 ? result.substring(0, 500) + '...' : result;
-  log.appendLine(`${stamp()} [Session ${sessionId}] ${elapsed(sessionId)}→ ${preview}`);
-  log.appendLine('');
-}
-
 export function logError(sessionId: number, message: string): void {
   const log = getGciLog();
-  log.appendLine(`${stamp()} [Session ${sessionId}] ${elapsed(sessionId)}ERROR: ${message}`);
+  log.appendLine(`${stamp()} [Session ${sessionId}] ERROR: ${message}`);
   log.appendLine('');
-}
-
-export function logGciCall(sessionId: number, func: string, args: Record<string, unknown>): void {
-  const log = getGciLog();
-  const formatted = Object.entries(args)
-    .map(([k, v]) => {
-      if (typeof v === 'bigint') return `${k}: 0x${v.toString(16)} (${v})`;
-      if (typeof v === 'string' && v.length > 100)
-        return `${k}: "${v.substring(0, 100)}..." (${v.length} chars)`;
-      if (typeof v === 'string') return `${k}: "${v}"`;
-      return `${k}: ${v}`;
-    })
-    .join(', ');
-  log.appendLine(`${stamp()} [Session ${sessionId}] GCI: ${func}(${formatted})`);
-}
-
-export function logGciResult(
-  sessionId: number,
-  func: string,
-  result: Record<string, unknown>,
-): void {
-  const log = getGciLog();
-  const formatted = Object.entries(result)
-    .map(([k, v]) => {
-      if (typeof v === 'bigint') return `${k}: 0x${v.toString(16)} (${v})`;
-      if (typeof v === 'string' && v.length > 200)
-        return `${k}: "${v.substring(0, 200)}..." (${v.length} chars)`;
-      if (typeof v === 'string') return `${k}: "${v}"`;
-      if (typeof v === 'object' && v !== null) return `${k}: ${JSON.stringify(v)}`;
-      return `${k}: ${v}`;
-    })
-    .join(', ');
-  log.appendLine(`${stamp()} [Session ${sessionId}]   → ${formatted}`);
 }
 
 export function logInfo(message: string): void {
@@ -95,11 +28,10 @@ export function logInfo(message: string): void {
 }
 
 /**
- * Test-only: drop the cached channel and any pending call-start timers so each
- * test starts from a clean slate (the channel is a module-level singleton
- * created once per process). Not used by production code.
+ * Test-only: drop the cached channel so each test starts from a clean slate
+ * (the channel is a module-level singleton created once per process). Not
+ * used by production code.
  */
 export function _resetGciLogForTests(): void {
   channel = undefined;
-  callStart.clear();
 }


### PR DESCRIPTION
## Summary
- `logResult` and `logQuery` (in `client/src/gciLog.ts`) logged every GCI query and its result to the "GemStone GCI" output channel. This existed to help iterate on Jasper itself, not for Jasper's end users, and as discussed in Slack it's being removed now that it's no longer needed for that purpose.
- `logQuery` was the only thing populating `gciLog`'s `callStart` map, so `logError`'s `(N ms)` duration reporting had already stopped working since nothing started the clock; this removes that now-unused `callStart`/`elapsed()` machinery too, along with an orphaned `label` variable in `codeExecutor.ts`'s `execute()`.
- `logError` and `logInfo` are intentionally left in place: `logError` until `GciLibraryError` replaces `BrowserQueryError` and the ad-hoc libgci error handling direct koffi callers use, and `logInfo` until GCI logging is centralized.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx tsc -p client/tsconfig.json --noEmit`
- [x] `npx vitest run` on the touched suites (`gciLog.test.ts`, `codeExecutor.test.ts`) — 108 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)