### PR TITLE
Migrate McpSession to executeAndFetchString

### DIFF
--- a/mcp-server/src/__tests__/mcpSession.test.ts
+++ b/mcp-server/src/__tests__/mcpSession.test.ts
@@ -19,13 +19,9 @@ vi.mock('../../../client/src/gciLibrary', () => {
   };
 });
 
-vi.mock('../../../client/src/gciConstants', () => ({
-  OOP_NIL: 0x14n,
-  OOP_ILLEGAL: 0x01n,
-}));
-
 import { McpSession, McpSessionConfig } from '../mcpSession';
 import { GciLibrary } from '../../../client/src/gciLibrary';
+import { GciLibraryError } from '../../../client/src/gciLibraryError';
 
 const noErr = {
   number: 0,
@@ -56,9 +52,8 @@ function createMockGci() {
       session: {},
       err: { ...noErr },
     })),
-    GciTsLogout: vi.fn(() => ({ err: { ...noErr } })),
-    GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({ data: 'result', bytesReturned: 6, err: { ...noErr } })),
+    logout: vi.fn(),
+    executeAndFetchString: vi.fn(() => 'result'),
   };
 }
 
@@ -119,62 +114,30 @@ describe('McpSession', () => {
   });
 
   describe('executeFetchString', () => {
-    it('resolves Utf8 class and executes code', () => {
+    it('executes code and returns the fetched string', () => {
       const session = new McpSession(makeConfig());
       const result = session.executeFetchString('3 + 4');
 
-      expect(mockGci.GciTsResolveSymbol).toHaveBeenCalled();
-      expect(mockGci.GciTsExecuteFetchBytes).toHaveBeenCalled();
+      expect(mockGci.executeAndFetchString).toHaveBeenCalledWith(expect.anything(), '3 + 4');
       expect(result).toBe('result');
     });
 
-    it('caches the Utf8 class OOP across calls', () => {
-      const session = new McpSession(makeConfig());
-
-      session.executeFetchString('1 + 1');
-      session.executeFetchString('2 + 2');
-
-      expect(mockGci.GciTsResolveSymbol).toHaveBeenCalledTimes(1);
-      expect(mockGci.GciTsExecuteFetchBytes).toHaveBeenCalledTimes(2);
-    });
-
-    it('throws on GCI execution error', () => {
-      const session = new McpSession(makeConfig());
-      mockGci.GciTsExecuteFetchBytes.mockReturnValue({
-        data: '',
-        bytesReturned: 0,
-        err: { ...noErr, number: 2101, message: 'MessageNotUnderstood' },
+    it('propagates errors from the underlying GCI call', () => {
+      mockGci.executeAndFetchString.mockImplementation(() => {
+        throw GciLibraryError.withMessage('MessageNotUnderstood');
       });
 
+      const session = new McpSession(makeConfig());
       expect(() => session.executeFetchString('bad code')).toThrow('MessageNotUnderstood');
-    });
-
-    it('throws on Utf8 resolve failure', () => {
-      mockGci.GciTsResolveSymbol.mockReturnValue({
-        result: 0n,
-        err: { ...noErr, number: 2023, message: 'symbol not found' },
-      });
-
-      const session = new McpSession(makeConfig());
-      expect(() => session.executeFetchString('anything')).toThrow('symbol not found');
     });
   });
 
   describe('logout', () => {
-    it('calls GciTsLogout', () => {
+    it('logs the session out', () => {
       const session = new McpSession(makeConfig());
       session.logout();
 
-      expect(mockGci.GciTsLogout).toHaveBeenCalled();
-    });
-
-    it('does not throw if logout fails', () => {
-      mockGci.GciTsLogout.mockImplementation(() => {
-        throw new Error('session already dead');
-      });
-
-      const session = new McpSession(makeConfig());
-      expect(() => session.logout()).not.toThrow();
+      expect(mockGci.logout).toHaveBeenCalledWith(expect.anything());
     });
   });
 });

--- a/mcp-server/src/mcpSession.ts
+++ b/mcp-server/src/mcpSession.ts
@@ -1,7 +1,4 @@
 import { GciLibrary } from '../../client/src/gciLibrary';
-import { OOP_NIL, OOP_ILLEGAL } from '../../client/src/gciConstants';
-
-const MAX_RESULT = 256 * 1024;
 
 export interface McpSessionConfig {
   libraryPath: string;
@@ -16,7 +13,6 @@ export interface McpSessionConfig {
 export class McpSession {
   private gci: GciLibrary;
   private handle: unknown;
-  private classUtf8Oop: bigint | undefined;
 
   constructor(config: McpSessionConfig) {
     this.gci = new GciLibrary(config.libraryPath);
@@ -37,38 +33,11 @@ export class McpSession {
     this.handle = result.session;
   }
 
-  private resolveClassUtf8(): bigint {
-    if (this.classUtf8Oop !== undefined) return this.classUtf8Oop;
-    const { result, err } = this.gci.GciTsResolveSymbol(this.handle, 'Utf8', OOP_NIL);
-    if (err.number !== 0) {
-      throw new Error(err.message || 'Cannot resolve Utf8 class');
-    }
-    this.classUtf8Oop = result;
-    return result;
-  }
-
   executeFetchString(code: string): string {
-    const oopClassUtf8 = this.resolveClassUtf8();
-    const { data, err } = this.gci.GciTsExecuteFetchBytes(
-      this.handle,
-      code,
-      -1,
-      oopClassUtf8,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      MAX_RESULT,
-    );
-    if (err.number !== 0) {
-      throw new Error(err.message || `GCI error ${err.number}`);
-    }
-    return data;
+    return this.gci.executeAndFetchString(this.handle, code);
   }
 
   logout(): void {
-    try {
-      this.gci.GciTsLogout(this.handle);
-    } catch {
-      // Session may already be dead
-    }
+    this.gci.logout(this.handle);
   }
 }


### PR DESCRIPTION
## Summary
- `McpSession` resolved the `Utf8` class OOP itself and drove `GciTsExecuteFetchBytes`/`GciTsResolveSymbol`/`GciTsLogout` directly, duplicating logic already centralized in `GciLibrary`'s ergonomic layer.
- Switched `executeFetchString`/`logout` to `GciLibrary`'s `executeAndFetchString`/`logout` helpers, removing the duplicated OOP-caching and error-handling code.
- Updated `mcpSession.test.ts` to mock the new higher-level calls instead of the old low-level ones.

## Test plan
- [x] npm run lint
- [x] npm run format:check
- [x] npm run compile
- [x] npm test (3319 client + 322 server + 92 mcp-server, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)