### PR TITLE
Drop the dead label parameter from QueryExecutor

### DIFF
--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -6,7 +6,7 @@ Run a single test file: `cd client && npx vitest run src/__tests__/extension.tes
 
 ## Conventions (non-standard — read before editing these areas)
 
-- **Queries** (`client/src/queries/`) are pure functions `(execute: QueryExecutor, ...args) => string` that build a Smalltalk snippet and call `execute(label, code)`. `QueryExecutor` is `(label: string, code: string) => string`, supplied by the caller, so the same query runs in the extension (executor wraps `gciLibrary`) and in the MCP server (its own session). Shared helpers live in `util.ts` (`escapeString`, `classLookupExpr`, …).
+- **Queries** (`client/src/queries/`) are pure functions `(execute: QueryExecutor, ...args) => string` that build a Smalltalk snippet and call `execute(code)`. `QueryExecutor` is `(code: string) => string`, supplied by the caller, so the same query runs in the extension (executor wraps `gciLibrary`) and in the MCP server (its own session). Shared helpers live in `util.ts` (`escapeString`, `classLookupExpr`, …).
 - **Webview scripts** (`debuggerView.js`, `listFilter.js`, `methodListView.js`, `enhancedInspectorColumns.js`) are plain JS that runs in the webview DOM, **not** compiled into the extension bundle. They are read at runtime via `fs.readFileSync` and injected as `<script>` tags, and live in separate files so they can be unit-tested in jsdom. Follow this pattern for new webview behavior.
 
 ## Architecture

--- a/client/src/__tests__/backup.integration.test.ts
+++ b/client/src/__tests__/backup.integration.test.ts
@@ -32,8 +32,7 @@ describe('full logical backup (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (label: string, code: string): string =>
-    q.executeFetchString(session(), label, code);
+  const exec = (code: string): string => q.executeFetchString(session(), code);
 
   it('confirms the connected user holds the FileControl privilege backups require', () => {
     expect(hasFileControlPrivilege(exec)).toBe(true);
@@ -66,16 +65,16 @@ describe('full logical backup (integration)', () => {
       };
 
       try {
-        const modeBefore = exec('mode', 'System transactionMode printString').trim();
+        const modeBefore = exec('System transactionMode printString').trim();
 
-        const result = exec('full backup', fullBackupCode(dest)).trim();
+        const result = exec(fullBackupCode(dest)).trim();
 
         expect(result).toBe('OK');
         expect(fs.existsSync(dest)).toBe(true);
         expect(fs.statSync(dest).size).toBeGreaterThan(0);
         // fullBackupTo: leaves the session in manualBegin; the ensure: block in
         // fullBackupCode must put the transaction mode back where it was.
-        expect(exec('mode', 'System transactionMode printString').trim()).toBe(modeBefore);
+        expect(exec('System transactionMode printString').trim()).toBe(modeBefore);
 
         // The produced file is discovered by the real (unmocked) tree provider.
         const provider = new DatabaseTreeProvider(

--- a/client/src/__tests__/backupManager.test.ts
+++ b/client/src/__tests__/backupManager.test.ts
@@ -9,7 +9,7 @@ import { runLogicalBackup, LogicalBackupDeps } from '../backupManager';
 
 function makeDeps(overrides?: Partial<LogicalBackupDeps>): LogicalBackupDeps {
   return {
-    execute: vi.fn((_label: string, code: string) => {
+    execute: vi.fn((code: string) => {
       if (code.includes('FileControl')) return 'true';
       if (code.includes('needsCommit')) return 'false';
       return 'aborted';
@@ -99,7 +99,7 @@ describe('runLogicalBackup', () => {
   });
 
   it('reports a pre-flight failure when the uncommitted-changes check errors', async () => {
-    const execute = vi.fn((_l: string, code: string) => {
+    const execute = vi.fn((code: string) => {
       if (code.includes('FileControl')) return 'true';
       throw new Error('gci down');
     });
@@ -115,7 +115,7 @@ describe('runLogicalBackup', () => {
   });
 
   it('reports a failure when aborting the uncommitted changes errors', async () => {
-    const execute = vi.fn((_l: string, code: string) => {
+    const execute = vi.fn((code: string) => {
       if (code.includes('FileControl')) return 'true';
       if (code.includes('needsCommit')) return 'true';
       throw new Error('abort failed');
@@ -146,9 +146,7 @@ describe('runLogicalBackup', () => {
 
   it('does not back up when the user declines to discard uncommitted changes', async () => {
     const deps = makeDeps({
-      execute: vi.fn((_l: string, code: string) =>
-        code.includes('needsCommit') ? 'true' : 'true',
-      ),
+      execute: vi.fn((code: string) => (code.includes('needsCommit') ? 'true' : 'true')),
     });
     vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined);
 
@@ -159,7 +157,7 @@ describe('runLogicalBackup', () => {
   });
 
   it('aborts the session then backs up when the user agrees to discard changes', async () => {
-    const execute = vi.fn((_l: string, code: string) => {
+    const execute = vi.fn((code: string) => {
       if (code.includes('FileControl')) return 'true';
       if (code.includes('needsCommit')) return 'true';
       return 'aborted';
@@ -172,7 +170,7 @@ describe('runLogicalBackup', () => {
     const ok = await runLogicalBackup(deps);
 
     expect(ok).toBe(true);
-    expect(execute.mock.calls.some(([, code]) => code.includes('System abortTransaction'))).toBe(
+    expect(execute.mock.calls.some(([code]) => code.includes('System abortTransaction'))).toBe(
       true,
     );
     expect(deps.runBackup).toHaveBeenCalledOnce();

--- a/client/src/__tests__/definedInstVars.test.ts
+++ b/client/src/__tests__/definedInstVars.test.ts
@@ -14,7 +14,7 @@ describe("a class's locally-defined instance variable names", () => {
 
     getDefinedInstVarNames(execute, 'Point');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     // Resolves the class (dict-scoped/quoted via classLookupExpr) then reads its own
     // instVarNames — not allInstVarNames (which would include inherited ones).
     expect(code).toContain("objectNamed: #'Point'");
@@ -27,7 +27,7 @@ describe("a class's locally-defined instance variable names", () => {
 
     getDefinedInstVarNames(execute, 'Point', 5);
 
-    expect(execute.mock.calls[0][1]).toContain('symbolList at: 5');
+    expect(execute.mock.calls[0][0]).toContain('symbolList at: 5');
   });
 
   it('returns nothing for a class that defines no variables', () => {
@@ -53,10 +53,7 @@ describe('counting locally-defined instance variables across a dictionary', () =
 
     getDefinedInstVarCounts(execute, 'UserGlobals');
 
-    expect(execute).toHaveBeenCalledWith(
-      expect.stringContaining('UserGlobals'),
-      expect.stringContaining("objectNamed: #'UserGlobals'"),
-    );
+    expect(execute).toHaveBeenCalledWith(expect.stringContaining("objectNamed: #'UserGlobals'"));
   });
 
   it('has no entries for an empty dictionary', () => {

--- a/client/src/__tests__/enhancedInspectorDataFetchers.test.ts
+++ b/client/src/__tests__/enhancedInspectorDataFetchers.test.ts
@@ -56,7 +56,7 @@ describe('fetchEnhancedInspectorListTotal', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '0');
     fetchEnhancedInspectorListTotal(execute, 99999n, 'gtItemsFor:');
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtItemsFor:');
   });
@@ -88,7 +88,7 @@ describe('fetchEnhancedInspectorListData', () => {
     expect.assertions(4);
     const execute = vi.fn(() => '[]');
     fetchEnhancedInspectorListData(execute, 99999n, 'gtItemsFor:', 1, 50);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtItemsFor:');
     expect(code).toContain('1');
@@ -178,7 +178,7 @@ describe('fetchEnhancedInspectorTextData', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '{}');
     fetchEnhancedInspectorTextData(execute, 99999n, 'gtTextFor:');
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtTextFor:');
   });
@@ -242,7 +242,7 @@ describe('fetchEnhancedInspectorPrintTabData', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '{}');
     fetchEnhancedInspectorPrintTabData(execute, 99999n, 'gtPrintTabFor:');
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtPrintTabFor:');
   });
@@ -334,7 +334,7 @@ describe('fetchEnhancedInspectorForwardListData', () => {
     expect.assertions(4);
     const execute = vi.fn(() => '[]');
     fetchEnhancedInspectorForwardListData(execute, 99999n, 'gtForwardFor:', 1, 50);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtForwardFor:');
     expect(code).toContain('1');
@@ -389,7 +389,7 @@ describe('fetchEnhancedInspectorForwardListTotal', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '0');
     fetchEnhancedInspectorForwardListTotal(execute, 99999n, 'gtForwardFor:');
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtForwardFor:');
   });
@@ -427,7 +427,7 @@ describe('fetchEnhancedInspectorTreeChildren', () => {
     expect.assertions(1);
     const execute = vi.fn(() => '[]');
     fetchEnhancedInspectorTreeChildren(execute, 1000n, 'gtTreeFor:', []);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('{}');
   });
 
@@ -435,7 +435,7 @@ describe('fetchEnhancedInspectorTreeChildren', () => {
     expect.assertions(1);
     const execute = vi.fn(() => '[]');
     fetchEnhancedInspectorTreeChildren(execute, 1000n, 'gtTreeFor:', [1]);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('{1}');
   });
 
@@ -443,7 +443,7 @@ describe('fetchEnhancedInspectorTreeChildren', () => {
     expect.assertions(1);
     const execute = vi.fn(() => '[]');
     fetchEnhancedInspectorTreeChildren(execute, 1000n, 'gtTreeFor:', [1, 2, 3]);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('{1. 2. 3}');
   });
 
@@ -451,7 +451,7 @@ describe('fetchEnhancedInspectorTreeChildren', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '[]');
     fetchEnhancedInspectorTreeChildren(execute, 99999n, 'gtTreeFor:', [1]);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtTreeFor:');
   });

--- a/client/src/__tests__/enhancedInspectorErrorIsolation.test.ts
+++ b/client/src/__tests__/enhancedInspectorErrorIsolation.test.ts
@@ -9,7 +9,7 @@ describe('enhancedInspectorExecute error isolation', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '{}');
     fetchObjectMeta(execute, 1000n);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('on: AbstractException do:');
     expect(code).toContain("'EIError:'");
   });

--- a/client/src/__tests__/enhancedInspectorGetViewSpecs.test.ts
+++ b/client/src/__tests__/enhancedInspectorGetViewSpecs.test.ts
@@ -123,7 +123,7 @@ describe('getEnhancedInspectorViewSpecs', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '[]');
     getEnhancedInspectorViewSpecs(execute, 99999n);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('GtRemotePhlowViewedObject');
   });

--- a/client/src/__tests__/enhancedInspectorInstall.test.ts
+++ b/client/src/__tests__/enhancedInspectorInstall.test.ts
@@ -23,7 +23,7 @@ const executeFetchStringMock = executeFetchString as ReturnType<typeof vi.fn>;
 const PAYLOAD_DIR = '/payload/enhancedInspector';
 
 // Default: gem can read everything, every file-in succeeds, verification passes.
-function happyPath(_s: unknown, _label: string, code: string): string {
+function happyPath(_s: unknown, code: string): string {
   if (code.includes('existsOnServer')) return 'true';
   if (code.includes('gtViewsInCurrentContext')) return 'true';
   if (code.includes('GsFileIn fromPath')) return 'true';
@@ -112,10 +112,10 @@ describe('installEnhancedInspectorSupport', () => {
   it('files the payload in the loader dependency order', async () => {
     const { session } = createMockSession();
     const order: string[] = [];
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       const f = filedInFileFrom(code);
       if (f) order.push(f);
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     await installEnhancedInspectorSupport(session, PAYLOAD_DIR);
@@ -129,7 +129,7 @@ describe('installEnhancedInspectorSupport', () => {
     await installEnhancedInspectorSupport(session, PAYLOAD_DIR);
 
     const fileInCalls = executeFetchStringMock.mock.calls.filter((c) =>
-      String(c[2]).includes('GsFileIn fromPath'),
+      String(c[1]).includes('GsFileIn fromPath'),
     );
     expect(fileInCalls).toHaveLength(ENHANCED_INSPECTOR_FILES.length);
   });
@@ -144,7 +144,7 @@ describe('installEnhancedInspectorSupport', () => {
     await installEnhancedInspectorSupport(session, PAYLOAD_DIR);
 
     const fileInCalls = executeFetchStringMock.mock.calls
-      .map((c) => String(c[2]))
+      .map((c) => String(c[1]))
       .filter((code) => code.includes('GsFileIn fromPath'));
     expect(fileInCalls).toHaveLength(ENHANCED_INSPECTOR_FILES.length);
     for (const code of fileInCalls) {
@@ -154,9 +154,9 @@ describe('installEnhancedInspectorSupport', () => {
 
   it('fails clearly without committing when the gem cannot read the payload', async () => {
     const { session, commit, abort } = createMockSession();
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('existsOnServer')) return 'false';
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     const result = await installEnhancedInspectorSupport(session, PAYLOAD_DIR);
@@ -170,11 +170,11 @@ describe('installEnhancedInspectorSupport', () => {
   it('stops at the first failing file, aborts, and commits nothing', async () => {
     const { session, commit, abort } = createMockSession();
     const failing = ENHANCED_INSPECTOR_FILES[1];
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('GsFileIn fromPath') && code.includes(failing)) {
         throw new Error('compile failed');
       }
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     const result = await installEnhancedInspectorSupport(session, PAYLOAD_DIR);
@@ -203,9 +203,9 @@ describe('installEnhancedInspectorSupport', () => {
 
   it('flags an incomplete install when verification fails after commit', async () => {
     const { session } = createMockSession();
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('gtViewsInCurrentContext')) return 'false';
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     const result = await installEnhancedInspectorSupport(session, PAYLOAD_DIR);

--- a/client/src/__tests__/enhancedInspectorMeta.test.ts
+++ b/client/src/__tests__/enhancedInspectorMeta.test.ts
@@ -32,7 +32,7 @@ describe('fetchObjectMeta', () => {
     expect.assertions(1);
     const execute = vi.fn(() => '{}');
     fetchObjectMeta(execute, 99999n);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
   });
 });
@@ -81,7 +81,7 @@ describe('fetchMethodBrowseLocation', () => {
     expect.assertions(1);
     const execute = vi.fn(() => '{}');
     fetchMethodBrowseLocation(execute, 1000n, 'size', isClassSide);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain(expected);
   });
 
@@ -89,7 +89,7 @@ describe('fetchMethodBrowseLocation', () => {
     expect.assertions(2);
     const execute = vi.fn(() => '{}');
     fetchMethodBrowseLocation(execute, 99999n, 'size', false);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('size');
   });
@@ -130,7 +130,7 @@ describe('fetchMethodSource', () => {
     expect.assertions(1);
     const execute = vi.fn(() => 'source');
     fetchMethodSource(execute, 1000n, 'size', isClassSide);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain(expected);
   });
 
@@ -138,7 +138,7 @@ describe('fetchMethodSource', () => {
     expect.assertions(2);
     const execute = vi.fn(() => 'source');
     fetchMethodSource(execute, 99999n, 'size', false);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('size');
   });

--- a/client/src/__tests__/enhancedInspectorRowOop.test.ts
+++ b/client/src/__tests__/enhancedInspectorRowOop.test.ts
@@ -60,7 +60,7 @@ describe.each([
     expect.assertions(3);
     const execute = vi.fn(() => '12345');
     fn(execute, 99999n, 'gtItemsFor:', 7);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
     expect(code).toContain('gtItemsFor:');
     expect(code).toContain('7');
@@ -72,7 +72,7 @@ describe('fetchEnhancedInspectorRowOop drills into the send-block result', () =>
     expect.assertions(2);
     const execute = vi.fn(() => '338');
     fetchEnhancedInspectorRowOop(execute, 1000n, 'gtRawFor:', 3);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('retrieveSentItemAt: 3');
     expect(code).not.toContain('targetObject');
   });

--- a/client/src/__tests__/enhancedInspectorViewSpecs.test.ts
+++ b/client/src/__tests__/enhancedInspectorViewSpecs.test.ts
@@ -56,7 +56,7 @@ describe('getEnhancedInspectorViewSpecs', () => {
     expect.assertions(1);
     const execute = vi.fn(() => '[]');
     getEnhancedInspectorViewSpecs(execute, 99999n);
-    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const code = (execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(code).toContain('99999');
   });
 });

--- a/client/src/__tests__/explorerQueries.integration.test.ts
+++ b/client/src/__tests__/explorerQueries.integration.test.ts
@@ -34,8 +34,7 @@ describe('explorer queries (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (code: string): string =>
-    q.executeFetchString(session(), 'explorerQueries-it', code);
+  const exec = (code: string): string => q.executeFetchString(session(), code);
 
   const isSystemProfile = (): boolean =>
     exec('System myUserProfile isSystemProfile printString').trim() === 'true';

--- a/client/src/__tests__/extentBackupManager.test.ts
+++ b/client/src/__tests__/extentBackupManager.test.ts
@@ -25,7 +25,7 @@ function makeExecutor(
     resume: 'OK',
     ...over,
   };
-  return vi.fn<QueryExecutor>((_label, code) => {
+  return vi.fn<QueryExecutor>((code) => {
     if (code.includes('FULL_LOGGING')) return r.fullLogging;
     if (code.includes('SystemRepository fileNames')) return r.extents;
     if (code.includes('suspendCheckpointsForMinutes')) return r.suspend;
@@ -51,9 +51,9 @@ function makeDeps(execute: QueryExecutor, over: Partial<ExtentBackupDeps> = {}):
 // The order index of the execute() call whose Smalltalk contains `needle`.
 function callOrder(execute: QueryExecutor, needle: string): number {
   const spy = execute as unknown as {
-    mock: { calls: [string, string][]; invocationCallOrder: number[] };
+    mock: { calls: [string][]; invocationCallOrder: number[] };
   };
-  const i = spy.mock.calls.findIndex(([, code]) => code.includes(needle));
+  const i = spy.mock.calls.findIndex(([code]) => code.includes(needle));
   return i === -1 ? -1 : spy.mock.invocationCallOrder[i];
 }
 

--- a/client/src/__tests__/forkGem.integration.test.ts
+++ b/client/src/__tests__/forkGem.integration.test.ts
@@ -31,8 +31,7 @@ describe('forking a gem (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const execute = (label: string, code: string): string =>
-    browserQueries.executeFetchString(session(), label, code);
+  const execute = (code: string): string => browserQueries.executeFetchString(session(), code);
 
   // The NetLDI this stone actually uses, as the harness itself connects through.
   const gemNrs = (): string => process.env.VITE_GEMSTONE_GEM_NRS!;
@@ -53,7 +52,7 @@ describe('forking a gem (integration)', () => {
   it('gives the new gem a session distinct from this one', (ctx) => {
     if (!supported()) return ctx.skip();
 
-    const mine = execute('mySession', 'GsCurrentSession currentSession serialNumber printString');
+    const mine = execute('GsCurrentSession currentSession serialNumber printString');
 
     const id = forkGemRunning(execute, 'System sleep: 1', gemNrs());
 
@@ -63,7 +62,7 @@ describe('forking a gem (integration)', () => {
   it('runs the gem as the user who asked, never SystemUser', (ctx) => {
     if (!supported()) return ctx.skip();
 
-    const me = execute('me', 'System myUserProfile userId').trim();
+    const me = execute('System myUserProfile userId').trim();
 
     // The gem logs in with a one-time password minted for this same user, so a
     // successful fork is itself the evidence — minting for anyone else would

--- a/client/src/__tests__/gci/probeFixture.ts
+++ b/client/src/__tests__/gci/probeFixture.ts
@@ -42,9 +42,9 @@ export const PROBE_FAILING_SELECTOR = 'testFails';
 export const PROBE_ERRORING_SELECTOR = 'testErrors';
 
 export function installProbeFixture(exec: QueryExecutor): void {
-  exec('installProbeFixture', SETUP_SOURCE);
+  exec(SETUP_SOURCE);
 }
 
 export function uninstallProbeFixture(exec: QueryExecutor): void {
-  exec('uninstallProbeFixture', TEARDOWN_SOURCE);
+  exec(TEARDOWN_SOURCE);
 }

--- a/client/src/__tests__/gci/queryHarness.ts
+++ b/client/src/__tests__/gci/queryHarness.ts
@@ -54,7 +54,7 @@ export function login(): HarnessSession {
   }
   const utf8Oop = utf8Class.result;
 
-  const exec: QueryExecutor = (_label, code) => {
+  const exec: QueryExecutor = (code) => {
     const { data, err } = gci.GciTsExecuteFetchBytes(
       handle,
       code,
@@ -98,5 +98,5 @@ export function selectorExists(
 ): boolean {
   const receiver = meta ? `${className} class` : className;
   const code = `(${receiver} canUnderstand: #'${selector.replace(/'/g, "''")}') printString`;
-  return exec('selectorExists', code).trim() === 'true';
+  return exec(code).trim() === 'true';
 }

