### PR TITLE
Fix flaky forkGem test: compare stone session ids, not serial vs slot

### DIFF
--- a/client/src/__tests__/forkGem.integration.test.ts
+++ b/client/src/__tests__/forkGem.integration.test.ts
@@ -52,11 +52,19 @@ describe('forking a gem (integration)', () => {
   it('gives the new gem a session distinct from this one', (ctx) => {
     if (!supported()) return ctx.skip();
 
-    const mine = execute('GsCurrentSession currentSession serialNumber printString');
+    // Compare stone session ids, not serial numbers. forkGemRunning answers the
+    // fork's `stoneSessionId` — its slot in the session table — so this session
+    // must be read the same way (`System session`). A session's `serialNumber`
+    // is a separate counter, so comparing one against the other is meaningless:
+    // they collide by coincidence (a harness whose serial is 5 against a fork
+    // that lands in slot 5), which is exactly what made this test flaky. Both
+    // sessions are live at the moment the fork's id is read, and two live
+    // sessions can never occupy the same slot, so this comparison is now exact.
+    const mySession = execute('System session printString');
 
     const id = forkGemRunning(execute, 'System sleep: 1', gemNrs());
 
-    expect(id.trim()).not.toBe(mine.trim());
+    expect(id.trim()).not.toBe(mySession.trim());
   });
 
   it('runs the gem as the user who asked, never SystemUser', (ctx) => {


### PR DESCRIPTION
Fixes the flaky `forkGem.integration.test.ts` > "gives the new gem a session distinct from this one" (grail#88).

## Root cause
The assertion compared two different numbers:
- `mine` = this session's **serialNumber**
- `id` = the fork's **stoneSessionId** (its slot in the session table, which is what `forkGemRunning` answers)

Serial number and session slot are separate counters, so their equality is coincidental. On a 3.7.2 Health Check cell the harness's serial happened to equal the fork's slot and the test failed (`expected '6' not to be '6'`); it was green on 3.7.5/3.6.8/3.6.2 in the same run and on main at the same commit — timing, not a regression.

Reproduced deterministically on a live 3.7.5 stone: `System session`=4, `serialNumber`=5, fork `stoneSessionId`=5 — i.e. serial (5) collided with the fork's slot (5).

## Fix
Read this session's slot the same way the fork reports its own — `System session` instead of `serialNumber`. Both sessions are live at the moment the fork's id is read, and two simultaneously-live sessions can never occupy the same slot, so the comparison is now exact rather than coincidental. One functional line plus a comment recording the invariant.

## Verification
- Reproduced the collision on 3.7.5, then the fixed test passed 5x consecutively
- Full client suite green (200 files, 3729 passed, 16 skipped)
- lint / format:check / compile clean across workspaces