### PR TITLE
Migrate transcript sink install to executeAndFetchString

### DIFF
--- a/client/src/__tests__/sessionManager.test.ts
+++ b/client/src/__tests__/sessionManager.test.ts
@@ -19,11 +19,8 @@ vi.mock('vscode', () => ({
 
 let pingErrNumber = 0;
 // The transcript-sink install (run at login) executes a doit via
-// GciTsExecuteFetchBytes; capture the calls so tests can assert on them.
-const executeFetchBytes = vi.fn((..._args: unknown[]) => ({
-  data: 'installed',
-  err: { number: 0, message: '' },
-}));
+// executeAndFetchString; capture the calls so tests can assert on them.
+const executeAndFetchStringMock = vi.fn((..._args: unknown[]) => 'installed');
 // login() aborts once after setup to drop the session-method-policy's spurious
 // write; capture those calls so tests can assert on them.
 const gciTsAbort = vi.fn((..._args: unknown[]) => ({
@@ -69,8 +66,8 @@ vi.mock('../gciLibrary', () => ({
         err: { number: pingErrNumber, message: pingErrNumber ? 'boom' : '' },
       };
     }
-    GciTsExecuteFetchBytes(...args: unknown[]) {
-      return executeFetchBytes(...(args as []));
+    executeAndFetchString(...args: unknown[]) {
+      return executeAndFetchStringMock(...(args as []));
     }
     GciTsAbort(...args: unknown[]) {
       return gciTsAbort(...(args as []));
@@ -96,6 +93,7 @@ vi.mock('../gciLog', () => ({
 
 import { SessionManager, evaluateLoginPolicy } from '../sessionManager';
 import { DEFAULT_LOGIN } from '../loginTypes';
+import { GciLibraryError } from '../gciLibraryError';
 
 describe('evaluateLoginPolicy', () => {
   it('allows the first login regardless of mode', () => {
@@ -144,7 +142,7 @@ describe('SessionManager', () => {
   it('installs the server-side Transcript sink at login', () => {
     manager.login({ ...DEFAULT_LOGIN, label: 'Test' }, '/mock/lib');
 
-    const installCall = executeFetchBytes.mock.calls.find(
+    const installCall = executeAndFetchStringMock.mock.calls.find(
       (c) => typeof c[1] === 'string' && c[1].includes('JasperTranscriptSink'),
     );
     expect(installCall).toBeDefined();
@@ -152,9 +150,8 @@ describe('SessionManager', () => {
   });
 
   it('still logs in when the Transcript sink install fails', () => {
-    executeFetchBytes.mockReturnValueOnce({
-      data: '',
-      err: { number: 4001, message: 'no compile privilege' },
+    executeAndFetchStringMock.mockImplementationOnce(() => {
+      throw GciLibraryError.withMessage('no compile privilege');
     });
 
     const session = manager.login({ ...DEFAULT_LOGIN, label: 'Test' }, '/mock/lib');

--- a/client/src/__tests__/transcriptSink.test.ts
+++ b/client/src/__tests__/transcriptSink.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../transcriptSink';
 import type { ActiveSession } from '../sessionManager';
 import type { GciError } from '../gciLibrary';
+import { GciLibraryError } from '../gciLibraryError';
 
 const OOP_ILLEGAL = 0x01n;
 
@@ -55,6 +56,7 @@ function makeGci(overrides: Record<string, unknown> = {}) {
     ),
     GciTsFetchOops: vi.fn(() => ({ result: 1, oops: [0x77n], err: { number: 0 } })),
     GciTsExecuteFetchBytes: vi.fn(() => ({ data: '', err: { number: 0 } })),
+    executeAndFetchString: vi.fn(() => ''),
     GciTsNbResult: vi.fn(() => ({ result: 42n, err: { number: 0, context: 0n } })),
     GciTsContinueWithAsync: vi.fn(async () => ({ result: 42n, err: { number: 0, context: 0n } })),
     ...overrides,
@@ -106,7 +108,7 @@ describe('transcriptSink', () => {
   describe('installTranscriptSink', () => {
     it('reports success when the install doit runs cleanly', () => {
       const gci = makeGci({
-        GciTsExecuteFetchBytes: vi.fn(() => ({ data: 'installed', err: { number: 0 } })),
+        executeAndFetchString: vi.fn(() => 'installed'),
       });
 
       expect(installTranscriptSink(makeSession(gci))).toBe(true);
@@ -114,7 +116,9 @@ describe('transcriptSink', () => {
 
     it('is non-fatal when the server rejects the install', () => {
       const gci = makeGci({
-        GciTsExecuteFetchBytes: vi.fn(() => ({ data: '', err: { number: 4001, message: 'nope' } })),
+        executeAndFetchString: vi.fn(() => {
+          throw GciLibraryError.withMessage('nope');
+        }),
       });
 
       expect(installTranscriptSink(makeSession(gci))).toBe(false);
@@ -122,7 +126,7 @@ describe('transcriptSink', () => {
 
     it('is non-fatal when the GCI call throws', () => {
       const gci = makeGci({
-        GciTsExecuteFetchBytes: vi.fn(() => {
+        executeAndFetchString: vi.fn(() => {
           throw new Error('socket closed');
         }),
       });

--- a/client/src/transcriptSink.ts
+++ b/client/src/transcriptSink.ts
@@ -140,20 +140,9 @@ sink == nil ifTrue: [''] ifFalse: [(sink jasperLive: ${live}) encodeAsUTF8]`;
  */
 export function installTranscriptSink(session: ActiveSession): boolean {
   try {
-    const { data, err } = session.gci.GciTsExecuteFetchBytes(
-      session.handle,
-      TRANSCRIPT_SINK_INSTALL_CODE,
-      -1,
-      OOP_CLASS_STRING,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      256,
-    );
-    if (err.number !== 0) {
-      logError(session.id, `Transcript sink install failed: ${err.message || err.number}`);
-      return false;
-    }
-    logInfo(`[Session ${session.id}] Transcript sink ${data}`);
+    const result = session.gci.executeAndFetchString(session.handle, TRANSCRIPT_SINK_INSTALL_CODE);
+
+    logInfo(`[Session ${session.id}] Transcript sink ${result}`);
     return true;
   } catch (e) {
     logError(


### PR DESCRIPTION
## Summary
- `installTranscriptSink` now delegates to `GciLibrary.executeAndFetchString` instead of calling `GciTsExecuteFetchBytes` directly, matching the query-layer migration in cb97bc3 and dropping the fixed 256-byte fetch cap and missing UTF-8 encoding on the install doit's result.
- Fixed `transcriptSink.test.ts` and `sessionManager.test.ts`, whose mocks stubbed `GciTsExecuteFetchBytes` and had silently stopped exercising `installTranscriptSink`'s success/error paths once that call moved.
- Removed the now-unused `GciTsExecuteFetchBytes` mock plumbing left behind in `sessionManager.test.ts`.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile`
- [x] `npm test` (client 3326, server 322, mcp-server 95, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)