### PR TITLE
Fix broken main after two PRs orphaned webview asset refs

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -70,6 +70,7 @@ client/src/**
 !client/src/refactoring/renameMethodPanelView.js
 !client/src/refactoring/renameClassEditorView.js
 !client/src/refactoring/classHistoryPanelView.js
+!client/src/refactoring/changeSignatureEditorView.js
 server/src/**
 mcp-server/src/**
 

--- a/client/src/refactoring/changeSignatureEditor.ts
+++ b/client/src/refactoring/changeSignatureEditor.ts
@@ -12,9 +12,9 @@ import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import { renderSignatureEditorHtml } from './changeSignatureEditorHtml';
 import { ChangeSignatureScope } from './queries/previewChangeSignature';
-import { readRefactoringWebviewScript } from './webviewAssets';
+import { readWebviewScript } from '../webviewAssets';
 
-const editorJs = readRefactoringWebviewScript('changeSignatureEditorView.js');
+const editorJs = readWebviewScript('changeSignatureEditorView.js', 'refactoring');
 
 export interface SignatureEditResult {
   /** New selector parts, in new (possibly reordered) order. */

--- a/client/src/refactoring/changeSignaturePanel.ts
+++ b/client/src/refactoring/changeSignaturePanel.ts
@@ -14,9 +14,9 @@ import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import { StartPreview, PreviewPage, ApplyResult } from './changeSignaturePreview';
 import { renderSignaturePanelHtml, renderSignatureCards } from './changeSignaturePanelHtml';
-import { readRefactoringWebviewScript } from './webviewAssets';
+import { readWebviewScript } from '../webviewAssets';
 
-const panelJs = readRefactoringWebviewScript('renameMethodPanelView.js');
+const panelJs = readWebviewScript('renameMethodPanelView.js', 'refactoring');
 
 export interface ChangeSignaturePanelHandlers {
   /** Fetch the page starting at `offset` (1-based). */

--- a/client/src/refactoring/extractTemporaryPanel.ts
+++ b/client/src/refactoring/extractTemporaryPanel.ts
@@ -15,9 +15,9 @@ import {
   renderExtractTemporaryPanelHtml,
   renderExtractTemporaryCards,
 } from './extractTemporaryPanelHtml';
-import { readRefactoringWebviewScript } from './webviewAssets';
+import { readWebviewScript } from '../webviewAssets';
 
-const panelJs = readRefactoringWebviewScript('renameMethodPanelView.js');
+const panelJs = readWebviewScript('renameMethodPanelView.js', 'refactoring');
 
 export interface ExtractTemporaryPanelHandlers {
   loadPage: (offset: number) => Promise<PreviewPage>;

--- a/client/src/refactoring/inlineTemporaryPanel.ts
+++ b/client/src/refactoring/inlineTemporaryPanel.ts
@@ -14,9 +14,9 @@ import {
   renderInlineTemporaryPanelHtml,
   renderInlineTemporaryCards,
 } from './inlineTemporaryPanelHtml';
-import { readRefactoringWebviewScript } from './webviewAssets';
+import { readWebviewScript } from '../webviewAssets';
 
-const panelJs = readRefactoringWebviewScript('renameMethodPanelView.js');
+const panelJs = readWebviewScript('renameMethodPanelView.js', 'refactoring');
 
 export interface InlineTemporaryPanelHandlers {
   loadPage: (offset: number) => Promise<PreviewPage>;


### PR DESCRIPTION
## Summary
- PR #315 deleted the `readRefactoringWebviewScript` wrapper and moved every call site to `readWebviewScript(name, 'refactoring')`; PR #316 landed around the same time with four new M5 change-signature files that still called the deleted wrapper. Neither PR touched the other's files, so they merged cleanly and left `main` uncompilable.
- PR #316 also added a new webview script, `changeSignatureEditorView.js`, without whitelisting it in `.vscodeignore` — it would have silently vanished from the packaged `.vsix` and broken activation.
- Switched the four orphaned files to the shared `readWebviewScript` helper and added the missing `.vscodeignore` entry.

## Test plan
- [x] `npm run compile` succeeds
- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm test` passes (client, server, mcp-server), including the `vscodeignoreShippedAssets` guard test that catches the missing whitelist entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)