### PR TITLE
Finish transcript drain/live-toggle migration

### DIFF
--- a/client/src/__tests__/codeExecutor.test.ts
+++ b/client/src/__tests__/codeExecutor.test.ts
@@ -63,13 +63,16 @@ function makeGci(overrides: Record<string, unknown> = {}) {
       err: { number: 0, message: '', context: OOP_NIL },
     })),
     GciTsPerformFetchBytes: vi.fn(() => ({ data: '42', err: { number: 0 } })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({ data: '', err: { number: 0 } })),
-    executeAndFetchString: vi.fn(() =>
-      expect.unreachable(
+    // Transcript sink toggle/drain calls (see transcriptSink.ts) also go through
+    // executeAndFetchString; default them to an empty buffer so tests that don't
+    // care about transcript output don't have to configure this mock at all.
+    executeAndFetchString: vi.fn((_handle: unknown, code: string) => {
+      if (code.includes('jasperLive:') || code.includes('jasperDrain')) return '';
+      return expect.unreachable(
         'executeAndFetchString mock not configured for this test -- call ' +
           '(gci.executeAndFetchString as Mock).mockReturnValue(...) before triggering Display It.',
-      ),
-    ),
+      );
+    }),
     GciTsClearStack: vi.fn(),
     GciTsObjExists: vi.fn(() => false),
     GciTsFetchClass: vi.fn(() => ({ result: 0n, err: { number: 0 } })),
