### PR TITLE
Report tests skipped in every CI suite run

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -158,11 +158,37 @@ jobs:
           GEMSTONE_VERSION: ${{ matrix.gemstone-version }}
         run: npm run test:server:start -- "$GEMSTONE_VERSION"
       - name: Run tests (without server plugin)
+        # zizmor(template-injection): bind the untrusted matrix values to an
+        # env var instead of interpolating ${{ }} directly into the script
+        env:
+          VITEST_JSON_OUTPUT: ${{ github.workspace }}/test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare.json
         run: npm test
+      - name: Upload skip report (without server plugin)
+        if: always()
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare
+          path: test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare.json
+          if-no-files-found: ignore
       - name: Install server plugin
         run: node client/bin/install-server-plugin.mjs
       - name: Run tests (with server plugin)
+        # zizmor(template-injection): bind the untrusted matrix values to an
+        # env var instead of interpolating ${{ }} directly into the script
+        env:
+          VITEST_JSON_OUTPUT: ${{ github.workspace }}/test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin.json
         run: npm test
+      - name: Upload skip report (with server plugin)
+        if: always()
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin
+          path: test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin.json
+          if-no-files-found: ignore
 
   # Single stable check for branch protection / the merge queue to require.
   # The matrix job's own check names embed the matrix values, so requiring
@@ -179,9 +205,9 @@ jobs:
     steps:
       - name: Verify all CI jobs succeeded
         run: |
-          if [ "${{ needs.prepare.result }}" != "success" ] || 
-            [ "${{ needs.lint-workflows.result }}" != "success" ] || 
-            [ "${{ needs.lint.result }}" != "success" ] || 
+          if [ "${{ needs.prepare.result }}" != "success" ] ||
+            [ "${{ needs.lint-workflows.result }}" != "success" ] ||
+            [ "${{ needs.lint.result }}" != "success" ] ||
             [ "${{ needs.health-check.result }}" != "success" ]; then
             echo "prepare=${{ needs.prepare.result }}"
             echo "lint-workflows=${{ needs.lint-workflows.result }}"
@@ -189,3 +215,44 @@ jobs:
             echo "health-check=${{ needs.health-check.result }}"
             exit 1
           fi
+
+  # Report-only, first step toward a future gate: aggregates the per-suite-run
+  # JSON reports (one per GemStone version x bare/plugin run) to find tests that
+  # are skipped (ctx.skip / it.skip / .todo) in every suite run — i.e. never
+  # actually executed anywhere — and posts them to the job summary. Never fails
+  # the build; see summarize-skipped-tests.mjs. Deliberately independent of
+  # ci-complete: it's report-only and never fails, so branch protection / the
+  # merge queue neither waits for it nor cares about its outcome.
+  report-skips:
+    name: Skipped tests report
+    timeout-minutes: 1
+    needs: [prepare, health-check]
+    if: always()
+    runs-on: ubuntu-latest
+    # download-artifact needs actions:read to list/fetch artifacts from this
+    # run; the top-level contents:read block doesn't cover that
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: |
+            scripts/summarize-skipped-tests.mjs
+          sparse-checkout-cone-mode: false
+          # zizmor(artipacked): checkout must not persist the token past
+          # this job
+          persist-credentials: false
+      - name: Download skip reports
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: skips-*
+          path: test-results
+          merge-multiple: true
+      - name: Summarize skipped tests
+        run: node scripts/summarize-skipped-tests.mjs test-results

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ gemstone
 .gemstone/
 tsconfig.tsbuildinfo
 .gemstone