--- a/client/src/__tests__/gci/querySunit.smoke.test.ts
+++ b/client/src/__tests__/gci/querySunit.smoke.test.ts
@@ -43,7 +43,7 @@ ws := WriteStream on: Unicode7 new.
 classes do: [:c |
   ws nextPutAll: c name; tab; nextPutAll: c isAbstract printString; lf].
 ws contents encodeAsUTF8`;
-  return splitLines(exec('discoverAllTestClasses', code)).map((line) => {
+  return splitLines(exec(code)).map((line) => {
     const [name, isAbstract] = line.split('\t');
     return { name: name || '', isAbstract: isAbstract === 'true' };
   });

--- a/client/src/__tests__/gci/refactoring/gciClassVarQueries.smoke.test.ts
+++ b/client/src/__tests__/gci/refactoring/gciClassVarQueries.smoke.test.ts
@@ -24,7 +24,6 @@ describe('class-variable Explorer queries (live GCI)', () => {
     s = login();
     userIndex = parseInt(
       s.exec(
-        'user-index',
         '| sl d | sl := System myUserProfile symbolList. ' +
           "d := sl detect: [:x | x name = #'UserGlobals'] ifNone: [nil]. " +
           '(d ifNil: [0] ifNotNil: [sl indexOf: d]) printString',
@@ -34,12 +33,10 @@ describe('class-variable Explorer queries (live GCI)', () => {
     // A base class with two class variables and a subclass declaring none, so the
     // "defined here, not inherited" semantics are observable.
     s.exec(
-      'define-base',
       `Object subclass: '${BASE}' instVarNames: #() classVars: #(Alpha Beta) ` +
         'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals. true printString',
     );
     s.exec(
-      'define-sub',
       `${BASE} subclass: '${SUB}' instVarNames: #() classVars: #() ` +
         'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals. true printString',
     );
