### PR TITLE
Tie class-sync's fetch buffer size to its chunk size

### DIFF
--- a/client/src/exportManager.ts
+++ b/client/src/exportManager.ts
@@ -206,7 +206,7 @@ export class ExportManager {
             exec,
             'manifest',
             MANIFEST_BUILD_EXPR,
-            {},
+            undefined,
             manifestStats,
             reqLog,
           );
@@ -280,7 +280,7 @@ export class ExportManager {
                 exec,
                 'content',
                 contentBuildExpr(batch),
-                {},
+                undefined,
                 contentStats,
                 reqLog,
               );

--- a/client/src/sync/__tests__/syncTransport.test.ts
+++ b/client/src/sync/__tests__/syncTransport.test.ts
@@ -38,7 +38,7 @@ describe('fetchBlob', () => {
   it('returns a payload that fits in one chunk with a single round trip', () => {
     const { exec } = makeFakeGem('small payload');
     const stats = newStats();
-    const out = fetchBlob(exec, 'manifest', 'BUILD', { chunkChars: 1000 }, stats);
+    const out = fetchBlob(exec, 'manifest', 'BUILD', 1000, stats);
     expect(out).toBe('small payload');
     expect(stats.roundTrips).toBe(1); // prepare only, nothing stored/released
     expect(stats.chars).toBe('small payload'.length);
@@ -49,7 +49,7 @@ describe('fetchBlob', () => {
     const payload = 'x'.repeat(25);
     const { exec } = makeFakeGem(payload);
     const stats = newStats();
-    const out = fetchBlob(exec, 'content', 'BUILD', { chunkChars: 10 }, stats);
+    const out = fetchBlob(exec, 'content', 'BUILD', 10, stats);
     expect(out).toBe(payload);
     // prepare + 2 fetches + release
     expect(stats.roundTrips).toBe(4);
@@ -61,7 +61,7 @@ describe('fetchBlob', () => {
   it('reassembles astral characters split across chunk boundaries by code point', () => {
     const payload = '😀😀😀😀😀'; // 5 code points, 10 UTF-16 units
     const { exec } = makeFakeGem(payload);
-    const out = fetchBlob(exec, 'content', 'BUILD', { chunkChars: 2 });
+    const out = fetchBlob(exec, 'content', 'BUILD', 2);
     expect(out).toBe(payload);
     expect([...out].length).toBe(5);
   });
@@ -69,7 +69,7 @@ describe('fetchBlob', () => {
   it('reports each request through the onRequest callback', () => {
     const { exec } = makeFakeGem('x'.repeat(25));
     const labels: string[] = [];
-    fetchBlob(exec, 'content', 'BUILD', { chunkChars: 10 }, undefined, (t) => labels.push(t.label));
+    fetchBlob(exec, 'content', 'BUILD', 10, undefined, (t) => labels.push(t.label));
     expect(labels).toEqual([
       'content:prepare',
       'content:fetch',
@@ -81,7 +81,7 @@ describe('fetchBlob', () => {
   it('handles an empty payload', () => {
     const { exec } = makeFakeGem('');
     const stats = newStats();
-    const out = fetchBlob(exec, 'manifest', 'BUILD', { chunkChars: 10 }, stats);
+    const out = fetchBlob(exec, 'manifest', 'BUILD', 10, stats);
     expect(out).toBe('');
     expect(stats.roundTrips).toBe(1);
   });

--- a/client/src/sync/syncProtocol.ts
+++ b/client/src/sync/syncProtocol.ts
@@ -33,10 +33,23 @@ export const SYNC_CHUNK_CHARS = 4_000_000;
 // each batch's payload near one chunk. The delta is processed in these groups.
 export const SYNC_REFS_PER_BATCH = 400;
 
-// Result buffer (bytes) the GCI fetch allocates. A chunk is at most
-// SYNC_CHUNK_CHARS code points; UTF-8 uses at most 4 bytes per code point, so
-// this guarantees no chunk is ever truncated mid-character.
-export const SYNC_MAX_RESULT_BYTES = SYNC_CHUNK_CHARS * 4 + 1024;
+/**
+ * The result buffer (bytes) the GCI fetch must allocate to receive a chunk of
+ * `chunkChars` code points without truncation.
+ *
+ * UTF-8 encodes any code point in at most 4 bytes, so `chunkChars * 4` bounds
+ * the encoded chunk itself; the `+ 1024` covers the small ASCII header
+ * (`serverMs \t total \n` / `serverMs \n`) that {@link prepareCode} and
+ * {@link fetchCode} prefix to each response. Always derive `maxBytes` from
+ * `chunkChars` through this function rather than choosing it independently:
+ * the two must move together, or a chunk can come back short with no error.
+ *
+ * @param chunkChars - The chunk size, in code points, that will be requested.
+ * @returns The minimum safe result-buffer size, in bytes.
+ */
+export function maxResultBytesFor(chunkChars: number): number {
+  return chunkChars * 4 + 1024;
+}
 
 // Wrap a multi-statement Smalltalk block as an expression yielding its value.
 function blockExpr(body: string): string {

--- a/client/src/sync/syncTransport.ts
+++ b/client/src/sync/syncTransport.ts
@@ -16,7 +16,7 @@ import {
   fetchCode,
   releaseCode,
   SYNC_CHUNK_CHARS,
-  SYNC_MAX_RESULT_BYTES,
+  maxResultBytesFor,
 } from './syncProtocol';
 
 export type LimitExecutor = (label: string, code: string, maxBytes: number) => string;
@@ -39,11 +39,6 @@ export interface RequestTiming {
 
 export type RequestLogger = (t: RequestTiming) => void;
 
-export interface TransportOptions {
-  chunkChars?: number;
-  maxBytes?: number;
-}
-
 export function newStats(): TransportStats {
   return { roundTrips: 0, chars: 0, serverMs: 0, wallMs: 0 };
 }
@@ -53,12 +48,11 @@ export function fetchBlob(
   exec: LimitExecutor,
   label: string,
   buildExpr: string,
-  opts: TransportOptions = {},
+  chunkChars: number = SYNC_CHUNK_CHARS,
   stats?: TransportStats,
   onRequest?: RequestLogger,
 ): string {
-  const chunkChars = opts.chunkChars ?? SYNC_CHUNK_CHARS;
-  const maxBytes = opts.maxBytes ?? SYNC_MAX_RESULT_BYTES;
+  const maxBytes = maxResultBytesFor(chunkChars);
 
   const timedExec = (lbl: string, code: string, max: number): { resp: string; wallMs: number } => {
     const t0 = Date.now();


### PR DESCRIPTION
## Summary
- `fetchBlob`'s `TransportOptions` let a caller set `chunkChars` (server-side slicing) and `maxBytes` (client fetch buffer) independently, with nothing enforcing they agreed.
- The single-shot GCI fetch this path goes through would silently truncate a chunk if `maxBytes` undershot the actual encoded size, no error raised.
- No caller was setting them independently, so `maxBytes` is now always derived from `chunkChars` via a new `maxResultBytesFor` helper, closing the gap.

## Test plan
- [x] `npx tsc -p client/tsconfig.json --noEmit`
- [x] `npx eslint` on touched files
- [x] `npx prettier --check` on touched files
- [x] `npx vitest run src/sync/__tests__/syncTransport.test.ts` (6/6 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)