@@ -406,7 +409,7 @@ describe('CodeExecutor', () => {
 
       await executor.executeIt();
 
-      const sinkCalls = (gci.GciTsExecuteFetchBytes as Mock).mock.calls
+      const sinkCalls = (gci.executeAndFetchString as Mock).mock.calls
         .map((c) => c[1] as string)
         .filter((code) => code.includes('jasperLive:'));
       expect(sinkCalls.some((code) => code.includes('jasperLive: true'))).toBe(true);
@@ -426,7 +429,7 @@ describe('CodeExecutor', () => {
 
       await executor.executeIt();
 
-      const sinkCalls = (gci.GciTsExecuteFetchBytes as Mock).mock.calls.map((c) => c[1] as string);
+      const sinkCalls = (gci.executeAndFetchString as Mock).mock.calls.map((c) => c[1] as string);
       expect(sinkCalls.some((code) => code.includes('jasperLive: false'))).toBe(true);
     });
 

--- a/client/src/__tests__/smalltalkNotebookController.test.ts
+++ b/client/src/__tests__/smalltalkNotebookController.test.ts
@@ -18,7 +18,7 @@ import { SessionManager } from '../sessionManager';
 // Cells run on the non-blocking execute path (live transcript). The mock gci
 // covers that path: NbExecute starts the doit, NbPoll reports ready, NbResult
 // yields the result oop, FetchUtf8 reads its string. The transcript sink's
-// live-toggle/drain calls go through GciTsExecuteFetchBytes.
+// live-toggle/drain calls go through executeAndFetchString.
 function makeGci(overrides: Record<string, unknown> = {}) {
   return {
     GciTsCallInProgress: vi.fn(() => ({ result: 0, err: { number: 0 } })),
@@ -31,7 +31,7 @@ function makeGci(overrides: Record<string, unknown> = {}) {
     GciTsNbPoll: vi.fn(() => ({ result: 1, err: { number: 0 } })),
     GciTsNbResult: vi.fn(() => ({ result: 200n, err: { number: 0, message: '', context: 0x14n } })),
     GciTsFetchUtf8: vi.fn(() => ({ data: '7', err: { number: 0 } })),
-    GciTsExecuteFetchBytes: vi.fn((..._args: unknown[]) => ({ data: '', err: { number: 0 } })),
+    executeAndFetchString: vi.fn((..._args: unknown[]) => ''),
     ...overrides,
   };
 }
@@ -119,7 +119,7 @@ describe('SmalltalkNotebookController', () => {
 
     await runCells([makeCell('3 + 4')]);
 
-    const sinkCalls = gci.GciTsExecuteFetchBytes.mock.calls
+    const sinkCalls = gci.executeAndFetchString.mock.calls
       .map((c) => c[1] as string)
       .filter((code) => code.includes('jasperLive:'));
     expect(sinkCalls.some((code) => code.includes('jasperLive: true'))).toBe(true);

--- a/client/src/__tests__/transcriptSink.test.ts
+++ b/client/src/__tests__/transcriptSink.test.ts
@@ -55,7 +55,6 @@ function makeGci(overrides: Record<string, unknown> = {}) {
         : { data: 'hello world', err: { number: 0 } },
     ),
     GciTsFetchOops: vi.fn(() => ({ result: 1, oops: [0x77n], err: { number: 0 } })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({ data: '', err: { number: 0 } })),
     executeAndFetchString: vi.fn(() => ''),
     GciTsNbResult: vi.fn(() => ({ result: 42n, err: { number: 0, context: 0n } })),
     GciTsContinueWithAsync: vi.fn(async () => ({ result: 42n, err: { number: 0, context: 0n } })),
@@ -138,7 +137,7 @@ describe('transcriptSink', () => {
   describe('setTranscriptLive / drainTranscript', () => {
     it('returns the text drained during a mode switch', () => {
       const gci = makeGci({
-        GciTsExecuteFetchBytes: vi.fn(() => ({ data: 'buffered output', err: { number: 0 } })),
+        executeAndFetchString: vi.fn(() => 'buffered output'),
       });
 
       expect(setTranscriptLive(makeSession(gci), true)).toBe('buffered output');
@@ -151,7 +150,7 @@ describe('transcriptSink', () => {
       setTranscriptLive(session, true);
       setTranscriptLive(session, false);
 
-      const codes = (gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock.calls.map(
+      const codes = (gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock.calls.map(
         (c) => c[1] as string,
       );
       expect(codes[0]).toContain('jasperLive: true');
@@ -162,14 +161,16 @@ describe('transcriptSink', () => {
       const gci = makeGci();
 
       expect(drainTranscript(makeSession(gci))).toBe('');
-      const code = (gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>).mock
+      const code = (gci.executeAndFetchString as ReturnType<typeof vi.fn>).mock
         .calls[0][1] as string;
       expect(code).toContain('jasperDrain');
     });
 
     it('returns empty (not an exception) when the sink call fails', () => {
       const gci = makeGci({
-        GciTsExecuteFetchBytes: vi.fn(() => ({ data: '', err: { number: 4100, message: 'busy' } })),
+        executeAndFetchString: vi.fn(() => {
+          throw GciLibraryError.withMessage('busy');
+        }),
       });
 
       expect(drainTranscript(makeSession(gci))).toBe('');

--- a/client/src/transcriptSink.ts
+++ b/client/src/transcriptSink.ts
@@ -1,7 +1,7 @@
 import type { GciError } from './gciLibrary';
 import type { ActiveSession } from './sessionManager';
-import { OOP_ILLEGAL, OOP_NIL, OOP_CLASS_STRING } from './gciConstants';
-import { logInfo, logError } from './gciLog';
+import { OOP_ILLEGAL } from './gciConstants';
+import { logError, logInfo } from './gciLog';
 
 /**
  * Jade-style server-side Transcript sink.
@@ -169,20 +169,7 @@ export function drainTranscript(session: ActiveSession): string {
 
 function runFetchString(session: ActiveSession, code: string): string {
   try {
-    const { data, err } = session.gci.GciTsExecuteFetchBytes(
-      session.handle,
-      code,
-      -1,
-      OOP_CLASS_STRING,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      MAX_TRANSCRIPT_FETCH,
-    );
-    if (err.number !== 0) {
-      logError(session.id, `Transcript sink call failed: ${err.message || err.number}`);
-      return '';
-    }
-    return data || '';
+    return session.gci.executeAndFetchString(session.handle, code);
   } catch (e) {
     logError(
       session.id,


### PR DESCRIPTION
## Summary
- PR #215 migrated the transcript sink's install doit to the ergonomic `executeAndFetchString` helper but left `drainTranscript`/`setTranscriptLive` on the older raw `GciTsExecuteFetchBytes` call with its own manual error handling.
- Both paths now go through `executeAndFetchString`, so all three sink operations (install, drain, live-toggle) share one error path and one way of decoding the result.
- Updated the tests in `transcriptSink.test.ts`, `codeExecutor.test.ts`, and `smalltalkNotebookController.test.ts` that were mocking/asserting the old `GciTsExecuteFetchBytes` call for the drain/live-toggle paths, so they actually exercise what the code calls now.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile`
- [x] `npm test` (client 3319, server 322, mcp-server 95 — all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)