### PR TITLE
Migrate debugQueries.ts to executeAndFetchString

### DIFF
--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -92,6 +92,7 @@ function createMockSession(): ActiveSession {
     GciTsFetchSize: vi.fn(() => ({ result: 0n, err: { ...noErr } })),
     GciTsFetchOops: vi.fn(() => ({ oops: [], err: { ...noErr } })),
     GciTsOopIsSpecial: vi.fn(() => false),
+    executeAndFetchString: vi.fn(() => ''),
   };
 
   return {
@@ -238,17 +239,9 @@ describe('debugQueries', () => {
   describe('getMethodUriInfo', () => {
     it('parses tab-separated result into MethodUriInfo', () => {
       const session = createMockSession();
-      // Mock GciTsResolveSymbol for Utf8 class
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      // Mock GciTsExecuteFetchBytes to return tab-separated URI info
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data: 'Globals\tSmallInteger\tinstance\tarithmetic\t/',
-        err: { ...noErr },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(
+        () => 'Globals\tSmallInteger\tinstance\tarithmetic\t/',
+      );
 
       const result = debug.getMethodUriInfo(session, METHOD_OOP);
 
@@ -261,42 +254,20 @@ describe('debugQueries', () => {
       });
     });
 
-    it('returns undefined when GciTsResolveSymbol fails', () => {
+    it('returns undefined when the execute fails', () => {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 0n,
-        err: { ...noErr, number: 2010, message: 'not found' },
-      }));
-
-      expect(debug.getMethodUriInfo(session, METHOD_OOP)).toBeUndefined();
-    });
-
-    it('returns undefined when GciTsExecuteFetchBytes fails', () => {
-      const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data: '',
-        err: { ...noErr, number: 1, message: 'error' },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(() => {
+        throw new Error('error');
+      });
 
       expect(debug.getMethodUriInfo(session, METHOD_OOP)).toBeUndefined();
     });
 
     it('parses class-side methods correctly', () => {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data: 'Globals\tArray\tclass\tinstance creation\tnew',
-        err: { ...noErr },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(
+        () => 'Globals\tArray\tclass\tinstance creation\tnew',
+      );
 
       const result = debug.getMethodUriInfo(session, METHOD_OOP);
 
@@ -315,15 +286,7 @@ describe('debugQueries', () => {
 
     function sessionReturning(data: string): ActiveSession {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data,
-        err: { ...noErr },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(() => data);
       return session;
     }
 
@@ -356,15 +319,9 @@ describe('debugQueries', () => {
 
     it('returns undefined when the execute fails', () => {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data: '',
-        err: { ...noErr, number: 1, message: 'boom' },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(() => {
+        throw new Error('boom');
+      });
       expect(debug.getDoesNotUnderstandInfo(session, GS_PROCESS)).toBeUndefined();
     });
   });
@@ -374,15 +331,7 @@ describe('debugQueries', () => {
 
     function sessionReturning(data: string): ActiveSession {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data,
-        err: { ...noErr },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(() => data);
       return session;
     }
 
@@ -432,15 +381,9 @@ describe('debugQueries', () => {
 
     it('returns [] when the execute fails', () => {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data: '',
-        err: { ...noErr, number: 1, message: 'boom' },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(() => {
+        throw new Error('boom');
+      });
       expect(debug.getReceiverClassChain(session, RECEIVER_OOP, 'Object')).toEqual([]);
     });
   });
@@ -450,15 +393,7 @@ describe('debugQueries', () => {
 
     function sessionReturning(data: string): ActiveSession {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data,
-        err: { ...noErr },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(() => data);
       return session;
     }
 
@@ -496,26 +431,11 @@ describe('debugQueries', () => {
       expect(debug.getBrowseTarget(sessionReturning(''), RECEIVER_OOP, 'foo')).toBeUndefined();
     });
 
-    it('returns undefined when symbol resolution fails', () => {
-      const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 0n,
-        err: { ...noErr, number: 2010, message: 'not found' },
-      }));
-      expect(debug.getBrowseTarget(session, RECEIVER_OOP, 'foo')).toBeUndefined();
-    });
-
     it('returns undefined when the execute fails', () => {
       const session = createMockSession();
-      (session.gci as unknown as Record<string, unknown>).GciTsResolveSymbol = vi.fn(() => ({
-        result: 9000n,
-        err: { ...noErr },
-      }));
-      (session.gci as unknown as Record<string, unknown>).GciTsExecuteFetchBytes = vi.fn(() => ({
-        bytesReturned: 0,
-        data: '',
-        err: { ...noErr, number: 1, message: 'boom' },
-      }));
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(() => {
+        throw new Error('boom');
+      });
       expect(debug.getBrowseTarget(session, RECEIVER_OOP, 'foo')).toBeUndefined();
     });
   });

--- a/client/src/__tests__/enhancedInspectorPrintString.test.ts
+++ b/client/src/__tests__/enhancedInspectorPrintString.test.ts
@@ -42,24 +42,12 @@ function createPrintStringSession(
   };
 }
 
-function createFullPrintSession(data = '', resolveErrNumber = 0, execErrNumber = 0): ActiveSession {
+function createFullPrintSession(data = '', execThrows = false): ActiveSession {
   const mockGci = {
-    GciTsResolveSymbol: vi.fn(() => ({
-      result: resolveErrNumber === 0 ? 1000n : 0n,
-      err: {
-        ...noErr,
-        number: resolveErrNumber,
-        message: resolveErrNumber === 0 ? '' : 'symbol not found',
-      },
-    })),
-    GciTsExecuteFetchBytes: vi.fn(() => ({
-      data,
-      err: {
-        ...noErr,
-        number: execErrNumber,
-        message: execErrNumber === 0 ? '' : 'execution failed',
-      },
-    })),
+    executeAndFetchString: vi.fn(() => {
+      if (execThrows) throw new Error('execution failed');
+      return data;
+    }),
   };
   return {
     id: 1,
@@ -167,23 +155,17 @@ describe('fetchFullPrintString', () => {
     expect(fetchFullPrintString(session, 1000n)).toBe('this is the full print string');
   });
 
-  it('returns error string when GciTsResolveSymbol fails', () => {
+  it('surfaces the underlying error message when the execute fails', () => {
     expect.assertions(1);
-    const session = createFullPrintSession('', 2010);
-    expect(fetchFullPrintString(session, 1000n)).toBe('<error: cannot resolve Utf8>');
-  });
-
-  it('returns error string when GciTsExecuteFetchBytes fails', () => {
-    expect.assertions(1);
-    const session = createFullPrintSession('', 0, 2010);
-    expect(fetchFullPrintString(session, 1000n)).toContain('<error:');
+    const session = createFullPrintSession('', true);
+    expect(fetchFullPrintString(session, 1000n)).toBe('<error: execution failed>');
   });
 
   it('embeds the oop in emitted Smalltalk', () => {
     expect.assertions(1);
     const session = createFullPrintSession('result');
     fetchFullPrintString(session, 99999n);
-    const mockExec = session.gci.GciTsExecuteFetchBytes as ReturnType<typeof vi.fn>;
+    const mockExec = session.gci.executeAndFetchString as ReturnType<typeof vi.fn>;
     const code = mockExec.mock.calls[0][1] as string;
     expect(code).toContain('99999');
   });

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -69,6 +69,16 @@ function intToOop(session: ActiveSession, n: number): bigint {
   return result;
 }
 
+function executeAndFetchString(session: ActiveSession, code: string): string {
+  try {
+    return session.gci.executeAndFetchString(session.handle, code);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logError(session.id, msg);
+    throw e;
+  }
+}
+
 // ── Frame info ──────────────────────────────────────────
 
 export interface FrameInfo {
@@ -204,13 +214,6 @@ export function getMethodUriInfo(
   methodOop: bigint,
 ): MethodUriInfo | undefined {
   try {
-    const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
-      session.handle,
-      'Utf8',
-      OOP_NIL,
-    );
-    if (resErr.number !== 0) return undefined;
-
     const code = `| method class baseClass dictName category |
 method := Object _objectForOop: ${methodOop}.
 class := method inClass.
@@ -225,16 +228,7 @@ dictName, String tab,
   category, String tab,
   method selector asString`;
 
-    const { data, err } = session.gci.GciTsExecuteFetchBytes(
-      session.handle,
-      code,
-      -1,
-      classUtf8,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      64 * 1024,
-    );
-    if (err.number !== 0) return undefined;
+    const data = executeAndFetchString(session, code);
 
     const parts = data.split('\t');
     if (parts.length < 5) return undefined;
@@ -292,13 +286,6 @@ export function getReceiverClassChain(
   selector: string,
 ): ClassHomeInfo[] {
   try {
-    const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
-      session.handle,
-      'Utf8',
-      OOP_NIL,
-    );
-    if (resErr.number !== 0) return [];
-
     // selector is a method selector (no quotes), but guard the quote anyway.
     const sel = selector.replace(/'/g, "''");
     const code = `| rcvr meta cls sel rows nm dn impl |
@@ -319,16 +306,7 @@ rows := OrderedCollection new.
   cls := cls superclass ].
 rows inject: '' into: [:acc :r | acc isEmpty ifTrue: [r] ifFalse: [acc, (String with: Character lf), r]]`;
 
-    const { data, err } = session.gci.GciTsExecuteFetchBytes(
-      session.handle,
-      code,
-      -1,
-      classUtf8,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      64 * 1024,
-    );
-    if (err.number !== 0) return [];
+    const data = executeAndFetchString(session, code);
 
     return data
       .split('\n')
@@ -378,13 +356,6 @@ export function getBrowseTarget(
   selector: string,
 ): BrowseTarget | undefined {
   try {
-    const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
-      session.handle,
-      'Utf8',
-      OOP_NIL,
-    );
-    if (resErr.number !== 0) return undefined;
-
     const sel = selector.replace(/'/g, "''");
     const code = `| rcvr meta cls sel def dn |
 rcvr := Object _objectForOop: ${receiverOop}.
@@ -404,16 +375,8 @@ def isNil ifTrue: [ '' ] ifFalse: [
     (meta ifTrue: ['class'] ifFalse: ['instance']), String tab, dn, String tab,
     ((def categoryOfSelector: sel environmentId: 0) ifNil: ['']) ]`;
 
-    const { data, err } = session.gci.GciTsExecuteFetchBytes(
-      session.handle,
-      code,
-      -1,
-      classUtf8,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      64 * 1024,
-    );
-    if (err.number !== 0) return undefined;
+    const data = executeAndFetchString(session, code);
+
     if (data.length === 0) return undefined; // selector not found in the chain
 
     const parts = data.split('\t');
@@ -461,13 +424,6 @@ export function getDoesNotUnderstandInfo(
   gsProcess: bigint,
 ): DnuInfo | undefined {
   try {
-    const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
-      session.handle,
-      'Utf8',
-      OOP_NIL,
-    );
-    if (resErr.number !== 0) return undefined;
-
     // Walk all frames for the doesNotUnderstand:/_doesNotUnderstand:… machinery
     // (selectors containing 'doesNotUnderstand'). `dnuTop` is the `doesNotUnderstand:`
     // frame (it carries `aMessageDescriptor` — `at: 1` selector, `at: 2` args);
@@ -502,16 +458,7 @@ dnuTop isNil
       sel asString, String tab,
       (descr at: 2) size printString ]`;
 
-    const { data, err } = session.gci.GciTsExecuteFetchBytes(
-      session.handle,
-      code,
-      -1,
-      classUtf8,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      64 * 1024,
-    );
-    if (err.number !== 0) return undefined;
+    const data = executeAndFetchString(session, code);
     if (data === '') return undefined; // not parked on a doesNotUnderstand:
 
     const parts = data.split('\t');
@@ -641,8 +588,6 @@ export function fetchPrintString(
   }
 }
 
-const MAX_FULL_PRINT = 256 * 1024;
-
 /**
  * Returns the full output of printOn: for an object, bypassing GemStone's
  * internal printString size cap.  printString uses a LimitedWriteStream
@@ -650,29 +595,14 @@ const MAX_FULL_PRINT = 256 * 1024;
  */
 export function fetchFullPrintString(session: ActiveSession, oop: bigint): string {
   try {
-    const { result: classUtf8, err: classErr } = session.gci.GciTsResolveSymbol(
-      session.handle,
-      'Utf8',
-      OOP_NIL,
-    );
-    if (classErr.number !== 0) return `<error: cannot resolve Utf8>`;
     const code = `| s |
 s := WriteStream on: String new.
 (Object _objectForOop: ${oop}) printOn: s.
 s contents`;
-    const { data, err } = session.gci.GciTsExecuteFetchBytes(
-      session.handle,
-      code,
-      -1,
-      classUtf8,
-      OOP_ILLEGAL,
-      OOP_NIL,
-      MAX_FULL_PRINT,
-    );
-    if (err.number !== 0) return `<error: ${err.message}>`;
-    return data;
-  } catch {
-    return '<error getting full printString>';
+    return executeAndFetchString(session, code);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return `<error: ${msg}>`;
   }
 }
 
@@ -753,13 +683,6 @@ export function parseStackDump(data: string): StackDumpRow[] {
  * fetch returns [] (the dump then shows headings without variables).
  */
 export function fetchStackDump(session: ActiveSession, gsProcess: bigint): StackDumpRow[] {
-  const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
-    session.handle,
-    'Utf8',
-    OOP_NIL,
-  );
-  if (resErr.number !== 0) return [];
-
   // self of each row is built server-side; names/printStrings are escaped (\\ \t
   // \n \r) so the tab/newline framing is safe, and printStrings are capped so one
   // huge object can't blow the payload. `_frameContentsAt:` layout matches
@@ -809,20 +732,12 @@ depth := proc localStackDepth.
   ] on: Error do: [:e | ] ].
 out contents`;
 
-  const { data, err } = session.gci.GciTsExecuteFetchBytes(
-    session.handle,
-    code,
-    -1,
-    classUtf8,
-    OOP_ILLEGAL,
-    OOP_NIL,
-    8 * 1024 * 1024,
-  );
-  if (err.number !== 0) {
-    logError(session.id, `fetchStackDump: ${err.message || `error ${err.number}`}`);
+  try {
+    const data = executeAndFetchString(session, code);
+    return parseStackDump(data);
+  } catch {
     return [];
   }
-  return parseStackDump(data);
 }
 
 /** One variable of a single frame (receiver / instVar / arg-temp / stack-temp). */
@@ -878,13 +793,6 @@ export function fetchFrameVariables(
   gsProcess: bigint,
   serverLevel: number,
 ): FrameVarRow[] {
-  const { result: classUtf8, err: resErr } = session.gci.GciTsResolveSymbol(
-    session.handle,
-    'Utf8',
-    OOP_NIL,
-  );
-  if (resErr.number !== 0) return [];
-
   const code = `| proc out tab esc psOf row arr receiver names |
 proc := Object _objectForOop: ${gsProcess}.
 out := WriteStream on: String new.
@@ -920,20 +828,12 @@ row := [:grp :nm :obj :idx |
 ] on: Error do: [:e | ].
 out contents`;
 
-  const { data, err } = session.gci.GciTsExecuteFetchBytes(
-    session.handle,
-    code,
-    -1,
-    classUtf8,
-    OOP_ILLEGAL,
-    OOP_NIL,
-    8 * 1024 * 1024,
-  );
-  if (err.number !== 0) {
-    logError(session.id, `fetchFrameVariables: ${err.message || `error ${err.number}`}`);
+  try {
+    const data = executeAndFetchString(session, code);
+    return parseFrameVars(data);
+  } catch {
     return [];
   }
-  return parseFrameVars(data);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `getMethodUriInfo`, `getReceiverClassChain`, `getBrowseTarget`, `getDoesNotUnderstandInfo`, `fetchFullPrintString`, `fetchStackDump`, and `fetchFrameVariables` each repeated the same boilerplate (resolve the `Utf8` class, then call `GciTsExecuteFetchBytes` with the same fixed arguments) seven times over.
- They now share one local `executeAndFetchString` helper that calls the GCI library's own `executeAndFetchString`, logs any failure to the session's output channel, and re-throws so each caller's existing `try`/`catch` degrades exactly as before.
- Two things carry over unchanged, on purpose (reviewed via `/code-review` and discussed one finding at a time): no busy-session guard (matches every other function in this file), and no fetch size cap (the old 64KB/256KB/8MB limits are gone for good, since the underlying paging has no total ceiling either).
- Fixed a real regression along the way: `fetchFullPrintString` now surfaces the actual failure message instead of a fixed generic error string.

## Test plan
- [x] `npx tsc -p client/tsconfig.json --noEmit`
- [x] `npm run lint` (eslint, clean)
- [x] `npm run format:check` (prettier, clean)
- [x] `npm run test:client` (215 test files / 3827 tests passing)
- [x] Manually verified against a live GemStone 3.7.5 session: left-click opens editable `gemstone://` source, right-click → Browse resolves inherited/class-side methods correctly (including `SmallInteger>>#/`), right-click → Implement in... resolves the receiver's class chain correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)