### PR TITLE
Replace GciTsResolveSymbol with resolveSymbol everywhere

### DIFF
--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -627,10 +627,9 @@ describe('debugQueries', () => {
         GciTsOopToI64: vi.fn(() => ({ value: 5n, err: { ...noErr } })),
         GciTsNewString: vi.fn(() => ({ result: EXPR_STRING, err: { ...noErr } })),
         GciTsNewSymbol: vi.fn(() => ({ result: AMOUNT_SYMBOL, err: { ...noErr } })),
-        GciTsResolveSymbol: vi.fn((_h: unknown, name: string) => ({
-          result: name === 'SymbolDictionary' ? 0xd1n : name === 'SymbolList' ? 0xd2n : 0xd3n,
-          err: { ...noErr },
-        })),
+        resolveSymbol: vi.fn((_h: unknown, name: string) =>
+          name === 'SymbolDictionary' ? 0xd1n : name === 'SymbolList' ? 0xd2n : 0xd3n,
+        ),
         // Frame array size = 11 (so values start at slot 11); names array size = 1.
         GciTsFetchSize: vi.fn((_h: unknown, oop: bigint) => ({
           result: oop === NAMES_ARRAY ? 1n : 11n,
@@ -700,11 +699,11 @@ describe('debugQueries', () => {
       const session = tempSession();
       // SymbolDictionary fails to resolve → no temp dictionary can be built, so
       // buildFrameSymbolList returns null and the eval falls back to self-only.
-      (session.gci.GciTsResolveSymbol as ReturnType<typeof vi.fn>).mockImplementation(
-        (_h: unknown, name: string) =>
-          name === 'SymbolDictionary'
-            ? { result: 0n, err: { ...noErr, number: 2110, message: 'not resolved' } }
-            : { result: 0xd2n, err: { ...noErr } },
+      (session.gci.resolveSymbol as ReturnType<typeof vi.fn>).mockImplementation(
+        (_h: unknown, name: string) => {
+          if (name === 'SymbolDictionary') throw new Error('not resolved');
+          return 0xd2n;
+        },
       );
       debug.evaluateInFrame(session, GS_PROCESS, 'amount * 2', 3);
 
@@ -816,10 +815,9 @@ describe('debugQueries', () => {
         GciTsOopToI64: vi.fn(() => ({ value: 5n, err: { ...noErr } })),
         GciTsNewString: vi.fn(() => ({ result: EXPR_STRING, err: { ...noErr } })),
         GciTsNewSymbol: vi.fn(() => ({ result: AMOUNT_SYMBOL, err: { ...noErr } })),
-        GciTsResolveSymbol: vi.fn((_h: unknown, name: string) => ({
-          result: name === 'SymbolDictionary' ? 0xd1n : name === 'SymbolList' ? 0xd2n : 0xd3n,
-          err: { ...noErr },
-        })),
+        resolveSymbol: vi.fn((_h: unknown, name: string) =>
+          name === 'SymbolDictionary' ? 0xd1n : name === 'SymbolList' ? 0xd2n : 0xd3n,
+        ),
         GciTsFetchSize: vi.fn((_h: unknown, oop: bigint) => ({
           result: oop === NAMES_ARRAY ? 1n : 11n,
           err: { ...noErr },

--- a/client/src/__tests__/gci/gciAsync.test.ts
+++ b/client/src/__tests__/gci/gciAsync.test.ts
@@ -16,7 +16,7 @@ describe('GCI Async Execution, Break, and Debugging', () => {
     expect(login.session).not.toBeNull();
     session = login.session;
 
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
+    OOP_CLASS_STRING = gci.resolveSymbol(session, 'String');
   });
 
   afterAll(() => {
@@ -202,7 +202,7 @@ describe('GCI Async Execution, Break, and Debugging', () => {
     it('sends with: with: to Array non-blocking', () => {
       const oop10 = gci.GciTsI64ToOop(session, 10n).result;
       const oop20 = gci.GciTsI64ToOop(session, 20n).result;
-      const OOP_CLASS_ARRAY = gci.GciTsResolveSymbol(session, 'Array', OOP_NIL).result;
+      const OOP_CLASS_ARRAY = gci.resolveSymbol(session, 'Array');
 
       const { success } = gci.GciTsNbPerform(
         session,

--- a/client/src/__tests__/gci/gciBackupRestore.test.ts
+++ b/client/src/__tests__/gci/gciBackupRestore.test.ts
@@ -77,9 +77,7 @@ function connect(gci: GciLibrary): unknown {
 
 // The Smalltalk source is interpreted as this class; Utf8 matches production.
 function sourceClass(gci: GciLibrary, session: unknown): bigint {
-  const { result, err } = gci.GciTsResolveSymbol(session, 'Utf8', OOP_NIL);
-  if (err.number !== 0) throw new Error(`Could not resolve Utf8: ${err.message}`);
-  return result;
+  return gci.utf8ClassOop(session);
 }
 
 // Execute and surface the raw GCI error NUMBER (not just a thrown message) so the

--- a/client/src/__tests__/gci/gciCompile.test.ts
+++ b/client/src/__tests__/gci/gciCompile.test.ts
@@ -16,7 +16,7 @@ describe('GciTsCompileMethod / ClassRemoveAllMethods / ProtectMethods', () => {
     expect(login.session).not.toBeNull();
     session = login.session;
 
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
+    OOP_CLASS_STRING = gci.resolveSymbol(session, 'String');
 
     // Shared fixture: every test operates on GciTestClass, so create it once
     // here rather than relying on an earlier test to have made it (which breaks
@@ -44,8 +44,7 @@ describe('GciTsCompileMethod / ClassRemoveAllMethods / ProtectMethods', () => {
 
   describe('GciTsCompileMethod', () => {
     it('compiles an instance method successfully', () => {
-      const { result: classOop } = gci.GciTsResolveSymbol(session, 'GciTestClass', OOP_NIL);
-      expect(classOop).not.toBe(OOP_ILLEGAL);
+      const classOop = gci.resolveSymbol(session, 'GciTestClass');
 
       // Compile a method: source must be an OOP of a String
       const sourceOop = gci.GciTsNewString(session, 'testMethod\n  ^ 42');
@@ -97,8 +96,7 @@ describe('GciTsCompileMethod / ClassRemoveAllMethods / ProtectMethods', () => {
 
     it('compiles a class method with GCI_COMPILE_CLASS_METH flag', () => {
       // Resolve the test class
-      const { result: classOop } = gci.GciTsResolveSymbol(session, 'GciTestClass', OOP_NIL);
-      expect(classOop).not.toBe(OOP_ILLEGAL);
+      const classOop = gci.resolveSymbol(session, 'GciTestClass');
 
       const sourceOop = gci.GciTsNewString(session, 'classTestMethod\n  ^ #classResult');
       expect(sourceOop.result).not.toBe(OOP_ILLEGAL);
@@ -136,7 +134,7 @@ describe('GciTsCompileMethod / ClassRemoveAllMethods / ProtectMethods', () => {
     });
 
     it('returns an error for invalid method source', () => {
-      const { result: classOop } = gci.GciTsResolveSymbol(session, 'GciTestClass', OOP_NIL);
+      const classOop = gci.resolveSymbol(session, 'GciTestClass');
       const sourceOop = gci.GciTsNewString(session, '!!! not valid smalltalk method !!!');
 
       const { result, err } = gci.GciTsCompileMethod(
@@ -164,7 +162,7 @@ describe('GciTsCompileMethod / ClassRemoveAllMethods / ProtectMethods', () => {
 
   describe('GciTsClassRemoveAllMethods', () => {
     it('removes all instance methods from a class', () => {
-      const { result: classOop } = gci.GciTsResolveSymbol(session, 'GciTestClass', OOP_NIL);
+      const classOop = gci.resolveSymbol(session, 'GciTestClass');
 
       // Compile our own method so this test doesn't depend on another having
       // run first, then verify it exists before removing.

--- a/client/src/__tests__/gci/gciExecute.test.ts
+++ b/client/src/__tests__/gci/gciExecute.test.ts
@@ -18,8 +18,8 @@ describe('GciTsExecute / GciTsPerform', () => {
     expect(login.session).not.toBeNull();
     session = login.session;
 
-    OOP_CLASS_ARRAY = gci.GciTsResolveSymbol(session, 'Array', OOP_NIL).result;
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
+    OOP_CLASS_ARRAY = gci.resolveSymbol(session, 'Array');
+    OOP_CLASS_STRING = gci.resolveSymbol(session, 'String');
     console.log(
       'Class OOPs - Array:',
       OOP_CLASS_ARRAY.toString(),

--- a/client/src/__tests__/gci/gciFetchStore.test.ts
+++ b/client/src/__tests__/gci/gciFetchStore.test.ts
@@ -19,9 +19,9 @@ describe('GCI Fetch/Store Bytes and OOPs', () => {
     expect(login.session).not.toBeNull();
     session = login.session;
 
-    OOP_CLASS_ARRAY = gci.GciTsResolveSymbol(session, 'Array', OOP_NIL).result;
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
-    OOP_CLASS_BYTE_ARRAY = gci.GciTsResolveSymbol(session, 'ByteArray', OOP_NIL).result;
+    OOP_CLASS_ARRAY = gci.resolveSymbol(session, 'Array');
+    OOP_CLASS_STRING = gci.resolveSymbol(session, 'String');
+    OOP_CLASS_BYTE_ARRAY = gci.resolveSymbol(session, 'ByteArray');
     console.log(
       'Class OOPs - Array:',
       OOP_CLASS_ARRAY.toString(),

--- a/client/src/__tests__/gci/gciMisc.test.ts
+++ b/client/src/__tests__/gci/gciMisc.test.ts
@@ -17,8 +17,8 @@ describe('GCI Priority 5: NSC, PerformFetchOops, FetchGbjInfo, NewStringFromUtf1
     expect(login.session).not.toBeNull();
     session = login.session;
 
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
-    OOP_CLASS_ARRAY = gci.GciTsResolveSymbol(session, 'Array', OOP_NIL).result;
+    OOP_CLASS_STRING = gci.resolveSymbol(session, 'String');
+    OOP_CLASS_ARRAY = gci.resolveSymbol(session, 'Array');
   });
 
   afterAll(() => {
@@ -272,7 +272,7 @@ describe('GCI Priority 5: NSC, PerformFetchOops, FetchGbjInfo, NewStringFromUtf1
 
       // Verify the class is Unicode7 (not String)
       const classOop = gci.GciTsFetchClass(session, result);
-      const { result: unicode7Oop } = gci.GciTsResolveSymbol(session, 'Unicode7', OOP_NIL);
+      const unicode7Oop = gci.resolveSymbol(session, 'Unicode7');
       expect(classOop.result).toBe(unicode7Oop);
 
       const fetched = gci.GciTsFetchUtf8(session, result, 1024);

--- a/client/src/__tests__/gci/gciObjects.test.ts
+++ b/client/src/__tests__/gci/gciObjects.test.ts
@@ -298,44 +298,6 @@ describe('GCI Object Creation and Inquiry', () => {
     });
   });
 
-  describe('GciTsResolveSymbol', () => {
-    it('resolves "Array" to a class OOP', () => {
-      const { result, err } = gci.GciTsResolveSymbol(session, 'Array', OOP_NIL);
-      console.log('ResolveSymbol("Array") - result:', result.toString(), 'err.number:', err.number);
-      expect(result).not.toBe(OOP_ILLEGAL);
-      expect(err.number).toBe(0);
-
-      // The resolved OOP should be a class - verify it exists
-      expect(gci.GciTsObjExists(session, result)).toBe(true);
-    });
-
-    it('resolves "String" to the same class OOP we discovered', () => {
-      const { result } = gci.GciTsResolveSymbol(session, 'String', OOP_NIL);
-      expect(result).toBe(OOP_CLASS_STRING);
-    });
-
-    it('resolves "Symbol" to the same class OOP we discovered', () => {
-      const { result } = gci.GciTsResolveSymbol(session, 'Symbol', OOP_NIL);
-      expect(result).toBe(OOP_CLASS_SYMBOL);
-    });
-
-    it('resolves "ByteArray" to the same class OOP we discovered', () => {
-      const { result } = gci.GciTsResolveSymbol(session, 'ByteArray', OOP_NIL);
-      expect(result).toBe(OOP_CLASS_BYTE_ARRAY);
-    });
-
-    it('returns OOP_ILLEGAL for a non-existent name', () => {
-      const { result, err } = gci.GciTsResolveSymbol(session, 'NoSuchClassXyz123', OOP_NIL);
-      console.log(
-        'ResolveSymbol(nonexistent) - result:',
-        result.toString(),
-        'err.number:',
-        err.number,
-      );
-      expect(result).toBe(OOP_ILLEGAL);
-    });
-  });
-
   describe('GciTsResolveSymbolObj', () => {
     it('resolves a Symbol OOP for "Array" to the Array class', () => {
       const { result: symOop } = gci.GciTsNewSymbol(session, 'Array');
@@ -351,7 +313,7 @@ describe('GCI Object Creation and Inquiry', () => {
       expect(result).not.toBe(OOP_ILLEGAL);
 
       // Should match what ResolveSymbol returns
-      const { result: expected } = gci.GciTsResolveSymbol(session, 'Array', OOP_NIL);
+      const expected = gci.resolveSymbol(session, 'Array');
       expect(result).toBe(expected);
     });
   });

--- a/client/src/__tests__/gci/gciTraversal.test.ts
+++ b/client/src/__tests__/gci/gciTraversal.test.ts
@@ -16,7 +16,7 @@ describe('GCI Traversal Functions', () => {
     expect(login.session).not.toBeNull();
     session = login.session;
 
-    OOP_CLASS_STRING = gci.GciTsResolveSymbol(session, 'String', OOP_NIL).result;
+    OOP_CLASS_STRING = gci.resolveSymbol(session, 'String');
   });
 
   afterAll(() => {

--- a/client/src/__tests__/gci/queryHarness.ts
+++ b/client/src/__tests__/gci/queryHarness.ts
@@ -47,12 +47,7 @@ export function login(): HarnessSession {
     );
   }
   const handle = result.session;
-  const utf8Class = gci.GciTsResolveSymbol(handle, 'Utf8', OOP_NIL);
-  if (utf8Class.err.number !== 0) {
-    gci.GciTsLogout(handle);
-    throw new Error(`Could not resolve Utf8 class: ${utf8Class.err.message}`);
-  }
-  const utf8Oop = utf8Class.result;
+  const utf8Oop = gci.utf8ClassOop(handle);
 
   const exec: QueryExecutor = (code) => {
     const { data, err } = gci.GciTsExecuteFetchBytes(

--- a/client/src/__tests__/gci/rowanExportFixpoint.test.ts
+++ b/client/src/__tests__/gci/rowanExportFixpoint.test.ts
@@ -46,7 +46,7 @@ function loginSystemUser(): SysSession {
     throw new Error(`SystemUser login failed: ${r.err.message || `error ${r.err.number}`}`);
   }
   const handle = r.session;
-  const utf8 = gci.GciTsResolveSymbol(handle, 'Utf8', OOP_NIL).result;
+  const utf8 = gci.utf8ClassOop(handle);
   const exec: QueryExecutor = (code) => {
     const { data, err } = gci.GciTsExecuteFetchBytes(
       handle,

--- a/client/src/__tests__/smalltalkNotebookController.test.ts
+++ b/client/src/__tests__/smalltalkNotebookController.test.ts
@@ -22,7 +22,6 @@ import { SessionManager } from '../sessionManager';
 function makeGci(overrides: Record<string, unknown> = {}) {
   return {
     GciTsCallInProgress: vi.fn(() => ({ result: 0, err: { number: 0 } })),
-    GciTsResolveSymbol: vi.fn(() => ({ result: 100n, err: { number: 0 } })),
     GciTsNbExecute: vi.fn((..._args: unknown[]) => ({
       success: true,
       err: { number: 0, message: '' },

--- a/client/src/__tests__/stepping.integration.test.ts
+++ b/client/src/__tests__/stepping.integration.test.ts
@@ -38,7 +38,7 @@ describe('debugger single-stepping (integration)', () => {
   const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
 
   const exec = (code: string, flags: number) => {
-    const { result: strClass } = gci.GciTsResolveSymbol(handle, 'String', OOP_NIL);
+    const strClass = gci.resolveSymbol(handle, 'String');
     return gci.GciTsExecute(handle, code, strClass, OOP_ILLEGAL, OOP_NIL, flags, 0);
   };
 

--- a/client/src/__tests__/sunitQueries.test.ts
+++ b/client/src/__tests__/sunitQueries.test.ts
@@ -10,20 +10,8 @@ import { ActiveSession } from '../sessionManager';
 import { GemStoneLogin } from '../loginTypes';
 import * as sunit from '../sunitQueries';
 
-const noErr = {
-  number: 0,
-  message: '',
-  context: 0n,
-  category: 0,
-  fatal: false,
-  argCount: 0,
-  exceptionObj: 0n,
-  args: [],
-};
-
 function createMockSession(executeFetchData = ''): ActiveSession {
   const mockGci = {
-    GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
     executeAndFetchString: vi.fn(() => executeFetchData),
     GciTsCallInProgress: vi.fn(() => ({ result: 0 })),
   };

--- a/client/src/commands/__tests__/findMethodInClass.test.ts
+++ b/client/src/commands/__tests__/findMethodInClass.test.ts
@@ -34,7 +34,6 @@ const methodListPayload = '0\tprinting\tfoo\n1\taccessing\tbar\n';
 
 function createMockSession(): ActiveSession {
   const mockGci = {
-    GciTsResolveSymbol: vi.fn(() => ({ result: 1000n, err: { ...noErr } })),
     GciTsPerform: vi.fn(() => ({ result: 2000n, err: { ...noErr } })),
     GciTsNewString: vi.fn(() => ({ result: 3000n, err: { ...noErr } })),
     GciTsNewSymbol: vi.fn(() => ({ result: 4000n, err: { ...noErr } })),

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -1395,9 +1395,11 @@ export function releaseObjs(session: ActiveSession, oops: bigint[]): void {
 
 /** Resolve a global (e.g. a class name) to its OOP; null if it doesn't resolve. */
 function resolveGlobalOop(session: ActiveSession, name: string): bigint | null {
-  const { result, err } = session.gci.GciTsResolveSymbol(session.handle, name, OOP_NIL);
-  if (err.number !== 0) return null;
-  return result;
+  try {
+    return session.gci.resolveSymbol(session.handle, name);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/client/src/enhancedInspector/__tests__/enhancedInspectorRouting.integration.test.ts
+++ b/client/src/enhancedInspector/__tests__/enhancedInspectorRouting.integration.test.ts
@@ -14,8 +14,6 @@ import {
 } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
 
-const OOP_NIL = 0x14n;
-
 /**
  * Integration tests for the unified "Inspect It" routing: it opens the Enhanced
  * Inspector when the session reports it as available, and otherwise falls back
@@ -76,8 +74,7 @@ describe('inspect it routing (integration)', () => {
   it('the classic-inspector fallback reads a live object through the real queries', (ctx) => {
     requireServerPluginFeatureAbsent(pluginFeatures.enhancedInspector, ctx, session());
 
-    const { result: globalsOop, err } = gci.GciTsResolveSymbol(handle, 'Globals', OOP_NIL);
-    expect(err.number).toBe(0);
+    const globalsOop = gci.resolveSymbol(handle, 'Globals');
 
     expect(debug.getObjectClassName(session(), globalsOop)).toBe('SymbolDictionary');
     expect(debug.getObjectPrintString(session(), globalsOop, 1024).length).toBeGreaterThan(0);

--- a/client/src/enhancedInspector/enhancedInspectorPerfTracker.ts
+++ b/client/src/enhancedInspector/enhancedInspectorPerfTracker.ts
@@ -38,7 +38,6 @@ const ROUND_TRIP_METHODS = new Set([
   'GciTsIsKindOfClass',
   'GciTsIsSubclassOfClass',
   'GciTsObjExists',
-  'GciTsResolveSymbol',
   'GciTsResolveSymbolObj',
   'GciTsNewObj',
   'GciTsNewByteArray',
@@ -73,6 +72,7 @@ const ROUND_TRIP_METHODS = new Set([
   'GciTsClearStack',
   'GciTsGemTrace',
   'GciTsContinueWith',
+  'GciTsContinueWithAsync',
   'GciTsWaitForEvent',
   'GciTsCancelWaitForEvent',
   'GciTsKeepAliveCount',
@@ -160,18 +160,32 @@ export const enhancedInspectorPerfTracker: EnhancedInspectorPerfTracker = {
   },
 };
 
+/**
+ * Wraps `gci` in a Proxy that increments {@link enhancedInspectorPerfTracker}
+ * for every call to a method in {@link ROUND_TRIP_METHODS}.
+ *
+ * Methods returned from the `get` trap are bound to `receiver` (the proxy
+ * itself), not `target`. Ergonomic GciLibrary methods (e.g. `resolveSymbol`)
+ * make their own nested calls to raw `GciTsXxx` round trips via `this`;
+ * binding to `receiver` means a nested `this.GciTsXxx()` call re-enters this
+ * same `get` trap and gets tracked individually, instead of silently
+ * bypassing it by running on the unwrapped `target`. This is safe because
+ * `GciLibrary` has no real `#`-private fields (only compile-time-only TS
+ * `private`) and this proxy defines no `set` trap, so property reads/writes
+ * still resolve to the one real `target` object either way.
+ */
 export function wrapWithEnhancedInspectorPerfProxy(gci: GciLibrary): GciLibrary {
   return new Proxy(gci, {
-    get(target, prop: string | symbol) {
+    get(target, prop: string | symbol, receiver) {
       const val = (target as unknown as Record<string, unknown>)[prop as string];
       if (typeof val === 'function' && ROUND_TRIP_METHODS.has(prop as string)) {
         return (...args: unknown[]) => {
           enhancedInspectorPerfTracker.increment(prop as string);
-          return (val as (...a: unknown[]) => unknown).apply(target, args);
+          return (val as (...a: unknown[]) => unknown).apply(receiver, args);
         };
       }
       return typeof val === 'function'
-        ? (val as (...args: unknown[]) => unknown).bind(target)
+        ? (val as (...args: unknown[]) => unknown).bind(receiver)
         : val;
     },
   });

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -239,7 +239,6 @@ export class GciLibrary {
   private _GciTsIsKindOfClass: koffi.KoffiFunction;
   private _GciTsIsSubclassOfClass: koffi.KoffiFunction;
   private _GciTsObjExists: koffi.KoffiFunction;
-  private _GciTsResolveSymbol: koffi.KoffiFunction;
   private _GciTsResolveSymbolObj: koffi.KoffiFunction;
   private _GciTsExecute: koffi.KoffiFunction;
   private _GciTsExecute_: koffi.KoffiFunction;
@@ -493,9 +492,6 @@ export class GciLibrary {
       `int GciTsIsSubclassOfClass(GciSessionPtr, ${OopType}, ${OopType}, _Out_ GciErrSType *)`,
     );
     this._GciTsObjExists = this.lib.func(`int GciTsObjExists(GciSessionPtr, ${OopType})`);
-    this._GciTsResolveSymbol = this.lib.func(
-      `${OopType} GciTsResolveSymbol(GciSessionPtr, const char *, ${OopType}, _Out_ GciErrSType *)`,
-    );
     this._GciTsResolveSymbolObj = this.lib.func(
       `${OopType} GciTsResolveSymbolObj(GciSessionPtr, ${OopType}, ${OopType}, _Out_ GciErrSType *)`,
     );
@@ -1256,16 +1252,6 @@ export class GciLibrary {
 
   GciTsObjExists(session: unknown, obj: bigint): boolean {
     return this._GciTsObjExists(session, obj) !== 0;
-  }
-
-  GciTsResolveSymbol(
-    session: unknown,
-    str: string,
-    symbolList: bigint,
-  ): { result: bigint; err: GciError } {
-    const err: Record<string, unknown> = {};
-    const raw = this._GciTsResolveSymbol(session, str, symbolList, err);
-    return { result: toBigInt(raw), err: err as unknown as GciError };
   }
 
   GciTsResolveSymbolObj(
@@ -2349,17 +2335,21 @@ export class GciLibrary {
 
   /**
    * Resolves a symbol name to its OOP using the user's symbol list
-   * (UserGlobals, Globals, and Published).
+   * (UserGlobals, Globals, and Published). This is the only supported way to
+   * resolve a symbol by name. Always go through this method (or
+   * {@link utf8ClassOop} for the `Utf8` class specifically) rather than
+   * binding the GCI call directly.
    *
    * Equivalent to evaluating `Smalltalk at: #symbol` in GemStone. This method
    * does not cache (`Utf8` is the one exception: it's cached separately by
    * {@link utf8ClassOop}).
    *
    * Goes through `createString` + `GciTsResolveSymbolObj` + `releaseObject`
-   * (three GCI round-trips) rather than the single-call `GciTsResolveSymbol`
-   * (which takes the name as a raw C string). `GciTsResolveSymbol` has a
-   * known memory leak that the GemStone team is currently investigating —
-   * use this slower path until that's fixed. See TODO.md.
+   * (three GCI round-trips) rather than the single-call `GciTsResolveSymbol`,
+   * which takes the name as a raw C string and is NOT bound here on purpose:
+   * it has a known memory leak that the GemStone team is currently
+   * investigating. Use this slower-but-safe path until that's fixed. See
+   * TODO.md.
    *
    * @param session - The GemStone session to operate in.
    * @param symbolName - The name to resolve (e.g. `'Object'`, `'Utf8'`).


### PR DESCRIPTION
## Summary

- `GciTsResolveSymbol` (the raw GCI binding for resolving a class/global
  by name) has a known memory leak the GemStone team is still
  investigating. Every call site that used it directly now goes
  through `resolveSymbol` (or `utf8ClassOop` for the cached `Utf8`
  lookup) instead, which resolves the same name via `createString` +
  `GciTsResolveSymbolObj` + `releaseObject` (three round trips, no
  leak). The raw binding and its koffi handle are deleted outright
  since nothing calls it anymore.
- Code review of this change turned up one real regression, which is
  fixed here: `wrapWithEnhancedInspectorPerfProxy` bound wrapped
  `GciLibrary` methods to the raw proxy target instead of the `get`
  trap's `receiver`, so `resolveSymbol`'s own internal round trips ran
  unproxied and silently dropped out of the Enhanced Inspector perf
  counter. Binding to `receiver` lets those nested calls re-enter the
  trap and get tracked individually.
- Also folded in along the way: `GciTsContinueWithAsync` was missing
  from the perf tracker's round-trip list despite driving the same
  wire call as the already-tracked `GciTsContinueWith`; two dead
  `expect(classOop).not.toBe(OOP_ILLEGAL)` assertions in
  `gciCompile.test.ts` were removed since `resolveSymbol` now throws
  instead of returning a sentinel value; and an em dash was removed
  from `resolveSymbol`'s JSDoc.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile`
- [x] `npm test` (240 client files / 4059 tests, 12 server files / 322
      tests, 3 mcp-server files / 92 tests, all passing)
- [x] `npm run test:gci -- --testNamePattern GciTsCompileMethod` (the
      file with the removed dead assertions, against a live stone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)