### PR TITLE
Reuse cached Utf8 class oop instead of duplicate lookup

### DIFF
--- a/client/src/__tests__/executeFetchStringNb.test.ts
+++ b/client/src/__tests__/executeFetchStringNb.test.ts
@@ -15,7 +15,7 @@ function fakeSession(overrides: Record<string, unknown> = {}): ActiveSession {
     login: { stone: 'test-stone' },
     gci: {
       GciTsCallInProgress: vi.fn(() => ({ result: 0, err: { number: 0 } })),
-      GciTsResolveSymbol: vi.fn(() => ({ result: 7n, err: { number: 0 } })),
+      utf8ClassOop: vi.fn(() => 7n),
       GciTsNbExecute: vi.fn(() => ({ success: true, err: { number: 0 } })),
       isAvailable: vi.fn(() => true),
       GciTsNbPoll: vi.fn(() => ({ result: 1, err: { number: 0 } })),

--- a/client/src/__tests__/executeFetchStringWithLimit.test.ts
+++ b/client/src/__tests__/executeFetchStringWithLimit.test.ts
@@ -13,7 +13,7 @@ import { ActiveSession } from '../sessionManager';
 function makeSession(gciOverrides: Record<string, unknown> = {}): ActiveSession {
   const gci = {
     GciTsCallInProgress: vi.fn(() => ({ result: 0 })),
-    GciTsResolveSymbol: vi.fn(() => ({ result: 42n, err: { number: 0 } })),
+    utf8ClassOop: vi.fn(() => 42n),
     GciTsExecuteFetchBytes: vi.fn(() => ({ bytesReturned: 3, data: 'abc', err: { number: 0 } })),
     ...gciOverrides,
   };

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -187,9 +187,6 @@ export type { ClassVersionInfo } from './refactoring/queries/getClassVersions';
 
 const MAX_RESULT = 256 * 1024;
 
-// Cache resolved OOP_CLASS_Utf8 per session handle (Node.js strings are UTF-8 when passed via koffi)
-const classUtf8Cache = new Map<unknown, bigint>();
-
 export class BrowserQueryError extends Error {
   constructor(
     message: string,
@@ -200,15 +197,7 @@ export class BrowserQueryError extends Error {
 }
 
 function resolveClassUtf8(session: ActiveSession): bigint {
-  let oop = classUtf8Cache.get(session.handle);
-  if (oop !== undefined) return oop;
-  const { result, err } = session.gci.GciTsResolveSymbol(session.handle, 'Utf8', OOP_NIL);
-  if (err.number !== 0) {
-    throw new BrowserQueryError(err.message || `Cannot resolve Utf8 class`, err.number);
-  }
-  oop = result;
-  classUtf8Cache.set(session.handle, oop);
-  return oop;
+  return session.gci.utf8ClassOop(session.handle);
 }
 
 // Evaluates `code` and fetches its result as a UTF-8 string via


### PR DESCRIPTION
## Summary
- `browserQueries.ts` kept its own `Map` cache of the `Utf8` class oop and resolved it via the raw `GciTsResolveSymbol` call, which GemStone has flagged as leaking memory.
- Switched to the existing `session.gci.utf8ClassOop()` on `GciLibrary`, which caches the same way but resolves through the safer `resolveSymbol` path and is released via `releaseCachedUtf8Oop` on session end — matching the approach `codeExecutor.ts` already uses.
- Updated the two test mocks (`executeFetchStringNb.test.ts`, `executeFetchStringWithLimit.test.ts`) that stubbed `GciTsResolveSymbol` directly to stub `utf8ClassOop` instead, matching the new call.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile`
- [x] `npm test` (client 4059 passed, server 322 passed, mcp-server 92 passed)