### PR TITLE
Enable merge queue triggers for health-check workflow

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,6 +1,10 @@
 name: Health Check
 
-on: push
+on:
+  push:
+    branches: [main, '*/wip/*']
+  pull_request:
+  merge_group:
 
 # zizmor(excessive-permissions): an explicit permissions block is required
 # instead of relying on the default GITHUB_TOKEN scope


### PR DESCRIPTION
## Summary
- Scope the `push` trigger on `health-check.yml` to `main`, and add `pull_request` and `merge_group` triggers so required checks run on PRs and when a PR enters the merge queue.
- Allow `push` on branches named `<name>/wip/<something>`: if you need to push and run CI without opening a draft PR yet, use that pattern in the branch name.