+test-results/
 
 # Claude Code: everything under .claude/ is personal/machine-local runtime state
 # by default (locks, checkpoints, mailbox, routines, daemon/registry state, …).

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -63,6 +63,22 @@ export default defineConfig({
       seed: shuffleSeed,
       sequencer: SeededSequencer,
     },
+    // CI sets VITEST_JSON_OUTPUT (an absolute path — workspaces run in their
+    // own cwd, so a relative outputFile resolved against the config dir would
+    // be fragile) to also emit a machine-readable JSON report alongside the
+    // normal console output, which health-check.yml's report-skips job
+    // aggregates across matrix cells to find tests skipped everywhere. Local
+    // `npm test` leaves this unset, so its output is unchanged (the key must
+    // be omitted, not set to undefined — vitest requires `reporters` to be
+    // iterable when the key is present at all).
+    ...(process.env.VITEST_JSON_OUTPUT
+      ? {
+          reporters: [
+            ['default'],
+            ['json', { outputFile: process.env.VITEST_JSON_OUTPUT }],
+          ] as const,
+        }
+      : {}),
     projects: [
       {
         test: {

--- a/scripts/summarize-skipped-tests.mjs
+++ b/scripts/summarize-skipped-tests.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+//
+// Aggregates the per-suite-run Vitest JSON reports produced by health-check.yml's
+// matrix (client/vitest.config.ts, gated by VITEST_JSON_OUTPUT) to find tests
+// that are skipped/pending/todo in EVERY suite run they appear in — i.e. never
+// actually executed anywhere. Report-only: this never fails the build. A
+// future gate can reuse the same intersection and flip the exit condition.
+//
+//   node scripts/summarize-skipped-tests.mjs <dir-of-json-reports>
+//
+// Writes Markdown to $GITHUB_STEP_SUMMARY (falls back to stdout when unset,
+// for local runs).
+
+import { readdirSync, readFileSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SKIPPED_STATUSES = new Set(['skipped', 'pending', 'todo']);
+
+function findReportFiles(dir) {
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(dir, name));
+}
+
+function collectTestStats(reportFiles) {
+  const stats = new Map();
+
+  for (const reportFile of reportFiles) {
+    const report = JSON.parse(readFileSync(reportFile, 'utf8'));
+
+    for (const testResult of report.testResults ?? []) {
+      for (const assertion of testResult.assertionResults ?? []) {
+        const key = `${testResult.name} ${assertion.fullName}`;
+        const entry = stats.get(key) ?? {
+          file: testResult.name,
+          fullName: assertion.fullName,
+          seen: 0,
+          skipped: 0,
+        };
+        entry.seen += 1;
+        if (SKIPPED_STATUSES.has(assertion.status)) {
+          entry.skipped += 1;
+        }
+        stats.set(key, entry);
+      }
+    }
+  }
+
+  return stats;
+}
+
+function renderSummary(stats) {
+  const entries = [...stats.values()];
+  const alwaysSkipped = entries
+    .filter((entry) => entry.seen > 0 && entry.skipped === entry.seen)
+    .sort((a, b) => a.file.localeCompare(b.file) || a.fullName.localeCompare(b.fullName));
+  const skippedSomewhere = entries.filter((entry) => entry.skipped > 0);
+
+  const lines = ['## Skipped tests report', ''];
+
+  if (alwaysSkipped.length === 0) {
+    lines.push('✅ No test is skipped in every suite run.', '');
+  } else {
+    lines.push(
+      `⚠️ **${alwaysSkipped.length} test${alwaysSkipped.length === 1 ? '' : 's'} skipped in every suite run (never executed anywhere).**`,
+      '',
+      '| Test | File |',
+      '| --- | --- |',
+    );
+    for (const entry of alwaysSkipped) {
+      lines.push(`| ${entry.fullName} | ${entry.file} |`);
+    }
+    lines.push('');
+  }
+
+  lines.push(
+    `<sub>${entries.length} distinct tests across suite runs; ${skippedSomewhere.length} skipped in at least one.</sub>`,
+    '',
+  );
+  return lines.join('\n');
+}
+
+function main() {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error('Usage: node summarize-skipped-tests.mjs <dir-of-json-reports>');
+    process.exit(0);
+    return;
+  }
+
+  const reportFiles = findReportFiles(dir);
+  const stats = collectTestStats(reportFiles);
+  const summary = renderSummary(stats);
+
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryFile) {
+    appendFileSync(summaryFile, summary);
+  } else {
+    console.log(summary);
+  }
+
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Goal
Automatically detect tests that are skipped across all suite runs we execute in CI. We don't fail the build for now because it's expected that some of the tests are still skipped while we improve our CI test infrastructure. But at some point we'll be able to fail the build if tests are skipped across all suite runs.

## Summary
- Client suite emits a per-suite-run JSON report (gated by `VITEST_JSON_OUTPUT`, so local `npm test` is unaffected)
- New `report-skips` job intersects all suite runs' reports to find tests skipped everywhere (never actually executed) and posts the list to the job summary, with a ✅/⚠️ headline so it's immediately clear whether anything needs attention
- Report-only — never fails the build; lays the backbone for a future gate

## Screenshots

<img width="2156" height="1298" alt="image" src="https://github.com/user-attachments/assets/ae1d6e11-86fb-4423-9a4c-206d8d0cc60f" />

<img width="2122" height="512" alt="image" src="https://github.com/user-attachments/assets/2de0caea-3d1c-4de2-8e89-f059b85fbdb9" />



## Test plan
- [x] Aggregator verified locally against hand-crafted JSON fixtures (always-skipped vs. partially-skipped)
- [x] Reporter wiring verified locally (with/without `VITEST_JSON_OUTPUT`, identical console output either way)
- [x] Confirm the `report-skips` job's Summary renders correctly on this PR's CI run, and the Node-floor smoke suite run's artifact name doesn't collide with the dev suite run's