@@ -47,7 +44,7 @@ describe('class-variable Explorer queries (live GCI)', () => {
 
   afterAll(() => {
     try {
-      s?.exec('cleanup', 'System abortTransaction. true printString');
+      s?.exec('System abortTransaction. true printString');
     } catch {
       /* best-effort — logout discards the uncommitted fixture regardless */
     }
@@ -76,11 +73,11 @@ describe('class-variable Explorer queries (live GCI)', () => {
   });
 
   it('reads class-variable names as strings, never leaving the transaction dirtier than found', () => {
-    const before = s.exec('needs-commit', 'System needsCommit printString').trim();
+    const before = s.exec('System needsCommit printString').trim();
 
     getDefinedClassVarNames(s.exec, BASE);
     getDefinedClassVarCounts(s.exec, userIndex);
 
-    expect(s.exec('needs-commit', 'System needsCommit printString').trim()).toBe(before);
+    expect(s.exec('System needsCommit printString').trim()).toBe(before);
   });
 });

--- a/client/src/__tests__/gci/refactoring/gciRenameClassVar.e2e.test.ts
+++ b/client/src/__tests__/gci/refactoring/gciRenameClassVar.e2e.test.ts
@@ -22,13 +22,11 @@ const BASE = 'JasperCvE2EBase';
 describe('rename class variable end-to-end (live GCI)', () => {
   let s: HarnessSession;
   let userIndex: number;
-  const asyncExec = (label: string, code: string): Promise<string> =>
-    Promise.resolve(s.exec(label, code));
+  const asyncExec = (code: string): Promise<string> => Promise.resolve(s.exec(code));
 
   const rbEnginePresent = (): boolean =>
     s
       .exec(
-        'engine-present',
         "(System myUserProfile symbolList objectNamed: 'GsRenameClassVariableRefactoring') notNil printString",
       )
       .trim() === 'true';
@@ -38,30 +36,26 @@ describe('rename class variable end-to-end (live GCI)', () => {
   // (shadow) — which must NOT be rewritten. A non-nil shared value is set on it.
   const defineFixture = (): void => {
     s.exec(
-      'define',
       `Object subclass: '${BASE}' instVarNames: #() classVars: #(Counter) ` +
         'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals. true printString',
     );
     s.exec(
-      'm-bump',
       `${BASE} compileMethod: 'bump Counter := (Counter ifNil: [0]) + 1' ` +
         "dictionaries: System myUserProfile symbolList category: 'accessing'. true printString",
     );
     // Resume the shadow warning so the fixture still installs.
     s.exec(
-      'm-shadow',
       `[${BASE} compileMethod: 'shadow | Counter | Counter := 5. ^Counter' ` +
         "dictionaries: System myUserProfile symbolList category: 'accessing'] " +
         'on: CompileWarning do: [:ex | ex resume: nil]. true printString',
     );
-    s.exec('set-value', `(${BASE} _classVars associationAt: #Counter) value: 7. true printString`);
+    s.exec(`(${BASE} _classVars associationAt: #Counter) value: 7. true printString`);
   };
 
   beforeAll(() => {
     s = login();
     userIndex = parseInt(
       s.exec(
-        'user-index',
         '| sl d | sl := System myUserProfile symbolList. ' +
           "d := sl detect: [:x | x name = #'UserGlobals'] ifNone: [nil]. " +
           '(d ifNil: [0] ifNotNil: [sl indexOf: d]) printString',
@@ -74,7 +68,7 @@ describe('rename class variable end-to-end (live GCI)', () => {
     // Discard the fixture (and any applied rename) so each test starts clean and
     // nothing is committed.
     try {
-      s.exec('abort', 'System abortTransaction. true printString');
+      s.exec('System abortTransaction. true printString');
     } catch {
       /* best-effort */
     }
@@ -116,7 +110,7 @@ describe('rename class variable end-to-end (live GCI)', () => {
 
     defineFixture();
     const token = `cve2e-apply-${BASE}`;
-    const historyBefore = s.exec('hist', `${BASE} classHistory size printString`).trim();
+    const historyBefore = s.exec(`${BASE} classHistory size printString`).trim();
 
     await startRenameClassVarPreview(
       asyncExec,
@@ -130,22 +124,13 @@ describe('rename class variable end-to-end (live GCI)', () => {
     const result = parseApplyResult(await applyRenameClassVar(asyncExec, token));
 
     expect(result.failed).toEqual([]);
-    expect(s.exec('cv', `(${BASE} classVarNames includes: #Tally) printString`).trim()).toBe(
-      'true',
-    );
-    expect(s.exec('cv', `(${BASE} classVarNames includes: #Counter) printString`).trim()).toBe(
-      'false',
-    );
-    expect(
-      s.exec('val', `(${BASE} _classVars associationAt: #Tally) value printString`).trim(),
-    ).toBe('7');
-    expect(s.exec('hist', `${BASE} classHistory size printString`).trim()).toBe(historyBefore);
+    expect(s.exec(`(${BASE} classVarNames includes: #Tally) printString`).trim()).toBe('true');
+    expect(s.exec(`(${BASE} classVarNames includes: #Counter) printString`).trim()).toBe('false');
+    expect(s.exec(`(${BASE} _classVars associationAt: #Tally) value printString`).trim()).toBe('7');
+    expect(s.exec(`${BASE} classHistory size printString`).trim()).toBe(historyBefore);
     // The shadowing method was never rewritten, so it still names its block temporary.
     expect(
-      s.exec(
-        'shadow-src',
-        `(${BASE} compiledMethodAt: #shadow environmentId: 0 otherwise: nil) sourceString`,
-      ),
+      s.exec(`(${BASE} compiledMethodAt: #shadow environmentId: 0 otherwise: nil) sourceString`),
     ).toContain('Counter');
   });
 });

--- a/client/src/__tests__/gci/rowanExportFixpoint.test.ts
+++ b/client/src/__tests__/gci/rowanExportFixpoint.test.ts
@@ -47,7 +47,7 @@ function loginSystemUser(): SysSession {
   }
   const handle = r.session;
   const utf8 = gci.GciTsResolveSymbol(handle, 'Utf8', OOP_NIL).result;
-  const exec: QueryExecutor = (_label, code) => {
+  const exec: QueryExecutor = (code) => {
     const { data, err } = gci.GciTsExecuteFetchBytes(
       handle,
       code,
@@ -146,22 +146,19 @@ describe('Rowan export is a deterministic reload-faithful fixpoint', () => {
       const targetA = path.join(dirA, PROJECT);
       const targetC = path.join(dirC, PROJECT);
 
-      expect(sys.exec('create', createCode(home)).trim()).toBe('ok');
+      expect(sys.exec(createCode(home)).trim()).toBe('ok');
 
       const a = exportRowanProject(sys.exec, PROJECT, targetA);
       expect(a.success, a.detail).toBe(true);
 
       expect(
-        sys
-          .exec('unload', `Rowan gemstoneTools topaz unloadProjectNamed: '${PROJECT}'. 'ok'`)
-          .trim(),
+        sys.exec(`Rowan gemstoneTools topaz unloadProjectNamed: '${PROJECT}'. 'ok'`).trim(),
       ).toBe('ok');
       expect(listRowanProjects(sys.exec).projects.some((p) => p.name === PROJECT)).toBe(false);
 
       expect(
         sys
           .exec(
-            'reload',
             `(Rowan projectFromUrl: 'file:${targetA}/rowan/specs/${PROJECT}.ston' projectsHome: '${targetA}') load. 'ok'`,
           )
           .trim(),

--- a/client/src/__tests__/getClassesWithCategory.test.ts
+++ b/client/src/__tests__/getClassesWithCategory.test.ts
@@ -21,10 +21,7 @@ describe("listing a dictionary's classes with their categories", () => {
 
     getClassesWithCategory(execute, 'UserGlobals');
 
-    expect(execute).toHaveBeenCalledWith(
-      expect.stringContaining('UserGlobals'),
-      expect.stringContaining("objectNamed: #'UserGlobals'"),
-    );
+    expect(execute).toHaveBeenCalledWith(expect.stringContaining("objectNamed: #'UserGlobals'"));
   });
 
   it('returns nothing for an empty dictionary', () => {

--- a/client/src/__tests__/mcpTools.test.ts
+++ b/client/src/__tests__/mcpTools.test.ts
@@ -185,7 +185,7 @@ describe('registerMcpTools', () => {
 
       expect(result.isError).toBeUndefined();
       expect(result.content[0].text).toBe('42');
-      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(codeArg).toContain('6 * 7');
       expect(codeArg).toContain('printString');
     });
@@ -198,7 +198,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('43');
       await server.getTool('execute_code')!.handler({ code: '| x | x := 42. x + 1' });
 
-      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(codeArg).toContain('[| x | x := 42. x + 1] value printString');
     });
 
@@ -210,7 +210,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('ok');
       await server.getTool('execute_code')!.handler({ code: '1 + 1' });
 
-      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(codeArg).toContain('on: AlmostOutOfStack');
     });
 
@@ -218,7 +218,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('ok');
       await server.getTool('execute_code')!.handler({ code: '1 + 1' });
 
-      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const codeArg = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(codeArg).toContain('on: AbstractException');
     });
 
@@ -419,7 +419,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('Transaction aborted');
       const result = await server.getTool('abort')!.handler({});
 
-      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(code).toContain('abortTransaction');
       expect(result.content[0].text).toBe('Transaction aborted');
     });
@@ -428,7 +428,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('Transaction committed');
       const result = await server.getTool('commit')!.handler({});
 
-      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(code).toContain('commitTransaction');
       expect(result.content[0].text).toBe('Transaction committed');
     });
@@ -550,7 +550,7 @@ describe('registerMcpTools', () => {
         selector: 'testSize',
       });
 
-      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(refreshCall).toContain('System needsCommit ifFalse:');
       expect(refreshCall).toContain('System abortTransaction');
     });
@@ -610,7 +610,7 @@ describe('registerMcpTools', () => {
       vi.mocked(sunit.runTestClass).mockReturnValue([]);
       await server.getTool('run_test_class')!.handler({ className: 'ArrayTest' });
 
-      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(refreshCall).toContain('System needsCommit ifFalse:');
       expect(refreshCall).toContain('System abortTransaction');
     });
@@ -673,7 +673,7 @@ describe('registerMcpTools', () => {
       vi.mocked(sunit.runFailingTests).mockReturnValue([]);
       await server.getTool('list_failing_tests')!.handler({});
 
-      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const refreshCall = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(refreshCall).toContain('System needsCommit ifFalse:');
       expect(refreshCall).toContain('System abortTransaction');
     });
@@ -793,7 +793,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('refreshed');
       const result = await server.getTool('refresh')!.handler({});
 
-      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(code).toContain('System needsCommit');
       expect(code).toContain('System abortTransaction');
       expect(result.content[0].text).toBe('refreshed');
@@ -803,7 +803,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('User: DataCurator\n...');
       const result = await server.getTool('status')!.handler({});
 
-      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(code).toContain('myUserProfile');
       expect(code).toContain('stoneName');
       expect(code).toContain('inTransaction');
@@ -820,7 +820,7 @@ describe('registerMcpTools', () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('');
       await server.getTool('status')!.handler({});
 
-      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][1];
       expect(code).toContain('System needsCommit');
       expect(code).toContain('System abortTransaction');
       expect(code).toContain('View: ');
@@ -835,7 +835,7 @@ describe('registerMcpTools', () => {
     it('coerces every value streamed in status to a CharacterCollection', async () => {
       vi.mocked(queries.executeFetchString).mockReturnValue('');
       await server.getTool('status')!.handler({});
-      const code = vi.mocked(queries.executeFetchString).mock.calls[0][2];
+      const code = vi.mocked(queries.executeFetchString).mock.calls[0][1];
 
       expect(code).toMatch(/myUserProfile userId (asString|printString)/);
       expect(code).toMatch(/stoneName (asString|printString)/);

--- a/client/src/__tests__/rowanQueries.test.ts
+++ b/client/src/__tests__/rowanQueries.test.ts
@@ -69,7 +69,7 @@ describe('findRowanClassOwners', () => {
   it('scans by includesKey so classes outside the symbolList are still found', () => {
     const execute = executor('');
     findRowanClassOwners(execute, 'STONReader');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("loadedClasses includesKey: 'STONReader'");
     expect(code).toContain("loadedClassExtensions includesKey: 'STONReader'");
   });
@@ -118,7 +118,7 @@ describe('unloadRowanProject', () => {
 
     unloadRowanProject(execute, 'STON');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("gemstoneTools topaz unloadProjectNamed: 'STON'");
     expect(code).toContain('System commitTransaction');
     expect(code).toContain('System abortTransaction');
@@ -204,7 +204,7 @@ describe('exportRowanProject', () => {
 
     exportRowanProject(execute, 'Cypress', '/out/Cypress');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('writeResolvedProject:');
     expect(code).toContain('exportLoadSpecification');
     expect(code).toContain("diskRepositoryRoot: '/out/Cypress'");
@@ -219,8 +219,8 @@ describe('getGemCacheKB', () => {
   it('queries GemTempObjCacheSize in KB units', () => {
     const execute = executor('0');
     getGemCacheKB(execute);
-    expect(execute.mock.calls[0][1]).toContain('GemTempObjCacheSize');
-    expect(execute.mock.calls[0][1]).toContain('// 1024');
+    expect(execute.mock.calls[0][0]).toContain('GemTempObjCacheSize');
+    expect(execute.mock.calls[0][0]).toContain('// 1024');
   });
 
   it('returns undefined when the value is not a positive number', () => {

--- a/client/src/__tests__/sessionMethods.integration.test.ts
+++ b/client/src/__tests__/sessionMethods.integration.test.ts
@@ -34,8 +34,7 @@ describe('session methods (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (code: string): string =>
-    browserQueries.executeFetchString(session(), 'sessionMethods-it', code);
+  const exec = (code: string): string => browserQueries.executeFetchString(session(), code);
 
   const isSystemProfile = (): boolean =>
     exec('System myUserProfile isSystemProfile printString').trim() === 'true';

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -180,7 +180,7 @@ function resolveClassUtf8(session: ActiveSession): bigint {
 // result as UTF-8 in Smalltalk before paging it out, so results decode
 // correctly regardless of their original encoding and are not capped at a
 // single fixed-size buffer.
-export function executeFetchString(session: ActiveSession, label: string, code: string): string {
+export function executeFetchString(session: ActiveSession, code: string): string {
   // Check if session is busy with an async operation (e.g., Display It)
   const { result: inProgress } = session.gci.GciTsCallInProgress(session.handle);
   if (inProgress !== 0) {
@@ -296,7 +296,6 @@ export function checkEnhancedInspectorAvailable(session: ActiveSession): boolean
   try {
     const result = executeFetchString(
       session,
-      'checkEnhancedInspectorAvailable',
       "[GtRemotePhlowViewedObject notNil printString] on: Error do: [:e | 'false']",
     );
     return result.trim() === 'true';
@@ -321,7 +320,6 @@ export function checkRefactoringSupportAvailable(session: ActiveSession): boolea
   try {
     const result = executeFetchString(
       session,
-      'checkRefactoringSupportAvailable',
       "(System myUserProfile symbolList objectNamed: 'GsRenameInstanceVariableRefactoring') notNil printString",
     );
     return result.trim() === 'true';
@@ -340,11 +338,7 @@ export function checkRefactoringSupportAvailable(session: ActiveSession): boolea
  */
 export function sessionNeedsCommit(session: ActiveSession): boolean | undefined {
   try {
-    const result = executeFetchString(
-      session,
-      'sessionNeedsCommit',
-      'System needsCommit printString',
-    ).trim();
+    const result = executeFetchString(session, 'System needsCommit printString').trim();
     if (result === 'true') return true;
     if (result === 'false') return false;
     return undefined;
@@ -365,7 +359,7 @@ export function sessionNeedsCommit(session: ActiveSession): boolean | undefined 
  * compile or execute, or the result cannot be resolved to a String.
  */
 export function defaultQueryExecutorUsing(activeSession: ActiveSession): QueryExecutor {
-  return (label, code) => executeFetchString(activeSession, label, code);
+  return (code) => executeFetchString(activeSession, code);
 }
 
 // ── Read-only queries (thin delegates to client/src/queries/) ─────────────

--- a/client/src/enhancedInspector.ts
+++ b/client/src/enhancedInspector.ts
@@ -413,7 +413,7 @@ export class EnhancedInspector {
   }
 
   private makeExecutor(): QueryExecutor {
-    return (label, code) => executeFetchString(this.session, label, code);
+    return (code) => executeFetchString(this.session, code);
   }
 
   private fetchEnhancedInspectorViewData(

--- a/client/src/enhancedInspectorInstall.ts
+++ b/client/src/enhancedInspectorInstall.ts
@@ -115,7 +115,6 @@ export function isEnhancedInspectorInstalled(session: ActiveSession): boolean {
   try {
     const result = executeFetchString(
       session,
-      'verifyEnhancedInspector',
       '[(GtRemotePhlowViewedObject notNil ' +
         'and: [Object includesSelector: #gtViewsInCurrentContext]) printString] ' +
         "on: Error do: [:e | 'false']",
@@ -172,7 +171,6 @@ export async function installEnhancedInspectorSupport(
     try {
       executeFetchString(
         session,
-        `install:${file}`,
         // #serverUtf8File (not fromServerPath:) because the payload contains
         // UTF-8 test data (e.g. GtWireEncodingExamples' 'čtyři'). The plain
         // file-in reads the file as the repository's StringConfiguration
@@ -232,7 +230,6 @@ function gemCanRead(session: ActiveSession, serverPath: string): boolean {
   try {
     const r = executeFetchString(
       session,
-      'gemCanRead',
       `[(GsFile existsOnServer: ${gsStringLiteral(serverPath)}) printString] ` +
         "on: Error do: [:e | 'false']",
     );

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -3578,7 +3578,7 @@ export function activate(context: vscode.ExtensionContext) {
           .getDatabases()
           .find((d) => d.config.stoneName === session.login.stone);
         const backedUp = await runLogicalBackup({
-          execute: (label, code) => queries.executeFetchString(session, label, code),
+          execute: (code) => queries.executeFetchString(session, code),
           runBackup: (code) =>
             queries.executeFetchStringNb(
               session,
@@ -3636,7 +3636,7 @@ export function activate(context: vscode.ExtensionContext) {
           return;
         }
         const backedUp = await runOnlineExtentBackup({
-          execute: (label, code) => queries.executeFetchString(session, label, code),
+          execute: (code) => queries.executeFetchString(session, code),
           stoneName: session.login.stone,
           dbPath: db.path,
           dataDir: path.join(db.path, 'data'),
@@ -3724,9 +3724,7 @@ export function activate(context: vscode.ExtensionContext) {
           dbPath: managed.path,
           backupFile,
           hasFileControl: () =>
-            hasFileControlPrivilege((label, code) =>
-              queries.executeFetchString(session, label, code),
-            ),
+            hasFileControlPrivilege((code) => queries.executeFetchString(session, code)),
           closeCurrentSession: async () => {
             sessionManager.logout(sessionId);
           },

--- a/client/src/mcpTools.ts
+++ b/client/src/mcpTools.ts
@@ -30,7 +30,6 @@ function refreshIfClean(session: ActiveSession): void {
   try {
     queries.executeFetchString(
       session,
-      'mcpRefreshIfClean',
       "System needsCommit ifFalse: [System abortTransaction]. 'ok'",
     );
   } catch {
@@ -844,5 +843,5 @@ function formatTestResults(results: TestRunResult[]): string {
 }
 
 function executeString(session: ActiveSession, code: string): string {
-  return queries.executeFetchString(session, 'mcpTool', code);
+  return queries.executeFetchString(session, code);
 }

--- a/client/src/queries/__tests__/backup.test.ts
+++ b/client/src/queries/__tests__/backup.test.ts
@@ -15,7 +15,7 @@ describe('full logical backup queries', () => {
       const held = hasFileControlPrivilege(execute);
 
       expect(held).toBe(true);
-      expect(execute.mock.calls[0][1]).toContain('privileges includes: #FileControl');
+      expect(execute.mock.calls[0][0]).toContain('privileges includes: #FileControl');
     });
 
     it('reports the privilege is missing for any non-true answer', () => {
@@ -32,7 +32,7 @@ describe('full logical backup queries', () => {
       const dirty = sessionNeedsCommit(execute);
 
       expect(dirty).toBe(true);
-      expect(execute.mock.calls[0][1]).toContain('System needsCommit');
+      expect(execute.mock.calls[0][0]).toContain('System needsCommit');
     });
 
     it('reports a clean session as having nothing to lose', () => {
@@ -48,7 +48,7 @@ describe('full logical backup queries', () => {
 
       abortTransaction(execute);
 
-      expect(execute.mock.calls[0][1]).toContain('System abortTransaction');
+      expect(execute.mock.calls[0][0]).toContain('System abortTransaction');
     });
   });
 

--- a/client/src/queries/__tests__/describeClass.test.ts
+++ b/client/src/queries/__tests__/describeClass.test.ts
@@ -8,16 +8,14 @@ describe('describeClass', () => {
     const execute = vi.fn<QueryExecutor>(() => sample);
 
     expect(describeClass(execute, 'Foo')).toBe(sample);
-    const [label, code] = execute.mock.calls[0];
-    expect(label).toBe('describeClass(Foo)');
+    const [code] = execute.mock.calls[0];
     expect(code).toContain("objectNamed: #'Foo'");
   });
 
   it('scopes lookup to a specific dictionary by name (disambiguates shadows)', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     describeClass(execute, 'Customer', 'UserGlobals');
-    const [label, code] = execute.mock.calls[0];
-    expect(label).toBe('describeClass(Customer, dict: UserGlobals)');
+    const [code] = execute.mock.calls[0];
     expect(code).toContain("objectNamed: #'UserGlobals'");
     expect(code).toContain("at: #'Customer' ifAbsent: [nil]");
   });
@@ -25,7 +23,7 @@ describe('describeClass', () => {
   it('scopes lookup to a dictionary by 1-based index when given a number', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     describeClass(execute, 'Customer', 2);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('(System myUserProfile symbolList at: 2) at: ');
     expect(code).toContain("#'Customer' ifAbsent: [nil]");
   });
@@ -33,7 +31,7 @@ describe('describeClass', () => {
   it('emits all five sections in the Smalltalk', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     describeClass(execute, 'X');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('=== Definition ===');
     expect(code).toContain('=== Comment ===');
     expect(code).toContain('=== Instance methods ===');
@@ -45,7 +43,7 @@ describe('describeClass', () => {
   it('lists selectors via sortedSelectorsIn: (own, not inherited) for both sides', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     describeClass(execute, 'X');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     // Instance side
     expect(code).toMatch(/cls categoryNames asSortedCollection do:/);
     expect(code).toContain('cls sortedSelectorsIn: cat');
@@ -57,7 +55,7 @@ describe('describeClass', () => {
   it('guards against nil (class not found) and non-class globals', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     describeClass(execute, 'Nope');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("cls ifNil: [^ 'Class not found: Nope']");
     expect(code).toContain("cls isBehavior ifFalse: [^ 'Not a class: Nope']");
   });
@@ -65,7 +63,7 @@ describe('describeClass', () => {
   it('escapes single quotes in the class name', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     describeClass(execute, "Foo'Bar");
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("#'Foo''Bar'");
     expect(code).toContain("'Class not found: Foo''Bar'");
   });

--- a/client/src/queries/__tests__/extentBackup.test.ts
+++ b/client/src/queries/__tests__/extentBackup.test.ts
@@ -24,7 +24,7 @@ describe('fullLoggingEnabled', () => {
     const exec = vi.fn<QueryExecutor>(() => 'true');
     fullLoggingEnabled(exec);
 
-    expect(exec.mock.calls[0][1]).toContain('STN_TRAN_FULL_LOGGING');
+    expect(exec.mock.calls[0][0]).toContain('STN_TRAN_FULL_LOGGING');
   });
 });
 
@@ -43,7 +43,7 @@ describe('extentFileNames', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     extentFileNames(exec);
 
-    expect(exec.mock.calls[0][1]).toContain('SystemRepository fileNames');
+    expect(exec.mock.calls[0][0]).toContain('SystemRepository fileNames');
   });
 });
 
@@ -70,7 +70,7 @@ describe('suspendCheckpoints', () => {
     const exec = vi.fn<QueryExecutor>(() => 'OK');
     suspendCheckpoints(exec, 45);
 
-    expect(exec.mock.calls[0][1]).toContain('suspendCheckpointsForMinutes: 45');
+    expect(exec.mock.calls[0][0]).toContain('suspendCheckpointsForMinutes: 45');
   });
 });
 

--- a/client/src/queries/__tests__/forkGem.test.ts
+++ b/client/src/queries/__tests__/forkGem.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { forkGemRunning } from '../forkGem';
 
 /** Captures the code a query builds, answering a canned result. */
-function capture(): { execute: (label: string, code: string) => string; code: () => string } {
+function capture(): { execute: (code: string) => string; code: () => string } {
   const execute = vi.fn().mockReturnValue('42');
-  return { execute, code: () => execute.mock.calls[0][1] as string };
+  return { execute, code: () => execute.mock.calls[0][0] as string };
 }
 
 const NRS = '!tcp@localhost#netldi:jasper-ldi#task!gemnetobject';

--- a/client/src/queries/__tests__/getMethodSource.test.ts
+++ b/client/src/queries/__tests__/getMethodSource.test.ts
@@ -7,10 +7,7 @@ describe('shared getMethodSource', () => {
     const execute = vi.fn(() => 'printOn: aStream');
     const result = getMethodSource(execute, 'Array', false, 'printOn:');
 
-    expect(execute).toHaveBeenCalledWith(
-      'getMethodSource(Array>>#printOn:)',
-      "(Array compiledMethodAt: #'printOn:') sourceString",
-    );
+    expect(execute).toHaveBeenCalledWith("(Array compiledMethodAt: #'printOn:') sourceString");
     expect(result).toBe('printOn: aStream');
   });
 
@@ -18,10 +15,7 @@ describe('shared getMethodSource', () => {
     const execute = vi.fn(() => 'new ^super new');
     getMethodSource(execute, 'Array', true, 'new');
 
-    expect(execute).toHaveBeenCalledWith(
-      'getMethodSource(Array class>>#new)',
-      "(Array class compiledMethodAt: #'new') sourceString",
-    );
+    expect(execute).toHaveBeenCalledWith("(Array class compiledMethodAt: #'new') sourceString");
   });
 
   it('includes environmentId clause when non-zero', () => {
@@ -29,7 +23,6 @@ describe('shared getMethodSource', () => {
     getMethodSource(execute, 'Array', false, 'size', 2);
 
     expect(execute).toHaveBeenCalledWith(
-      'getMethodSource(Array>>#size env:2)',
       "(Array compiledMethodAt: #'size' environmentId: 2) sourceString",
     );
   });
@@ -38,10 +31,7 @@ describe('shared getMethodSource', () => {
     const execute = vi.fn(() => '');
     getMethodSource(execute, 'Array', false, "o'clock");
 
-    expect(execute).toHaveBeenCalledWith(
-      "getMethodSource(Array>>#o'clock)",
-      "(Array compiledMethodAt: #'o''clock') sourceString",
-    );
+    expect(execute).toHaveBeenCalledWith("(Array compiledMethodAt: #'o''clock') sourceString");
   });
 
   it('propagates the executor return value unchanged', () => {
@@ -53,18 +43,15 @@ describe('shared getMethodSource', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getMethodSource(execute, 'object', false, 'printString', 0, 1);
 
-    const [label, code] = execute.mock.calls[0];
-    // The code resolves the class within dictionary index 1…
+    const [code] = execute.mock.calls[0];
     expect(code).toContain("(System myUserProfile symbolList at: 1) at: #'object' ifAbsent: [nil]");
     expect(code).toContain("compiledMethodAt: #'printString'");
-    // …while the log label stays the readable bare-name form.
-    expect(label).toBe('getMethodSource(object>>#printString)');
   });
 
   it('scopes the class-side receiver to a SymbolList index', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getMethodSource(execute, 'object', true, 'new', 0, 1);
-    expect(execute.mock.calls[0][1]).toContain(
+    expect(execute.mock.calls[0][0]).toContain(
       "(System myUserProfile symbolList at: 1) at: #'object' ifAbsent: [nil]) class",
     );
   });

--- a/client/src/queries/__tests__/listQueries.test.ts
+++ b/client/src/queries/__tests__/listQueries.test.ts
@@ -28,20 +28,19 @@ describe('getClassNames', () => {
   it('embeds dictIndex in the Smalltalk code when given a number', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getClassNames(execute, 7);
-    expect(execute.mock.calls[0][1]).toContain('symbolList at: 7');
+    expect(execute.mock.calls[0][0]).toContain('symbolList at: 7');
   });
 
   it('uses objectNamed: when given a dictionary name', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Array\n');
     getClassNames(execute, 'Globals');
-    expect(execute.mock.calls[0][1]).toContain("objectNamed: #'Globals'");
-    expect(execute.mock.calls[0][0]).toBe('getClassNames(dictName: Globals)');
+    expect(execute.mock.calls[0][0]).toContain("objectNamed: #'Globals'");
   });
 
   it('escapes single quotes in dictionary names', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getClassNames(execute, "it's");
-    expect(execute.mock.calls[0][1]).toContain("objectNamed: #'it''s'");
+    expect(execute.mock.calls[0][0]).toContain("objectNamed: #'it''s'");
   });
 
   it('returns [] for unknown dictionary names (Smalltalk returns empty)', () => {
@@ -64,19 +63,19 @@ describe('getDictionaryClassFileOutOrder', () => {
   it('walks the superclass chain to compute depth', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getDictionaryClassFileOutOrder(execute, 1);
-    expect(execute.mock.calls[0][1]).toContain('sc := sc superclass');
+    expect(execute.mock.calls[0][0]).toContain('sc := sc superclass');
   });
 
   it('embeds dictIndex in the Smalltalk code when given a number', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getDictionaryClassFileOutOrder(execute, 7);
-    expect(execute.mock.calls[0][1]).toContain('symbolList at: 7');
+    expect(execute.mock.calls[0][0]).toContain('symbolList at: 7');
   });
 
   it('uses objectNamed: when given a dictionary name', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getDictionaryClassFileOutOrder(execute, 'Globals');
-    expect(execute.mock.calls[0][1]).toContain("objectNamed: #'Globals'");
+    expect(execute.mock.calls[0][0]).toContain("objectNamed: #'Globals'");
   });
 
   it('returns [] for an unknown dictionary', () => {
@@ -93,13 +92,13 @@ describe('getMethodCategories', () => {
   it('uses "<class>" receiver for instance side', () => {
     const execute = vi.fn<QueryExecutor>(() => 'accessing\nprinting\n');
     expect(getMethodCategories(execute, 'Array', false)).toEqual(['accessing', 'printing']);
-    expect(execute.mock.calls[0][1]).toContain('Array categoryNames');
+    expect(execute.mock.calls[0][0]).toContain('Array categoryNames');
   });
 
   it('uses "<class> class" receiver for class side', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getMethodCategories(execute, 'Array', true);
-    expect(execute.mock.calls[0][1]).toContain('Array class categoryNames');
+    expect(execute.mock.calls[0][0]).toContain('Array class categoryNames');
   });
 });
 
@@ -107,7 +106,7 @@ describe('getInstVarNames', () => {
   it('parses allInstVarNames output', () => {
     const execute = vi.fn<QueryExecutor>(() => 'name\nsize\n');
     expect(getInstVarNames(execute, 'Foo')).toEqual(['name', 'size']);
-    expect(execute.mock.calls[0][1]).toContain('Foo allInstVarNames');
+    expect(execute.mock.calls[0][0]).toContain('Foo allInstVarNames');
   });
 });
 
@@ -115,7 +114,7 @@ describe('getAllSelectors', () => {
   it('parses allSelectors sorted output', () => {
     const execute = vi.fn<QueryExecutor>(() => 'at:\nsize\n');
     expect(getAllSelectors(execute, 'Foo')).toEqual(['at:', 'size']);
-    expect(execute.mock.calls[0][1]).toContain('Foo allSelectors asSortedCollection');
+    expect(execute.mock.calls[0][0]).toContain('Foo allSelectors asSortedCollection');
   });
 });
 
@@ -128,6 +127,6 @@ describe('getSourceOffsets', () => {
   it('passes environmentId to compiledMethodAt:', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getSourceOffsets(execute, 'Array', false, 'size', 2);
-    expect(execute.mock.calls[0][1]).toContain('environmentId: 2');
+    expect(execute.mock.calls[0][0]).toContain('environmentId: 2');
   });
 });

--- a/client/src/queries/__tests__/methodSearch.test.ts
+++ b/client/src/queries/__tests__/methodSearch.test.ts
@@ -51,7 +51,7 @@ describe('searchMethodSource', () => {
   it('passes ignoreCase flag and escaped term to Smalltalk', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     searchMethodSource(execute, "foo's", false);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("substringSearch: 'foo''s' ignoreCase: false");
   });
 });
@@ -60,7 +60,7 @@ describe('sendersOf', () => {
   it('uses sendersOf: and "at: 1" to unwrap the result array', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     sendersOf(execute, 'size');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("sendersOf: #'size'");
     expect(code).toMatch(/sendersOf: #'size'\) at: 1/s);
   });
@@ -68,7 +68,7 @@ describe('sendersOf', () => {
   it('propagates environmentId to both the query and the serialization', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     sendersOf(execute, 'x', 3);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('environmentId: 3');
     expect(code).toContain('categoryOfSelector: each selector environmentId: 3');
   });
@@ -78,7 +78,7 @@ describe('implementorsOf', () => {
   it('uses implementorsOf: and asArray to normalize the collection', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     implementorsOf(execute, 'size');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("implementorsOf: #'size'");
     expect(code).toContain('asArray');
   });
@@ -88,7 +88,7 @@ describe('referencesToObject', () => {
   it('uses ClassOrganizer referencesToObject: with objectNamed: lookup', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     referencesToObject(execute, 'MyGlobal');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('referencesToObject:');
     expect(code).toContain("objectNamed: #'MyGlobal'");
   });
@@ -100,7 +100,7 @@ describe('methodSerialization home-dictionary resolution', () => {
   it('only treats a dict as a class home when keyed by the class name', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     implementorsOf(execute, 'size');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('k = v name asSymbol');
   });
 });
@@ -109,7 +109,7 @@ describe('hierarchyImplementorsOf', () => {
   it('walks the full superclass chain for direction up', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     hierarchyImplementorsOf(execute, 1, 'Array', 'at:', false, 'up');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('superclass');
     expect(code).toContain('[cur notNil] whileTrue:');
     expect(code).toContain("includesSelector: #'at:'");
@@ -119,7 +119,7 @@ describe('hierarchyImplementorsOf', () => {
   it('walks all subclasses for direction down', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     hierarchyImplementorsOf(execute, 1, 'Array', 'at:', false, 'down');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('allSubclasses do:');
     expect(code).toContain("includesSelector: #'at:'");
     expect(code).not.toContain('whileTrue:');
@@ -128,21 +128,21 @@ describe('hierarchyImplementorsOf', () => {
   it('targets the metaclass side when isMeta is true (up)', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     hierarchyImplementorsOf(execute, 1, 'Array', 'new', true, 'up');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('(class class) superclass');
   });
 
   it('targets each subclass metaclass when isMeta is true (down)', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     hierarchyImplementorsOf(execute, 1, 'Array', 'new', true, 'down');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('tgt := sub class');
   });
 
   it('uses the instance side (class / sub) when isMeta is false', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     hierarchyImplementorsOf(execute, 1, 'Array', 'at:', false, 'down');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('tgt := sub.');
     expect(code).not.toContain('sub class');
   });
@@ -150,7 +150,7 @@ describe('hierarchyImplementorsOf', () => {
   it('embeds the dictIndex and escapes class name and selector', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     hierarchyImplementorsOf(execute, 7, "Foo'Bar", "o'clock", false, 'up');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('symbolList at: 7');
     expect(code).toContain("#'Foo''Bar'");
     expect(code).toContain("#'o''clock'");

--- a/client/src/queries/__tests__/simpleStringQueries.test.ts
+++ b/client/src/queries/__tests__/simpleStringQueries.test.ts
@@ -9,13 +9,13 @@ describe('getClassDefinition', () => {
   it('sends "<class> definition" and returns the raw result', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Object subclass: #Foo');
     expect(getClassDefinition(execute, 'Foo')).toBe('Object subclass: #Foo');
-    expect(execute).toHaveBeenCalledWith('getClassDefinition(Foo)', 'Foo definition');
+    expect(execute).toHaveBeenCalledWith('Foo definition');
   });
 
   it('scopes the lookup to a SymbolList index when a dict is given', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Object subclass: #Foo');
     getClassDefinition(execute, 'Foo', 9);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('System myUserProfile symbolList at: 9');
     expect(code).toContain("at: #'Foo' ifAbsent: [nil]");
     expect(code).toContain('cls definition');
@@ -26,13 +26,13 @@ describe('getClassComment', () => {
   it('sends "<class> comment" and returns the raw result', () => {
     const execute = vi.fn<QueryExecutor>(() => 'a class for testing');
     expect(getClassComment(execute, 'Foo')).toBe('a class for testing');
-    expect(execute).toHaveBeenCalledWith('getClassComment(Foo)', 'Foo comment');
+    expect(execute).toHaveBeenCalledWith('Foo comment');
   });
 
   it('scopes the lookup to a SymbolList index when a dict is given', () => {
     const execute = vi.fn<QueryExecutor>(() => 'c');
     getClassComment(execute, 'Foo', 3);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('System myUserProfile symbolList at: 3');
     expect(code).toContain('cls comment');
   });
@@ -57,7 +57,7 @@ describe('canClassBeWritten', () => {
   it('scopes the lookup to a SymbolList index when a dict is given', () => {
     const execute = vi.fn<QueryExecutor>(() => 'true');
     canClassBeWritten(execute, 'Foo', 5);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('System myUserProfile symbolList at: 5');
     expect(code).toContain('cls canBeWritten printString');
   });
@@ -72,7 +72,7 @@ describe('fileOutClass', () => {
   it('defaults to global objectNamed: lookup when no dict is given', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     fileOutClass(execute, "Foo'Bar");
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("objectNamed: #'Foo''Bar'");
     expect(code).toContain('fileOutClass');
   });
@@ -80,7 +80,7 @@ describe('fileOutClass', () => {
   it('scopes to a specific dictionary by index when given a number', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     fileOutClass(execute, 'Foo', 3);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('(System myUserProfile symbolList at: 3) at: ');
     expect(code).toContain("#'Foo' ifAbsent: [nil]");
   });
@@ -88,7 +88,7 @@ describe('fileOutClass', () => {
   it('scopes to a specific dictionary by name when given a string', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     fileOutClass(execute, 'Foo', 'UserGlobals');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("symbolList objectNamed: #'UserGlobals'");
     expect(code).toContain("at: #'Foo' ifAbsent: [nil]");
   });
@@ -96,7 +96,7 @@ describe('fileOutClass', () => {
   it('returns "Class not found" when lookup yields nil', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Class not found: Bogus');
     expect(fileOutClass(execute, 'Bogus')).toBe('Class not found: Bogus');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("cls ifNil: [^ 'Class not found: Bogus']");
   });
 });

--- a/client/src/queries/__tests__/structuredQueries.test.ts
+++ b/client/src/queries/__tests__/structuredQueries.test.ts
@@ -93,7 +93,7 @@ describe('getAllClassNames', () => {
   it('emits a query that lists every (dictionary, key) pair without an identity filter', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getAllClassNames(execute);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).not.toContain('IdentitySet');
     expect(code).not.toContain('seen');
   });
@@ -192,7 +192,7 @@ describe('getClassEnvironments', () => {
   it('emits the session-detection primitives (transient/persistent dicts, at:otherwise:)', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getClassEnvironments(execute, 1, 'Object', 0);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('transientMethodDictForEnv:');
     expect(code).toContain('persistentMethodDictForEnv:');
     expect(code).toContain('at: each otherwise: nil'); // NOT includesKey: on the transient dict
@@ -201,7 +201,7 @@ describe('getClassEnvironments', () => {
   it('embeds dictIndex, escaped class name, and maxEnv', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getClassEnvironments(execute, 3, "Foo'Bar", 2);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('symbolList at: 3');
     expect(code).toContain("#'Foo''Bar'");
     expect(code).toContain('envs := 2');
@@ -213,7 +213,7 @@ describe('getClassEnvironments', () => {
     // detection is exercised by a live-GCI smoke test, not this unit test.
     const execute = vi.fn<QueryExecutor>(() => '');
     getClassEnvironments(execute, 1, 'Array', 0);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('whichClassIncludesSelector:'); // walks all ancestors
     expect(code).toContain('allSubclasses'); // walks all descendants
     expect(code).not.toContain('lookupSelector:'); // the rejected approach
@@ -224,7 +224,7 @@ describe('getBaseMethodSource', () => {
   it('reads the persistent (base) method, not the merged/session view', () => {
     const execute = vi.fn<QueryExecutor>(() => 'isVowel\n  ^ base');
     getBaseMethodSource(execute, 'Character', false, 'isVowel', 0);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('persistentMethodDictForEnv: 0');
     expect(code).toContain("at: #'isVowel' otherwise: nil");
     expect(code).not.toContain('compiledMethodAt:'); // that would return the override
@@ -233,20 +233,20 @@ describe('getBaseMethodSource', () => {
   it('targets the metaclass for a class-side selector', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getBaseMethodSource(execute, 'Character', true, 'foo', 0);
-    expect(execute.mock.calls[0][1]).toContain('Character class');
+    expect(execute.mock.calls[0][0]).toContain('Character class');
   });
 
   it('threads a non-zero environment id into the persistent lookup', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getBaseMethodSource(execute, 'Character', false, 'foo', 2);
-    expect(execute.mock.calls[0][1]).toContain('persistentMethodDictForEnv: 2');
+    expect(execute.mock.calls[0][0]).toContain('persistentMethodDictForEnv: 2');
   });
 
   it('emits ASCII-only source (3.6.x miscompiles non-ASCII: ComStrmSetCursor)', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     getBaseMethodSource(execute, 'Character', false, 'isVowel', 0);
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     // eslint-disable-next-line no-control-regex -- \x00-\x7F is the intentional ASCII range, not a stray control char
     const asciiOnly = /^[\x00-\x7F]*$/;
     expect(asciiOnly.test(code)).toBe(true);
@@ -274,7 +274,7 @@ describe('getClassHierarchy', () => {
   it('iterates superclasses with do: (root-first), not reverseDo:', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     getClassHierarchy(exec, 'String');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('supers do: [:each |');
     expect(code).not.toContain('supers reverseDo:');
   });
@@ -348,7 +348,7 @@ describe('runFailingTests', () => {
   it('uses the discover-all path when no classNames are given', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('symbolList');
     expect(code).toContain('isSubclassOf: TestCase');
     expect(code).toContain('IdentitySet');
@@ -362,7 +362,7 @@ describe('runFailingTests', () => {
   it('uses the explicit-list path when classNames are given, building the list at runtime', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec, ['ArrayTest', 'StringTest']);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("objectNamed: #'ArrayTest'");
     expect(code).toContain("objectNamed: #'StringTest'");
     expect(code).toContain('reject: [:c | c isNil]');
@@ -371,7 +371,7 @@ describe('runFailingTests', () => {
   it('escapes single quotes in classNames', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec, ["it's"]);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("#'it''s'");
   });
 
@@ -388,7 +388,7 @@ describe('runFailingTests', () => {
   it('does not send #testCase to failure/error wrappers', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).not.toMatch(/testCase\s+class\s+name/);
     expect(code).not.toMatch(/testCase\s+selector/);
   });
@@ -401,7 +401,7 @@ describe('runFailingTests', () => {
   it('caps each captured message at 1024 chars to stay under MAX_RESULT', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('s size min: 1024');
   });
 
@@ -415,7 +415,7 @@ describe('runFailingTests', () => {
   it('clips each captured message via copyFrom:to: before the boundary encode', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
 
     // Full slice form must be present — the cap is a substring, not just a size calc.
     expect(code).toMatch(/s copyFrom: 1 to: \(s size min: 1024\)/);
@@ -436,7 +436,7 @@ describe('runFailingTests', () => {
   it('wraps DISCOVER_ALL in a block so its temps do not collide with the outer assignment', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toMatch(/classes := \[\| sl seen list \|/);
     expect(code).toContain('] value');
   });
@@ -447,7 +447,7 @@ describe('runFailingTests', () => {
   it('captures exception class and messageText per failing test via re-run', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('on: AbstractException');
     expect(code).toContain('t setUp');
     expect(code).toContain('t perform: t selector');
@@ -465,7 +465,7 @@ describe('runFailingTests', () => {
   it('builds the output as an internal String, encodeAsUTF8 at the boundary', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('WriteStream on: Unicode7 new');
     expect(code).toMatch(/ws contents encodeAsUTF8/);
     // Negative guards: the round-2 Utf8 buffer and the round-3 lossy ASCII
@@ -483,7 +483,7 @@ describe('runFailingTests', () => {
   it('uses matchPattern: with a parsed Array when classNamePattern is given', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec, undefined, 'Bytes*TestCase');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('isSubclassOf: TestCase');
     // The exact parsed form — pinning the literal Array source guards
     // against the parser regressing (e.g. losing the suffix segment).
@@ -497,7 +497,7 @@ describe('runFailingTests', () => {
   it('explicit classNames wins over classNamePattern (precedence)', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec, ['ArrayTest'], 'Bytes*TestCase');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     // classNames path runs (no pattern matching in the snippet).
     expect(code).toContain("objectNamed: #'ArrayTest'");
     expect(code).not.toContain('matchPattern:');
@@ -511,7 +511,7 @@ describe('runFailingTests', () => {
   it('skips abstract TestCase classes in the no-args discovery walk', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     runFailingTests(exec);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('v isAbstract not');
   });
 });
@@ -617,7 +617,7 @@ describe('describeTestFailure', () => {
   it('uses AbstractException for the live exception capture', () => {
     const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
     describeTestFailure(exec, 'ArrayTest', 'testGood');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('on: AbstractException');
     expect(code).not.toMatch(/on: Exception\b/);
   });
@@ -626,7 +626,7 @@ describe('describeTestFailure', () => {
   it('runs setUp / perform / tearDown manually rather than going through TestCase>>run', () => {
     const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
     describeTestFailure(exec, 'ArrayTest', 'testGood');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('tc setUp');
     expect(code).toContain('tc perform:');
     expect(code).toContain('tc tearDown');
@@ -636,7 +636,7 @@ describe('describeTestFailure', () => {
   it('escapes single quotes in className and selector', () => {
     const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
     describeTestFailure(exec, "Foo'Bar", "test'X");
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("Foo''Bar");
     expect(code).toContain("test''X");
   });
@@ -647,7 +647,7 @@ describe('describeTestFailure', () => {
   it('toggles GemExceptionSignalCapturesStack around the run and restores after', () => {
     const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
     describeTestFailure(exec, 'ArrayTest', 'testGood');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
 
     // Saved before, set true during, restored in ensure: after.
     expect(code).toContain('System gemConfigurationAt: #GemExceptionSignalCapturesStack');
@@ -700,7 +700,7 @@ describe('describeTestFailure', () => {
   it('caps stackReport at 16384 chars', () => {
     const exec = vi.fn<QueryExecutor>(() => 'status: passed\n');
     describeTestFailure(exec, 'X', 'y');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('size min: 16384');
   });
 });
@@ -714,7 +714,7 @@ describe('python (Grail) queries', () => {
   it('uses objectNamed: ModuleAst rather than a direct class reference', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("objectNamed: #'ModuleAst'");
     expect(code).toContain('dispatcher isNil');
   });
@@ -722,7 +722,7 @@ describe('python (Grail) queries', () => {
   it('emits a graceful "Grail not detected" hint as the nil-branch result', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('Grail (GemStone-Python) not detected');
     expect(code).toContain('class ModuleAst not found');
   });
@@ -733,7 +733,7 @@ describe('python (Grail) queries', () => {
   it('eval_python uses ModuleAst evaluateSource: (returns the printed result)', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'print(1+2)');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('dispatcher evaluateSource: src');
     expect(code).toContain('printString');
   });
@@ -741,7 +741,7 @@ describe('python (Grail) queries', () => {
   it('compile_python uses (ModuleAst parseSource: src) smalltalkSource', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     compilePython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('dispatcher parseSource: src');
     expect(code).toContain('smalltalkSource');
   });
@@ -751,7 +751,7 @@ describe('python (Grail) queries', () => {
   it('escapes single quotes in Python source', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, "x = 'hello'");
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("''hello''");
   });
 
@@ -764,7 +764,7 @@ describe('python (Grail) queries', () => {
   it('wraps the Grail call in an inner on: AlmostOutOfStack do:', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('on: AlmostOutOfStack');
     expect(code).toContain("'Error: AlmostOutOfStack");
     // AlmostOutOfStack must appear *before* AbstractException in the source
@@ -780,7 +780,7 @@ describe('python (Grail) queries', () => {
   it('wraps the Grail call in on: AbstractException do:', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('on: AbstractException');
     // Build internally with the natural String class (which widens
     // transparently for non-ASCII content), then `encodeAsUTF8` at the boundary
@@ -799,7 +799,7 @@ describe('python (Grail) queries', () => {
   it('does not build the error string via , concatenation (UTF-16 leak guard)', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).not.toMatch(/'Error: ' , e class name/);
   });
 
@@ -811,7 +811,7 @@ describe('python (Grail) queries', () => {
   it('does not write through a Utf8 stream (Utf8 immutability guard)', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).not.toContain('WriteStream on: Utf8 new');
   });
 
@@ -823,7 +823,7 @@ describe('python (Grail) queries', () => {
   it('does not use per-char ASCII gating with `?` substitution', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPython(exec, 'x = 1');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).not.toContain('asInteger < 128');
     expect(code).not.toContain('ifFalse: [$?]');
   });
@@ -850,7 +850,7 @@ describe('python (Grail) queries', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     const source = 'def f(n):\n    return n * 2\nf(5)';
     evalPython(exec, source);
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
 
     // The full multi-line body appears inside the Smalltalk string literal
     // with its actual newlines preserved.
@@ -871,7 +871,7 @@ describe('python (Grail) scoped queries — notebook kernel', () => {
   it('evaluates through evaluateSource:usingModuleScope: with a persistent scope', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPythonInScope(exec, 'x = 1', 'file:///nb/a.ipynb');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('dispatcher evaluateSource: src usingModuleScope: scope');
     expect(code).toContain("SessionTemps current at: #'__vscGrailScopes'");
     expect(code).toContain("at: 'file:///nb/a.ipynb' ifAbsentPut: [SymbolDictionary new]");
@@ -883,7 +883,7 @@ describe('python (Grail) scoped queries — notebook kernel', () => {
   it('keeps the detection, stack-guard, and encoding scaffolding', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPythonInScope(exec, 'x = 1', 'nb');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("objectNamed: #'ModuleAst'");
     expect(code).toContain('Grail (GemStone-Python) not detected');
     expect(code.indexOf('on: AlmostOutOfStack')).toBeLessThan(
@@ -898,7 +898,7 @@ describe('python (Grail) scoped queries — notebook kernel', () => {
   it('escapes single quotes in both source and scopeId', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     evalPythonInScope(exec, "x = 'hi'", "file:///o'brien/nb.ipynb");
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("''hi''");
     expect(code).toContain("o''brien");
   });
@@ -917,7 +917,7 @@ describe('python (Grail) scoped queries — notebook kernel', () => {
   it('resetPythonScope removes only the given scope and needs no dispatcher', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     resetPythonScope(exec, 'file:///nb/a.ipynb');
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("removeKey: 'file:///nb/a.ipynb' ifAbsent: []");
     expect(code).toContain("SessionTemps current at: #'__vscGrailScopes'");
     expect(code).not.toContain('ModuleAst');
@@ -927,7 +927,7 @@ describe('python (Grail) scoped queries — notebook kernel', () => {
   it('resetPythonScope escapes single quotes in scopeId', () => {
     const exec = vi.fn<QueryExecutor>(() => '');
     resetPythonScope(exec, "o'brien");
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain("removeKey: 'o''brien'");
   });
 });
@@ -988,7 +988,7 @@ describe('getGrailStubReflection', () => {
 
     getGrailStubReflection(exec, 'Account', 5);
 
-    const code = exec.mock.calls[0][1];
+    const code = exec.mock.calls[0][0];
     expect(code).toContain('symbolList at: 5');
     expect(code).toContain('canUnderstand:');
   });

--- a/client/src/queries/__tests__/writePathQueries.test.ts
+++ b/client/src/queries/__tests__/writePathQueries.test.ts
@@ -23,7 +23,7 @@ describe('compileMethod', () => {
   it('uses Behavior>>compileMethod:dictionaries:category:environmentId:', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Compiled: Array >> foo');
     compileMethod(execute, 'Array', false, 'accessing', 'foo\n  ^ 42');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('compileMethod:');
     expect(code).toContain("category: 'accessing'");
     expect(code).toContain('dictionaries: System myUserProfile symbolList');
@@ -33,20 +33,20 @@ describe('compileMethod', () => {
   it("uses target = 'base class' for class-side compiles", () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     compileMethod(execute, 'Array', true, 'creation', 'new\n  ^ super new');
-    expect(execute.mock.calls[0][1]).toContain('target := base class');
+    expect(execute.mock.calls[0][0]).toContain('target := base class');
   });
 
   it("uses target = 'base' for instance-side compiles", () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     compileMethod(execute, 'Array', false, 'acc', 'foo');
-    expect(execute.mock.calls[0][1]).toContain('target := base');
-    expect(execute.mock.calls[0][1]).not.toContain('target := base class');
+    expect(execute.mock.calls[0][0]).toContain('target := base');
+    expect(execute.mock.calls[0][0]).not.toContain('target := base class');
   });
 
   it('scopes lookup to a dictionary when dict is provided', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     compileMethod(execute, 'Foo', false, 'cat', 'x', 0, 'UserGlobals');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("objectNamed: #'UserGlobals'");
     expect(code).toContain("at: #'Foo' ifAbsent: [nil]");
   });
@@ -54,13 +54,13 @@ describe('compileMethod', () => {
   it('returns "Class not found" guard when the class lookup yields nil', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     compileMethod(execute, 'Nope', false, 'cat', 'x');
-    expect(execute.mock.calls[0][1]).toContain("base ifNil: [^ 'Class not found: Nope']");
+    expect(execute.mock.calls[0][0]).toContain("base ifNil: [^ 'Class not found: Nope']");
   });
 
   it('escapes single quotes in class name, category, and source', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     compileMethod(execute, "Foo'", true, "cat's", "foo\n  ^ 'hi'");
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("#'Foo'''"); // className in Smalltalk symbol
     expect(code).toContain("category: 'cat''s'");
     expect(code).toContain("'foo\n  ^ ''hi'''");
@@ -72,7 +72,7 @@ describe('compileClassDefinition', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Foo');
     const result = compileClassDefinition(execute, "Object subclass: 'Foo'");
     expect(result).toBe('Foo');
-    expect(execute.mock.calls[0][1]).toBe("(Object subclass: 'Foo') name");
+    expect(execute.mock.calls[0][0]).toBe("(Object subclass: 'Foo') name");
   });
 });
 
@@ -80,14 +80,14 @@ describe('setClassComment', () => {
   it('sets comment and returns a confirmation', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Comment set: Foo');
     expect(setClassComment(execute, 'Foo', 'hi')).toBe('Comment set: Foo');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("cls comment: 'hi'");
   });
 
   it('escapes quotes in class name and comment', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     setClassComment(execute, "Foo'", "it's a comment");
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("#'Foo'''");
     expect(code).toContain("comment: 'it''s a comment'");
   });
@@ -95,7 +95,7 @@ describe('setClassComment', () => {
   it('scopes lookup when dict is provided', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     setClassComment(execute, 'Foo', 'x', 2);
-    expect(execute.mock.calls[0][1]).toContain('symbolList at: 2');
+    expect(execute.mock.calls[0][0]).toContain('symbolList at: 2');
   });
 });
 
@@ -103,21 +103,21 @@ describe('deleteMethod', () => {
   it('removes the selector and returns confirmation', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Deleted: Array >> size');
     expect(deleteMethod(execute, 'Array', false, 'size')).toBe('Deleted: Array >> size');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("target removeSelector: #'size'");
   });
 
   it('returns "Selector not found" when the selector is missing', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     deleteMethod(execute, 'Array', false, 'missing');
-    expect(execute.mock.calls[0][1]).toContain('includesSelector:');
-    expect(execute.mock.calls[0][1]).toContain("'Selector not found: '");
+    expect(execute.mock.calls[0][0]).toContain('includesSelector:');
+    expect(execute.mock.calls[0][0]).toContain("'Selector not found: '");
   });
 
   it('uses base class for class-side deletes', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     deleteMethod(execute, 'Array', true, 'new');
-    expect(execute.mock.calls[0][1]).toContain('target := base class');
+    expect(execute.mock.calls[0][0]).toContain('target := base class');
   });
 });
 
@@ -125,7 +125,7 @@ describe('recategorizeMethod', () => {
   it('sends moveMethod:toCategory: with escaped args', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     recategorizeMethod(execute, 'Array', false, 'size', "it's new");
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("moveMethod: #'size'");
     expect(code).toContain("toCategory: 'it''s new'");
   });
@@ -133,7 +133,7 @@ describe('recategorizeMethod', () => {
   it('scopes the receiver to a SymbolList index when a dict is given', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     recategorizeMethod(execute, 'object', false, 'size', 'cat', 1);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("(System myUserProfile symbolList at: 1) at: #'object' ifAbsent: [nil]");
   });
 });
@@ -142,7 +142,7 @@ describe('renameCategory', () => {
   it('sends renameCategory:to: with escaped args', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     renameCategory(execute, 'Array', false, 'old', 'new');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("renameCategory: 'old' to: 'new'");
   });
 });
@@ -151,7 +151,7 @@ describe('deleteClass', () => {
   it('scopes to a dict by index when given a number', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Deleted class: Foo');
     expect(deleteClass(execute, 1, 'Foo')).toBe('Deleted class: Foo');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('symbolList at: 1');
     expect(code).toContain("removeKey: #'Foo' ifAbsent: [nil]");
   });
@@ -159,13 +159,13 @@ describe('deleteClass', () => {
   it('scopes to a dict by name when given a string', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     deleteClass(execute, 'UserGlobals', 'Foo');
-    expect(execute.mock.calls[0][1]).toContain("objectNamed: #'UserGlobals'");
+    expect(execute.mock.calls[0][0]).toContain("objectNamed: #'UserGlobals'");
   });
 
   it('returns "Class not found" when the dict lacks the key', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     deleteClass(execute, 1, 'Foo');
-    expect(execute.mock.calls[0][1]).toContain("'Class not found: Foo'");
+    expect(execute.mock.calls[0][0]).toContain("'Class not found: Foo'");
   });
 });
 
@@ -173,7 +173,7 @@ describe('moveClass', () => {
   it('moves a class between dicts and reports', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Moved class: Foo');
     expect(moveClass(execute, 1, 2, 'Foo')).toBe('Moved class: Foo');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('symbolList at: 1');
     expect(code).toContain('symbolList at: 2');
     expect(code).toContain('destDict at:');
@@ -182,7 +182,7 @@ describe('moveClass', () => {
   it('returns "Class not found in source" if src dict lacks the key', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     moveClass(execute, 1, 2, 'Foo');
-    expect(execute.mock.calls[0][1]).toContain('Class not found in source dictionary');
+    expect(execute.mock.calls[0][0]).toContain('Class not found in source dictionary');
   });
 });
 
@@ -190,7 +190,7 @@ describe('addDictionary', () => {
   it('creates a new SymbolDictionary and appends it to the symbolList', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Added dictionary: MyDict');
     expect(addDictionary(execute, 'MyDict')).toBe('Added dictionary: MyDict');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('SymbolDictionary new');
     expect(code).toContain("dict name: #'MyDict'");
     expect(code).toContain('symbolList add: dict');
@@ -201,19 +201,19 @@ describe('removeDictionary', () => {
   it('removes by index when given a number', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Removed dictionary: X');
     expect(removeDictionary(execute, 3)).toBe('Removed dictionary: X');
-    expect(execute.mock.calls[0][1]).toContain('symbolList at: 3');
+    expect(execute.mock.calls[0][0]).toContain('symbolList at: 3');
   });
 
   it('removes by name when given a string', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     removeDictionary(execute, 'MyDict');
-    expect(execute.mock.calls[0][1]).toContain("objectNamed: #'MyDict'");
+    expect(execute.mock.calls[0][0]).toContain("objectNamed: #'MyDict'");
   });
 
   it('returns "Dictionary not found" when lookup yields nil', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     removeDictionary(execute, 'Bogus');
-    expect(execute.mock.calls[0][1]).toContain("'Dictionary not found'");
+    expect(execute.mock.calls[0][0]).toContain("'Dictionary not found'");
   });
 });
 
@@ -221,7 +221,7 @@ describe('moveDictionaryUp / moveDictionaryDown', () => {
   it('moveDictionaryUp swaps with the previous slot', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     moveDictionaryUp(execute, 3);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('3 > 1 ifTrue:');
     expect(code).toContain('sl at: 3 - 1');
   });
@@ -229,7 +229,7 @@ describe('moveDictionaryUp / moveDictionaryDown', () => {
   it('moveDictionaryDown swaps with the next slot', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     moveDictionaryDown(execute, 1);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('1 < sl size ifTrue:');
     expect(code).toContain('sl at: 1 + 1');
   });
@@ -239,7 +239,7 @@ describe('breakpoint ops', () => {
   it('setBreakAtStepPoint composes the setBreakAtStepPoint: send', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     setBreakAtStepPoint(execute, 'Array', false, 'size', 3);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("compiledMethodAt: #'size'");
     expect(code).toContain('setBreakAtStepPoint: 3');
   });
@@ -247,19 +247,19 @@ describe('breakpoint ops', () => {
   it('clearBreakAtStepPoint composes the clearBreakAtStepPoint: send', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     clearBreakAtStepPoint(execute, 'Array', false, 'size', 3);
-    expect(execute.mock.calls[0][1]).toContain('clearBreakAtStepPoint: 3');
+    expect(execute.mock.calls[0][0]).toContain('clearBreakAtStepPoint: 3');
   });
 
   it('clearAllBreaks composes the clearAllBreaks send', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     clearAllBreaks(execute, 'Array', false, 'size');
-    expect(execute.mock.calls[0][1]).toContain('clearAllBreaks');
+    expect(execute.mock.calls[0][0]).toContain('clearAllBreaks');
   });
 
   it('handles class-side breakpoints via the "Class class" receiver', () => {
     const execute = vi.fn<QueryExecutor>(() => 'ok');
     setBreakAtStepPoint(execute, 'Array', true, 'new', 2);
-    expect(execute.mock.calls[0][1]).toContain('Array class compiledMethodAt:');
+    expect(execute.mock.calls[0][0]).toContain('Array class compiledMethodAt:');
   });
 });
 
@@ -267,19 +267,19 @@ describe('recategorizeClass', () => {
   it('sets the class category via Class>>category:', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Recategorized: Array');
     recategorizeClass(execute, 'Array', 'Collections');
-    expect(execute.mock.calls[0][1]).toContain("cls category: 'Collections'");
+    expect(execute.mock.calls[0][0]).toContain("cls category: 'Collections'");
   });
 
   it('guards against a missing class', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     recategorizeClass(execute, 'Nope', 'Cat');
-    expect(execute.mock.calls[0][1]).toContain("cls ifNil: [^ 'Class not found: Nope']");
+    expect(execute.mock.calls[0][0]).toContain("cls ifNil: [^ 'Class not found: Nope']");
   });
 
   it('escapes the class name and category', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     recategorizeClass(execute, "Fo'o", "Ca't");
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("#'Fo''o'");
     expect(code).toContain("category: 'Ca''t'");
   });
@@ -287,7 +287,7 @@ describe('recategorizeClass', () => {
   it('scopes the lookup to a dictionary index when given', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     recategorizeClass(execute, 'Array', 'Cat', 2);
-    expect(execute.mock.calls[0][1]).toContain('symbolList at: 2');
+    expect(execute.mock.calls[0][0]).toContain('symbolList at: 2');
   });
 });
 
@@ -295,7 +295,7 @@ describe('copyMethodToClass', () => {
   it('reads the source method and category and compiles it into the target', () => {
     const execute = vi.fn<QueryExecutor>(() => 'Copied: Set >> name');
     copyMethodToClass(execute, 'Array', 'Set', false, 'name');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("compiledMethodAt: #'name'");
     expect(code).toContain("categoryOfSelector: #'name'");
     expect(code).toContain('compileMethod: source');
@@ -305,7 +305,7 @@ describe('copyMethodToClass', () => {
   it('guards against missing source and target classes', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     copyMethodToClass(execute, 'Src', 'Dst', false, 'sel');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("^ 'Source class not found: Src'");
     expect(code).toContain("^ 'Target class not found: Dst'");
   });
@@ -313,7 +313,7 @@ describe('copyMethodToClass', () => {
   it('copies class-side methods via the "Class class" receiver on both sides', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     copyMethodToClass(execute, 'Array', 'Set', true, 'new');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('srcRecv := src class');
     expect(code).toContain('tgtRecv := target class');
   });
@@ -321,7 +321,7 @@ describe('copyMethodToClass', () => {
   it('reads from the given environment when non-zero', () => {
     const execute = vi.fn<QueryExecutor>(() => '');
     copyMethodToClass(execute, 'Array', 'Set', false, 'name', 1);
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("compiledMethodAt: #'name' environmentId: 1");
     expect(code).toContain('environmentId: 1');
   });

--- a/client/src/queries/abortTransaction.ts
+++ b/client/src/queries/abortTransaction.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
 
 export function abortTransaction(execute: QueryExecutor): string {
-  return execute('abortTransaction', `System abortTransaction. 'Transaction aborted'`);
+  return execute(`System abortTransaction. 'Transaction aborted'`);
 }

--- a/client/src/queries/addDictionary.ts
+++ b/client/src/queries/addDictionary.ts
@@ -9,5 +9,5 @@ dict := SymbolDictionary new.
 dict name: #'${escapeString(dictName)}'.
 System myUserProfile symbolList add: dict.
 'Added dictionary: ' , dict name`;
-  return execute(`addDictionary(${dictName})`, code);
+  return execute(code);
 }

--- a/client/src/queries/backup.ts
+++ b/client/src/queries/backup.ts
@@ -12,10 +12,8 @@ import { escapeString } from './util';
 // raises a raw GCI error. Pre-flighting lets us stop with a clear message.
 export function hasFileControlPrivilege(execute: QueryExecutor): boolean {
   return (
-    execute(
-      'backup: FileControl privilege check',
-      '(System myUserProfile privileges includes: #FileControl) printString',
-    ).trim() === 'true'
+    execute('(System myUserProfile privileges includes: #FileControl) printString').trim() ===
+    'true'
   );
 }
 
@@ -23,15 +21,13 @@ export function hasFileControlPrivilege(execute: QueryExecutor): boolean {
 // (rtErrAbortWouldLoseData) when the session holds uncommitted changes. Pre-flight
 // so we can warn the user before anything is discarded.
 export function sessionNeedsCommit(execute: QueryExecutor): boolean {
-  return (
-    execute('backup: uncommitted-changes check', 'System needsCommit printString').trim() === 'true'
-  );
+  return execute('System needsCommit printString').trim() === 'true';
 }
 
 // Discard the session's uncommitted changes so the subsequent backup won't be
 // refused. Only call this after the user has explicitly consented to lose them.
 export function abortTransaction(execute: QueryExecutor): void {
-  execute('backup: abort uncommitted changes', "System abortTransaction. 'aborted'");
+  execute("System abortTransaction. 'aborted'");
 }
 
 // Smalltalk for a full backup to a server-side path. Returned verbatim as a

--- a/client/src/queries/canClassBeWritten.ts
+++ b/client/src/queries/canClassBeWritten.ts
@@ -17,8 +17,6 @@ export function canClassBeWritten(
 cls := ${classLookupExpr(className, dict)}.
 cls ifNil: [^ 'false'].
 cls canBeWritten printString`;
-  const label =
-    dict === undefined ? `canBeWritten(${className})` : `canBeWritten(${className}, dict: ${dict})`;
-  const result = execute(label, code);
+  const result = execute(code);
   return result.trim() === 'true';
 }

--- a/client/src/queries/clearAllBreaks.ts
+++ b/client/src/queries/clearAllBreaks.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { compiledMethodExpr, receiver } from './util';
+import { compiledMethodExpr } from './util';
 
 export function clearAllBreaks(
   execute: QueryExecutor,
@@ -11,5 +11,5 @@ export function clearAllBreaks(
 ): string {
   const method = compiledMethodExpr(className, isMeta, selector, environmentId, dict);
   const code = `${method} clearAllBreaks. 'ok'`;
-  return execute(`clearAllBreaks(${receiver(className, isMeta)}>>#${selector})`, code);
+  return execute(code);
 }

--- a/client/src/queries/clearBreakAtStepPoint.ts
+++ b/client/src/queries/clearBreakAtStepPoint.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { compiledMethodExpr, receiver } from './util';
+import { compiledMethodExpr } from './util';
 
 export function clearBreakAtStepPoint(
   execute: QueryExecutor,
@@ -12,8 +12,5 @@ export function clearBreakAtStepPoint(
 ): string {
   const method = compiledMethodExpr(className, isMeta, selector, environmentId, dict);
   const code = `${method} clearBreakAtStepPoint: ${stepPoint}. 'ok'`;
-  return execute(
-    `clearBreak(${receiver(className, isMeta)}>>#${selector}, step:${stepPoint})`,
-    code,
-  );
+  return execute(code);
 }

--- a/client/src/queries/commitTransaction.ts
+++ b/client/src/queries/commitTransaction.ts
@@ -2,7 +2,6 @@ import { QueryExecutor } from './types';
 
 export function commitTransaction(execute: QueryExecutor): string {
   return execute(
-    'commitTransaction',
     `System commitTransaction
   ifTrue: ['Transaction committed']
   ifFalse: ['Commit failed — possible conflict. Use abort to reset, then retry.']`,

--- a/client/src/queries/compileClassDefinition.ts
+++ b/client/src/queries/compileClassDefinition.ts
@@ -7,5 +7,5 @@ export function compileClassDefinition(execute: QueryExecutor, source: string): 
   // Wrap so the result is a String (the class name) — GciTsExecuteFetchBytes
   // requires a byte-object result, but class definitions return a Class.
   const code = `(${source}) name`;
-  return execute('compileClassDefinition', code);
+  return execute(code);
 }

--- a/client/src/queries/compileMethod.ts
+++ b/client/src/queries/compileMethod.ts
@@ -29,9 +29,5 @@ result := target
   category: '${escapeString(category)}'
   environmentId: ${environmentId}.
 'Compiled: ' , target name , ' >> ' , result selector asString`;
-  const label =
-    dict === undefined
-      ? `compileMethod(${isMeta ? className + ' class' : className}, '${category}')`
-      : `compileMethod(${isMeta ? className + ' class' : className}, '${category}', dict: ${dict})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/copyMethodToClass.ts
+++ b/client/src/queries/copyMethodToClass.ts
@@ -37,6 +37,5 @@ tgtRecv
   category: (category ifNil: ['as yet unclassified']) asString
   environmentId: ${environmentId}.
 'Copied: ' , tgtRecv name , ' >> ${sel}'`;
-  const label = `copyMethodToClass(${isMeta ? sourceClass + ' class' : sourceClass} >> #${selector} -> ${targetClass})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/deleteClass.ts
+++ b/client/src/queries/deleteClass.ts
@@ -19,5 +19,5 @@ d := ${dictExpr}.
 d ifNil: [^ 'Dictionary not found'].
 removed := d removeKey: #'${esc}' ifAbsent: [nil].
 removed ifNil: ['Class not found: ${esc}'] ifNotNil: ['Deleted class: ' , removed name]`;
-  return execute(`deleteClass(${className}, dict: ${dict})`, code);
+  return execute(code);
 }

--- a/client/src/queries/deleteMethod.ts
+++ b/client/src/queries/deleteMethod.ts
@@ -20,9 +20,5 @@ target := ${isMeta ? 'base class' : 'base'}.
 (target includesSelector: #'${sel}') ifFalse: [^ 'Selector not found: ' , target name , ' >> ${sel}'].
 target removeSelector: #'${sel}'.
 'Deleted: ' , target name , ' >> ${sel}'`;
-  const label =
-    dict === undefined
-      ? `deleteMethod(${isMeta ? className + ' class' : className}>>#${selector})`
-      : `deleteMethod(${isMeta ? className + ' class' : className}>>#${selector}, dict: ${dict})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/describeClass.ts
+++ b/client/src/queries/describeClass.ts
@@ -40,9 +40,5 @@ cls class categoryNames asSortedCollection do: [:cat |
   (cls class sortedSelectorsIn: cat) do: [:sel |
     ws nextPutAll: '  '; nextPutAll: sel; lf]].
 ws contents`;
-  const label =
-    dict === undefined
-      ? `describeClass(${className})`
-      : `describeClass(${className}, dict: ${dict})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/describeTestFailure.ts
+++ b/client/src/queries/describeTestFailure.ts
@@ -117,7 +117,7 @@ captured isNil ifTrue: [
     ws nextPutAll: s]].
 ws contents`;
 
-  const data = execute('describeTestFailure', code);
+  const data = execute(code);
   return parseDetails(data);
 }
 

--- a/client/src/queries/discoverTestClasses.ts
+++ b/client/src/queries/discoverTestClasses.ts
@@ -39,7 +39,7 @@ classDict keysAndValuesDo: [:cls :dictName |
     nextPutAll: cls name; tab;
     nextPutAll: cls testSelectors size printString; lf].
 ws contents`;
-  const data = execute('discoverTestClasses', code);
+  const data = execute(code);
   return splitLines(data).map((line) => {
     const [dictName, className, count] = line.split('\t');
     return { dictName, className, testCount: parseTestCount(count) };

--- a/client/src/queries/discoverTestMethods.ts
+++ b/client/src/queries/discoverTestMethods.ts
@@ -22,7 +22,7 @@ cls testSelectors asSortedCollection do: [:each |
     nextPutAll: ((cls categoryOfSelector: each environmentId: 0) ifNil: ['']);
     lf].
 ws contents`;
-  const data = execute(`discoverTestMethods(${className})`, code);
+  const data = execute(code);
   return splitLines(data).map((line) => {
     const [selector, category] = line.split('\t');
     return { selector, category: category || '' };

--- a/client/src/queries/extentBackup.ts
+++ b/client/src/queries/extentBackup.ts
@@ -20,7 +20,7 @@ import { splitLines } from './util';
 export function fullLoggingEnabled(execute: QueryExecutor): boolean | undefined {
   const code = `[(System stoneConfigurationAt: #STN_TRAN_FULL_LOGGING) printString]
   on: Error do: [:e | 'unknown']`;
-  const result = execute('extentBackup: full-logging check', code).trim();
+  const result = execute(code).trim();
   if (result === 'true') return true;
   if (result === 'false') return false;
   return undefined;
@@ -34,7 +34,7 @@ export function extentFileNames(execute: QueryExecutor): string[] {
 ws := WriteStream on: String new.
 SystemRepository fileNames do: [:nm | ws nextPutAll: nm asString; lf].
 ws contents] on: Error do: [:e | '']`;
-  return splitLines(execute('extentBackup: extent file names', code));
+  return splitLines(execute(code));
 }
 
 // Suspend checkpoints for `minutes`. true => suspended, safe to copy the
@@ -45,7 +45,7 @@ ws contents] on: Error do: [:e | '']`;
 export function suspendCheckpoints(execute: QueryExecutor, minutes: number): boolean {
   const code = `(System suspendCheckpointsForMinutes: ${Math.trunc(minutes)})
   ifTrue: ['OK'] ifFalse: ['FAILED']`;
-  return execute('extentBackup: suspend checkpoints', code).trim() === 'OK';
+  return execute(code).trim() === 'OK';
 }
 
 // Resume checkpoints. The result MUST be checked: false means checkpoints had
@@ -53,5 +53,5 @@ export function suspendCheckpoints(execute: QueryExecutor, minutes: number): boo
 // the copied extents are not a usable backup.
 export function resumeCheckpoints(execute: QueryExecutor): boolean {
   const code = "(System resumeCheckpoints) ifTrue: ['OK'] ifFalse: ['FAILED']";
-  return execute('extentBackup: resume checkpoints', code).trim() === 'OK';
+  return execute(code).trim() === 'OK';
 }

--- a/client/src/queries/fileOutClass.ts
+++ b/client/src/queries/fileOutClass.ts
@@ -17,7 +17,5 @@ export function fileOutClass(
 cls := ${classLookupExpr(className, dict)}.
 cls ifNil: [^ 'Class not found: ${escapeString(className)}'].
 cls fileOutClass`;
-  const label =
-    dict === undefined ? `fileOutClass(${className})` : `fileOutClass(${className}, dict: ${dict})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/forkGem.ts
+++ b/client/src/queries/forkGem.ts
@@ -15,7 +15,6 @@ import { escapeString } from './util';
  */
 export function canForkGem(execute: QueryExecutor): boolean {
   const answer = execute(
-    'canForkGem',
     `((GsCurrentSession currentSession respondsTo: #'createOnetimePasswordForUserId:validForSeconds:')
       and: [(System myUserProfile symbolList objectNamed: #'GsTsExternalSession') notNil]) printString`,
   );
@@ -51,7 +50,6 @@ export function canForkGem(execute: QueryExecutor): boolean {
  */
 export function forkGemRunning(execute: QueryExecutor, expression: string, gemNrs: string): string {
   return execute(
-    'forkGemRunning',
     `| gem id |
 gem := GsTsExternalSession newDefault.
 gem gemNRS: '${escapeString(gemNrs)}'.

--- a/client/src/queries/getAllClassNames.ts
+++ b/client/src/queries/getAllClassNames.ts
@@ -24,7 +24,7 @@ sl := System myUserProfile symbolList.
       ws nextPutAll: idx printString; tab; nextPutAll: dict name; tab; nextPutAll: k; lf]]].
 ws contents`;
 
-  const raw = execute('getAllClassNames', code);
+  const raw = execute(code);
   const results: ClassNameEntry[] = [];
   for (const line of raw.split('\n')) {
     if (line.length === 0) continue;

--- a/client/src/queries/getAllSelectors.ts
+++ b/client/src/queries/getAllSelectors.ts
@@ -7,5 +7,5 @@ ws := WriteStream on: Unicode7 new.
 ${className} allSelectors asSortedCollection do: [:each |
   ws nextPutAll: each; lf].
 ws contents`;
-  return splitLines(execute(`getAllSelectors(${className})`, code));
+  return splitLines(execute(code));
 }

--- a/client/src/queries/getBaseMethodSource.ts
+++ b/client/src/queries/getBaseMethodSource.ts
@@ -24,8 +24,5 @@ export function getBaseMethodSource(
     `ifNotNil: [:d | d at: #'${sel}' otherwise: nil]) ` +
     `ifNil: ['"(no base method: this selector has no persistent implementation on this class)"'] ` +
     `ifNotNil: [:m | m sourceString]`;
-  return execute(
-    `getBaseMethodSource(${receiver(className, isMeta)}>>#${selector} env:${environmentId})`,
-    code,
-  );
+  return execute(code);
 }

--- a/client/src/queries/getClassComment.ts
+++ b/client/src/queries/getClassComment.ts
@@ -11,11 +11,11 @@ export function getClassComment(
   dict?: number | string,
 ): string {
   if (dict === undefined) {
-    return execute(`getClassComment(${className})`, `${className} comment`);
+    return execute(`${className} comment`);
   }
   const code = `| cls |
 cls := ${classLookupExpr(className, dict)}.
 cls ifNil: [^ ''].
 cls comment`;
-  return execute(`getClassComment(${className}, dict: ${dict})`, code);
+  return execute(code);
 }

--- a/client/src/queries/getClassDefinition.ts
+++ b/client/src/queries/getClassDefinition.ts
@@ -11,11 +11,11 @@ export function getClassDefinition(
   dict?: number | string,
 ): string {
   if (dict === undefined) {
-    return execute(`getClassDefinition(${className})`, `${className} definition`);
+    return execute(`${className} definition`);
   }
   const code = `| cls |
 cls := ${classLookupExpr(className, dict)}.
 cls ifNil: [^ 'Class not found: ${escapeString(className)}'].
 cls definition`;
-  return execute(`getClassDefinition(${className}, dict: ${dict})`, code);
+  return execute(code);
 }

--- a/client/src/queries/getClassEnvironments.ts
+++ b/client/src/queries/getClassEnvironments.ts
@@ -82,7 +82,7 @@ stream := WriteStream on: Unicode7 new.
 ].
 stream contents`;
 
-  const raw = execute(`getClassEnvironments(${className}, ${maxEnv})`, code);
+  const raw = execute(code);
 
   const results: EnvCategoryLine[] = [];
   for (const line of raw.split('\n')) {

--- a/client/src/queries/getClassHierarchy.ts
+++ b/client/src/queries/getClassHierarchy.ts
@@ -39,7 +39,7 @@ stream nextPutAll: (classDict at: class ifAbsent: ['']); tab;
     nextPutAll: each name; tab; nextPutAll: 'subclass'; lf].
 stream contents`;
 
-  const raw = execute(`getClassHierarchy(${className})`, code);
+  const raw = execute(code);
   const results: ClassHierarchyEntry[] = [];
   for (const line of raw.split('\n')) {
     if (line.length === 0) continue;

--- a/client/src/queries/getClassNames.ts
+++ b/client/src/queries/getClassNames.ts
@@ -16,9 +16,5 @@ ws := WriteStream on: String new.
 dict keysAndValuesDo: [:k :v |
   v isBehavior ifTrue: [ws nextPutAll: k; lf]].
 ws contents`;
-  const label =
-    typeof dict === 'number'
-      ? `getClassNames(dictIndex: ${dict})`
-      : `getClassNames(dictName: ${dict})`;
-  return splitLines(execute(label, code)).sort();
+  return splitLines(execute(code)).sort();
 }

--- a/client/src/queries/getClassesWithCategory.ts
+++ b/client/src/queries/getClassesWithCategory.ts
@@ -30,11 +30,7 @@ dict keysAndValuesDo: [:k :v |
     (cat isNil or: [cat isEmpty]) ifTrue: [cat := 'as yet unclassified'].
     ws nextPutAll: cat asString; tab; nextPutAll: k; lf]].
 ws contents`;
-  const label =
-    typeof dict === 'number'
-      ? `getClassesWithCategory(dictIndex: ${dict})`
-      : `getClassesWithCategory(dictName: ${dict})`;
-  return splitLines(execute(label, code)).map((line) => {
+  return splitLines(execute(code)).map((line) => {
     const tab = line.indexOf('\t');
     return {
       category: line.slice(0, tab),

--- a/client/src/queries/getDefinedInstVarCounts.ts
+++ b/client/src/queries/getDefinedInstVarCounts.ts
@@ -24,12 +24,8 @@ dict keysAndValuesDo: [:k :v |
     n := [v instVarNames size] on: Error do: [:e | 0].
     ws nextPutAll: k; tab; print: n; lf]].
 ws contents`;
-  const label =
-    typeof dict === 'number'
-      ? `getDefinedInstVarCounts(dictIndex: ${dict})`
-      : `getDefinedInstVarCounts(dictName: ${dict})`;
   const map = new Map<string, number>();
-  for (const line of splitLines(execute(label, code))) {
+  for (const line of splitLines(execute(code))) {
     const tab = line.indexOf('\t');
     if (tab < 0) continue;
     map.set(line.slice(0, tab), parseInt(line.slice(tab + 1), 10) || 0);

--- a/client/src/queries/getDefinedInstVarNames.ts
+++ b/client/src/queries/getDefinedInstVarNames.ts
@@ -22,5 +22,5 @@ ws := WriteStream on: String new.
 (cls ifNil: [#()] ifNotNil: [:c | c instVarNames]) do: [:each |
   ws nextPutAll: each asString; lf].
 ws contents`;
-  return splitLines(execute(`getDefinedInstVarNames(${className})`, code));
+  return splitLines(execute(code));
 }

--- a/client/src/queries/getDictionaryClassFileOutOrder.ts
+++ b/client/src/queries/getDictionaryClassFileOutOrder.ts
@@ -27,11 +27,7 @@ dict keysAndValuesDo: [:k :v |
     [sc notNil] whileTrue: [depth := depth + 1. sc := sc superclass].
     ws nextPutAll: depth printString; tab; nextPutAll: k; lf]].
 ws contents`;
-  const label =
-    typeof dict === 'number'
-      ? `getDictionaryClassFileOutOrder(dictIndex: ${dict})`
-      : `getDictionaryClassFileOutOrder(dictName: ${dict})`;
-  return splitLines(execute(label, code))
+  return splitLines(execute(code))
     .map((line) => {
       const tab = line.indexOf('\t');
       return { depth: parseInt(line.slice(0, tab), 10), name: line.slice(tab + 1) };

--- a/client/src/queries/getDictionaryEntries.ts
+++ b/client/src/queries/getDictionaryEntries.ts
@@ -24,11 +24,7 @@ dict keysAndValuesDo: [:k :v |
     ifFalse: [ws nextPutAll: '0'; tab; tab; nextPutAll: k asString; lf]].
 ws contents`;
 
-  const label =
-    typeof dict === 'number'
-      ? `getDictionaryEntries(dictIndex: ${dict})`
-      : `getDictionaryEntries(dictName: ${dict})`;
-  const raw = execute(label, code);
+  const raw = execute(code);
 
   const results: DictEntry[] = [];
   for (const line of raw.split('\n')) {

--- a/client/src/queries/getDictionaryNames.ts
+++ b/client/src/queries/getDictionaryNames.ts
@@ -7,5 +7,5 @@ ws := WriteStream on: String new.
 System myUserProfile symbolList names do: [:each |
   ws nextPutAll: each; lf].
 ws contents`;
-  return splitLines(execute('getDictionaryNames', code));
+  return splitLines(execute(code));
 }

--- a/client/src/queries/getEnhancedInspectorViewSpecs.ts
+++ b/client/src/queries/getEnhancedInspectorViewSpecs.ts
@@ -30,14 +30,10 @@ export interface EnhancedInspectorViewSpec {
   }>;
 }
 
-function enhancedInspectorExecute(
-  execute: QueryExecutor,
-  label: string,
-  code: string,
-): string | null {
+function enhancedInspectorExecute(execute: QueryExecutor, code: string): string | null {
   const wrapped = `[${code}] on: AbstractException do: [:e | 'EIError:', e messageText asString]`;
   try {
-    const result = execute(label, wrapped);
+    const result = execute(wrapped);
     return result.startsWith('EIError:') ? null : result;
   } catch {
     return null;
@@ -54,7 +50,7 @@ function resolveForwardViewSpec(
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
 ds := (viewed viewSpecificationsBySelector at: #'${escapeString(forwardSelector)}') phlowDataSource.
 STONJSON toString: ds retrieveViewSpecificationForForwarding`;
-  const result = enhancedInspectorExecute(execute, 'resolveForwardViewSpec', code);
+  const result = enhancedInspectorExecute(execute, code);
   if (!result) return null;
   try {
     const spec = JSON.parse(result);
@@ -74,7 +70,7 @@ export function getEnhancedInspectorViewSpecs(
   const code = `| viewed |
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
 STONJSON toString: (viewed getInspectorSpecificationData at: 'views')`;
-  const result = enhancedInspectorExecute(execute, 'getEnhancedInspectorViewSpecs', code);
+  const result = enhancedInspectorExecute(execute, code);
   if (!result) return null;
   try {
     const specs = JSON.parse(result) as EnhancedInspectorViewSpec[];
@@ -109,7 +105,7 @@ s := WriteStream on: String new.
 obj printOn: s.
 textData at: 'truncated' put: (s position > (textData at: 'string') size).
 STONJSON toString: textData`;
-  const result = enhancedInspectorExecute(execute, 'fetchEnhancedInspectorPrintTabData', code);
+  const result = enhancedInspectorExecute(execute, code);
   let truncated = false;
   if (result) {
     try {
@@ -131,7 +127,7 @@ export function fetchEnhancedInspectorTextData(
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
 ds := (viewed viewSpecificationsBySelector at: #'${escapeString(methodSelector)}') phlowDataSource.
 STONJSON toString: ds getText`;
-  return enhancedInspectorExecute(execute, 'fetchEnhancedInspectorTextData', code);
+  return enhancedInspectorExecute(execute, code);
 }
 
 export function fetchEnhancedInspectorForwardRowOop(
@@ -148,7 +144,7 @@ ds retrieveViewSpecificationForForwarding.
 forwardDs := ds retrieveForwardTargetDataSource.
 item := forwardDs retrieveSentItemAt: ${nodeId}.
 [item asOop printString] on: Error do: [:e | '']`;
-  const result = enhancedInspectorExecute(execute, 'fetchEnhancedInspectorForwardRowOop', code);
+  const result = enhancedInspectorExecute(execute, code);
   if (!result || result.trim() === '') return null;
   try {
     return BigInt(result.trim());
@@ -177,7 +173,7 @@ ds := (viewed viewSpecificationsBySelector at: #'${escapeString(methodSelector)}
 ds retrieveItems: 1 fromIndex: ${nodeId}.
 item := ds retrieveSentItemAt: ${nodeId}.
 [item asOop printString] on: Error do: [:e | '']`;
-  const result = enhancedInspectorExecute(execute, 'fetchEnhancedInspectorRowOop', code);
+  const result = enhancedInspectorExecute(execute, code);
   if (!result || result.trim() === '') return null;
   try {
     return BigInt(result.trim());
@@ -196,7 +192,7 @@ export function fetchEnhancedInspectorListTotal(
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
 ds := (viewed viewSpecificationsBySelector at: #'${escapeString(methodSelector)}') phlowDataSource.
 ds retrieveTotalItemsCount printString`;
-  const result = enhancedInspectorExecute(execute, 'fetchEnhancedInspectorListTotal', code);
+  const result = enhancedInspectorExecute(execute, code);
   if (!result) return null;
   const n = parseInt(result.trim(), 10);
   return isNaN(n) ? null : n;
@@ -214,7 +210,7 @@ export function fetchEnhancedInspectorTreeChildren(
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${itemOop}).
 ds := (viewed viewSpecificationsBySelector at: #'${escapeString(methodSelector)}') phlowDataSource.
 STONJSON toString: (ds retrieveChildrenForNodeAtPath: ${stPath})`;
-  return enhancedInspectorExecute(execute, 'fetchEnhancedInspectorTreeChildren', code);
+  return enhancedInspectorExecute(execute, code);
 }
 
 export function fetchMethodBrowseLocation(
@@ -235,7 +231,7 @@ STONJSON toString: (Dictionary new
   at: 'className' put: baseCls name;
   at: 'category' put: category;
   yourself)`;
-  const result = enhancedInspectorExecute(execute, 'fetchMethodBrowseLocation', code);
+  const result = enhancedInspectorExecute(execute, code);
   if (!result) return null;
   try {
     return JSON.parse(result);
@@ -255,7 +251,7 @@ export function fetchMethodSource(
     ? `(Object _objectForOop: ${oop}) class theNonMetaClass class`
     : `(Object _objectForOop: ${oop}) class theNonMetaClass`;
   const code = `${recv} sourceCodeAt: #'${escapeString(methodSelector)}'`;
-  return enhancedInspectorExecute(execute, 'fetchMethodSource', code);
+  return enhancedInspectorExecute(execute, code);
 }
 
 export function fetchObjectMeta(execute: QueryExecutor, oop: bigint): string | null {
@@ -271,7 +267,7 @@ STONJSON toString: (Dictionary new
   at: 'methodSelectors' put: baseCls selectors asSortedCollection asArray;
   at: 'classMethodSelectors' put: baseCls class selectors asSortedCollection asArray;
   yourself)`;
-  return enhancedInspectorExecute(execute, 'fetchObjectMeta', code);
+  return enhancedInspectorExecute(execute, code);
 }
 
 export function fetchEnhancedInspectorListData(
@@ -288,7 +284,7 @@ export function fetchEnhancedInspectorListData(
 viewed := GtRemotePhlowViewedObject new initializeWith: (Object _objectForOop: ${oop}).
 ds := (viewed viewSpecificationsBySelector at: #'${escapeString(methodSelector)}') phlowDataSource.
 STONJSON toString: (ds retrieveItems: ${count} fromIndex: ${fromIndex})`;
-  return enhancedInspectorExecute(execute, 'fetchEnhancedInspectorListData', code);
+  return enhancedInspectorExecute(execute, code);
 }
 
 export function fetchEnhancedInspectorForwardListData(
@@ -307,7 +303,7 @@ ds := (viewed viewSpecificationsBySelector at: #'${escapeString(forwardSelector)
 ds retrieveViewSpecificationForForwarding.
 forwardDs := ds retrieveForwardTargetDataSource.
 STONJSON toString: (forwardDs retrieveItems: ${count} fromIndex: ${fromIndex})`;
-  return enhancedInspectorExecute(execute, 'fetchEnhancedInspectorForwardListData', code);
+  return enhancedInspectorExecute(execute, code);
 }
 
 export function fetchEnhancedInspectorForwardListTotal(
@@ -322,7 +318,7 @@ ds := (viewed viewSpecificationsBySelector at: #'${escapeString(forwardSelector)
 ds retrieveViewSpecificationForForwarding.
 forwardDs := ds retrieveForwardTargetDataSource.
 forwardDs retrieveTotalItemsCount printString`;
-  const result = enhancedInspectorExecute(execute, 'fetchEnhancedInspectorForwardListTotal', code);
+  const result = enhancedInspectorExecute(execute, code);
   if (!result) return null;
   const n = parseInt(result.trim(), 10);
   return isNaN(n) ? null : n;

--- a/client/src/queries/getGlobalsForDictionary.ts
+++ b/client/src/queries/getGlobalsForDictionary.ts
@@ -20,7 +20,7 @@ dict keysAndValuesDo: [:k :v |
        nextPutAll: ps; lf]].
 ws contents`;
 
-  const raw = execute(`getGlobalsForDictionary(dictIndex: ${dictIndex})`, code);
+  const raw = execute(code);
 
   const results: GlobalEntry[] = [];
   for (const line of raw.split('\n')) {

--- a/client/src/queries/getInstVarNames.ts
+++ b/client/src/queries/getInstVarNames.ts
@@ -7,5 +7,5 @@ ws := WriteStream on: String new.
 ${className} allInstVarNames do: [:each |
   ws nextPutAll: each; lf].
 ws contents`;
-  return splitLines(execute(`getInstVarNames(${className})`, code));
+  return splitLines(execute(code));
 }

--- a/client/src/queries/getMethodCategories.ts
+++ b/client/src/queries/getMethodCategories.ts
@@ -13,5 +13,5 @@ ws := WriteStream on: String new.
 ${recv} categoryNames asSortedCollection do: [:each |
   ws nextPutAll: each; lf].
 ws contents`;
-  return splitLines(execute(`getMethodCategories(${receiver(className, isMeta)})`, code));
+  return splitLines(execute(code));
 }

--- a/client/src/queries/getMethodList.ts
+++ b/client/src/queries/getMethodList.ts
@@ -20,7 +20,7 @@ class := ${className}.
         nextPutAll: cat; tab;
         nextPutAll: sel; lf]]].
 ws contents`;
-  const raw = execute(`getMethodList(${className})`, code);
+  const raw = execute(code);
   const results: MethodEntry[] = [];
   for (const line of raw.split('\n')) {
     if (line.length === 0) continue;

--- a/client/src/queries/getMethodSource.ts
+++ b/client/src/queries/getMethodSource.ts
@@ -10,14 +10,9 @@ export function getMethodSource(
   dict?: number | string,
 ): string {
   const recv = receiver(className, isMeta, dict);
-  const labelRecv = receiver(className, isMeta);
   const code =
     environmentId === 0
       ? `(${recv} compiledMethodAt: #'${escapeString(selector)}') sourceString`
       : `(${recv} compiledMethodAt: #'${escapeString(selector)}' environmentId: ${environmentId}) sourceString`;
-  const label =
-    environmentId === 0
-      ? `getMethodSource(${labelRecv}>>#${selector})`
-      : `getMethodSource(${labelRecv}>>#${selector} env:${environmentId})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/getSourceOffsets.ts
+++ b/client/src/queries/getSourceOffsets.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { compiledMethodExpr, receiver, splitLines } from './util';
+import { compiledMethodExpr, splitLines } from './util';
 
 export function getSourceOffsets(
   execute: QueryExecutor,
@@ -15,7 +15,5 @@ ws := WriteStream on: String new.
 ${method} _sourceOffsets do: [:each |
   ws nextPutAll: each printString; lf].
 ws contents`;
-  return splitLines(
-    execute(`getSourceOffsets(${receiver(className, isMeta)}>>#${selector})`, code),
-  ).map((s) => parseInt(s, 10));
+  return splitLines(execute(code)).map((s) => parseInt(s, 10));
 }

--- a/client/src/queries/getStepPointSelectorRanges.ts
+++ b/client/src/queries/getStepPointSelectorRanges.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { compiledMethodExpr, receiver } from './util';
+import { compiledMethodExpr } from './util';
 
 export interface StepPointSelectorInfo {
   stepPoint: number;
@@ -41,10 +41,7 @@ ws := WriteStream on: String new.
          nextPutAll: (source copyFrom: offset1 to: end - 1); lf]]].
 ws contents`;
 
-  const raw = execute(
-    `getStepPointSelectorRanges(${receiver(className, isMeta)}>>#${selector})`,
-    code,
-  );
+  const raw = execute(code);
 
   const results: StepPointSelectorInfo[] = [];
   for (const line of raw.split('\n')) {

--- a/client/src/queries/grailStubReflection.ts
+++ b/client/src/queries/grailStubReflection.ts
@@ -65,7 +65,7 @@ cls instVarNames do: [:iv |
 ws nextPutAll: '===COMMENT==='; lf.
 ws nextPutAll: (cls comment ifNil: ['']).
 ws contents`;
-  return parseGrailStubReflection(execute(`getGrailStubReflection(${className})`, code));
+  return parseGrailStubReflection(execute(code));
 }
 
 export function parseGrailStubReflection(raw: string): GrailStubReflection {

--- a/client/src/queries/methodSearch.ts
+++ b/client/src/queries/methodSearch.ts
@@ -67,7 +67,7 @@ results := ClassOrganizer new substringSearch: '${escapeString(term)}' ignoreCas
 methods := results at: 1.
 ${methodSerialization(0)}`;
 
-  return parseMethodSearchResults(execute(`searchMethodSource('${term}')`, code));
+  return parseMethodSearchResults(execute(code));
 }
 
 export function sendersOf(
@@ -80,7 +80,7 @@ methods := ((ClassOrganizer new environmentId: ${environmentId}; yourself)
   sendersOf: #'${escapeString(selector)}') at: 1.
 ${methodSerialization(environmentId)}`;
 
-  return parseMethodSearchResults(execute(`sendersOf(#${selector}, env:${environmentId})`, code));
+  return parseMethodSearchResults(execute(code));
 }
 
 export function implementorsOf(
@@ -93,9 +93,7 @@ methods := ((ClassOrganizer new environmentId: ${environmentId}; yourself)
   implementorsOf: #'${escapeString(selector)}') asArray.
 ${methodSerialization(environmentId)}`;
 
-  return parseMethodSearchResults(
-    execute(`implementorsOf(#${selector}, env:${environmentId})`, code),
-  );
+  return parseMethodSearchResults(execute(code));
 }
 
 // Implementations of `selector` in a class's hierarchy: the full superclass
@@ -128,9 +126,7 @@ ${collect}
 methods := methods asArray.
 ${methodSerialization(environmentId)}`;
 
-  return parseMethodSearchResults(
-    execute(`hierarchyImplementorsOf(#${selector}, ${direction})`, code),
-  );
+  return parseMethodSearchResults(execute(code));
 }
 
 export function referencesToObject(
@@ -143,5 +139,5 @@ methods := (ClassOrganizer new referencesToObject:
   (System myUserProfile symbolList objectNamed: #'${escapeString(objectName)}')).
 ${methodSerialization(environmentId)}`;
 
-  return parseMethodSearchResults(execute(`referencesToObject(${objectName})`, code));
+  return parseMethodSearchResults(execute(code));
 }

--- a/client/src/queries/moveClass.ts
+++ b/client/src/queries/moveClass.ts
@@ -16,5 +16,5 @@ cls := srcDict removeKey: #'${esc}' ifAbsent: [nil].
 cls ifNil: [^ 'Class not found in source dictionary: ${esc}'].
 destDict at: #'${esc}' put: cls.
 'Moved class: ' , cls name`;
-  return execute(`moveClass(${className}: ${srcDictIndex} -> ${destDictIndex})`, code);
+  return execute(code);
 }

--- a/client/src/queries/moveDictionaryDown.ts
+++ b/client/src/queries/moveDictionaryDown.ts
@@ -10,5 +10,5 @@ ${dictIndex} < sl size ifTrue: [
   sl at: ${dictIndex} put: (sl at: ${dictIndex} + 1).
   sl at: ${dictIndex} + 1 put: temp].
 'ok'`;
-  return execute(`moveDictionaryDown(${dictIndex})`, code);
+  return execute(code);
 }

--- a/client/src/queries/moveDictionaryUp.ts
+++ b/client/src/queries/moveDictionaryUp.ts
@@ -10,5 +10,5 @@ ${dictIndex} > 1 ifTrue: [
   sl at: ${dictIndex} put: (sl at: ${dictIndex} - 1).
   sl at: ${dictIndex} - 1 put: temp].
 'ok'`;
-  return execute(`moveDictionaryUp(${dictIndex})`, code);
+  return execute(code);
 }

--- a/client/src/queries/python.ts
+++ b/client/src/queries/python.ts
@@ -22,7 +22,7 @@ const GRAIL_HINT =
 // inline as `Error: <class> — <messageText>` so the agent can act on it.
 export function evalPython(execute: QueryExecutor, source: string): string {
   const code = buildPythonQuery('(dispatcher evaluateSource: src) printString', source);
-  return execute('evalPython', code);
+  return execute(code);
 }
 
 // Like evalPython, but with REPL semantics: globals persist across calls
@@ -43,7 +43,7 @@ export function evalPythonInScope(execute: QueryExecutor, source: string, scopeI
        scope := scopes at: '${escScope}' ifAbsentPut: [SymbolDictionary new].
        (dispatcher evaluateSource: src usingModuleScope: scope) printString`;
   const code = buildPythonQuery(expr, source);
-  return execute('evalPythonInScope', code);
+  return execute(code);
 }
 
 // Drop the persistent module scope for scopeId so the next evalPythonInScope
@@ -56,7 +56,7 @@ export function resetPythonScope(execute: QueryExecutor, scopeId: string): strin
 scopes := SessionTemps current at: #'__vscGrailScopes' ifAbsent: [nil].
 scopes ifNotNil: [scopes removeKey: '${escScope}' ifAbsent: []].
 'scope reset' encodeAsUTF8`;
-  return execute('resetPythonScope', code);
+  return execute(code);
 }
 
 // Transpile a Python source string to Smalltalk via Grail and return the
@@ -65,7 +65,7 @@ scopes ifNotNil: [scopes removeKey: '${escScope}' ifAbsent: []].
 // codegen pipeline). Errors are reported inline, same shape as evalPython.
 export function compilePython(execute: QueryExecutor, source: string): string {
   const code = buildPythonQuery('(dispatcher parseSource: src) smalltalkSource', source);
-  return execute('compilePython', code);
+  return execute(code);
 }
 
 function buildPythonQuery(grailExpression: string, pythonSource: string): string {

--- a/client/src/queries/recategorizeClass.ts
+++ b/client/src/queries/recategorizeClass.ts
@@ -16,9 +16,5 @@ cls ifNil: [^ 'Class not found: ${esc}'].
 cls isBehavior ifFalse: [^ 'Not a class: ${esc}'].
 cls category: '${escapeString(newCategory)}'.
 'Recategorized: ' , cls name`;
-  const label =
-    dict === undefined
-      ? `recategorizeClass(${className} -> '${newCategory}')`
-      : `recategorizeClass(${className} -> '${newCategory}', dict: ${dict})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/recategorizeMethod.ts
+++ b/client/src/queries/recategorizeMethod.ts
@@ -12,8 +12,5 @@ export function recategorizeMethod(
 ): string {
   const recv = receiver(className, isMeta, dict);
   const code = `${recv} moveMethod: #'${escapeString(selector)}' toCategory: '${escapeString(newCategory)}'. 'ok'`;
-  return execute(
-    `recategorizeMethod(${receiver(className, isMeta)}>>#${selector} -> '${newCategory}')`,
-    code,
-  );
+  return execute(code);
 }

--- a/client/src/queries/removeDictionary.ts
+++ b/client/src/queries/removeDictionary.ts
@@ -14,5 +14,5 @@ d := ${dictExpr}.
 d ifNil: [^ 'Dictionary not found'].
 sl remove: d.
 'Removed dictionary: ' , d name`;
-  return execute(`removeDictionary(${dict})`, code);
+  return execute(code);
 }

--- a/client/src/queries/renameCategory.ts
+++ b/client/src/queries/renameCategory.ts
@@ -12,8 +12,5 @@ export function renameCategory(
 ): string {
   const recv = receiver(className, isMeta, dict);
   const code = `${recv} renameCategory: '${escapeString(oldCategory)}' to: '${escapeString(newCategory)}'. 'ok'`;
-  return execute(
-    `renameCategory(${receiver(className, isMeta)}, '${oldCategory}' -> '${newCategory}')`,
-    code,
-  );
+  return execute(code);
 }

--- a/client/src/queries/rowan/diffRowanProject.ts
+++ b/client/src/queries/rowan/diffRowanProject.ts
@@ -44,7 +44,7 @@ patches do: [:assoc | | pkg |
        nextPutAll: ([op definition printString] on: Error do: [:e | '?']); lf]].
 ws contents`;
 
-  const raw = execute(`diffRowanProject(${projectName})`, code);
+  const raw = execute(code);
   const trimmed = raw.trimStart();
   if (trimmed.startsWith(NO_ROWAN))
     return { ok: false, error: 'Rowan is not installed in this image.', operations: [] };

--- a/client/src/queries/rowan/exportRowanProject.ts
+++ b/client/src/queries/rowan/exportRowanProject.ts
@@ -34,7 +34,7 @@ lp isNil ifTrue: [^'ERR' , sep , 'Project ${escapeString(projectName)} is not lo
   on: Error do: [:e | ^'ERR' , sep , e messageText].
 'OK' , sep , '${escapeString(targetDir)}'`;
 
-  const raw = execute(`exportRowanProject(${projectName} -> ${targetDir})`, code);
+  const raw = execute(code);
   const tab = raw.indexOf('\t');
   const status = tab === -1 ? raw.trim() : raw.slice(0, tab);
   const detail = tab === -1 ? '' : raw.slice(tab + 1).trim();

--- a/client/src/queries/rowan/findRowanClassOwners.ts
+++ b/client/src/queries/rowan/findRowanClassOwners.ts
@@ -33,7 +33,7 @@ ws := WriteStream on: Unicode7 new.
   on: Error do: [:e | nil].
 ws contents`;
 
-  const raw = execute(`findRowanClassOwners(${className})`, code);
+  const raw = execute(code);
 
   const owners: RowanClassOwners = { defined: [], extended: [] };
   for (const line of raw.split('\n')) {

--- a/client/src/queries/rowan/getGemCacheKB.ts
+++ b/client/src/queries/rowan/getGemCacheKB.ts
@@ -9,10 +9,7 @@ import { QueryExecutor } from '../types';
 // GemStone reports GemTempObjCacheSize in bytes; return KB to match the
 // GEM_TEMPOBJ_CACHE_SIZE config unit. Returns undefined if it can't be read.
 export function getGemCacheKB(execute: QueryExecutor): number | undefined {
-  const raw = execute(
-    'getGemCacheKB',
-    '(System configurationAt: #GemTempObjCacheSize) // 1024',
-  ).trim();
+  const raw = execute('(System configurationAt: #GemTempObjCacheSize) // 1024').trim();
   const kb = Number(raw);
   return Number.isFinite(kb) && kb > 0 ? kb : undefined;
 }

--- a/client/src/queries/rowan/listAllRowanClasses.ts
+++ b/client/src/queries/rowan/listAllRowanClasses.ts
@@ -28,7 +28,7 @@ ws := WriteStream on: Unicode7 new.
   on: Error do: [:e | nil].
 ws contents`;
 
-  const raw = execute('listAllRowanClasses', code);
+  const raw = execute(code);
 
   const classes: RowanClassLocation[] = [];
   for (const line of raw.split('\n')) {

--- a/client/src/queries/rowan/listRowanProjects.ts
+++ b/client/src/queries/rowan/listRowanProjects.ts
@@ -40,7 +40,7 @@ names do: [:projName | | proj dirty url builtin |
      nextPutAll: builtin printString; lf].
 ws contents`;
 
-  const raw = execute('listRowanProjects', code);
+  const raw = execute(code);
   if (raw.trim() === NO_ROWAN) return { available: false, projects: [] };
 
   const projects: RowanProject[] = [];

--- a/client/src/queries/rowan/unloadRowanProject.ts
+++ b/client/src/queries/rowan/unloadRowanProject.ts
@@ -24,7 +24,7 @@ r isNil ifTrue: [^'ERR' , sep , 'Rowan is not installed in this image'].
   on: Error do: [:e | System abortTransaction. ^'ERR' , sep , e messageText].
 'OK' , sep , '${esc}'`;
 
-  const raw = execute(`unloadRowanProject(${projectName})`, code);
+  const raw = execute(code);
   const tab = raw.indexOf('\t');
   const status = tab === -1 ? raw.trim() : raw.slice(0, tab);
   const detail = tab === -1 ? '' : raw.slice(tab + 1).trim();

--- a/client/src/queries/runFailingTests.ts
+++ b/client/src/queries/runFailingTests.ts
@@ -106,7 +106,7 @@ classes do: [:cls |
       nextPutAll: 'error'; tab;
       nextPutAll: (captureMessage value: e); lf]].
 ws contents encodeAsUTF8`;
-  const data = execute('runFailingTests', code);
+  const data = execute(code);
   return splitLines(data).map((line) => {
     const parts = line.split('\t');
     return {

--- a/client/src/queries/runTestClass.ts
+++ b/client/src/queries/runTestClass.ts
@@ -61,7 +61,7 @@ result errors do: [:each |
   captureMessage value: each.
   ws lf].
 ws contents encodeAsUTF8`;
-  const data = execute(`runTestClass(${className})`, code);
+  const data = execute(code);
   return splitLines(data).map((line) => {
     const parts = line.split('\t');
     return {

--- a/client/src/queries/runTestMethod.ts
+++ b/client/src/queries/runTestMethod.ts
@@ -54,7 +54,7 @@ captured isNil
     ws tab].
 ws nextPutAll: (endMs - startMs) printString.
 ws contents encodeAsUTF8`;
-  const data = execute(`runTestMethod(${className}>>#${selector})`, code);
+  const data = execute(code);
   const parts = data.split('\t');
   return {
     className,

--- a/client/src/queries/setBreakAtStepPoint.ts
+++ b/client/src/queries/setBreakAtStepPoint.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { compiledMethodExpr, receiver } from './util';
+import { compiledMethodExpr } from './util';
 
 export function setBreakAtStepPoint(
   execute: QueryExecutor,
@@ -12,5 +12,5 @@ export function setBreakAtStepPoint(
 ): string {
   const method = compiledMethodExpr(className, isMeta, selector, environmentId, dict);
   const code = `${method} setBreakAtStepPoint: ${stepPoint}. 'ok'`;
-  return execute(`setBreak(${receiver(className, isMeta)}>>#${selector}, step:${stepPoint})`, code);
+  return execute(code);
 }

--- a/client/src/queries/setClassComment.ts
+++ b/client/src/queries/setClassComment.ts
@@ -16,9 +16,5 @@ cls ifNil: [^ 'Class not found: ${esc}'].
 cls isBehavior ifFalse: [^ 'Not a class: ${esc}'].
 cls comment: '${escapeString(comment)}'.
 'Comment set: ' , cls name`;
-  const label =
-    dict === undefined
-      ? `setClassComment(${className})`
-      : `setClassComment(${className}, dict: ${dict})`;
-  return execute(label, code);
+  return execute(code);
 }

--- a/client/src/queries/types.ts
+++ b/client/src/queries/types.ts
@@ -2,7 +2,4 @@
 // their own executor — the client wraps `browserQueries.executeFetchString`
 // (which handles logging and busy-session checks); the MCP server wraps
 // `McpSession.executeFetchString` (its own GCI session, no logging).
-//
-// The `label` is descriptive metadata used only for client-side logging.
-// Executors that don't log can ignore it.
-export type QueryExecutor = (label: string, code: string) => string;
+export type QueryExecutor = (code: string) => string;

--- a/client/src/refactoring/__tests__/classHistory.test.ts
+++ b/client/src/refactoring/__tests__/classHistory.test.ts
@@ -7,7 +7,7 @@ describe('classHistory queries', () => {
 
     getClassHistory(execute, 'Account');
 
-    expect(execute.mock.calls[0][1]).toContain("GsClassHistory forClassNamed: 'Account'");
+    expect(execute.mock.calls[0][0]).toContain("GsClassHistory forClassNamed: 'Account'");
   });
 
   it('builds a revert-to-version query', () => {
@@ -15,7 +15,7 @@ describe('classHistory queries', () => {
 
     revertClassToVersion(execute, 'Account', 2);
 
-    expect(execute.mock.calls[0][1]).toContain("revertClassNamed: 'Account' toIndex: 2");
+    expect(execute.mock.calls[0][0]).toContain("revertClassNamed: 'Account' toIndex: 2");
   });
 
   it('builds a remove-version query', () => {
@@ -23,6 +23,6 @@ describe('classHistory queries', () => {
 
     removeClassVersion(execute, 'Account', 1);
 
-    expect(execute.mock.calls[0][1]).toContain("removeVersionOf: 'Account' index: 1");
+    expect(execute.mock.calls[0][0]).toContain("removeVersionOf: 'Account' index: 1");
   });
 });

--- a/client/src/refactoring/__tests__/getClassVersions.test.ts
+++ b/client/src/refactoring/__tests__/getClassVersions.test.ts
@@ -25,7 +25,7 @@ describe('getClassVersions query', () => {
 
     getClassVersions(execute, 3);
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('classHistory');
     expect(code).toContain('hist size > 1');
     expect(code).toContain('hist indexOf: v');
@@ -37,7 +37,7 @@ describe('getClassVersions query', () => {
 
     getClassVersions(execute, 3);
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('System myUserProfile symbolList at: 3');
   });
 
@@ -46,7 +46,7 @@ describe('getClassVersions query', () => {
 
     getClassVersions(execute, 'UserGlobals');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("objectNamed: #'UserGlobals'");
   });
 

--- a/client/src/refactoring/__tests__/getDefinedClassVar.test.ts
+++ b/client/src/refactoring/__tests__/getDefinedClassVar.test.ts
@@ -20,7 +20,7 @@ describe('getDefinedClassVarNames', () => {
 
     getDefinedClassVarNames(execute, 'Account', 5);
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('symbolList at: 5');
     expect(code).toContain('ifNil: [#()]');
     expect(code).toContain('classVarNames');
@@ -31,7 +31,7 @@ describe('getDefinedClassVarNames', () => {
 
     getDefinedClassVarNames(execute, 'Account');
 
-    expect(execute.mock.calls[0][1]).toContain("objectNamed: #'Account'");
+    expect(execute.mock.calls[0][0]).toContain("objectNamed: #'Account'");
   });
 });
 
@@ -64,10 +64,10 @@ describe('getDefinedClassVarCounts', () => {
   it('scopes by index or by name in the generated query', () => {
     const byIndex = vi.fn().mockReturnValue('');
     getDefinedClassVarCounts(byIndex, 4);
-    expect(byIndex.mock.calls[0][1]).toContain('symbolList at: 4');
+    expect(byIndex.mock.calls[0][0]).toContain('symbolList at: 4');
 
     const byName = vi.fn().mockReturnValue('');
     getDefinedClassVarCounts(byName, 'MyDict');
-    expect(byName.mock.calls[0][1]).toContain("objectNamed: #'MyDict'");
+    expect(byName.mock.calls[0][0]).toContain("objectNamed: #'MyDict'");
   });
 });

--- a/client/src/refactoring/__tests__/getVisibleClassVarNames.test.ts
+++ b/client/src/refactoring/__tests__/getVisibleClassVarNames.test.ts
@@ -13,7 +13,7 @@ describe("a class's visible class-variable names", () => {
 
     getVisibleClassVarNames(execute, 'R5Demo');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('allSuperclasses');
     expect(code).toContain('classVarNames');
   });
@@ -23,7 +23,7 @@ describe("a class's visible class-variable names", () => {
 
     getVisibleClassVarNames(execute, 'R5Demo', 5);
 
-    expect(execute.mock.calls[0][1]).toContain('symbolList at: 5');
+    expect(execute.mock.calls[0][0]).toContain('symbolList at: 5');
   });
 
   it('returns nothing for an unbound class name', () => {

--- a/client/src/refactoring/__tests__/globalNameInUse.test.ts
+++ b/client/src/refactoring/__tests__/globalNameInUse.test.ts
@@ -19,7 +19,7 @@ describe('globalNameInUse query', () => {
 
     globalNameInUse(execute, 'Account');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('symbolList objectNamed:');
     expect(code).toContain("#'Account'");
   });

--- a/client/src/refactoring/__tests__/isKernelClass.test.ts
+++ b/client/src/refactoring/__tests__/isKernelClass.test.ts
@@ -19,7 +19,7 @@ describe('isKernelClass query', () => {
 
     isKernelClass(execute, 'Foo');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('Globals at:');
     expect(code).not.toContain('isModifiable');
   });

--- a/client/src/refactoring/__tests__/previewRenameClass.test.ts
+++ b/client/src/refactoring/__tests__/previewRenameClass.test.ts
@@ -78,6 +78,6 @@ describe('previewRenameClass queries', () => {
 
     clearRenameClassPreview(execute, 'tok');
 
-    expect(execute.mock.calls[0][1]).toContain("clearToken: 'tok'");
+    expect(execute.mock.calls[0][0]).toContain("clearToken: 'tok'");
   });
 });

--- a/client/src/refactoring/__tests__/previewRenameClassVar.test.ts
+++ b/client/src/refactoring/__tests__/previewRenameClassVar.test.ts
@@ -53,7 +53,7 @@ describe('previewRenameClassVar queries', () => {
 
     clearRenameClassVarPreview(execute, 'tok');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("clearToken: 'tok'");
   });
 });

--- a/client/src/refactoring/__tests__/previewRenameInstVar.test.ts
+++ b/client/src/refactoring/__tests__/previewRenameInstVar.test.ts
@@ -8,7 +8,7 @@ describe('previewRenameInstVar query', () => {
     const result = previewRenameInstVar(execute, 'Account', 'balance', 'amount');
 
     expect(result).toBe('[{"id":"1"}]');
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('GsRenameInstanceVariableRefactoring');
     expect(code).toContain("renameInstVar: 'balance'");
     expect(code).toContain("to: 'amount'");
@@ -20,7 +20,7 @@ describe('previewRenameInstVar query', () => {
 
     previewRenameInstVar(execute, 'Account', 'balance', 'amount');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("objectNamed: #'Account'");
     expect(code).not.toContain('symbolList at:');
   });
@@ -30,7 +30,7 @@ describe('previewRenameInstVar query', () => {
 
     previewRenameInstVar(execute, 'Account', 'balance', 'amount', 3);
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('(System myUserProfile symbolList at: 3)');
   });
 
@@ -40,7 +40,7 @@ describe('previewRenameInstVar query', () => {
     // Not a real ivar name, but the builder must never break the string literal.
     previewRenameInstVar(execute, 'Account', "od'd", "ne'w");
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain("renameInstVar: 'od''d'");
     expect(code).toContain("to: 'ne''w'");
   });
@@ -50,7 +50,7 @@ describe('previewRenameInstVar query', () => {
 
     previewRenameInstVar(execute, 'Account', 'balance', 'amount');
 
-    const code = execute.mock.calls[0][1];
+    const code = execute.mock.calls[0][0];
     expect(code).toContain('cls isNil ifTrue:');
   });
 });

--- a/client/src/refactoring/__tests__/previewRenameTemporary.test.ts
+++ b/client/src/refactoring/__tests__/previewRenameTemporary.test.ts
@@ -88,6 +88,6 @@ describe('rename-temporary preview queries', () => {
 
     clearRenameTemporaryPreview(exec, 'tok');
 
-    expect(exec.mock.calls[0][1]).toBe("GsRenameTemporaryRefactoring clearToken: 'tok'");
+    expect(exec.mock.calls[0][0]).toBe("GsRenameTemporaryRefactoring clearToken: 'tok'");
   });
 });

--- a/client/src/refactoring/__tests__/refactoring.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoring.integration.test.ts
@@ -36,13 +36,7 @@ describe('rename instance variable (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (code: string): string => q.executeFetchString(session(), 'refactoring-it', code);
-  // previewRenameInstVar wants a QueryExecutor `(label, code) => string` and calls it
-  // as `execute(label, code)`. Adapt to the two-arg shape (a single-arg `exec` would
-  // send the label as code), forwarding the descriptive label so query logging matches
-  // production.
-  const execQuery = (label: string, code: string): string =>
-    q.executeFetchString(session(), label, code);
+  const exec = (code: string): string => q.executeFetchString(session(), code);
 
   const engineLoaded = (): boolean => q.checkRefactoringSupportAvailable(session());
   const rbEnginePresent = (): boolean =>
@@ -103,7 +97,7 @@ describe('rename instance variable (integration)', () => {
     defineCounterHierarchy();
 
     const changes = parseRenameChanges(
-      previewRenameInstVar(execQuery, COUNTER, 'count', 'tally', userIndex()),
+      previewRenameInstVar(exec, COUNTER, 'count', 'tally', userIndex()),
     );
 
     expect(changeFor(changes, COUNTER, 'increment')?.newSource).toContain('tally := tally + 1');
@@ -117,7 +111,7 @@ describe('rename instance variable (integration)', () => {
     defineCounterHierarchy();
 
     const changes = parseRenameChanges(
-      previewRenameInstVar(execQuery, COUNTER, 'count', 'tally', userIndex()),
+      previewRenameInstVar(exec, COUNTER, 'count', 'tally', userIndex()),
     );
 
     const classDef = changes.find((c) => c.kind === 'classDefinitionEdit');
@@ -132,7 +126,7 @@ describe('rename instance variable (integration)', () => {
     defineCounterHierarchy();
     const needsCommitBefore = exec('System needsCommit printString').trim();
 
-    previewRenameInstVar(execQuery, COUNTER, 'count', 'tally', userIndex());
+    previewRenameInstVar(exec, COUNTER, 'count', 'tally', userIndex());
 
     expect(exec('System needsCommit printString').trim()).toBe(needsCommitBefore);
   });

--- a/client/src/refactoring/__tests__/refactoringClass.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringClass.integration.test.ts
@@ -38,7 +38,7 @@ describe('rename class + class history (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (code: string): string => q.executeFetchString(session(), 'rename-class-it', code);
+  const exec = (code: string): string => q.executeFetchString(session(), code);
   const asyncExec = (_label: string, code: string): Promise<string> => Promise.resolve(exec(code));
 
   const rbEnginePresent = (): boolean =>

--- a/client/src/refactoring/__tests__/refactoringClassVariable.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringClassVariable.integration.test.ts
@@ -36,8 +36,7 @@ describe('rename class variable (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (code: string): string =>
-    q.executeFetchString(session(), 'rename-classvar-it', code);
+  const exec = (code: string): string => q.executeFetchString(session(), code);
   const asyncExec = (_label: string, code: string): Promise<string> => Promise.resolve(exec(code));
 
   const rbEnginePresent = (): boolean =>

--- a/client/src/refactoring/__tests__/refactoringInstall.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInstall.test.ts
@@ -27,7 +27,7 @@ const OK_REPORT =
 
 // Default: gem can read everything, the loader file-in succeeds, the loader run
 // reports success ("OK" verdict line + a report).
-function happyPath(_s: unknown, _label: string, code: string): string {
+function happyPath(_s: unknown, code: string): string {
   if (code.includes('existsOnServer')) return 'true';
   if (code.includes('loadFromServerDir')) return `OK\n${OK_REPORT}`;
   if (code.includes('GsFileIn')) return 'ok';
@@ -88,10 +88,10 @@ describe('installRefactoringSupport', () => {
   it('files in the loader before driving it', async () => {
     const { session } = createMockSession();
     const order: string[] = [];
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('GsFileIn')) order.push('file-in');
       if (code.includes('loadFromServerDir')) order.push('run');
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     await installRefactoringSupport(session, PAYLOAD_DIR);
@@ -105,7 +105,7 @@ describe('installRefactoringSupport', () => {
     await installRefactoringSupport(session, PAYLOAD_DIR);
 
     const runCalls = executeFetchStringMock.mock.calls.filter((c) =>
-      String(c[2]).includes('loadFromServerDir'),
+      String(c[1]).includes('loadFromServerDir'),
     );
     expect(runCalls).toHaveLength(1);
   });
@@ -116,7 +116,7 @@ describe('installRefactoringSupport', () => {
     await installRefactoringSupport(session, PAYLOAD_DIR);
 
     const fileInCode = String(
-      executeFetchStringMock.mock.calls.find((c) => String(c[2]).includes('GsFileIn'))?.[2],
+      executeFetchStringMock.mock.calls.find((c) => String(c[1]).includes('GsFileIn'))?.[1],
     );
     expect(fileInCode).toContain('on: #serverUtf8File to: nil');
     expect(fileInCode).toContain(REFACTORING_LOADER_FILE);
@@ -128,7 +128,7 @@ describe('installRefactoringSupport', () => {
     await installRefactoringSupport(session, PAYLOAD_DIR);
 
     const fileInCode = String(
-      executeFetchStringMock.mock.calls.find((c) => String(c[2]).includes('GsFileIn'))?.[2],
+      executeFetchStringMock.mock.calls.find((c) => String(c[1]).includes('GsFileIn'))?.[1],
     );
     expect(fileInCode).toContain('fromServerPath:');
     expect(fileInCode).not.toContain('serverUtf8File');
@@ -136,9 +136,9 @@ describe('installRefactoringSupport', () => {
 
   it('fails clearly without running the loader when the gem cannot read the payload', async () => {
     const { session } = createMockSession();
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('existsOnServer')) return 'false';
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     const result = await installRefactoringSupport(session, PAYLOAD_DIR);
@@ -146,16 +146,16 @@ describe('installRefactoringSupport', () => {
     expect(result.success).toBe(false);
     expect(result.message).toContain('cannot read');
     const ranLoader = executeFetchStringMock.mock.calls.some((c) =>
-      String(c[2]).includes('loadFromServerDir'),
+      String(c[1]).includes('loadFromServerDir'),
     );
     expect(ranLoader).toBe(false);
   });
 
   it('rolls back and reports failure when the loader file-in raises', async () => {
     const { session, abort } = createMockSession();
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('GsFileIn')) throw new Error('compile failed');
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     const result = await installRefactoringSupport(session, PAYLOAD_DIR);
@@ -167,9 +167,9 @@ describe('installRefactoringSupport', () => {
 
   it('rolls back and reports failure when the loader cannot even run', async () => {
     const { session, abort } = createMockSession();
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('loadFromServerDir')) throw new Error('session dropped');
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     const result = await installRefactoringSupport(session, PAYLOAD_DIR);
@@ -183,9 +183,9 @@ describe('installRefactoringSupport', () => {
     const failReport =
       '[GsRefactoring]   [FAIL] Classes present -- missing: RBParser\n' +
       '[GsRefactoring] INCOMPLETE -- one or more checks failed (see above).\n';
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('loadFromServerDir')) return `FAIL\n${failReport}`;
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     const result = await installRefactoringSupport(session, PAYLOAD_DIR);
@@ -210,12 +210,12 @@ describe('installRefactoringSupport', () => {
   it('checks that the gem can read every payload file, not just the loader', async () => {
     const { session } = createMockSession();
     const checked: string[] = [];
-    executeFetchStringMock.mockImplementation((s, label, code: string) => {
+    executeFetchStringMock.mockImplementation((s, code: string) => {
       if (code.includes('existsOnServer')) {
         const f = REFACTORING_PAYLOAD_FILES.find((name) => code.includes(name));
         if (f) checked.push(f);
       }
-      return happyPath(s, label, code);
+      return happyPath(s, code);
     });
 
     await installRefactoringSupport(session, PAYLOAD_DIR);

--- a/client/src/refactoring/__tests__/refactoringMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringMethod.integration.test.ts
@@ -42,7 +42,7 @@ describe('rename method (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (code: string): string => q.executeFetchString(session(), 'rename-method-it', code);
+  const exec = (code: string): string => q.executeFetchString(session(), code);
   // The paginated query builders take an async executor; the GCI sync path is
   // fine here (small fixture), so wrap it in a resolved promise.
   const asyncExec = (_label: string, code: string): Promise<string> => Promise.resolve(exec(code));

--- a/client/src/refactoring/__tests__/refactoringTemporary.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringTemporary.integration.test.ts
@@ -40,7 +40,7 @@ describe('rename temporary/argument (integration)', () => {
   });
 
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
-  const exec = (code: string): string => q.executeFetchString(session(), 'rename-temp-it', code);
+  const exec = (code: string): string => q.executeFetchString(session(), code);
   const asyncExec = (_label: string, code: string): Promise<string> => Promise.resolve(exec(code));
 
   const rbEnginePresent = (): boolean =>

--- a/client/src/refactoring/queries/classHistory.ts
+++ b/client/src/refactoring/queries/classHistory.ts
@@ -8,10 +8,7 @@ import { escapeString } from '../../queries/util';
 // the methods added/removed/modified relative to the previous version. Built on
 // GemStone's native classHistory, so it is this-stone-only and read-only.
 export function getClassHistory(execute: QueryExecutor, className: string): string {
-  return execute(
-    `getClassHistory(${className})`,
-    `GsClassHistory forClassNamed: '${escapeString(className)}'`,
-  );
+  return execute(`GsClassHistory forClassNamed: '${escapeString(className)}'`);
 }
 
 // Restore a historical version's shape + methods as a NEW version under the
@@ -22,10 +19,7 @@ export function revertClassToVersion(
   className: string,
   index: number,
 ): string {
-  return execute(
-    `revertClassToVersion(${className} -> [${index}])`,
-    `GsClassHistory revertClassNamed: '${escapeString(className)}' toIndex: ${index}`,
-  );
+  return execute(`GsClassHistory revertClassNamed: '${escapeString(className)}' toIndex: ${index}`);
 }
 
 // Remove the version at `index` from a class's class history (it no longer
@@ -36,8 +30,5 @@ export function removeClassVersion(
   className: string,
   index: number,
 ): string {
-  return execute(
-    `removeClassVersion(${className} -> [${index}])`,
-    `GsClassHistory removeVersionOf: '${escapeString(className)}' index: ${index}`,
-  );
+  return execute(`GsClassHistory removeVersionOf: '${escapeString(className)}' index: ${index}`);
 }

--- a/client/src/refactoring/queries/getClassVersions.ts
+++ b/client/src/refactoring/queries/getClassVersions.ts
@@ -35,12 +35,8 @@ dict keysAndValuesDo: [:k :v |
     (hist notNil and: [hist size > 1]) ifTrue: [
       ws nextPutAll: k; tab; print: (hist indexOf: v); tab; print: hist size; lf]]].
 ws contents`;
-  const label =
-    typeof dict === 'number'
-      ? `getClassVersions(dictIndex: ${dict})`
-      : `getClassVersions(dictName: ${dict})`;
   const map = new Map<string, ClassVersionInfo>();
-  for (const line of splitLines(execute(label, code))) {
+  for (const line of splitLines(execute(code))) {
     const parts = line.split('\t');
     if (parts.length < 3) continue;
     const current = parseInt(parts[1], 10);

--- a/client/src/refactoring/queries/getDefinedClassVarCounts.ts
+++ b/client/src/refactoring/queries/getDefinedClassVarCounts.ts
@@ -25,12 +25,8 @@ dict keysAndValuesDo: [:k :v |
     n := [v classVarNames size] on: Error do: [:e | 0].
     ws nextPutAll: k; tab; print: n; lf]].
 ws contents`;
-  const label =
-    typeof dict === 'number'
-      ? `getDefinedClassVarCounts(dictIndex: ${dict})`
-      : `getDefinedClassVarCounts(dictName: ${dict})`;
   const map = new Map<string, number>();
-  for (const line of splitLines(execute(label, code))) {
+  for (const line of splitLines(execute(code))) {
     const tab = line.indexOf('\t');
     if (tab < 0) continue;
     map.set(line.slice(0, tab), parseInt(line.slice(tab + 1), 10) || 0);

--- a/client/src/refactoring/queries/getDefinedClassVarNames.ts
+++ b/client/src/refactoring/queries/getDefinedClassVarNames.ts
@@ -23,5 +23,5 @@ ws := WriteStream on: String new.
 (cls ifNil: [#()] ifNotNil: [:c | c classVarNames]) do: [:each |
   ws nextPutAll: each asString; lf].
 ws contents`;
-  return splitLines(execute(`getDefinedClassVarNames(${className})`, code));
+  return splitLines(execute(code));
 }

--- a/client/src/refactoring/queries/getVisibleClassVarNames.ts
+++ b/client/src/refactoring/queries/getVisibleClassVarNames.ts
@@ -23,5 +23,5 @@ chain do: [:c |
   c classVarNames do: [:each |
     ws nextPutAll: each asString; lf]].
 ws contents`;
-  return splitLines(execute(`getVisibleClassVarNames(${className})`, code));
+  return splitLines(execute(code));
 }

--- a/client/src/refactoring/queries/globalNameInUse.ts
+++ b/client/src/refactoring/queries/globalNameInUse.ts
@@ -8,7 +8,6 @@ import { escapeString } from '../../queries/util';
 export function globalNameInUse(execute: QueryExecutor, name: string): boolean {
   return (
     execute(
-      `globalNameInUse(${name})`,
       `(System myUserProfile symbolList objectNamed: #'${escapeString(name)}') notNil printString`,
     ).trim() === 'true'
   );

--- a/client/src/refactoring/queries/isKernelClass.ts
+++ b/client/src/refactoring/queries/isKernelClass.ts
@@ -13,5 +13,5 @@ export function isKernelClass(execute: QueryExecutor, name: string): boolean {
   const code = `| c |
 c := System myUserProfile symbolList objectNamed: #'${esc}'.
 (c notNil and: [c isBehavior and: [(Globals at: #'${esc}' ifAbsent: [nil]) == c]]) printString`;
-  return execute(`isKernelClass(${name})`, code).trim() === 'true';
+  return execute(code).trim() === 'true';
 }

--- a/client/src/refactoring/queries/previewRenameClass.ts
+++ b/client/src/refactoring/queries/previewRenameClass.ts
@@ -97,8 +97,5 @@ export function applyRenameClass(
 
 // Drop a finished preview from SessionTemps.
 export function clearRenameClassPreview(execute: QueryExecutor, token: string): string {
-  return execute(
-    `clearRenameClassPreview(${token})`,
-    `GsRenameClassRefactoring clearToken: '${escapeString(token)}'`,
-  );
+  return execute(`GsRenameClassRefactoring clearToken: '${escapeString(token)}'`);
 }

--- a/client/src/refactoring/queries/previewRenameClassVar.ts
+++ b/client/src/refactoring/queries/previewRenameClassVar.ts
@@ -62,8 +62,5 @@ export function applyRenameClassVar(execute: AsyncQueryExecutor, token: string):
 
 // Drop a finished preview from SessionTemps.
 export function clearRenameClassVarPreview(execute: QueryExecutor, token: string): string {
-  return execute(
-    `clearRenameClassVarPreview(${token})`,
-    `GsRenameClassVariableRefactoring clearToken: '${escapeString(token)}'`,
-  );
+  return execute(`GsRenameClassVariableRefactoring clearToken: '${escapeString(token)}'`);
 }

--- a/client/src/refactoring/queries/previewRenameInstVar.ts
+++ b/client/src/refactoring/queries/previewRenameInstVar.ts
@@ -24,5 +24,5 @@ cls isNil ifTrue: [^ 'Class not found: ${escapeString(className)}'].
   class: cls
   renameInstVar: '${escapeString(oldName)}'
   to: '${escapeString(newName)}') previewJsonString`;
-  return execute(`previewRenameInstVar(${className}, '${oldName}' -> '${newName}')`, code);
+  return execute(code);
 }

--- a/client/src/refactoring/queries/previewRenameMethod.ts
+++ b/client/src/refactoring/queries/previewRenameMethod.ts
@@ -94,8 +94,5 @@ export function applyRenameMethod(
 
 // Drop a finished preview from SessionTemps.
 export function clearRenameMethodPreview(execute: QueryExecutor, token: string): string {
-  return execute(
-    `clearRenameMethodPreview(${token})`,
-    `GsRenameMethodRefactoring clearToken: '${escapeString(token)}'`,
-  );
+  return execute(`GsRenameMethodRefactoring clearToken: '${escapeString(token)}'`);
 }

--- a/client/src/refactoring/queries/previewRenameTemporary.ts
+++ b/client/src/refactoring/queries/previewRenameTemporary.ts
@@ -99,8 +99,5 @@ export function applyRenameTemporary(execute: AsyncQueryExecutor, token: string)
 
 // Drop a finished preview from SessionTemps.
 export function clearRenameTemporaryPreview(execute: QueryExecutor, token: string): string {
-  return execute(
-    `clearRenameTemporaryPreview(${token})`,
-    `GsRenameTemporaryRefactoring clearToken: '${escapeString(token)}'`,
-  );
+  return execute(`GsRenameTemporaryRefactoring clearToken: '${escapeString(token)}'`);
 }

--- a/client/src/refactoring/refactoringInstall.ts
+++ b/client/src/refactoring/refactoringInstall.ts
@@ -132,7 +132,6 @@ export async function installRefactoringSupport(
   try {
     executeFetchString(
       session,
-      'install:refactoring-loader',
       // Must end in a byte object (a String): executeFetchString fetches the
       // result via GciTsExecuteFetchBytes, so a non-byte result raises 2103.
       `${fileInExpr(session, serverPath(REFACTORING_LOADER_FILE))}. 'ok'`,
@@ -156,7 +155,6 @@ export async function installRefactoringSupport(
   try {
     raw = executeFetchString(
       session,
-      'install:refactoring-load',
       '| ldr | ' +
         `ldr := GsRefactoringLoader loadFromServerDir: ${gsStringLiteral(payloadDir)}. ` +
         "(ldr allOk ifTrue: ['OK'] ifFalse: ['FAIL']), (String with: Character lf), ldr reportString",
@@ -220,7 +218,6 @@ function gemCanRead(session: ActiveSession, serverPath: string): boolean {
   try {
     const r = executeFetchString(
       session,
-      'gemCanRead',
       `[(GsFile existsOnServer: ${gsStringLiteral(serverPath)}) printString] ` +
         "on: Error do: [:e | 'false']",
     );

--- a/client/src/systemUserSession.ts
+++ b/client/src/systemUserSession.ts
@@ -90,8 +90,7 @@ export async function refreshWorkingSession(
 ): Promise<boolean> {
   let needsCommit: boolean | undefined;
   try {
-    needsCommit =
-      executeFetchString(base, 'needsCommit', 'System needsCommit printString').trim() === 'true';
+    needsCommit = executeFetchString(base, 'System needsCommit printString').trim() === 'true';
   } catch {
     needsCommit = undefined;
   }

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -141,8 +141,7 @@ export function registerTools(rawServer: McpServer, session: McpSession): void {
   const server = withMcpErrorMap(rawServer) as unknown as McpServer;
 
   // Bind this session into the QueryExecutor shape shared queries expect.
-  // Label is used only for client-side logging, ignored here.
-  const exec: QueryExecutor = (_label, code) => session.executeFetchString(code);
+  const exec: QueryExecutor = (code) => session.executeFetchString(code);
 
   // Tools are registered in alphabetical order.
 


### PR DESCRIPTION
## Summary
- `QueryExecutor` carried a `label: string` alongside every Smalltalk snippet, but nothing ever read it: the client executor never logged it, and the MCP server's executor discarded it outright — the labels went dark once query-level GCI logging was removed.
- Dropped `label` from the `QueryExecutor` type and updated every implementation and call site (~90 query functions under `client/src/queries/`, `browserQueries.ts`, `enhancedInspector.ts`, `extension.ts`, `mcp-server/src/tools.ts`) to the one-argument signature, removing the now-dead label-only locals/imports and updating `client/CLAUDE.md`'s convention doc to match.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile` (all three workspaces)
- [x] `npm test` (client 3320, mcp-server 95, server 322 — all passing)
- [x] `npm run test:gci` — same pre-existing failure set before and after (an unrelated 3.6.x compiler bug), confirmed via `git stash` diff