### PR TITLE
M7/M8: Push Up / Push Down Method refactorings

### DIFF
--- a/client/src/__tests__/explorerPushMethod.test.ts
+++ b/client/src/__tests__/explorerPushMethod.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+// The controller module pulls in browserQueries (→ native GCI). Stub it; this test spies
+// out every controller method that would touch it (reveal / reload / close-stale-editors).
+vi.mock('../browserQueries', () => ({}));
+vi.mock('../refactoring/pushMethodCommand', () => ({ pushMethod: vi.fn() }));
+
+import { ExplorerController } from '../gemstoneExplorer';
+import { pushMethod } from '../refactoring/pushMethodCommand';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+import type { PushOutcome } from '../refactoring/pushMethodCommand';
+
+/**
+ * Drives ExplorerController.pushMethod — the reveal-vs-reload branch after a push. Mocks the
+ * pushMethod command and spies the controller's own navigation methods, so the test pins the
+ * wiring (which side effect fires for which outcome) without a live tree or stone.
+ */
+
+const ITEM = { info: { selector: 'wildStatus' }, isMeta: false } as never;
+
+function makeController(session: ActiveSession | undefined) {
+  const sessionManager = {
+    getSelectedSession: () => session,
+  } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.className = 'Sub';
+  ctl.state.dictName = 'UserGlobals';
+  ctl.state.dictIndex = 1;
+  const reveal = vi
+    .spyOn(ctl as unknown as { revealClass: () => Promise<void> }, 'revealClass')
+    .mockResolvedValue();
+  const reload = vi
+    .spyOn(ctl as unknown as { reloadCurrentClassMethods: () => void }, 'reloadCurrentClassMethods')
+    .mockImplementation(() => {});
+  const closeStale = vi
+    .spyOn(
+      ctl as unknown as { closeStaleSourceMethodEditors: () => Promise<void> },
+      'closeStaleSourceMethodEditors',
+    )
+    .mockResolvedValue();
+  return { ctl, reveal, reload, closeStale };
+}
+
+const outcome = (over: Partial<PushOutcome> = {}): PushOutcome => ({
+  applied: 2,
+  moved: ['wildStatus'],
+  targetClass: 'Super',
+  revealClass: 'Super',
+  isMeta: false,
+  ...over,
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('ExplorerController.pushMethod', () => {
+  it('does nothing when there is no selected session', async () => {
+    const { ctl, reveal, reload } = makeController(undefined);
+
+    await ctl.pushMethod(ITEM, 'up');
+
+    expect(pushMethod).not.toHaveBeenCalled();
+    expect(reveal).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('passes the clicked method + direction to the command', async () => {
+    const { ctl } = makeController({} as ActiveSession);
+    vi.mocked(pushMethod).mockResolvedValue(outcome());
+
+    await ctl.pushMethod(ITEM, 'up');
+
+    expect(pushMethod).toHaveBeenCalledWith(
+      expect.objectContaining({
+        direction: 'up',
+        sourceClass: 'Sub',
+        selectors: ['wildStatus'],
+        isMeta: false,
+        dict: 1,
+      }),
+    );
+  });
+
+  it('reveals the target class and does not reload when the outcome names a reveal target', async () => {
+    const { ctl, reveal, reload, closeStale } = makeController({} as ActiveSession);
+    vi.mocked(pushMethod).mockResolvedValue(outcome({ revealClass: 'Super' }));
+
+    await ctl.pushMethod(ITEM, 'up');
+
+    expect(closeStale).toHaveBeenCalled();
+    expect(reveal).toHaveBeenCalledWith('UserGlobals', 1, 'Super', {
+      revealMethod: { selector: 'wildStatus', isMeta: false },
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads the source method list when the outcome has no reveal target', async () => {
+    const { ctl, reveal, reload, closeStale } = makeController({} as ActiveSession);
+    vi.mocked(pushMethod).mockResolvedValue(outcome({ revealClass: null, targetClass: null }));
+
+    await ctl.pushMethod(ITEM, 'down');
+
+    expect(closeStale).toHaveBeenCalled();
+    expect(reveal).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing further when the push was cancelled or nothing applied', async () => {
+    const { ctl, reveal, reload, closeStale } = makeController({} as ActiveSession);
+    vi.mocked(pushMethod).mockResolvedValue(undefined);
+
+    await ctl.pushMethod(ITEM, 'up');
+
+    expect(closeStale).not.toHaveBeenCalled();
+    expect(reveal).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/gci/gciMoveMethod.e2e.test.ts
+++ b/client/src/__tests__/gci/gciMoveMethod.e2e.test.ts
@@ -121,7 +121,9 @@ describe('move method (gci e2e)', () => {
       expect(includesSelector(TARGET, 'gciPure')).toBe(true);
       expect(includesSelector(SOURCE, 'gciPure')).toBe(false);
     } finally {
-      exec('System abortTransaction');
+      // Evaluate to a String: executeFetchString sends #encodeAsUTF8 to the result, which
+      // the System class (the value of `System abortTransaction`) does not understand.
+      exec("System abortTransaction. 'ok'");
     }
   });
 
@@ -150,7 +152,9 @@ describe('move method (gci e2e)', () => {
       expect(includesSelector(SOURCE, 'gciSuper')).toBe(true);
       expect(includesSelector(TARGET, 'gciSuper')).toBe(false);
     } finally {
-      exec('System abortTransaction');
+      // Evaluate to a String: executeFetchString sends #encodeAsUTF8 to the result, which
+      // the System class (the value of `System abortTransaction`) does not understand.
+      exec("System abortTransaction. 'ok'");
     }
   });
 });

--- a/client/src/__tests__/gci/gciPushMethod.e2e.test.ts
+++ b/client/src/__tests__/gci/gciPushMethod.e2e.test.ts
@@ -63,6 +63,9 @@ describe('push method up/down (gci e2e)', () => {
     );
     q.compileMethod(session, BASE, false, 'accessing', 'pumDown\n\t^100');
     q.compileMethod(session, SUBA, false, 'accessing', 'pumUpPure\n\t^7');
+    // Collision: both the superclass and subclass A define pumCollide -> push-up overwrite.
+    q.compileMethod(session, BASE, false, 'accessing', "pumCollide\n\t^'base'");
+    q.compileMethod(session, SUBA, false, 'accessing', "pumCollide\n\t^'suba'");
   };
 
   const definesSelector = (cls: string, selector: string): boolean =>
@@ -70,8 +73,16 @@ describe('push method up/down (gci e2e)', () => {
       `(${cls} compiledMethodAt: #'${selector}' environmentId: 0 otherwise: nil) notNil printString`,
     ).trim() === 'true';
 
+  const sourceOf = (cls: string, selector: string): string =>
+    exec(
+      `(${cls} compiledMethodAt: #'${selector}' environmentId: 0 otherwise: nil) ` +
+        "ifNil: [''] ifNotNil: [:m | m sourceString]",
+    );
+
   const abort = (): void => {
-    exec('System abortTransaction');
+    // Evaluate to a String: executeFetchString sends #encodeAsUTF8 to the result, which
+    // the System class (the value of `System abortTransaction`) does not understand.
+    exec("System abortTransaction. 'ok'");
   };
 
   beforeAll(() => {
@@ -123,6 +134,41 @@ describe('push method up/down (gci e2e)', () => {
       expect(result.failed).toEqual([]);
       expect(definesSelector(BASE, 'pumUpPure')).toBe(true);
       expect(definesSelector(SUBA, 'pumUpPure')).toBe(false);
+    } finally {
+      abort();
+    }
+  });
+
+  it('pushes up onto a colliding superclass as an opt-in overwrite, then rolls back', async (ctx) => {
+    if (!enginePresent) return ctx.skip();
+
+    try {
+      defineFixture();
+      const analysis = parseAnalysis(
+        await analyzePushMethod(asyncExec, 'up', SUBA, ['pumCollide'], false),
+      );
+      expect(analysis.selectors[0].decline).toBeNull();
+      expect(analysis.selectors[0].warning).not.toBeNull();
+
+      const token = `pum-e2e-up-collide`;
+      const start = parseStartPreview(
+        await startPushMethodPreview(
+          asyncExec,
+          'up',
+          SUBA,
+          ['pumCollide'],
+          false,
+          token,
+          PREVIEW_PAGE_BYTES,
+        ),
+      );
+      const add = start.page.changes.find((c) => c.kind === 'methodAdd');
+      expect(add?.oldSource).toContain('base');
+      const result = parseApplyResult(await applyPushMethod(asyncExec, 'up', token, []));
+
+      expect(result.failed).toEqual([]);
+      expect(sourceOf(BASE, 'pumCollide')).toContain('suba');
+      expect(definesSelector(SUBA, 'pumCollide')).toBe(false);
     } finally {
       abort();
     }

--- a/client/src/__tests__/gci/gciPushMethod.e2e.test.ts
+++ b/client/src/__tests__/gci/gciPushMethod.e2e.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+// Mock vscode since browserQueries → gciLog → vscode.
+vi.mock('vscode', () => ({
+  window: {
+    createOutputChannel: () => ({ appendLine: () => {} }),
+  },
+}));
+
+import { GciLibrary } from '../../gciLibrary';
+import { GCI_LIBRARY_PATH, STONE_NRS, GEM_NRS, GS_USER, GS_PASSWORD } from './gciTestConfig';
+import { ActiveSession } from '../../sessionManager';
+import { GemStoneLogin } from '../../loginTypes';
+import * as q from '../../browserQueries';
+import {
+  analyzePushMethod,
+  startPushMethodPreview,
+  applyPushMethod,
+} from '../../refactoring/queries/previewPushMethod';
+import { PREVIEW_PAGE_BYTES } from '../../refactoring/queries/previewRenameMethod';
+import {
+  parseAnalysis,
+  parseStartPreview,
+  parseApplyResult,
+} from '../../refactoring/pushMethodPreview';
+
+/**
+ * On-demand GCI end-to-end test (`npm run test:gci`) for the push-up / push-down method
+ * refactorings (M7 / M8). Drives the real query builders + parsers against a live stone
+ * over the GCI transport, then rolls everything back.
+ *
+ * GUARDED on the engine being loaded: on a bare stone (no GsPushUpMethodRefactoring) each
+ * test skips with a reason. Fully transient — every test aborts the transaction in a
+ * `finally`, so the fixture classes and the applied changes never commit.
+ */
+describe('push method up/down (gci e2e)', () => {
+  let gci: GciLibrary;
+  let session: ActiveSession;
+  let enginePresent = false;
+
+  const exec = (code: string): string => q.executeFetchString(session, code);
+  const asyncExec = (_label: string, code: string): Promise<string> => Promise.resolve(exec(code));
+
+  const BASE = 'PumE2eBase';
+  const SUBA = 'PumE2eA';
+  const SUBB = 'PumE2eB';
+
+  const defineFixture = (): void => {
+    q.compileClassDefinition(
+      session,
+      `Object subclass: '${BASE}' instVarNames: #('state') classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    q.compileClassDefinition(
+      session,
+      `${BASE} subclass: '${SUBA}' instVarNames: #() classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    q.compileClassDefinition(
+      session,
+      `${BASE} subclass: '${SUBB}' instVarNames: #() classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    q.compileMethod(session, BASE, false, 'accessing', 'pumDown\n\t^100');
+    q.compileMethod(session, SUBA, false, 'accessing', 'pumUpPure\n\t^7');
+  };
+
+  const definesSelector = (cls: string, selector: string): boolean =>
+    exec(
+      `(${cls} compiledMethodAt: #'${selector}' environmentId: 0 otherwise: nil) notNil printString`,
+    ).trim() === 'true';
+
+  const abort = (): void => {
+    exec('System abortTransaction');
+  };
+
+  beforeAll(() => {
+    gci = new GciLibrary(GCI_LIBRARY_PATH);
+    const login = gci.GciTsLogin(STONE_NRS, null, null, false, GEM_NRS, GS_USER, GS_PASSWORD, 0, 0);
+    expect(login.session).not.toBeNull();
+    session = {
+      id: 1,
+      gci,
+      handle: login.session,
+      login: { label: 'Test' } as GemStoneLogin,
+      stoneVersion: '3.7.5',
+    };
+    enginePresent =
+      exec(
+        '(System myUserProfile symbolList objectNamed: #GsPushUpMethodRefactoring) notNil printString',
+      ).trim() === 'true';
+  });
+
+  afterAll(() => {
+    if (session?.handle) gci.GciTsLogout(session.handle);
+    gci?.close();
+  });
+
+  it('pushes a pure method up to its superclass, then rolls back', async (ctx) => {
+    if (!enginePresent) return ctx.skip();
+
+    try {
+      defineFixture();
+      const analysis = parseAnalysis(
+        await analyzePushMethod(asyncExec, 'up', SUBA, ['pumUpPure'], false),
+      );
+      expect(analysis.targetClass).toBe(BASE);
+
+      const token = `pum-e2e-up`;
+      parseStartPreview(
+        await startPushMethodPreview(
+          asyncExec,
+          'up',
+          SUBA,
+          ['pumUpPure'],
+          false,
+          token,
+          PREVIEW_PAGE_BYTES,
+        ),
+      );
+      const result = parseApplyResult(await applyPushMethod(asyncExec, 'up', token, []));
+
+      expect(result.failed).toEqual([]);
+      expect(definesSelector(BASE, 'pumUpPure')).toBe(true);
+      expect(definesSelector(SUBA, 'pumUpPure')).toBe(false);
+    } finally {
+      abort();
+    }
+  });
+
+  it('pushes a method down into every subclass, then rolls back', async (ctx) => {
+    if (!enginePresent) return ctx.skip();
+
+    try {
+      defineFixture();
+      const token = `pum-e2e-down`;
+      const start = parseStartPreview(
+        await startPushMethodPreview(
+          asyncExec,
+          'down',
+          BASE,
+          ['pumDown'],
+          false,
+          token,
+          PREVIEW_PAGE_BYTES,
+        ),
+      );
+      expect(start.total).toBe(3);
+      const result = parseApplyResult(await applyPushMethod(asyncExec, 'down', token, []));
+
+      expect(result.failed).toEqual([]);
+      expect(definesSelector(SUBA, 'pumDown')).toBe(true);
+      expect(definesSelector(SUBB, 'pumDown')).toBe(true);
+      expect(definesSelector(BASE, 'pumDown')).toBe(false);
+    } finally {
+      abort();
+    }
+  });
+});

--- a/client/src/__tests__/gci/querySunit.smoke.test.ts
+++ b/client/src/__tests__/gci/querySunit.smoke.test.ts
@@ -202,7 +202,9 @@ describe('SUnit queries (live GCI)', () => {
 
         expect(Array.isArray(results)).toBe(true);
       }
-    });
+      // On a small image this runs SUnit across every test class; on a freshly provisioned
+      // (cold) stone that legitimately takes ~30s, past vitest's 5s default — give it room.
+    }, 120000);
   });
 
   describe('describeTestFailure', () => {

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -53,6 +53,14 @@ import {
   ChangeSignatureScope,
 } from './refactoring/queries/previewChangeSignature';
 import {
+  analyzePushMethod as sharedAnalyzePushMethod,
+  startPushMethodPreview as sharedStartPushMethodPreview,
+  pagePushMethodPreview as sharedPagePushMethodPreview,
+  applyPushMethod as sharedApplyPushMethod,
+  clearPushMethodPreview as sharedClearPushMethodPreview,
+  PushDirection,
+} from './refactoring/queries/previewPushMethod';
+import {
   startRenameClassPreview as sharedStartRenameClassPreview,
   pageRenameClassPreview as sharedPageRenameClassPreview,
   applyRenameClass as sharedApplyRenameClass,
@@ -793,6 +801,77 @@ export function applyChangeSignature(
 
 export function clearChangeSignaturePreview(session: ActiveSession, token: string): string {
   return sharedClearChangeSignaturePreview(defaultQueryExecutorUsing(session), token);
+}
+
+// Push-up / push-down method (M7 / M8) wrappers: mirror the move-method shape but with
+// the target(s) resolved server-side (the superclass, or the immediate subclasses).
+// Paginated preview fetched NON-BLOCKING; apply is server-side (no commit).
+export function analyzePushMethod(
+  session: ActiveSession,
+  direction: PushDirection,
+  sourceClass: string,
+  selectors: string[],
+  isMeta: boolean,
+  dict?: number | string,
+): Promise<string> {
+  const exec = (label: string, code: string): Promise<string> =>
+    executeFetchStringNb(session, label, code, 'Analysing push…');
+  return sharedAnalyzePushMethod(exec, direction, sourceClass, selectors, isMeta, dict);
+}
+
+export function startPushMethodPreview(
+  session: ActiveSession,
+  direction: PushDirection,
+  sourceClass: string,
+  selectors: string[],
+  isMeta: boolean,
+  token: string,
+  maxBytes: number,
+  dict?: number | string,
+): Promise<string> {
+  const exec = (label: string, code: string): Promise<string> =>
+    executeFetchStringNb(session, label, code, `Previewing push of ${sourceClass}…`);
+  return sharedStartPushMethodPreview(
+    exec,
+    direction,
+    sourceClass,
+    selectors,
+    isMeta,
+    token,
+    maxBytes,
+    dict,
+  );
+}
+
+export function pagePushMethodPreview(
+  session: ActiveSession,
+  direction: PushDirection,
+  token: string,
+  offset: number,
+  maxBytes: number,
+): Promise<string> {
+  const exec = (label: string, code: string): Promise<string> =>
+    executeFetchStringNb(session, label, code, 'Loading more changes…');
+  return sharedPagePushMethodPreview(exec, direction, token, offset, maxBytes);
+}
+
+export function applyPushMethod(
+  session: ActiveSession,
+  direction: PushDirection,
+  token: string,
+  deselectedIds: string[],
+): Promise<string> {
+  const exec = (label: string, code: string): Promise<string> =>
+    executeFetchStringNb(session, label, code, 'Applying push…');
+  return sharedApplyPushMethod(exec, direction, token, deselectedIds);
+}
+
+export function clearPushMethodPreview(
+  session: ActiveSession,
+  direction: PushDirection,
+  token: string,
+): string {
+  return sharedClearPushMethodPreview(defaultQueryExecutorUsing(session), direction, token);
 }
 
 // Paginated rename-class preview: fetched NON-BLOCKING (progress + responsive),

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -896,6 +896,66 @@ export class ExplorerController {
     }
   }
 
+  // After a push moves a method OUT of its source class, an editor still open on the
+  // source method is stale — the method no longer resolves there — and, via syncToEditor
+  // (onDidChangeActiveTextEditor), it drags the navigator back to the source, clobbering
+  // the reveal of the method in its NEW home. Close such editors (non-dirty only), but only
+  // for selectors the source no longer defines: a partial push-down can leave the source
+  // method in place, and that editor is still valid.
+  private async closeStaleSourceMethodEditors(
+    session: ActiveSession,
+    dictName: string,
+    sourceClass: string,
+    selectors: string[],
+    isMeta: boolean,
+  ): Promise<void> {
+    for (const { tab, uri } of listOpenGemstoneTabs()) {
+      if (tab.isDirty) continue;
+      let parsed;
+      try {
+        parsed = parseUri(uri);
+      } catch {
+        continue;
+      }
+      if (parsed.kind !== 'method' || parsed.sessionId !== session.id) continue;
+      if (parsed.base || parsed.diffView) continue;
+      if (parsed.className !== sourceClass || parsed.dictName !== dictName) continue;
+      if (parsed.isMeta !== isMeta) continue;
+      const sel = unescapeSelectorSlashes(parsed.selector);
+      if (!selectors.includes(sel)) continue;
+      if (this.classStillDefines(session, sourceClass, sel, isMeta)) continue;
+      try {
+        await vscode.window.tabGroups.close(tab);
+      } catch {
+        /* best-effort: a failed close just leaves the (now stale) tab open */
+      }
+    }
+  }
+
+  // True when className still defines selector on the given side (its OWN method), used to
+  // decide whether a source-method editor is stale after a push. On any query error, assume
+  // it is still defined (do not close the editor).
+  private classStillDefines(
+    session: ActiveSession,
+    className: string,
+    selector: string,
+    isMeta: boolean,
+  ): boolean {
+    const behavior = isMeta ? `${className} class` : className;
+    try {
+      return (
+        queries
+          .executeFetchString(
+            session,
+            `((${behavior} compiledMethodAt: #'${selector}' environmentId: 0 otherwise: nil) notNil) printString`,
+          )
+          .trim() === 'true'
+      );
+    } catch {
+      return true;
+    }
+  }
+
   selectClass(item: ClassItem): void {
     this.state.className = item.className;
     this.state.selectedSelector = undefined;
@@ -1647,9 +1707,9 @@ export class ExplorerController {
   // Push a method up to its superclass (M7) or down into its subclasses (M8), from the
   // method row's context menu. The engine resolves the target(s) and declines with a
   // clear reason when impossible (no superclass / no subclasses / precondition). After a
-  // successful push, reveal where the method went: for push-up, navigate to the
-  // superclass and select the moved method; for push-down (many targets), just reload
-  // the source class's method list (the method is now gone from it).
+  // successful push, navigate to where the method landed and highlight it: the superclass
+  // for push-up, the first recipient subclass for push-down. If there is nowhere to reveal
+  // (or we lack the dict context), just reload the source list so the removed row vanishes.
   async pushMethod(item: MethodItem, direction: PushDirection): Promise<void> {
     const className = this.state.className;
     const session = this.session();
@@ -1663,17 +1723,27 @@ export class ExplorerController {
       dict: this.state.dictIndex ?? this.state.dictName,
     });
     if (!outcome) return;
-    if (direction === 'up' && outcome.targetClass) {
-      const { dictName, dictIndex } = this.state;
-      if (dictName !== undefined && dictIndex !== undefined) {
-        await this.revealClass(dictName, dictIndex, outcome.targetClass, {
-          revealMethod: { selector: item.info.selector, isMeta: item.isMeta },
-        });
-        return;
-      }
+    const { dictName, dictIndex } = this.state;
+    // The source method(s) moved away; an editor still open on the source is now stale and
+    // would yank the navigator back to the source via syncToEditor, clobbering the reveal.
+    // Close those (only where the source truly lost the method) BEFORE revealing.
+    if (dictName !== undefined) {
+      await this.closeStaleSourceMethodEditors(
+        session,
+        dictName,
+        className,
+        outcome.moved,
+        item.isMeta,
+      );
     }
-    // Push-down (or a push-up we can't reveal): the source lost the method — reload its
-    // method list so the removed row disappears.
+    if (outcome.revealClass && dictName !== undefined && dictIndex !== undefined) {
+      await this.revealClass(dictName, dictIndex, outcome.revealClass, {
+        revealMethod: { selector: item.info.selector, isMeta: item.isMeta },
+      });
+      return;
+    }
+    // Nowhere to reveal: the source lost the method — reload its method list so the removed
+    // row disappears.
     this.reloadCurrentClassMethods();
   }
 

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -44,6 +44,8 @@ import { PREVIEW_PAGE_BYTES } from './refactoring/queries/previewRenameMethod';
 import { showRenameMethodEditor } from './refactoring/renameMethodEditor';
 import { showRenameMethodPanel } from './refactoring/renameMethodPanel';
 import { beginChangeSignature, changeSignatureCommand } from './refactoring/changeSignatureCommand';
+import { pushMethod } from './refactoring/pushMethodCommand';
+import { PushDirection } from './refactoring/queries/previewPushMethod';
 import {
   parseStartPreview as parseStartClassPreview,
   parsePage as parseClassPage,
@@ -1642,6 +1644,39 @@ export class ExplorerController {
     );
   }
 
+  // Push a method up to its superclass (M7) or down into its subclasses (M8), from the
+  // method row's context menu. The engine resolves the target(s) and declines with a
+  // clear reason when impossible (no superclass / no subclasses / precondition). After a
+  // successful push, reveal where the method went: for push-up, navigate to the
+  // superclass and select the moved method; for push-down (many targets), just reload
+  // the source class's method list (the method is now gone from it).
+  async pushMethod(item: MethodItem, direction: PushDirection): Promise<void> {
+    const className = this.state.className;
+    const session = this.session();
+    if (!className || !session) return;
+    const outcome = await pushMethod({
+      session,
+      direction,
+      sourceClass: className,
+      selectors: [item.info.selector],
+      isMeta: item.isMeta,
+      dict: this.state.dictIndex ?? this.state.dictName,
+    });
+    if (!outcome) return;
+    if (direction === 'up' && outcome.targetClass) {
+      const { dictName, dictIndex } = this.state;
+      if (dictName !== undefined && dictIndex !== undefined) {
+        await this.revealClass(dictName, dictIndex, outcome.targetClass, {
+          revealMethod: { selector: item.info.selector, isMeta: item.isMeta },
+        });
+        return;
+      }
+    }
+    // Push-down (or a push-up we can't reveal): the source lost the method — reload its
+    // method list so the removed row disappears.
+    this.reloadCurrentClassMethods();
+  }
+
   // Bring the tree and any open editors up to date after a signature change: the
   // method environment is stale (selectors changed) and an editor open on a renamed
   // implementor must reopen under its new selector. Public so BOTH entry points (the
@@ -3109,6 +3144,22 @@ export function registerGemStoneExplorer(
       void ctl.changeSignature(item).catch((e: unknown) => {
         const msg = e instanceof Error ? e.message : String(e);
         void vscode.window.showErrorMessage(`Change signature failed: ${msg}`);
+      });
+    }),
+    // Push a method up to its superclass (M7) — context menu on the method row.
+    vscode.commands.registerCommand('gemstone.explorer.pushUpMethod', (item?: MethodItem) => {
+      if (!(item instanceof MethodItem)) return;
+      void ctl.pushMethod(item, 'up').catch((e: unknown) => {
+        const msg = e instanceof Error ? e.message : String(e);
+        void vscode.window.showErrorMessage(`Push up failed: ${msg}`);
+      });
+    }),
+    // Push a method down into its subclasses (M8) — context menu on the method row.
+    vscode.commands.registerCommand('gemstone.explorer.pushDownMethod', (item?: MethodItem) => {
+      if (!(item instanceof MethodItem)) return;
+      void ctl.pushMethod(item, 'down').catch((e: unknown) => {
+        const msg = e instanceof Error ? e.message : String(e);
+        void vscode.window.showErrorMessage(`Push down failed: ${msg}`);
       });
     }),
     // Change the edited method's signature from a source editor (the Refactor… code

--- a/client/src/refactoring/__tests__/previewPushMethod.test.ts
+++ b/client/src/refactoring/__tests__/previewPushMethod.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  pushEngineClass,
+  analyzePushMethod,
+  startPushMethodPreview,
+  pagePushMethodPreview,
+  applyPushMethod,
+  clearPushMethodPreview,
+} from '../queries/previewPushMethod';
+
+describe('push-method query builders', () => {
+  it('maps the direction to the right engine class', () => {
+    expect(pushEngineClass('up')).toBe('GsPushUpMethodRefactoring');
+    expect(pushEngineClass('down')).toBe('GsPushDownMethodRefactoring');
+  });
+
+  describe('analyzePushMethod', () => {
+    it('addresses the push-up engine with the source class, selectors, and side', async () => {
+      const exec = vi.fn().mockResolvedValue('{}');
+
+      await analyzePushMethod(exec, 'up', 'Sub', ['foo', 'bar:'], false, 2);
+
+      const [, code] = exec.mock.calls[0];
+      expect(code).toContain('GsPushUpMethodRefactoring');
+      expect(code).toContain('analyzeForClass: cls');
+      expect(code).toContain("{#'foo'. #'bar:'}");
+      expect(code).toContain('meta: false');
+    });
+
+    it('uses the push-down engine and marks the class side', async () => {
+      const exec = vi.fn().mockResolvedValue('{}');
+
+      await analyzePushMethod(exec, 'down', 'Base', ['makeOne'], true);
+
+      const [label, code] = exec.mock.calls[0];
+      expect(code).toContain('GsPushDownMethodRefactoring');
+      expect(code).toContain('meta: true');
+      expect(label).toContain('Base class');
+    });
+
+    it('returns a source-not-found envelope guard in the generated code', async () => {
+      const exec = vi.fn().mockResolvedValue('{}');
+
+      await analyzePushMethod(exec, 'up', 'Missing', ['foo'], false);
+
+      const [, code] = exec.mock.calls[0];
+      expect(code).toContain('cls isNil ifTrue:');
+      expect(code).toContain('Source class not found: Missing');
+    });
+  });
+
+  describe('startPushMethodPreview', () => {
+    it('builds the refactoring and starts a token preview', async () => {
+      const exec = vi.fn().mockResolvedValue('{}');
+
+      await startPushMethodPreview(exec, 'up', 'Sub', ['foo'], false, 'tok1', 4096, 'UserGlobals');
+
+      const [, code] = exec.mock.calls[0];
+      expect(code).toContain('GsPushUpMethodRefactoring');
+      expect(code).toContain('sourceClass: cls');
+      expect(code).toContain("startPreviewToken: 'tok1' maxBytes: 4096");
+    });
+  });
+
+  describe('pagePushMethodPreview / applyPushMethod / clearPushMethodPreview', () => {
+    it('pages by token against the matching engine', async () => {
+      const exec = vi.fn().mockResolvedValue('{}');
+
+      await pagePushMethodPreview(exec, 'down', 'tok2', 3, 4096);
+
+      const [, code] = exec.mock.calls[0];
+      expect(code).toContain('GsPushDownMethodRefactoring pageForToken:');
+      expect(code).toContain("'tok2'");
+      expect(code).toContain('from: 3 maxBytes: 4096');
+    });
+
+    it('applies by token, passing the deselected ids', async () => {
+      const exec = vi.fn().mockResolvedValue('{}');
+
+      await applyPushMethod(exec, 'up', 'tok3', ['5', '7']);
+
+      const [, code] = exec.mock.calls[0];
+      expect(code).toContain('GsPushUpMethodRefactoring applyForToken:');
+      expect(code).toContain("deselected: #('5' '7')");
+    });
+
+    it('clears the preview session by token', () => {
+      const exec = vi.fn().mockReturnValue('ok');
+
+      const out = clearPushMethodPreview(exec, 'down', 'tok4');
+
+      expect(out).toBe('ok');
+      expect(exec).toHaveBeenCalledWith(
+        expect.stringContaining("GsPushDownMethodRefactoring clearToken: 'tok4'"),
+      );
+    });
+  });
+});

--- a/client/src/refactoring/__tests__/pushMethodCommand.test.ts
+++ b/client/src/refactoring/__tests__/pushMethodCommand.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('vscode', () => import('../../__mocks__/vscode'));
+vi.mock('../../browserQueries', () => ({
+  analyzePushMethod: vi.fn(),
+  startPushMethodPreview: vi.fn(),
+  pagePushMethodPreview: vi.fn(),
+  applyPushMethod: vi.fn(),
+  clearPushMethodPreview: vi.fn(),
+}));
+vi.mock('../pushMethodPanel', () => ({
+  showPushMethodPanel: vi.fn(),
+}));
+
+import * as vscode from 'vscode';
+import * as queries from '../../browserQueries';
+import { showPushMethodPanel } from '../pushMethodPanel';
+import { pushMethod, PushMethodRequest } from '../pushMethodCommand';
+import type { ActiveSession } from '../../sessionManager';
+
+/**
+ * Drives the push-up / push-down COMMAND orchestrator (not the engine). Pins the
+ * pre-flight → preview → apply → reveal flow and the "always say why nothing happened"
+ * contract: engine-unavailable, a global decline, nothing-movable (1-vs-many wording), a
+ * failed pre-flight / preview (with token cleanup), an out-of-scope or empty preview, a
+ * failed apply, the "everything un-ticked" (applied === 0) case, and the reveal target the
+ * outcome carries for each direction. The parsers run for real; only the GCI queries and
+ * the preview panel are mocked.
+ */
+
+const req = (over: Partial<PushMethodRequest> = {}): PushMethodRequest => ({
+  session: { id: 1, rbSupportAvailable: true } as unknown as ActiveSession,
+  direction: 'up',
+  sourceClass: 'Sub',
+  selectors: ['foo'],
+  isMeta: false,
+  ...over,
+});
+
+const analysisJson = (over: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    targetClass: 'Super',
+    globalDecline: null,
+    movableCount: 1,
+    selectors: [{ selector: 'foo', decline: null, warning: null }],
+    ...over,
+  });
+
+const change = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: 'a',
+  kind: 'methodAdd',
+  className: 'Super',
+  isMeta: false,
+  selector: 'foo',
+  category: 'x',
+  oldSource: '',
+  newSource: 'foo\n\t^ 1',
+  warning: null,
+  ...over,
+});
+
+const startJson = (over: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    token: 'tok',
+    total: 2,
+    targetClass: 'Super',
+    movableCount: 1,
+    outOfScope: { collision: null, decline: null },
+    skippedMethods: [],
+    page: {
+      changes: [change(), change({ id: 'b', kind: 'methodRemove', className: 'Sub' })],
+      nextOffset: 3,
+      done: true,
+    },
+    ...over,
+  });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('push method command', () => {
+  it('does not run a pre-flight when the engine is unavailable and the user declines install', async () => {
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined);
+
+    const outcome = await pushMethod(
+      req({ session: { id: 1, rbSupportAvailable: false } as ActiveSession }),
+    );
+
+    expect(outcome).toBeUndefined();
+    expect(queries.analyzePushMethod).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed pre-flight and never opens the preview', async () => {
+    vi.mocked(queries.analyzePushMethod).mockRejectedValue(new Error('boom'));
+
+    await pushMethod(req());
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    expect(queries.startPushMethodPreview).not.toHaveBeenCalled();
+  });
+
+  it('refuses a global decline and never opens the preview', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(
+      analysisJson({ globalDecline: 'Cannot push up: Object has no superclass.', movableCount: 0 }),
+    );
+
+    await pushMethod(req());
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('no superclass'),
+    );
+    expect(queries.startPushMethodPreview).not.toHaveBeenCalled();
+  });
+
+  it('leads with the single decline reason when nothing is movable', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(
+      analysisJson({
+        movableCount: 0,
+        selectors: [
+          { selector: 'foo', decline: 'Cannot push up #foo: it sends super.', warning: null },
+        ],
+      }),
+    );
+
+    await pushMethod(req());
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('it sends super'),
+    );
+    expect(queries.startPushMethodPreview).not.toHaveBeenCalled();
+  });
+
+  it('counts and leads when several selectors cannot be pushed', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(
+      analysisJson({
+        movableCount: 0,
+        selectors: [
+          { selector: 'foo', decline: 'Cannot push up #foo: it sends super.', warning: null },
+          { selector: 'bar', decline: 'Cannot push up #bar: ivar.', warning: null },
+        ],
+      }),
+    );
+
+    await pushMethod(req({ selectors: ['foo', 'bar'] }));
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('2 methods cannot be pushed'),
+    );
+  });
+
+  it('reports a failed preview and clears the token', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson());
+    vi.mocked(queries.startPushMethodPreview).mockRejectedValue(new Error('kaboom'));
+
+    await pushMethod(req());
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('kaboom'));
+    expect(queries.clearPushMethodPreview).toHaveBeenCalled();
+    expect(showPushMethodPanel).not.toHaveBeenCalled();
+  });
+
+  it('refuses an out-of-scope decline from the preview and clears the token', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson());
+    vi.mocked(queries.startPushMethodPreview).mockResolvedValue(
+      startJson({ outOfScope: { collision: null, decline: 'no can do' } }),
+    );
+
+    await pushMethod(req());
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('no can do'),
+    );
+    expect(queries.clearPushMethodPreview).toHaveBeenCalled();
+    expect(showPushMethodPanel).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the preview has nothing to push', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson());
+    vi.mocked(queries.startPushMethodPreview).mockResolvedValue(
+      startJson({ total: 0, page: { changes: [], nextOffset: 1, done: true } }),
+    );
+
+    await pushMethod(req());
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Nothing to push'),
+    );
+    expect(showPushMethodPanel).not.toHaveBeenCalled();
+  });
+
+  it('does nothing further when the user cancels the preview', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson());
+    vi.mocked(queries.startPushMethodPreview).mockResolvedValue(startJson());
+    vi.mocked(showPushMethodPanel).mockResolvedValue(undefined);
+
+    const outcome = await pushMethod(req());
+
+    expect(outcome).toBeUndefined();
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed apply', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson());
+    vi.mocked(queries.startPushMethodPreview).mockResolvedValue(startJson());
+    vi.mocked(showPushMethodPanel).mockResolvedValue({
+      applied: 0,
+      failed: [{ id: 'a', label: 'Super>>foo', error: 'boom' }],
+    });
+
+    await pushMethod(req());
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('reports when every target was left un-ticked (nothing applied)', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson());
+    vi.mocked(queries.startPushMethodPreview).mockResolvedValue(startJson());
+    vi.mocked(showPushMethodPanel).mockResolvedValue({ applied: 0, failed: [] });
+
+    const outcome = await pushMethod(req());
+
+    expect(outcome).toBeUndefined();
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('every target was left un-ticked'),
+    );
+  });
+
+  it('reveals the superclass after a push-up', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson());
+    vi.mocked(queries.startPushMethodPreview).mockResolvedValue(startJson());
+    vi.mocked(showPushMethodPanel).mockResolvedValue({ applied: 2, failed: [] });
+
+    const outcome = await pushMethod(req({ direction: 'up' }));
+
+    expect(outcome?.revealClass).toBe('Super');
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Pushed #foo up'),
+    );
+  });
+
+  it('reveals the first fresh recipient subclass after a push-down', async () => {
+    vi.mocked(queries.analyzePushMethod).mockResolvedValue(analysisJson({ targetClass: null }));
+    vi.mocked(queries.startPushMethodPreview).mockResolvedValue(
+      startJson({
+        targetClass: null,
+        total: 3,
+        page: {
+          changes: [
+            change({ id: 'over', className: 'Cat', warning: 'overwrites Cat>>foo' }),
+            change({ id: 'fresh', className: 'Dog', warning: null }),
+            change({ id: 'rm', kind: 'methodRemove', className: 'Sub' }),
+          ],
+          nextOffset: 4,
+          done: true,
+        },
+      }),
+    );
+    vi.mocked(showPushMethodPanel).mockResolvedValue({ applied: 2, failed: [] });
+
+    const outcome = await pushMethod(req({ direction: 'down' }));
+
+    expect(outcome?.revealClass).toBe('Dog');
+  });
+});

--- a/client/src/refactoring/__tests__/pushMethodPanelHtml.test.ts
+++ b/client/src/refactoring/__tests__/pushMethodPanelHtml.test.ts
@@ -12,6 +12,7 @@ const add: PushChange = {
   category: 'accessing',
   oldSource: '',
   newSource: 'foo\n\t^ 1',
+  warning: null,
 };
 const remove: PushChange = {
   id: '2',
@@ -23,6 +24,19 @@ const remove: PushChange = {
   category: 'accessing',
   oldSource: 'foo\n\t^ 1',
   newSource: '',
+  warning: null,
+};
+const overwrite: PushChange = {
+  id: '3',
+  kind: 'methodAdd',
+  dictName: 'UserGlobals',
+  className: 'Sub',
+  isMeta: false,
+  selector: 'foo',
+  category: 'accessing',
+  oldSource: 'foo\n\t^ 99',
+  newSource: 'foo\n\t^ 1',
+  warning: 'Pushing down overwrites Sub>>foo -- its current override is lost.',
 };
 
 describe('push-method panel HTML', () => {
@@ -43,10 +57,35 @@ describe('push-method panel HTML', () => {
       expect(html).not.toContain('line add');
     });
 
-    it('makes every change a required (checked + disabled) row', () => {
-      const html = renderPushCards([add]);
+    it('makes the source removal a required (checked, disabled) row', () => {
+      const html = renderPushCards([remove]);
 
       expect(html).toContain('checked disabled');
+    });
+
+    it('makes a fresh-target add a deselectable (checked, enabled) row', () => {
+      const html = renderPushCards([add]);
+
+      expect(html).toContain('class="sel" checked');
+      expect(html).not.toContain('checked disabled');
+    });
+
+    it('makes an overwrite add opt-in: unchecked, enabled, with a data-loss warning', () => {
+      const html = renderPushCards([overwrite]);
+
+      expect(html).toContain('overwrite existing');
+      expect(html).toContain('current override is lost');
+      const input = html.match(/<input[^>]*class="sel"[^>]*>/)?.[0] ?? '';
+      expect(input).toContain('overwrite, opt-in');
+      expect(input).not.toContain('checked');
+      expect(input).not.toContain('disabled');
+    });
+
+    it('renders an overwrite as a before/after diff of the replaced method', () => {
+      const html = renderPushCards([overwrite]);
+
+      expect(html).toContain('line del');
+      expect(html).toContain('line add');
     });
 
     it('escapes HTML metacharacters in the source', () => {

--- a/client/src/refactoring/__tests__/pushMethodPanelHtml.test.ts
+++ b/client/src/refactoring/__tests__/pushMethodPanelHtml.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { renderPushPanelHtml, renderPushCards } from '../pushMethodPanelHtml';
+import { PushChange } from '../pushMethodPreview';
+
+const add: PushChange = {
+  id: '1',
+  kind: 'methodAdd',
+  dictName: 'UserGlobals',
+  className: 'Base',
+  isMeta: false,
+  selector: 'foo',
+  category: 'accessing',
+  oldSource: '',
+  newSource: 'foo\n\t^ 1',
+};
+const remove: PushChange = {
+  id: '2',
+  kind: 'methodRemove',
+  dictName: 'UserGlobals',
+  className: 'Sub',
+  isMeta: false,
+  selector: 'foo',
+  category: 'accessing',
+  oldSource: 'foo\n\t^ 1',
+  newSource: '',
+};
+
+describe('push-method panel HTML', () => {
+  describe('renderPushCards', () => {
+    it('renders a methodAdd as an all-added single-sided diff', () => {
+      const html = renderPushCards([add]);
+
+      expect(html).toContain('add to target');
+      expect(html).toContain('line add');
+      expect(html).not.toContain('line del');
+    });
+
+    it('renders a methodRemove as an all-removed single-sided diff', () => {
+      const html = renderPushCards([remove]);
+
+      expect(html).toContain('remove from source');
+      expect(html).toContain('line del');
+      expect(html).not.toContain('line add');
+    });
+
+    it('makes every change a required (checked + disabled) row', () => {
+      const html = renderPushCards([add]);
+
+      expect(html).toContain('checked disabled');
+    });
+
+    it('escapes HTML metacharacters in the source', () => {
+      const html = renderPushCards([{ ...add, newSource: 'foo\n\t^ a < b & c' }]);
+
+      expect(html).toContain('&lt; b &amp; c');
+      expect(html).not.toContain('< b & c');
+    });
+  });
+
+  describe('renderPushPanelHtml', () => {
+    const opts = {
+      heading: 'Push up to Base',
+      total: 2,
+      changes: [add, remove],
+      done: true,
+      outOfScope: { collision: null, decline: null },
+      skippedMethods: [],
+      nonce: 'abc123',
+      script: 'const x = 1;',
+    };
+
+    it('shows the heading and a strict CSP with the nonce', () => {
+      const html = renderPushPanelHtml(opts);
+
+      expect(html).toContain('Push up to Base');
+      expect(html).toContain("script-src 'nonce-abc123'");
+      expect(html).toContain('<script nonce="abc123">const x = 1;</script>');
+    });
+
+    it('hides the pager when the first page is the last', () => {
+      const html = renderPushPanelHtml(opts);
+
+      expect(html).toContain('pager hidden');
+    });
+
+    it('shows the pager when more pages remain', () => {
+      const html = renderPushPanelHtml({ ...opts, done: false });
+
+      expect(html).toMatch(/pager"/);
+      expect(html).not.toContain('pager hidden');
+    });
+
+    it('renders a global-decline banner that blocks apply', () => {
+      const html = renderPushPanelHtml({
+        ...opts,
+        outOfScope: { collision: null, decline: 'Cannot push down: no subclasses.' },
+      });
+
+      expect(html).toContain('oos');
+      expect(html).toContain('no subclasses');
+    });
+
+    it('lists skipped methods with their reasons', () => {
+      const html = renderPushPanelHtml({
+        ...opts,
+        skippedMethods: [{ selector: 'bar', reason: 'sends super' }],
+      });
+
+      expect(html).toContain('will NOT move');
+      expect(html).toContain('bar');
+      expect(html).toContain('sends super');
+    });
+  });
+});

--- a/client/src/refactoring/__tests__/pushMethodPanelShow.test.ts
+++ b/client/src/refactoring/__tests__/pushMethodPanelShow.test.ts
@@ -64,6 +64,7 @@ const start: StartPushPreview = {
         category: 'accessing',
         oldSource: '',
         newSource: 'foo\n\t^1',
+        warning: null,
       },
     ],
     nextOffset: 2,

--- a/client/src/refactoring/__tests__/pushMethodPanelShow.test.ts
+++ b/client/src/refactoring/__tests__/pushMethodPanelShow.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// A controllable webview panel so the paginated push-method panel's message wiring
+// (loadMore / loadAll / apply / cancel / dispose) can be driven.
+vi.mock('vscode', () => ({
+  ViewColumn: { Active: 1 },
+  window: {
+    createWebviewPanel: vi.fn(() => {
+      const messageCbs: Array<(m: unknown) => void> = [];
+      const disposeCbs: Array<() => void> = [];
+      return {
+        webview: {
+          html: '',
+          postMessage: vi.fn(),
+          onDidReceiveMessage: (cb: (m: unknown) => void) => {
+            messageCbs.push(cb);
+            return { dispose() {} };
+          },
+        },
+        onDidDispose: (cb: () => void) => {
+          disposeCbs.push(cb);
+          return { dispose() {} };
+        },
+        dispose: () => disposeCbs.forEach((c) => c()),
+        __emit: (m: unknown) => messageCbs.forEach((c) => c(m)),
+      };
+    }),
+    showErrorMessage: vi.fn(),
+  },
+}));
+
+import * as vscode from 'vscode';
+import { showPushMethodPanel } from '../pushMethodPanel';
+import { StartPushPreview } from '../pushMethodPreview';
+
+interface MockPanel {
+  __emit: (m: unknown) => void;
+  dispose: () => void;
+  webview: { postMessage: ReturnType<typeof vi.fn> };
+}
+function lastPanel(): MockPanel {
+  const mock = vscode.window.createWebviewPanel as unknown as {
+    mock: { results: Array<{ value: MockPanel }> };
+  };
+  return mock.mock.results[mock.mock.results.length - 1].value;
+}
+
+const start: StartPushPreview = {
+  token: 'tok',
+  total: 2,
+  targetClass: 'Base',
+  movableCount: 1,
+  outOfScope: { collision: null, decline: null },
+  skippedMethods: [],
+  page: {
+    changes: [
+      {
+        id: '1',
+        kind: 'methodAdd',
+        dictName: 'UserGlobals',
+        className: 'Base',
+        isMeta: false,
+        selector: 'foo',
+        category: 'accessing',
+        oldSource: '',
+        newSource: 'foo\n\t^1',
+      },
+    ],
+    nextOffset: 2,
+    done: false,
+  },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('showPushMethodPanel', () => {
+  it('applies with the deselected ids and resolves the apply result', async () => {
+    const handlers = {
+      loadPage: vi.fn(),
+      apply: vi.fn(async () => ({ applied: 2, failed: [] })),
+      cleanup: vi.fn(),
+    };
+
+    const result = showPushMethodPanel('Push up to Base', start, handlers);
+    lastPanel().__emit({ command: 'apply', deselected: [] });
+
+    expect(await result).toEqual({ applied: 2, failed: [] });
+    expect(handlers.apply).toHaveBeenCalledWith([]);
+    expect(handlers.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves undefined and cleans up on cancel', async () => {
+    const handlers = { loadPage: vi.fn(), apply: vi.fn(), cleanup: vi.fn() };
+
+    const result = showPushMethodPanel('Push up to Base', start, handlers);
+    lastPanel().__emit({ command: 'cancel' });
+
+    expect(await result).toBeUndefined();
+    expect(handlers.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves undefined and cleans up when the panel is disposed', async () => {
+    const handlers = { loadPage: vi.fn(), apply: vi.fn(), cleanup: vi.fn() };
+
+    const result = showPushMethodPanel('Push down into subclasses of Base', start, handlers);
+    lastPanel().dispose();
+
+    expect(await result).toBeUndefined();
+    expect(handlers.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches the next page when asked for more', async () => {
+    const handlers = {
+      loadPage: vi.fn(async () => ({ changes: [], nextOffset: 3, done: true })),
+      apply: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    void showPushMethodPanel('Push up to Base', start, handlers);
+    lastPanel().__emit({ command: 'loadMore' });
+
+    await vi.waitFor(() => expect(handlers.loadPage).toHaveBeenCalledWith(2));
+  });
+
+  it('drains every remaining page on loadAll', async () => {
+    const pages = [
+      { changes: [], nextOffset: 3, done: false },
+      { changes: [], nextOffset: 4, done: true },
+    ];
+    const handlers = {
+      loadPage: vi.fn(async () => pages.shift()!),
+      apply: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    void showPushMethodPanel('Push up to Base', start, handlers);
+    lastPanel().__emit({ command: 'loadAll' });
+
+    await vi.waitFor(() => expect(handlers.loadPage).toHaveBeenCalledTimes(2));
+  });
+
+  it('surfaces an error and stays open when applying fails', async () => {
+    const handlers = {
+      loadPage: vi.fn(),
+      apply: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+      cleanup: vi.fn(),
+    };
+
+    void showPushMethodPanel('Push up to Base', start, handlers);
+    lastPanel().__emit({ command: 'apply', deselected: [] });
+
+    await vi.waitFor(() =>
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('boom')),
+    );
+    expect(handlers.cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/refactoring/__tests__/pushMethodPreview.test.ts
+++ b/client/src/refactoring/__tests__/pushMethodPreview.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseAnalysis,
+  parseStartPreview,
+  parsePage,
+  parseApplyResult,
+  pushChangeLabel,
+  PushChange,
+} from '../pushMethodPreview';
+
+describe('push-method preview parsing', () => {
+  describe('parseAnalysis', () => {
+    it('reads the resolved target, movable count, and per-selector declines', () => {
+      const json = JSON.stringify({
+        targetClass: 'Base',
+        globalDecline: null,
+        movableCount: 1,
+        selectors: [
+          { selector: 'foo', decline: null },
+          { selector: 'bar', decline: 'Cannot push up #bar: it sends super.' },
+        ],
+      });
+
+      const a = parseAnalysis(json);
+
+      expect(a.targetClass).toBe('Base');
+      expect(a.globalDecline).toBeNull();
+      expect(a.movableCount).toBe(1);
+      expect(a.selectors).toHaveLength(2);
+      expect(a.selectors[1].decline).toContain('super');
+    });
+
+    it('accepts a null target (push-down lands in many subclasses)', () => {
+      const a = parseAnalysis(
+        JSON.stringify({ targetClass: null, globalDecline: null, movableCount: 2, selectors: [] }),
+      );
+
+      expect(a.targetClass).toBeNull();
+      expect(a.movableCount).toBe(2);
+    });
+
+    it('surfaces a global decline', () => {
+      const a = parseAnalysis(
+        JSON.stringify({
+          targetClass: null,
+          globalDecline: 'Cannot push down: Leaf has no subclasses.',
+          movableCount: 0,
+          selectors: [],
+        }),
+      );
+
+      expect(a.globalDecline).toContain('no subclasses');
+    });
+
+    it('throws on a bare (non-JSON) engine error string', () => {
+      expect(() => parseAnalysis('Source class not found: Foo')).toThrow();
+    });
+  });
+
+  describe('parseStartPreview', () => {
+    const base = {
+      token: 'tok',
+      total: 3,
+      targetClass: 'Base',
+      movableCount: 1,
+      outOfScope: { references: 0, skipped: 0, scope: 'class', collision: null, decline: null },
+      skippedMethods: [],
+      page: { changes: [], nextOffset: 1, done: true },
+    };
+
+    it('reads totals, the target, and an empty page', () => {
+      const s = parseStartPreview(JSON.stringify(base));
+
+      expect(s.token).toBe('tok');
+      expect(s.total).toBe(3);
+      expect(s.targetClass).toBe('Base');
+      expect(s.movableCount).toBe(1);
+      expect(s.page.done).toBe(true);
+    });
+
+    it('reads skipped methods and a declining out-of-scope banner', () => {
+      const s = parseStartPreview(
+        JSON.stringify({
+          ...base,
+          outOfScope: { ...base.outOfScope, decline: 'Cannot push down: no subclasses.' },
+          skippedMethods: [{ selector: 'bar', reason: 'sends super' }],
+        }),
+      );
+
+      expect(s.outOfScope.decline).toContain('no subclasses');
+      expect(s.skippedMethods).toEqual([{ selector: 'bar', reason: 'sends super' }]);
+    });
+
+    it('parses the changes in the first page', () => {
+      const s = parseStartPreview(
+        JSON.stringify({
+          ...base,
+          page: {
+            changes: [
+              {
+                id: '1',
+                kind: 'methodAdd',
+                dictName: 'UserGlobals',
+                className: 'Base',
+                isMeta: false,
+                selector: 'foo',
+                category: 'accessing',
+                newSource: 'foo ^ 1',
+              },
+            ],
+            nextOffset: 2,
+            done: false,
+          },
+        }),
+      );
+
+      expect(s.page.changes).toHaveLength(1);
+      expect(s.page.changes[0].kind).toBe('methodAdd');
+      expect(s.page.done).toBe(false);
+    });
+
+    it('throws when the token is missing', () => {
+      expect(() => parseStartPreview(JSON.stringify({ total: 1 }))).toThrow(/token/);
+    });
+  });
+
+  describe('parsePage', () => {
+    it('parses a page of changes', () => {
+      const p = parsePage(
+        JSON.stringify({
+          changes: [
+            {
+              id: '2',
+              kind: 'methodRemove',
+              className: 'Base',
+              isMeta: false,
+              oldSource: 'foo ^ 1',
+            },
+          ],
+          nextOffset: 3,
+          done: true,
+        }),
+      );
+
+      expect(p.changes[0].kind).toBe('methodRemove');
+      expect(p.changes[0].oldSource).toBe('foo ^ 1');
+      expect(p.done).toBe(true);
+    });
+
+    it('throws the engine error carried on an expired-session page', () => {
+      expect(() =>
+        parsePage(JSON.stringify({ error: 'preview session expired', changes: [] })),
+      ).toThrow(/expired/);
+    });
+
+    it('rejects an unknown change kind', () => {
+      expect(() =>
+        parsePage(JSON.stringify({ changes: [{ id: '1', kind: 'nope', className: 'X' }] })),
+      ).toThrow(/unknown kind/);
+    });
+  });
+
+  describe('parseApplyResult', () => {
+    it('reads the applied count and an empty failure list', () => {
+      const r = parseApplyResult(JSON.stringify({ applied: 3, failed: [] }));
+
+      expect(r.applied).toBe(3);
+      expect(r.failed).toEqual([]);
+    });
+
+    it('reads a reported failure', () => {
+      const r = parseApplyResult(
+        JSON.stringify({ applied: 1, failed: [{ id: '2', label: 'Base', error: 'boom' }] }),
+      );
+
+      expect(r.failed).toHaveLength(1);
+      expect(r.failed[0].error).toBe('boom');
+    });
+  });
+
+  describe('pushChangeLabel', () => {
+    const change = (over: Partial<PushChange>): PushChange => ({
+      id: '1',
+      kind: 'methodAdd',
+      dictName: null,
+      className: 'Base',
+      isMeta: false,
+      selector: 'foo',
+      category: null,
+      oldSource: '',
+      newSource: '',
+      ...over,
+    });
+
+    it('tags a methodAdd as add-to-target', () => {
+      expect(pushChangeLabel(change({ kind: 'methodAdd' }))).toBe('Base>>foo (add to target)');
+    });
+
+    it('tags a methodRemove as remove-from-source and marks the class side', () => {
+      expect(pushChangeLabel(change({ kind: 'methodRemove', isMeta: true }))).toBe(
+        'Base class>>foo (remove from source)',
+      );
+    });
+  });
+});

--- a/client/src/refactoring/__tests__/pushMethodPreview.test.ts
+++ b/client/src/refactoring/__tests__/pushMethodPreview.test.ts
@@ -52,6 +52,19 @@ describe('push-method preview parsing', () => {
       expect(a.globalDecline).toContain('no subclasses');
     });
 
+    it('reads a per-selector overwrite warning', () => {
+      const a = parseAnalysis(
+        JSON.stringify({
+          targetClass: 'Base',
+          globalDecline: null,
+          movableCount: 1,
+          selectors: [{ selector: 'foo', decline: null, warning: 'overwrites Base>>foo' }],
+        }),
+      );
+
+      expect(a.selectors[0].warning).toBe('overwrites Base>>foo');
+    });
+
     it('throws on a bare (non-JSON) engine error string', () => {
       expect(() => parseAnalysis('Source class not found: Foo')).toThrow();
     });
@@ -147,6 +160,30 @@ describe('push-method preview parsing', () => {
       expect(p.done).toBe(true);
     });
 
+    it('reads a data-loss warning on an overwrite change and defaults it to null otherwise', () => {
+      const p = parsePage(
+        JSON.stringify({
+          changes: [
+            {
+              id: '1',
+              kind: 'methodAdd',
+              className: 'Sub',
+              isMeta: false,
+              oldSource: 'foo ^ 99',
+              newSource: 'foo ^ 1',
+              warning: 'overwrites Sub>>foo',
+            },
+            { id: '2', kind: 'methodAdd', className: 'Other', isMeta: false, newSource: 'foo ^ 1' },
+          ],
+          nextOffset: 3,
+          done: true,
+        }),
+      );
+
+      expect(p.changes[0].warning).toBe('overwrites Sub>>foo');
+      expect(p.changes[1].warning).toBeNull();
+    });
+
     it('throws the engine error carried on an expired-session page', () => {
       expect(() =>
         parsePage(JSON.stringify({ error: 'preview session expired', changes: [] })),
@@ -189,11 +226,18 @@ describe('push-method preview parsing', () => {
       category: null,
       oldSource: '',
       newSource: '',
+      warning: null,
       ...over,
     });
 
     it('tags a methodAdd as add-to-target', () => {
       expect(pushChangeLabel(change({ kind: 'methodAdd' }))).toBe('Base>>foo (add to target)');
+    });
+
+    it('tags an overwriting methodAdd as overwrite-existing', () => {
+      expect(pushChangeLabel(change({ kind: 'methodAdd', warning: 'overwrites Base>>foo' }))).toBe(
+        'Base>>foo (overwrite existing)',
+      );
     });
 
     it('tags a methodRemove as remove-from-source and marks the class side', () => {

--- a/client/src/refactoring/__tests__/refactoringPushMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringPushMethod.integration.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as path from 'path';
+vi.mock('vscode', () => import('../../__mocks__/vscode'));
+
+import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
+import { GciLibrary } from '../../gciLibrary';
+import * as q from '../../browserQueries';
+import { escapeString } from '../../queries/util';
+import {
+  analyzePushMethod,
+  startPushMethodPreview,
+  applyPushMethod,
+} from '../queries/previewPushMethod';
+import { PREVIEW_PAGE_BYTES } from '../queries/previewRenameMethod';
+import { parseAnalysis, parseStartPreview, parseApplyResult } from '../pushMethodPreview';
+import type { ActiveSession } from '../../sessionManager';
+import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
+import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+
+/**
+ * Automatic GCI integration test for the push-up / push-down method (M7 / M8)
+ * refactorings, over the real GCI transport.
+ *
+ * Layers, mirroring the other refactoring integration tests:
+ *  1. The engines' GS SUnit suites, filed in from the built payload and run in-stone.
+ *  2. Client round trips through the real query builders and parsers: push a pure method
+ *     UP to its superclass, decline a super-sender; push a method DOWN into every
+ *     subclass, decline when there are no subclasses, and confirm a deselected subclass
+ *     add leaves the source method in place (the guarded remove).
+ *
+ * Gated via the shared server-plugin feature gate; the engine-dependent tests run in the
+ * plugin-installed CI pass and skip, with a reason, against a bare stone. Fully
+ * transient: the harness aborts each test, so the fixture classes and any applied change
+ * are rolled back and nothing is committed. All emitted Smalltalk is ASCII-only for the
+ * 3.6.x matrix.
+ */
+describe('push method up/down (integration)', () => {
+  let gci: GciLibrary;
+  let handle: unknown;
+  useIntegrationTest((testContext) => {
+    gci = testContext.gciLibrary;
+    handle = testContext.session;
+  });
+
+  const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
+  const exec = (code: string): string => q.executeFetchString(session(), code);
+  const asyncExec = (_label: string, code: string): Promise<string> => Promise.resolve(exec(code));
+
+  const enginePresent = (): boolean =>
+    exec(
+      '((System myUserProfile symbolList objectNamed: #GsPushUpMethodRefactoring) notNil and: ' +
+        '[(System myUserProfile symbolList objectNamed: #GsPushDownMethodRefactoring) notNil]) printString',
+    ).trim() === 'true';
+
+  const engineTestsPayload = (): string =>
+    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
+
+  const fileInTests = (): string => {
+    const p = escapeString(engineTestsPayload());
+    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
+  };
+
+  const BASE = 'PumItBase';
+  const SUBA = 'PumItA';
+  const SUBB = 'PumItB';
+
+  // A super/sub hierarchy with selectors unique to this fixture.
+  const defineFixture = (): void => {
+    q.compileClassDefinition(
+      session(),
+      `Object subclass: '${BASE}' instVarNames: #('state') classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    q.compileClassDefinition(
+      session(),
+      `${BASE} subclass: '${SUBA}' instVarNames: #() classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    q.compileClassDefinition(
+      session(),
+      `${BASE} subclass: '${SUBB}' instVarNames: #() classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    // Push-DOWN candidates on the base.
+    q.compileMethod(session(), BASE, false, 'accessing', 'pumDown\n\t^100');
+    q.compileMethod(session(), BASE, false, 'accessing', 'pumSuperDown\n\t^super hash');
+    // Push-UP candidates on subclass A.
+    q.compileMethod(session(), SUBA, false, 'accessing', 'pumUpPure\n\t^7');
+    q.compileMethod(session(), SUBA, false, 'accessing', 'pumUpSuper\n\t^super hash');
+  };
+
+  const definesSelector = (cls: string, selector: string): boolean =>
+    exec(
+      `(${cls} compiledMethodAt: #'${selector}' environmentId: 0 otherwise: nil) notNil printString`,
+    ).trim() === 'true';
+
+  it('reports push engine availability matching the shared refactoring probe', () => {
+    expect(enginePresent()).toBe(q.checkRefactoringSupportAvailable(session()));
+  });
+
+  it('runs the push-up GS SUnit suite in-stone with zero failures', (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    const code = `| r |
+${fileInTests()}
+r := (System myUserProfile symbolList objectNamed: #GsPushUpMethodRefactoringTest) suite run.
+(r failures size + r errors size) printString`;
+
+    expect(exec(code).trim()).toBe('0');
+  });
+
+  it('runs the push-down GS SUnit suite in-stone with zero failures', (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    const code = `| r |
+${fileInTests()}
+r := (System myUserProfile symbolList objectNamed: #GsPushDownMethodRefactoringTest) suite run.
+(r failures size + r errors size) printString`;
+
+    expect(exec(code).trim()).toBe('0');
+  });
+
+  it('pushes a pure method up to its superclass', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+    const analysis = parseAnalysis(
+      await analyzePushMethod(asyncExec, 'up', SUBA, ['pumUpPure'], false),
+    );
+    expect(analysis.targetClass).toBe(BASE);
+    expect(analysis.movableCount).toBe(1);
+
+    const token = `pum-up-${SUBA}`;
+    const start = parseStartPreview(
+      await startPushMethodPreview(
+        asyncExec,
+        'up',
+        SUBA,
+        ['pumUpPure'],
+        false,
+        token,
+        PREVIEW_PAGE_BYTES,
+      ),
+    );
+    expect(start.outOfScope.decline).toBeNull();
+    const result = parseApplyResult(await applyPushMethod(asyncExec, 'up', token, []));
+
+    expect(result.failed).toEqual([]);
+    expect(definesSelector(BASE, 'pumUpPure')).toBe(true);
+    expect(definesSelector(SUBA, 'pumUpPure')).toBe(false);
+  });
+
+  it('declines pushing up a method that sends super', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+
+    const analysis = parseAnalysis(
+      await analyzePushMethod(asyncExec, 'up', SUBA, ['pumUpSuper'], false),
+    );
+
+    expect(analysis.movableCount).toBe(0);
+    expect(analysis.selectors[0].decline).toContain('super');
+  });
+
+  it('pushes a method down into every subclass and removes it from the source', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+    const token = `pum-down-${BASE}`;
+
+    const start = parseStartPreview(
+      await startPushMethodPreview(
+        asyncExec,
+        'down',
+        BASE,
+        ['pumDown'],
+        false,
+        token,
+        PREVIEW_PAGE_BYTES,
+      ),
+    );
+    expect(start.total).toBe(3); // two adds + one remove
+    const result = parseApplyResult(await applyPushMethod(asyncExec, 'down', token, []));
+
+    expect(result.failed).toEqual([]);
+    expect(definesSelector(SUBA, 'pumDown')).toBe(true);
+    expect(definesSelector(SUBB, 'pumDown')).toBe(true);
+    expect(definesSelector(BASE, 'pumDown')).toBe(false);
+  });
+
+  it('declines pushing down from a class with no subclasses', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+    q.compileMethod(session(), SUBA, false, 'accessing', 'pumLeaf\n\t^1');
+
+    const analysis = parseAnalysis(
+      await analyzePushMethod(asyncExec, 'down', SUBA, ['pumLeaf'], false),
+    );
+
+    expect(analysis.globalDecline).not.toBeNull();
+    expect(analysis.globalDecline).toContain('no subclasses');
+  });
+
+  it('leaves the source method in place when a subclass add is deselected', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+    const token = `pum-down-deselect-${BASE}`;
+
+    const start = parseStartPreview(
+      await startPushMethodPreview(
+        asyncExec,
+        'down',
+        BASE,
+        ['pumDown'],
+        false,
+        token,
+        PREVIEW_PAGE_BYTES,
+      ),
+    );
+    const addB = start.page.changes.find((c) => c.kind === 'methodAdd' && c.className === SUBB);
+    expect(addB).toBeDefined();
+
+    const result = parseApplyResult(await applyPushMethod(asyncExec, 'down', token, [addB!.id]));
+
+    expect(result.failed).toEqual([]);
+    expect(definesSelector(BASE, 'pumDown')).toBe(true); // guarded remove skipped
+    expect(definesSelector(SUBA, 'pumDown')).toBe(true);
+    expect(definesSelector(SUBB, 'pumDown')).toBe(false);
+  });
+});

--- a/client/src/refactoring/__tests__/refactoringPushMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringPushMethod.integration.test.ts
@@ -84,15 +84,27 @@ describe('push method up/down (integration)', () => {
     // Push-DOWN candidates on the base.
     q.compileMethod(session(), BASE, false, 'accessing', 'pumDown\n\t^100');
     q.compileMethod(session(), BASE, false, 'accessing', 'pumSuperDown\n\t^super hash');
+    // Push-DOWN where subclass A already overrides -> an opt-in overwrite for A.
+    q.compileMethod(session(), BASE, false, 'accessing', "pumOver\n\t^'base'");
+    q.compileMethod(session(), SUBA, false, 'accessing', "pumOver\n\t^'a'");
     // Push-UP candidates on subclass A.
     q.compileMethod(session(), SUBA, false, 'accessing', 'pumUpPure\n\t^7');
     q.compileMethod(session(), SUBA, false, 'accessing', 'pumUpSuper\n\t^super hash');
+    // Push-UP where the superclass already defines it -> an opt-in overwrite.
+    q.compileMethod(session(), BASE, false, 'accessing', "pumCollide\n\t^'base'");
+    q.compileMethod(session(), SUBA, false, 'accessing', "pumCollide\n\t^'suba'");
   };
 
   const definesSelector = (cls: string, selector: string): boolean =>
     exec(
       `(${cls} compiledMethodAt: #'${selector}' environmentId: 0 otherwise: nil) notNil printString`,
     ).trim() === 'true';
+
+  const sourceOf = (cls: string, selector: string): string =>
+    exec(
+      `(${cls} compiledMethodAt: #'${selector}' environmentId: 0 otherwise: nil) ` +
+        "ifNil: [''] ifNotNil: [:m | m sourceString]",
+    );
 
   it('reports push engine availability matching the shared refactoring probe', () => {
     expect(enginePresent()).toBe(q.checkRefactoringSupportAvailable(session()));
@@ -148,6 +160,93 @@ r := (System myUserProfile symbolList objectNamed: #GsPushDownMethodRefactoringT
     expect(result.failed).toEqual([]);
     expect(definesSelector(BASE, 'pumUpPure')).toBe(true);
     expect(definesSelector(SUBA, 'pumUpPure')).toBe(false);
+  });
+
+  it('pushes up onto a colliding superclass as an opt-in overwrite', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+    const analysis = parseAnalysis(
+      await analyzePushMethod(asyncExec, 'up', SUBA, ['pumCollide'], false),
+    );
+    expect(analysis.movableCount).toBe(1);
+    expect(analysis.selectors[0].decline).toBeNull();
+    expect(analysis.selectors[0].warning).not.toBeNull();
+
+    const token = `pum-up-collide-${SUBA}`;
+    const start = parseStartPreview(
+      await startPushMethodPreview(
+        asyncExec,
+        'up',
+        SUBA,
+        ['pumCollide'],
+        false,
+        token,
+        PREVIEW_PAGE_BYTES,
+      ),
+    );
+    const add = start.page.changes.find((c) => c.kind === 'methodAdd');
+    expect(add?.warning).not.toBeNull();
+    expect(add?.oldSource).toContain('base');
+    const result = parseApplyResult(await applyPushMethod(asyncExec, 'up', token, []));
+
+    expect(result.failed).toEqual([]);
+    expect(sourceOf(BASE, 'pumCollide')).toContain('suba');
+    expect(definesSelector(SUBA, 'pumCollide')).toBe(false);
+  });
+
+  it('keeps the source and the superclass method when a push-up overwrite is deselected', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+    const token = `pum-up-collide-deselect-${SUBA}`;
+    const start = parseStartPreview(
+      await startPushMethodPreview(
+        asyncExec,
+        'up',
+        SUBA,
+        ['pumCollide'],
+        false,
+        token,
+        PREVIEW_PAGE_BYTES,
+      ),
+    );
+    const add = start.page.changes.find((c) => c.kind === 'methodAdd');
+
+    const result = parseApplyResult(await applyPushMethod(asyncExec, 'up', token, [add!.id]));
+
+    expect(result.failed).toEqual([]);
+    expect(sourceOf(BASE, 'pumCollide')).toContain('base'); // superclass unchanged
+    expect(definesSelector(SUBA, 'pumCollide')).toBe(true); // source NOT stranded
+  });
+
+  it('shows an overriding subclass as an opt-in overwrite on push-down', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    defineFixture();
+    const token = `pum-down-over-${BASE}`;
+    const start = parseStartPreview(
+      await startPushMethodPreview(
+        asyncExec,
+        'down',
+        BASE,
+        ['pumOver'],
+        false,
+        token,
+        PREVIEW_PAGE_BYTES,
+      ),
+    );
+    const addA = start.page.changes.find((c) => c.kind === 'methodAdd' && c.className === SUBA);
+    const addB = start.page.changes.find((c) => c.kind === 'methodAdd' && c.className === SUBB);
+    expect(addA?.warning).not.toBeNull(); // A already overrides -> overwrite
+    expect(addB?.warning).toBeNull(); // B is a fresh add
+
+    const result = parseApplyResult(await applyPushMethod(asyncExec, 'down', token, []));
+
+    expect(result.failed).toEqual([]);
+    expect(sourceOf(SUBA, 'pumOver')).toContain('base'); // A's override replaced
+    expect(definesSelector(SUBB, 'pumOver')).toBe(true);
+    expect(definesSelector(BASE, 'pumOver')).toBe(false);
   });
 
   it('declines pushing up a method that sends super', async (ctx) => {

--- a/client/src/refactoring/pushMethodCommand.ts
+++ b/client/src/refactoring/pushMethodCommand.ts
@@ -42,6 +42,9 @@ export interface PushOutcome {
   moved: string[];
   /** The superclass a push-up landed in; null for push-down (many subclasses). */
   targetClass: string | null;
+  /** A class to navigate to and highlight the moved method in: the superclass for push-up,
+   *  the first fresh recipient subclass for push-down; null if there is nowhere to reveal. */
+  revealClass: string | null;
   isMeta: boolean;
 }
 
@@ -152,6 +155,15 @@ export async function pushMethod(req: PushMethodRequest): Promise<PushOutcome | 
     return undefined;
   }
 
+  // Nothing was applied — e.g. every target row (including opt-in overwrites, which start
+  // un-ticked) was left unchecked. Report it plainly and skip the reveal/refresh.
+  if (result.applied === 0) {
+    void vscode.window.showInformationMessage(
+      'No changes were applied — every target was left un-ticked.',
+    );
+    return undefined;
+  }
+
   const moved = analysis.selectors.filter((s) => !s.decline).map((s) => s.selector);
   const n = moved.length;
   const where =
@@ -161,10 +173,13 @@ export async function pushMethod(req: PushMethodRequest): Promise<PushOutcome | 
       ? `Pushed #${moved[0]} ${direction} ${where}.`
       : `Pushed ${n} methods ${direction} ${where}.`,
   );
-  return {
-    applied: result.applied,
-    moved,
-    targetClass: direction === 'up' ? (start.targetClass ?? analysis.targetClass) : null,
-    isMeta,
-  };
+  const targetClass = direction === 'up' ? (start.targetClass ?? analysis.targetClass) : null;
+  // Where to reveal + highlight the moved method: the superclass for push-up; for push-down,
+  // the first FRESH recipient (a plain add, most likely applied), falling back to the first
+  // recipient of any kind. Reveal is best-effort, so a missing target just no-ops.
+  const firstAdd = start.page.changes.find((c) => c.kind === 'methodAdd');
+  const firstFreshAdd = start.page.changes.find((c) => c.kind === 'methodAdd' && !c.warning);
+  const revealClass =
+    direction === 'up' ? targetClass : ((firstFreshAdd ?? firstAdd)?.className ?? null);
+  return { applied: result.applied, moved, targetClass, revealClass, isMeta };
 }

--- a/client/src/refactoring/pushMethodCommand.ts
+++ b/client/src/refactoring/pushMethodCommand.ts
@@ -1,0 +1,170 @@
+/**
+ * The Push Up / Push Down Method (M7 / M8) orchestration, driven from the GemStone
+ * Explorer: push one OR MORE methods from a source class to its immediate SUPERCLASS
+ * (up) or into its immediate SUBCLASSES (down), same side. Runs a server-side pre-flight
+ * (which selectors can move, and why the rest can't), previews the change set (a
+ * methodAdd on each target + a methodRemove on the source), applies it server-side (no
+ * commit), then lets the caller refresh/reveal the Explorer.
+ *
+ * The direction and target(s) are resolved by the engine — this module just previews
+ * and applies a fully-specified push. Nothing is ever committed; the user commits
+ * explicitly, exactly like the rest of the refactoring family.
+ */
+import * as vscode from 'vscode';
+import { ActiveSession } from '../sessionManager';
+import * as queries from '../browserQueries';
+import { PREVIEW_PAGE_BYTES } from './queries/previewRenameMethod';
+import { PushDirection } from './queries/previewPushMethod';
+import { parseAnalysis, parseStartPreview, parsePage, parseApplyResult } from './pushMethodPreview';
+import { showPushMethodPanel } from './pushMethodPanel';
+import { ensureRbSupport, refuse } from './renameAtCursorShared';
+import { logInfo } from '../gciLog';
+
+export interface PushMethodRequest {
+  session: ActiveSession;
+  /** Push up (to the superclass) or down (into the subclasses). */
+  direction: PushDirection;
+  /** The class the methods currently live in. */
+  sourceClass: string;
+  /** The selectors to push (one or many). */
+  selectors: string[];
+  /** The source side: true = class side (metaclass), false = instance side. */
+  isMeta: boolean;
+  /** Dict scope for the source-class lookup (1-based SymbolList index or name). */
+  dict?: number | string;
+}
+
+/** The result of a completed, applied push — so the caller can reveal the methods in
+ *  their new home. */
+export interface PushOutcome {
+  applied: number;
+  /** The selectors that actually moved (the movable subset). */
+  moved: string[];
+  /** The superclass a push-up landed in; null for push-down (many subclasses). */
+  targetClass: string | null;
+  isMeta: boolean;
+}
+
+const VERB: Record<PushDirection, string> = { up: 'Push up', down: 'Push down' };
+
+/** Preview + apply a fully-specified push. Answers the outcome when changes were
+ *  applied, or undefined when cancelled, declined, or nothing was movable. Surfaces its
+ *  own user-facing messages; the CALLER reveals/refreshes the affected classes. */
+export async function pushMethod(req: PushMethodRequest): Promise<PushOutcome | undefined> {
+  const { session, direction, sourceClass, selectors, isMeta, dict } = req;
+  logInfo(`[pushMethod:${direction}] ${sourceClass} ${selectors.length} selector(s)`);
+
+  if (selectors.length === 0) return undefined;
+  if (!(await ensureRbSupport(session, `${VERB[direction]} of a method`))) {
+    logInfo(`[pushMethod:${direction}] refactoring engine unavailable; user declined install`);
+    return undefined;
+  }
+
+  // Pre-flight: refuse a global decline (or a nothing-movable push) before opening the
+  // preview, and explain why.
+  let analysis;
+  try {
+    analysis = parseAnalysis(
+      await queries.analyzePushMethod(session, direction, sourceClass, selectors, isMeta, dict),
+    );
+  } catch (e: unknown) {
+    void vscode.window.showErrorMessage(
+      `Push pre-flight failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return undefined;
+  }
+  if (analysis.globalDecline) {
+    refuse(analysis.globalDecline);
+    return undefined;
+  }
+  if (analysis.movableCount === 0) {
+    // Lead with the engine's reason (it already starts "Cannot push … #sel: …"), so the
+    // actionable part is visible up front in the toast; list a count when several fail.
+    const declined = analysis.selectors.filter((s) => s.decline);
+    refuse(
+      declined.length <= 1
+        ? (declined[0]?.decline ?? 'None of the selected methods can be pushed.')
+        : `${declined.length} methods cannot be pushed. ${declined[0].decline}`,
+    );
+    return undefined;
+  }
+
+  const token = `push_${direction}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const safeClear = (): void => {
+    try {
+      queries.clearPushMethodPreview(session, direction, token);
+    } catch {
+      /* best-effort cleanup */
+    }
+  };
+
+  let start;
+  try {
+    start = parseStartPreview(
+      await queries.startPushMethodPreview(
+        session,
+        direction,
+        sourceClass,
+        selectors,
+        isMeta,
+        token,
+        PREVIEW_PAGE_BYTES,
+        dict,
+      ),
+    );
+  } catch (e: unknown) {
+    void vscode.window.showErrorMessage(
+      `Push preview failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    safeClear();
+    return undefined;
+  }
+
+  if (start.outOfScope.decline) {
+    refuse(start.outOfScope.decline);
+    safeClear();
+    return undefined;
+  }
+  if (start.total === 0) {
+    refuse('Nothing to push.');
+    safeClear();
+    return undefined;
+  }
+
+  const heading =
+    direction === 'up'
+      ? `Push up to ${start.targetClass ?? analysis.targetClass ?? 'superclass'}`
+      : `Push down into subclasses of ${sourceClass}`;
+  const result = await showPushMethodPanel(heading, start, {
+    loadPage: async (off) =>
+      parsePage(
+        await queries.pagePushMethodPreview(session, direction, token, off, PREVIEW_PAGE_BYTES),
+      ),
+    apply: async (deselected) =>
+      parseApplyResult(await queries.applyPushMethod(session, direction, token, deselected)),
+    cleanup: safeClear,
+  });
+  if (!result) return undefined;
+
+  if (result.failed.length > 0) {
+    const first = result.failed[0];
+    void vscode.window.showErrorMessage(`Push failed: ${first.label}: ${first.error}`);
+    return undefined;
+  }
+
+  const moved = analysis.selectors.filter((s) => !s.decline).map((s) => s.selector);
+  const n = moved.length;
+  const where =
+    direction === 'up' ? `to ${start.targetClass ?? 'the superclass'}` : 'to the subclasses';
+  void vscode.window.showInformationMessage(
+    n === 1
+      ? `Pushed #${moved[0]} ${direction} ${where}.`
+      : `Pushed ${n} methods ${direction} ${where}.`,
+  );
+  return {
+    applied: result.applied,
+    moved,
+    targetClass: direction === 'up' ? (start.targetClass ?? analysis.targetClass) : null,
+    isMeta,
+  };
+}

--- a/client/src/refactoring/pushMethodPanel.ts
+++ b/client/src/refactoring/pushMethodPanel.ts
@@ -1,0 +1,124 @@
+/**
+ * The paginated push-up / push-down method (M7 / M8) preview panel. Shows every staged
+ * change (a `methodAdd` on the target + a `methodRemove` on the source, per movable
+ * selector) as a required row, lists any selectors that could not move, fetches further
+ * pages on demand, and applies server-side (no commit). Resolves with the apply result,
+ * or undefined if cancelled/closed. UI-only: the caller supplies the page/apply/cleanup
+ * handlers.
+ *
+ * Reuses Jasper's webview convention and the shared renameMethodPanelView.js (read at
+ * runtime, injected under a nonce) for diff/pagination/apply behaviour. Because every
+ * row is required (checked + disabled), the deselected set the view reports is always
+ * empty; apply passes it through unchanged.
+ */
+import * as vscode from 'vscode';
+import * as crypto from 'crypto';
+import { StartPushPreview, PushPreviewPage, PushApplyResult } from './pushMethodPreview';
+import { renderPushPanelHtml, renderPushCards } from './pushMethodPanelHtml';
+import { readWebviewScript } from '../webviewAssets';
+
+const panelJs = readWebviewScript('renameMethodPanelView.js', 'refactoring');
+
+export interface PushMethodPanelHandlers {
+  /** Fetch the page starting at `offset` (1-based). */
+  loadPage: (offset: number) => Promise<PushPreviewPage>;
+  /** Apply server-side, skipping `deselectedIds` (always empty here); no commit. */
+  apply: (deselectedIds: string[]) => Promise<PushApplyResult>;
+  /** Drop the preview session (called exactly once when the panel closes). */
+  cleanup: () => void;
+}
+
+/** Show the paginated preview; resolve with the apply result, or undefined if the
+ *  user cancelled/closed it. `heading` names the direction + target. */
+export function showPushMethodPanel(
+  heading: string,
+  start: StartPushPreview,
+  handlers: PushMethodPanelHandlers,
+): Promise<PushApplyResult | undefined> {
+  const panel = vscode.window.createWebviewPanel(
+    'gemstonePushMethod',
+    heading,
+    vscode.ViewColumn.Active,
+    { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
+  );
+
+  const nonce = crypto.randomBytes(16).toString('hex');
+  panel.webview.html = renderPushPanelHtml({
+    heading,
+    total: start.total,
+    changes: start.page.changes,
+    done: start.page.done,
+    outOfScope: start.outOfScope,
+    skippedMethods: start.skippedMethods,
+    nonce,
+    script: panelJs,
+  });
+
+  let offset = start.page.nextOffset;
+  let done = start.page.done;
+
+  return new Promise<PushApplyResult | undefined>((resolve) => {
+    let settled = false;
+    const finish = (result: PushApplyResult | undefined): void => {
+      if (settled) return;
+      settled = true;
+      handlers.cleanup();
+      resolve(result);
+      panel.dispose();
+    };
+
+    const fetchOne = async (): Promise<boolean> => {
+      const page = await handlers.loadPage(offset);
+      void panel.webview.postMessage({
+        command: 'appendChanges',
+        html: renderPushCards(page.changes),
+        done: page.done,
+      });
+      offset = page.nextOffset;
+      done = page.done;
+      return done;
+    };
+
+    let loading = false;
+    panel.webview.onDidReceiveMessage((message) => {
+      void (async () => {
+        try {
+          if (message?.command === 'loadMore' || message?.command === 'loadAll') {
+            if (loading) return;
+            if (done) {
+              void panel.webview.postMessage({ command: 'busyDone' });
+              return;
+            }
+            loading = true;
+            try {
+              if (message.command === 'loadAll') {
+                while (!done) {
+                  await fetchOne();
+                }
+              } else {
+                await fetchOne();
+              }
+            } finally {
+              loading = false;
+            }
+          } else if (message?.command === 'apply') {
+            const deselected: string[] = Array.isArray(message.deselected)
+              ? message.deselected
+              : [];
+            const result = await handlers.apply(deselected);
+            finish(result);
+          } else if (message?.command === 'cancel') {
+            finish(undefined);
+          }
+        } catch (e: unknown) {
+          loading = false;
+          const msg = e instanceof Error ? e.message : String(e);
+          void vscode.window.showErrorMessage(`Push preview: ${msg}`);
+          void panel.webview.postMessage({ command: 'busyDone' });
+        }
+      })();
+    });
+
+    panel.onDidDispose(() => finish(undefined));
+  });
+}

--- a/client/src/refactoring/pushMethodPanelHtml.ts
+++ b/client/src/refactoring/pushMethodPanelHtml.ts
@@ -1,0 +1,231 @@
+/**
+ * Pure HTML rendering for the push-up / push-down method (M7 / M8) preview panel.
+ * Every row is a CORE change — a `methodAdd` on the target (superclass or a subclass)
+ * or a `methodRemove` on the source — rendered with a checked, DISABLED checkbox: the
+ * user chose which methods to push at command time, so the preview is confirm-or-cancel,
+ * not a per-change picker (and a selector's changes must apply together). Selectors that
+ * could NOT move are listed in a summary; a global decline (which blocks Apply) sits in
+ * a banner. Paginated exactly like the other refactoring panels, reusing
+ * renameMethodPanelView.js for the DOM behaviour.
+ *
+ * Kept free of any `vscode` dependency so it unit-tests directly.
+ */
+import {
+  PushChange,
+  PushOutOfScope,
+  PushSkippedMethod,
+  pushChangeLabel,
+} from './pushMethodPreview';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderAllOfType(source: string, type: 'add' | 'del'): string {
+  const p = type === 'add' ? '+' : '-';
+  return source
+    .split('\n')
+    .map((t) => `<div class="line ${type}">${escapeHtml(p + t)}</div>`)
+    .join('');
+}
+
+function renderCard(change: PushChange): string {
+  const label = escapeHtml(pushChangeLabel(change));
+  const badge = change.category ? `<span class="badge">${escapeHtml(change.category)}</span>` : '';
+  // methodAdd has no old source (all-added on the target); methodRemove has no new
+  // source (all-removed from the source). Render each as a single-sided diff rather
+  // than diffing against '' (which shows a phantom empty line).
+  const diff =
+    change.kind === 'methodAdd'
+      ? renderAllOfType(change.newSource, 'add')
+      : renderAllOfType(change.oldSource, 'del');
+  // Every push change is required: a checked, DISABLED checkbox stays checked, so the
+  // shared view JS (which derives the deselected set from UNCHECKED boxes) never
+  // reports it — the push always applies in full.
+  const cb = `<input type="checkbox" class="sel" checked disabled title="This change is required" aria-label="${label} (required)">`;
+  return `<li class="change" data-id="${escapeHtml(change.id)}">
+  <div class="change-head">
+    ${cb}
+    <span class="label">${label}</span>
+    ${badge}
+    <button class="toggle" title="Show/hide diff" aria-expanded="false">▸</button>
+  </div>
+  <pre class="diff hidden">${diff}</pre>
+</li>`;
+}
+
+/** Render a batch of cards. All push changes are core, so no core/optional split. Pure. */
+export function renderPushCards(changes: PushChange[]): string {
+  return changes.map((c) => renderCard(c)).join('\n');
+}
+
+function renderBanner(oos: PushOutOfScope): string {
+  if (!oos.decline) return '';
+  return `<div class="oos">⛔ ${escapeHtml(oos.decline)}</div>`;
+}
+
+function renderSkipped(skipped: PushSkippedMethod[]): string {
+  if (skipped.length === 0) return '';
+  const items = skipped
+    .map((s) => `<li><code>${escapeHtml(s.selector)}</code> — ${escapeHtml(s.reason)}</li>`)
+    .join('');
+  const n = skipped.length;
+  return `<div class="skipped">
+    <div class="skipped-head">${n} method${n === 1 ? '' : 's'} will NOT move:</div>
+    <ul>${items}</ul>
+  </div>`;
+}
+
+export interface PushPanelHtmlOptions {
+  /** The panel heading, e.g. "Push Up to Foo" or "Push Down into subclasses of Foo". */
+  heading: string;
+  /** Total number of changes across all pages. */
+  total: number;
+  /** The first page of changes. */
+  changes: PushChange[];
+  /** True when the first page is also the last (no More button). */
+  done: boolean;
+  outOfScope: PushOutOfScope;
+  skippedMethods: PushSkippedMethod[];
+  nonce: string;
+  script: string;
+}
+
+/** Build the panel's HTML. Pure (no vscode) so it unit-tests directly. */
+export function renderPushPanelHtml(opts: PushPanelHtmlOptions): string {
+  const { heading, total, changes, done, outOfScope, skippedMethods, nonce, script } = opts;
+  const cards = renderPushCards(changes);
+  const pagerHidden = done ? ' hidden' : '';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <title>Push Method</title>
+  <style>
+    body {
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      color: var(--vscode-foreground);
+      background: var(--vscode-editor-background);
+      padding: 0; margin: 0;
+    }
+    header {
+      position: sticky; top: 0; z-index: 1;
+      background: var(--vscode-editor-background);
+      border-bottom: 1px solid var(--vscode-panel-border, transparent);
+      padding: 12px 16px;
+      display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    }
+    .title { font-size: 1.1em; }
+    .title code {
+      font-family: var(--vscode-editor-font-family, monospace);
+      background: var(--vscode-textCodeBlock-background, rgba(127,127,127,0.15));
+      padding: 1px 5px; border-radius: 3px;
+    }
+    .actions { display: flex; gap: 8px; flex: none; }
+    button {
+      padding: 5px 14px;
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      border: none; border-radius: 2px; cursor: pointer;
+      font-family: var(--vscode-font-family); font-size: var(--vscode-font-size);
+    }
+    button:hover { background: var(--vscode-button-hoverBackground); }
+    button.secondary {
+      background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground);
+    }
+    button:disabled { opacity: 0.5; cursor: default; }
+    button.toggle { background: none; color: var(--vscode-foreground); padding: 0 4px; opacity: 0.7; }
+    button.toggle:hover { background: none; opacity: 1; }
+    .oos {
+      margin: 8px 16px 0; padding: 8px 12px;
+      border: 1px solid var(--vscode-inputValidation-errorBorder, rgba(200,0,0,0.6));
+      background: var(--vscode-inputValidation-errorBackground, rgba(200,0,0,0.12));
+      border-radius: 4px;
+    }
+    .skipped {
+      margin: 8px 16px 0; padding: 8px 12px;
+      border: 1px solid var(--vscode-inputValidation-warningBorder, rgba(200,140,0,0.6));
+      background: var(--vscode-inputValidation-warningBackground, rgba(200,140,0,0.10));
+      border-radius: 4px;
+    }
+    .skipped-head { margin-bottom: 4px; }
+    .skipped ul { margin: 0; padding-left: 20px; }
+    .skipped code, .summary code, .title code { font-family: var(--vscode-editor-font-family, monospace); }
+    .summary { padding: 8px 16px; opacity: 0.85; display: flex; align-items: center; gap: 10px; }
+    button.linkish { background: none; color: var(--vscode-textLink-foreground); padding: 0; font-size: 0.95em; }
+    button.linkish:hover { background: none; text-decoration: underline; }
+    ul.changes { list-style: none; margin: 0; padding: 0 8px; }
+    li.change {
+      border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.25));
+      border-radius: 4px; margin: 8px; overflow: hidden;
+    }
+    li.change.deselected { opacity: 0.5; }
+    .change-head {
+      display: flex; align-items: center; gap: 8px;
+      padding: 8px 10px;
+      background: var(--vscode-sideBar-background, transparent);
+      cursor: pointer; user-select: none;
+    }
+    .change-head:hover { background: var(--vscode-list-hoverBackground, transparent); }
+    .change-head .sel { cursor: default; }
+    .change-head .label { font-family: var(--vscode-editor-font-family, monospace); flex: 1; }
+    .badge {
+      font-size: 0.8em; opacity: 0.75;
+      border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.4));
+      border-radius: 10px; padding: 1px 8px;
+    }
+    pre.diff {
+      margin: 0; padding: 6px 0; overflow-x: auto;
+      font-family: var(--vscode-editor-font-family, monospace);
+      font-size: var(--vscode-editor-font-size, var(--vscode-font-size));
+      border-top: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.2));
+    }
+    pre.diff.hidden { display: none; }
+    .line { padding: 0 12px; white-space: pre; }
+    .line.add {
+      background: var(--vscode-diffEditor-insertedTextBackground, rgba(0,180,0,0.15));
+      color: var(--vscode-gitDecoration-addedResourceForeground, inherit);
+    }
+    .line.del {
+      background: var(--vscode-diffEditor-removedTextBackground, rgba(220,0,0,0.15));
+      color: var(--vscode-gitDecoration-deletedResourceForeground, inherit);
+    }
+    .pager { display: flex; align-items: center; gap: 10px; padding: 4px 16px 24px; }
+    .pager.hidden { display: none; }
+    #pagerStatus { opacity: 0.75; }
+  </style>
+</head>
+<body data-total="${total}">
+  <header>
+    <div class="title">${escapeHtml(heading)}</div>
+    <div class="actions">
+      <button id="apply">Apply <span id="count">${total}</span></button>
+      <button id="cancel" class="secondary">Cancel</button>
+    </div>
+  </header>
+  ${renderBanner(outOfScope)}
+  ${renderSkipped(skippedMethods)}
+  <div class="summary">
+    <span id="selcount">${total}</span> of ${total} change${total === 1 ? '' : 's'} selected
+    <button id="toggleAll" class="linkish" aria-expanded="false">Expand all</button>
+  </div>
+  <ul class="changes">
+${cards}
+  </ul>
+  <div class="pager${pagerHidden}" id="pager">
+    <button id="more">More</button>
+    <button id="loadAll" class="secondary">Load all</button>
+    <span id="pagerStatus">${changes.length} of ${total} loaded</span>
+  </div>
+  <script nonce="${nonce}">${script}</script>
+</body>
+</html>`;
+}

--- a/client/src/refactoring/pushMethodPanelHtml.ts
+++ b/client/src/refactoring/pushMethodPanelHtml.ts
@@ -1,12 +1,17 @@
 /**
  * Pure HTML rendering for the push-up / push-down method (M7 / M8) preview panel.
- * Every row is a CORE change — a `methodAdd` on the target (superclass or a subclass)
- * or a `methodRemove` on the source — rendered with a checked, DISABLED checkbox: the
- * user chose which methods to push at command time, so the preview is confirm-or-cancel,
- * not a per-change picker (and a selector's changes must apply together). Selectors that
- * could NOT move are listed in a summary; a global decline (which blocks Apply) sits in
- * a banner. Paginated exactly like the other refactoring panels, reusing
- * renameMethodPanelView.js for the DOM behaviour.
+ * Rows are one of three kinds:
+ *   - a plain `methodAdd` onto a fresh target — enabled + CHECKED, so the user can un-tick
+ *     a target they do not want (a copy-down convenience; the source is kept);
+ *   - an OVERWRITE `methodAdd` onto a target that already defines the selector — enabled +
+ *     UNCHECKED by default, flagged with a ⚠ data-loss warning and a before/after diff, so
+ *     replacing the existing method is an explicit opt-in;
+ *   - a source `methodRemove` — CORE (checked + disabled): the server fires it only once
+ *     the targets actually hold the method, so it is not a user choice.
+ * Selectors that could NOT move (a hard decline) are listed in a summary; a global decline
+ * (which blocks Apply) sits in a banner. Paginated exactly like the other refactoring
+ * panels, reusing renameMethodPanelView.js for the DOM behaviour (it derives the deselected
+ * set from unchecked boxes and recomputes the count on load).
  *
  * Kept free of any `vscode` dependency so it unit-tests directly.
  */
@@ -36,24 +41,43 @@ function renderAllOfType(source: string, type: 'add' | 'del'): string {
 function renderCard(change: PushChange): string {
   const label = escapeHtml(pushChangeLabel(change));
   const badge = change.category ? `<span class="badge">${escapeHtml(change.category)}</span>` : '';
-  // methodAdd has no old source (all-added on the target); methodRemove has no new
-  // source (all-removed from the source). Render each as a single-sided diff rather
-  // than diffing against '' (which shows a phantom empty line).
-  const diff =
-    change.kind === 'methodAdd'
-      ? renderAllOfType(change.newSource, 'add')
-      : renderAllOfType(change.oldSource, 'del');
-  // Every push change is required: a checked, DISABLED checkbox stays checked, so the
-  // shared view JS (which derives the deselected set from UNCHECKED boxes) never
-  // reports it — the push always applies in full.
-  const cb = `<input type="checkbox" class="sel" checked disabled title="This change is required" aria-label="${label} (required)">`;
-  return `<li class="change" data-id="${escapeHtml(change.id)}">
+  const isRemove = change.kind === 'methodRemove';
+  const isOverwrite = change.kind === 'methodAdd' && change.warning != null;
+  // Diff: a plain add is all-added; a remove is all-removed; an OVERWRITE shows the
+  // existing body (removed) above the pushed body (added) — a real before/after so the
+  // user sees exactly what is lost.
+  const diff = isRemove
+    ? renderAllOfType(change.oldSource, 'del')
+    : isOverwrite
+      ? renderAllOfType(change.oldSource, 'del') + renderAllOfType(change.newSource, 'add')
+      : renderAllOfType(change.newSource, 'add');
+  // Checkbox policy:
+  //  - a source #methodRemove is CORE (checked + disabled): the server fires it only once
+  //    the targets actually hold the method, so it is not a user choice;
+  //  - an OVERWRITE add is opt-in: enabled and UNCHECKED by default, so the destructive
+  //    replace happens only if the user ticks it;
+  //  - a plain add (a fresh target) is enabled and CHECKED, so the user can un-tick a
+  //    target they do not want (a copy-down convenience; the source is then kept).
+  // The shared view JS derives the deselected set from UNCHECKED boxes and recomputes the
+  // count on load, so a default-unchecked overwrite is reported deselected from the start.
+  let cb: string;
+  if (isRemove) {
+    cb = `<input type="checkbox" class="sel" checked disabled title="Removed from the source automatically, once every target has the method" aria-label="${label} (automatic)">`;
+  } else if (isOverwrite) {
+    cb = `<input type="checkbox" class="sel" title="Overwrites an existing method — tick to replace it (data loss)" aria-label="${label} (overwrite, opt-in)">`;
+  } else {
+    cb = `<input type="checkbox" class="sel" checked title="Untick to skip this target" aria-label="${label}">`;
+  }
+  const warn = change.warning ? `<div class="warn">⚠ ${escapeHtml(change.warning)}</div>` : '';
+  const liClass = isOverwrite ? 'change warn deselected' : 'change';
+  return `<li class="${liClass}" data-id="${escapeHtml(change.id)}">
   <div class="change-head">
     ${cb}
     <span class="label">${label}</span>
     ${badge}
     <button class="toggle" title="Show/hide diff" aria-expanded="false">▸</button>
   </div>
+  ${warn}
   <pre class="diff hidden">${diff}</pre>
 </li>`;
 }
@@ -158,6 +182,16 @@ export function renderPushPanelHtml(opts: PushPanelHtmlOptions): string {
     }
     .skipped-head { margin-bottom: 4px; }
     .skipped ul { margin: 0; padding-left: 20px; }
+    li.change.warn {
+      border-color: var(--vscode-inputValidation-warningBorder, rgba(200,140,0,0.6));
+    }
+    .warn {
+      margin: 0; padding: 6px 10px;
+      font-size: 0.9em;
+      color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+      background: var(--vscode-inputValidation-warningBackground, rgba(200,140,0,0.10));
+      border-top: 1px solid var(--vscode-inputValidation-warningBorder, rgba(200,140,0,0.4));
+    }
     .skipped code, .summary code, .title code { font-family: var(--vscode-editor-font-family, monospace); }
     .summary { padding: 8px 16px; opacity: 0.85; display: flex; align-items: center; gap: 10px; }
     button.linkish { background: none; color: var(--vscode-textLink-foreground); padding: 0; font-size: 0.95em; }
@@ -175,7 +209,8 @@ export function renderPushPanelHtml(opts: PushPanelHtmlOptions): string {
       cursor: pointer; user-select: none;
     }
     .change-head:hover { background: var(--vscode-list-hoverBackground, transparent); }
-    .change-head .sel { cursor: default; }
+    .change-head .sel { cursor: pointer; }
+    .change-head .sel:disabled { cursor: default; }
     .change-head .label { font-family: var(--vscode-editor-font-family, monospace); flex: 1; }
     .badge {
       font-size: 0.8em; opacity: 0.75;

--- a/client/src/refactoring/pushMethodPreview.ts
+++ b/client/src/refactoring/pushMethodPreview.ts
@@ -1,0 +1,235 @@
+/**
+ * Pure helpers for the push-up / push-down method (M7 / M8) preview: parsing the
+ * engine's pre-flight analysis, the paginated preview envelope, and the apply result.
+ * No `vscode` dependency, so it unit-tests directly.
+ *
+ * Push-UP relocates one OR MORE methods from a class to its immediate SUPERCLASS.
+ * Push-DOWN relocates them from a class into its immediate SUBCLASSES. Both keep the
+ * selector and the source verbatim and the same side (no instance↔class flip). Per
+ * movable selector, push-up stages one `methodAdd` on the superclass + one
+ * `methodRemove` on the source; push-down stages one `methodAdd` per receiving subclass
+ * + a single `methodRemove` on the source. Both changes for a selector are required
+ * together, so every row is a CORE row (checked + disabled): the user chose WHICH
+ * methods to push at command time, not in the preview.
+ *
+ * A selector that cannot move is dropped from the change set and reported in
+ * `skippedMethods` (with a reason); a GLOBAL decline (no superclass for push-up, no
+ * subclasses for push-down) empties the whole change set and rides in
+ * `outOfScope.decline`. The engine's JSON shape is identical to move-method's, so this
+ * module mirrors it.
+ */
+
+export type PushChangeKind = 'methodAdd' | 'methodRemove';
+
+/** One staged change: a `methodAdd` (compile on the target, no old source) or a
+ *  `methodRemove` (delete from the source, no new source). */
+export interface PushChange {
+  id: string;
+  kind: PushChangeKind;
+  dictName: string | null;
+  className: string;
+  isMeta: boolean;
+  selector: string | null;
+  category: string | null;
+  /** Empty for a `methodAdd` (brand-new on the target) — the diff renders all-added. */
+  oldSource: string;
+  /** Empty for a `methodRemove` (deleted) — the diff renders all-removed. */
+  newSource: string;
+}
+
+/** A selector that will NOT move, with the reason. */
+export interface PushSkippedMethod {
+  selector: string;
+  reason: string;
+}
+
+/** Preview preconditions. `decline` (a global decline) blocks Apply; `collision` is
+ *  always null for push (per-selector collisions ride in `skippedMethods`). */
+export interface PushOutOfScope {
+  collision: string | null;
+  decline: string | null;
+}
+
+export interface PushPreviewPage {
+  changes: PushChange[];
+  nextOffset: number;
+  done: boolean;
+}
+
+export interface StartPushPreview {
+  token: string;
+  total: number;
+  /** The superclass name for push-up; null for push-down (the method lands in many
+   *  subclasses). */
+  targetClass: string | null;
+  movableCount: number;
+  outOfScope: PushOutOfScope;
+  skippedMethods: PushSkippedMethod[];
+  page: PushPreviewPage;
+}
+
+export interface PushApplyResult {
+  applied: number;
+  failed: { id: string; label: string; error: string }[];
+  error?: string;
+}
+
+/** One selector's pre-flight verdict. */
+export interface PushSelectorAnalysis {
+  selector: string;
+  decline: string | null;
+}
+
+/** The engine pre-flight: the resolved target (superclass name, or null for
+ *  push-down), a global decline (if any), the count that will move, and a per-selector
+ *  decline. */
+export interface PushAnalysis {
+  targetClass: string | null;
+  globalDecline: string | null;
+  movableCount: number;
+  selectors: PushSelectorAnalysis[];
+}
+
+function asCount(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : 0;
+}
+
+function parseChange(raw: unknown, i: number): PushChange {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error(`Push preview change ${i} is malformed.`);
+  }
+  const c = raw as Record<string, unknown>;
+  if (c.kind !== 'methodAdd' && c.kind !== 'methodRemove') {
+    throw new Error(`Push preview change ${i} has an unknown kind: ${String(c.kind)}`);
+  }
+  if (typeof c.id !== 'string' || typeof c.className !== 'string') {
+    throw new Error(`Push preview change ${i} is missing required fields.`);
+  }
+  return {
+    id: c.id,
+    kind: c.kind,
+    dictName: typeof c.dictName === 'string' ? c.dictName : null,
+    className: c.className,
+    isMeta: c.isMeta === true,
+    selector: typeof c.selector === 'string' ? c.selector : null,
+    category: typeof c.category === 'string' ? c.category : null,
+    oldSource: typeof c.oldSource === 'string' ? c.oldSource : '',
+    newSource: typeof c.newSource === 'string' ? c.newSource : '',
+  };
+}
+
+function parsePageObject(env: Record<string, unknown>): PushPreviewPage {
+  if (typeof env.error === 'string') throw new Error(env.error);
+  if (!Array.isArray(env.changes)) {
+    throw new Error('Push preview page is missing its change list.');
+  }
+  return {
+    changes: env.changes.map(parseChange),
+    nextOffset: asCount(env.nextOffset),
+    done: env.done === true,
+  };
+}
+
+function parseSkipped(raw: unknown): PushSkippedMethod[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((s): s is Record<string, unknown> => typeof s === 'object' && s !== null)
+    .map((s) => ({
+      selector: typeof s.selector === 'string' ? s.selector : '?',
+      reason: typeof s.reason === 'string' ? s.reason : 'cannot move',
+    }));
+}
+
+/** Parse the pre-flight analysis payload. Throws on a bare error string (which fails
+ *  JSON.parse). */
+export function parseAnalysis(json: string): PushAnalysis {
+  const parsed: unknown = JSON.parse(json);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Push analysis did not return an envelope.');
+  }
+  const env = parsed as Record<string, unknown>;
+  const selectors = Array.isArray(env.selectors)
+    ? env.selectors
+        .filter((s): s is Record<string, unknown> => typeof s === 'object' && s !== null)
+        .map((s) => ({
+          selector: typeof s.selector === 'string' ? s.selector : '?',
+          decline: typeof s.decline === 'string' ? s.decline : null,
+        }))
+    : [];
+  return {
+    targetClass: typeof env.targetClass === 'string' ? env.targetClass : null,
+    globalDecline: typeof env.globalDecline === 'string' ? env.globalDecline : null,
+    movableCount: asCount(env.movableCount),
+    selectors,
+  };
+}
+
+/** Parse the start of a paginated preview. Throws on a malformed payload. */
+export function parseStartPreview(json: string): StartPushPreview {
+  const parsed: unknown = JSON.parse(json);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Push preview did not return a preview envelope.');
+  }
+  const env = parsed as Record<string, unknown>;
+  if (typeof env.token !== 'string') {
+    throw new Error('Push preview did not return a session token.');
+  }
+  const oos =
+    typeof env.outOfScope === 'object' && env.outOfScope !== null
+      ? (env.outOfScope as Record<string, unknown>)
+      : {};
+  const page =
+    typeof env.page === 'object' && env.page !== null
+      ? parsePageObject(env.page as Record<string, unknown>)
+      : { changes: [], nextOffset: 0, done: true };
+  return {
+    token: env.token,
+    total: asCount(env.total),
+    targetClass: typeof env.targetClass === 'string' ? env.targetClass : null,
+    movableCount: asCount(env.movableCount),
+    outOfScope: {
+      collision: typeof oos.collision === 'string' ? oos.collision : null,
+      decline: typeof oos.decline === 'string' ? oos.decline : null,
+    },
+    skippedMethods: parseSkipped(env.skippedMethods),
+    page,
+  };
+}
+
+export function parsePage(json: string): PushPreviewPage {
+  const parsed: unknown = JSON.parse(json);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Push preview page did not return an envelope.');
+  }
+  return parsePageObject(parsed as Record<string, unknown>);
+}
+
+export function parseApplyResult(json: string): PushApplyResult {
+  const parsed: unknown = JSON.parse(json);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Apply did not return a result envelope.');
+  }
+  const env = parsed as Record<string, unknown>;
+  const failed = Array.isArray(env.failed)
+    ? env.failed
+        .filter((f): f is Record<string, unknown> => typeof f === 'object' && f !== null)
+        .map((f) => ({
+          id: typeof f.id === 'string' ? f.id : '?',
+          label: typeof f.label === 'string' ? f.label : '?',
+          error: typeof f.error === 'string' ? f.error : 'unknown error',
+        }))
+    : [];
+  return {
+    applied: asCount(env.applied),
+    failed,
+    error: typeof env.error === 'string' ? env.error : undefined,
+  };
+}
+
+/** A human label for a preview row: "Class[ class]>>selector" tagged with the push
+ *  direction (add onto the target / remove from the source). */
+export function pushChangeLabel(change: PushChange): string {
+  const side = change.isMeta ? ' class' : '';
+  const base = `${change.className}${side}>>${change.selector ?? '?'}`;
+  return change.kind === 'methodAdd' ? `${base} (add to target)` : `${base} (remove from source)`;
+}

--- a/client/src/refactoring/pushMethodPreview.ts
+++ b/client/src/refactoring/pushMethodPreview.ts
@@ -31,10 +31,16 @@ export interface PushChange {
   isMeta: boolean;
   selector: string | null;
   category: string | null;
-  /** Empty for a `methodAdd` (brand-new on the target) — the diff renders all-added. */
+  /** Empty for a plain `methodAdd` (brand-new on the target) — the diff renders all-added.
+   *  Non-empty for an OVERWRITE add (the target already defines the selector): the existing
+   *  body, so the diff renders a before/after. */
   oldSource: string;
   /** Empty for a `methodRemove` (deleted) — the diff renders all-removed. */
   newSource: string;
+  /** A data-loss warning when this change overwrites an existing method (its definition is
+   *  lost); null for a non-destructive change. Overwrite rows are shown un-ticked by default
+   *  so the user opts in. */
+  warning: string | null;
 }
 
 /** A selector that will NOT move, with the reason. */
@@ -78,6 +84,10 @@ export interface PushApplyResult {
 export interface PushSelectorAnalysis {
   selector: string;
   decline: string | null;
+  /** A data-loss warning when pushing this selector would overwrite an existing method
+   *  (push-up: the superclass's; push-down: one or more subclass overrides); null otherwise.
+   *  The selector still moves — the overwrite is opt-in in the preview. */
+  warning: string | null;
 }
 
 /** The engine pre-flight: the resolved target (superclass name, or null for
@@ -115,6 +125,7 @@ function parseChange(raw: unknown, i: number): PushChange {
     category: typeof c.category === 'string' ? c.category : null,
     oldSource: typeof c.oldSource === 'string' ? c.oldSource : '',
     newSource: typeof c.newSource === 'string' ? c.newSource : '',
+    warning: typeof c.warning === 'string' ? c.warning : null,
   };
 }
 
@@ -154,6 +165,7 @@ export function parseAnalysis(json: string): PushAnalysis {
         .map((s) => ({
           selector: typeof s.selector === 'string' ? s.selector : '?',
           decline: typeof s.decline === 'string' ? s.decline : null,
+          warning: typeof s.warning === 'string' ? s.warning : null,
         }))
     : [];
   return {
@@ -226,10 +238,12 @@ export function parseApplyResult(json: string): PushApplyResult {
   };
 }
 
-/** A human label for a preview row: "Class[ class]>>selector" tagged with the push
- *  direction (add onto the target / remove from the source). */
+/** A human label for a preview row: "Class[ class]>>selector" tagged with what the change
+ *  does — add onto the target, OVERWRITE an existing target method, or remove from the
+ *  source. */
 export function pushChangeLabel(change: PushChange): string {
   const side = change.isMeta ? ' class' : '';
   const base = `${change.className}${side}>>${change.selector ?? '?'}`;
-  return change.kind === 'methodAdd' ? `${base} (add to target)` : `${base} (remove from source)`;
+  if (change.kind === 'methodRemove') return `${base} (remove from source)`;
+  return change.warning ? `${base} (overwrite existing)` : `${base} (add to target)`;
 }

--- a/client/src/refactoring/queries/previewPushMethod.ts
+++ b/client/src/refactoring/queries/previewPushMethod.ts
@@ -1,0 +1,118 @@
+import { QueryExecutor } from '../../queries/types';
+import { AsyncQueryExecutor } from './previewRenameMethod';
+import { classLookupExpr, escapeString } from '../../queries/util';
+
+// Push-up / push-down method (M7 / M8) query builders. Both engines
+// (GsPushUpMethodRefactoring / GsPushDownMethodRefactoring) share one class-side API,
+// so these builders are parametrized by `direction`. Each is addressed by a SOURCE
+// class + a COLLECTION of selectors + the source side (isMeta); the target(s) — the
+// superclass for push-up, the immediate subclasses for push-down — are resolved
+// server-side. Per movable selector, push-up stages a `methodAdd` on the superclass +
+// a `methodRemove` on the source; push-down stages a `methodAdd` per receiving subclass
+// + a single `methodRemove` on the source. A selector that cannot move is dropped and
+// reported. It stashes the change set under `token` and returns totals + the first
+// page. `dict` scopes the source-class lookup (1-based SymbolList index, canonical for
+// Jasper, or a name).
+
+export type PushDirection = 'up' | 'down';
+
+/** The engine class name for a direction. */
+export function pushEngineClass(direction: PushDirection): string {
+  return direction === 'up' ? 'GsPushUpMethodRefactoring' : 'GsPushDownMethodRefactoring';
+}
+
+/** A Smalltalk brace-array of Symbol literals, e.g. `{#'foo'. #'bar:'}` (or `#()`). */
+function selectorArrayExpr(selectors: string[]): string {
+  if (selectors.length === 0) return '#()';
+  return `{${selectors.map((s) => `#'${escapeString(s)}'`).join('. ')}}`;
+}
+
+/** Pre-flight (before opening the preview): the resolved target (superclass name for
+ *  push-up, null for push-down), a per-selector decline reason (nil when movable), a
+ *  global decline (no superclass / no subclasses), and the count that will move. */
+export function analyzePushMethod(
+  execute: AsyncQueryExecutor,
+  direction: PushDirection,
+  sourceClass: string,
+  selectors: string[],
+  isMeta: boolean,
+  dict?: number | string,
+): Promise<string> {
+  const engine = pushEngineClass(direction);
+  const code = `| cls |
+cls := ${classLookupExpr(sourceClass, dict)}.
+cls isNil ifTrue: [^ '{"targetClass":null,"globalDecline":"Source class not found: ${escapeString(
+    sourceClass,
+  )}","movableCount":0,"selectors":[]}'].
+${engine}
+  analyzeForClass: cls
+  selectors: ${selectorArrayExpr(selectors)}
+  meta: ${isMeta ? 'true' : 'false'}`;
+  const side = isMeta ? ' class' : '';
+  return execute(`analyzePush${direction}(${sourceClass}${side} ${selectors.length}sel)`, code);
+}
+
+/** Start a paginated push preview under `token`. */
+export function startPushMethodPreview(
+  execute: AsyncQueryExecutor,
+  direction: PushDirection,
+  sourceClass: string,
+  selectors: string[],
+  isMeta: boolean,
+  token: string,
+  maxBytes: number,
+  dict?: number | string,
+): Promise<string> {
+  const engine = pushEngineClass(direction);
+  const code = `| cls ref |
+cls := ${classLookupExpr(sourceClass, dict)}.
+cls isNil ifTrue: [^ 'Source class not found: ${escapeString(sourceClass)}'].
+ref := ${engine}
+  sourceClass: cls
+  selectors: ${selectorArrayExpr(selectors)}
+  meta: ${isMeta ? 'true' : 'false'}.
+^ref startPreviewToken: '${escapeString(token)}' maxBytes: ${maxBytes}`;
+  const side = isMeta ? ' class' : '';
+  return execute(
+    `startPush${direction}Preview(${sourceClass}${side} ${selectors.length}sel)`,
+    code,
+  );
+}
+
+/** Fetch the next page of a started preview, by token. */
+export function pagePushMethodPreview(
+  execute: AsyncQueryExecutor,
+  direction: PushDirection,
+  token: string,
+  offset: number,
+  maxBytes: number,
+): Promise<string> {
+  const engine = pushEngineClass(direction);
+  const code =
+    `${engine} pageForToken: '${escapeString(token)}' ` + `from: ${offset} maxBytes: ${maxBytes}`;
+  return execute(`pagePush${direction}Preview(${token} @ ${offset})`, code);
+}
+
+/** Apply a started preview server-side (compile on the target(s) + remove from the
+ *  source, the removal guarded so a deselected add never strands a method), WITHOUT
+ *  committing. `deselectedIds` skips individual staged changes. */
+export function applyPushMethod(
+  execute: AsyncQueryExecutor,
+  direction: PushDirection,
+  token: string,
+  deselectedIds: string[],
+): Promise<string> {
+  const engine = pushEngineClass(direction);
+  const ids = deselectedIds.map((id) => `'${escapeString(id)}'`).join(' ');
+  const code = `${engine} applyForToken: '${escapeString(token)}' ` + `deselected: #(${ids})`;
+  return execute(`applyPush${direction}(${token})`, code);
+}
+
+/** Drop a finished preview from SessionTemps. */
+export function clearPushMethodPreview(
+  execute: QueryExecutor,
+  direction: PushDirection,
+  token: string,
+): string {
+  return execute(`${pushEngineClass(direction)} clearToken: '${escapeString(token)}'`);
+}

--- a/gs-src/refactoring/engine/GsPushDownMethodRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsPushDownMethodRefactoring.class.st
@@ -1,0 +1,479 @@
+"
+Push one OR MORE methods DOWN (M8) from a source class into its immediate SUBCLASSES,
+keeping the selector and the method source verbatim and the same side (instance stays
+instance, class stays class -- no side flip). The refactoring is addressed by the source
+class + a COLLECTION of selectors + the source side (isMeta); the targets (the immediate
+subclasses) are resolved server-side, so the engine -- not the client -- owns the ''which
+classes'' logic and can be tested in isolation. Single-method push-down is just a
+one-element collection, so single- and multi-method share one path.
+
+Push-down is the inverse of push-up (M7) and a many-target relative of move-method (M6);
+it reuses the same change kinds and preview/apply/token machinery. Per movable selector it
+stages a #methodAdd on EVERY immediate subclass that does not already override the selector
+(each keeps its own override, and is silently skipped) plus a SINGLE #methodRemove on the
+source. So one pushed-down selector produces N adds + 1 remove (N = the receiving subclass
+count). Both change kinds already exist; no new kind is introduced. Each selector is
+analysed independently; a declined selector is dropped from the change set and reported, so
+a multi-push relocates the movable methods and explains the rest.
+
+A GLOBAL decline (the source has no subclasses) empties the whole change set. A per-selector
+decline is recorded when: the source method is missing; the method sends super (its meaning
+depends on the source class''s superclass, which changes once the home moves down); or EVERY
+immediate subclass already overrides the selector (nothing to push, and removing it from the
+source would only endanger the source's own direct instances). Instance-variable access needs
+no check: the method already lives on the source, so every accessed ivar is defined on (or
+inherited by) the source, and every subclass inherits those same ivars.
+
+This is the SIMPLEST SOUND variant: the definition is copied into each immediate subclass
+that lacks its own and removed from the source; senders are NOT rewritten and no forwarding
+method is left behind. NOTE the intended semantics: after push-down the source class no
+longer understands the selector, so this is meant for an abstract superclass (or one whose
+direct instances do not use the method). Building the change set compiles nothing and commits
+nothing; the server-side apply compiles each subclass and removes the source, guarding the
+removal so it fires only once EVERY immediate subclass understands the selector (a
+deselected/failed add leaves the source method in place rather than stranding a subclass),
+and NEVER commits (the user commits explicitly).
+"
+Class {
+	#name : 'GsPushDownMethodRefactoring',
+	#superclass : 'Object',
+	#instVars : [
+		'environment',
+		'sourceClass',
+		'selectors',
+		'isMeta',
+		'subClasses',
+		'recipients',
+		'changeSet',
+		'analysisDone',
+		'globalDecline',
+		'declines'
+	],
+	#category : 'Refactoring-Core'
+}
+
+{ #category : 'instance creation' }
+GsPushDownMethodRefactoring class >> sourceClass: aClass selectors: aCollection meta: aBool [
+	"Push aCollection of selectors from the aBool side of aClass down into the same side
+	 of aClass's immediate subclasses."
+	^self
+		environment: GsRefactoringEnvironment new
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+]
+
+{ #category : 'instance creation' }
+GsPushDownMethodRefactoring class >> environment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool [
+	^self new
+		setEnvironment: anEnvironment
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+]
+
+{ #category : 'preconditions' }
+GsPushDownMethodRefactoring class >> analyzeForClass: aClass selectors: aCollection meta: aBool [
+	"A pre-flight the client runs before opening the preview: a per-selector decline
+	 reason (nil when movable) and the count that will move. targetClass is null because
+	 the method lands in many subclasses."
+	^(self
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool) analysisJsonString
+]
+
+{ #category : 'paginated preview' }
+GsPushDownMethodRefactoring class >> pageForToken: token from: startIndex maxBytes: maxBytes [
+	"A page from a previously-started preview (see startPreviewToken:maxBytes:), by
+	 token. Answers an error envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"error":"preview session expired","changes":[],"nextOffset":0,"done":true}']
+		ifNotNil: [:ref | ref pageJsonFrom: startIndex maxBytes: maxBytes]
+]
+
+{ #category : 'paginated preview' }
+GsPushDownMethodRefactoring class >> applyForToken: token deselected: deselectedIds [
+	"Apply a previously-started preview (by token). No commit. Answers an error
+	 envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"applied":0,"failed":[],"error":"preview session expired"}']
+		ifNotNil: [:ref | ref applyDeselected: deselectedIds]
+]
+
+{ #category : 'paginated preview' }
+GsPushDownMethodRefactoring class >> clearToken: token [
+	"Drop a finished preview from SessionTemps."
+	SessionTemps current removeKey: token asSymbol ifAbsent: [].
+	^'ok'
+]
+
+{ #category : 'private' }
+GsPushDownMethodRefactoring >> setEnvironment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool [
+	environment := anEnvironment.
+	sourceClass := aClass.
+	selectors := aCollection collect: [:s | s asSymbol].
+	isMeta := aBool.
+	analysisDone := false
+]
+
+{ #category : 'accessing' }
+GsPushDownMethodRefactoring >> environment [
+	^environment
+]
+
+{ #category : 'accessing' }
+GsPushDownMethodRefactoring >> selectors [
+	^selectors
+]
+
+{ #category : 'private' }
+GsPushDownMethodRefactoring >> sourceBehavior [
+	"The behaviour that holds the methods being pushed: the metaclass for a class-side
+	 source."
+	^isMeta ifTrue: [sourceClass class] ifFalse: [sourceClass]
+]
+
+{ #category : 'private' }
+GsPushDownMethodRefactoring >> behaviorFor: aClass [
+	"The relevant side of a subclass (its metaclass for a class-side push)."
+	^isMeta ifTrue: [aClass class] ifFalse: [aClass]
+]
+
+{ #category : 'private - analysis' }
+GsPushDownMethodRefactoring >> ensureAnalysis [
+	analysisDone ifFalse: [
+		analysisDone := true.
+		[self computeAnalysis] on: Error do: [:e |
+			globalDecline := 'The push-down could not be analysed: ', e messageText]]
+]
+
+{ #category : 'private - analysis' }
+GsPushDownMethodRefactoring >> computeAnalysis [
+	"Resolve the immediate subclasses, reject a class with none, then record a
+	 per-selector decline (nil when movable) and, for movable selectors, the subclasses
+	 that will receive a copy (those not already overriding it)."
+	globalDecline := nil.
+	declines := Dictionary new.
+	recipients := Dictionary new.
+	subClasses := (sourceClass subclasses ifNil: [#()]) asArray.
+	subClasses isEmpty ifTrue: [
+		^globalDecline := 'Cannot push down: ', sourceClass name asString, ' has no subclasses.'].
+	selectors do: [:sel | self analyzeSelector: sel]
+]
+
+{ #category : 'private - analysis' }
+GsPushDownMethodRefactoring >> analyzeSelector: aSelector [
+	"Record the decline reason (nil when movable) and the receiving subclasses for one
+	 selector."
+	| method src tree recips |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	method isNil ifTrue: [
+		^declines at: aSelector put:
+			'Cannot push down #', aSelector asString, ': it is not defined in ', sourceClass name asString, '.'].
+	src := method sourceString.
+	tree := [RBParser parseMethod: src] on: Error do: [:e | nil].
+	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
+		^declines at: aSelector put:
+			'Cannot push down #', aSelector asString, ': it sends super, whose meaning depends on the class''s superclass.'].
+	recips := subClasses reject: [:s | (self behaviorFor: s) includesSelector: aSelector].
+	recips isEmpty ifTrue: [
+		^declines at: aSelector put:
+			'Cannot push down #', aSelector asString, ': every subclass already overrides it.'].
+	recipients at: aSelector put: recips.
+	declines at: aSelector put: nil
+]
+
+{ #category : 'private - analysis' }
+GsPushDownMethodRefactoring >> tree: aTree referencesName: aName [
+	"True if aTree or any descendant is a variable node named aName."
+	aTree nodesDo: [:n | (n isVariable and: [n name = aName]) ifTrue: [^true]].
+	^false
+]
+
+{ #category : 'private' }
+GsPushDownMethodRefactoring >> dictNameForClass: aClass [
+	| dicts |
+	dicts := environment dictionariesDefiningClassNamed: aClass name.
+	^dicts isEmpty ifTrue: [nil] ifFalse: [dicts first name asString]
+]
+
+{ #category : 'private' }
+GsPushDownMethodRefactoring >> categoryOfSelector: aSelector [
+	^((self sourceBehavior categoryOfSelector: aSelector environmentId: 0)
+		ifNil: ['as yet unclassified']) asString
+]
+
+{ #category : 'preconditions' }
+GsPushDownMethodRefactoring >> globalDecline [
+	"nil if the push-down as a whole is viable, otherwise a reason that empties the
+	 change set (the source has no subclasses)."
+	self ensureAnalysis.
+	^globalDecline
+]
+
+{ #category : 'preconditions' }
+GsPushDownMethodRefactoring >> declineFor: aSelector [
+	"nil if aSelector will move, otherwise the per-selector (or inherited global)
+	 reason it will not."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^globalDecline].
+	^declines at: aSelector asSymbol ifAbsent: [nil]
+]
+
+{ #category : 'accessing' }
+GsPushDownMethodRefactoring >> recipientsFor: aSelector [
+	"The immediate subclasses that will receive a copy of aSelector (empty for a declined
+	 or unknown selector)."
+	self ensureAnalysis.
+	^recipients at: aSelector asSymbol ifAbsent: [#()]
+]
+
+{ #category : 'accessing' }
+GsPushDownMethodRefactoring >> movableSelectors [
+	"The selectors that will actually move, preserving request order."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^#()].
+	^selectors select: [:sel | (declines at: sel ifAbsent: [nil]) isNil]
+]
+
+{ #category : 'accessing' }
+GsPushDownMethodRefactoring >> movableCount [
+	^self movableSelectors size
+]
+
+{ #category : 'building' }
+GsPushDownMethodRefactoring >> changeSet [
+	"The staged, non-committing change set, computed once and cached. Empty on a global
+	 decline; otherwise, per movable selector, one add per receiving subclass plus one
+	 remove from the source."
+	changeSet isNil ifTrue: [changeSet := self buildChangeSet].
+	^changeSet
+]
+
+{ #category : 'building' }
+GsPushDownMethodRefactoring >> buildChangeSet [
+	| cs |
+	cs := GsRefactoringChangeSet new.
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^cs].
+	self movableSelectors do: [:sel | self stagePushOf: sel into: cs].
+	^cs
+]
+
+{ #category : 'building' }
+GsPushDownMethodRefactoring >> stagePushOf: aSelector into: cs [
+	"Stage an add on every receiving subclass, then a single remove from the source."
+	| method src cat |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	src := method sourceString.
+	cat := self categoryOfSelector: aSelector.
+	(self recipientsFor: aSelector) do: [:sub |
+		cs
+			addMethodAddInDictionary: (self dictNameForClass: sub)
+			className: sub name asString
+			isMeta: isMeta
+			selector: aSelector
+			category: cat
+			newSource: src].
+	cs
+		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
+		className: sourceClass name asString
+		isMeta: isMeta
+		selector: aSelector
+		category: cat
+		oldSource: src
+]
+
+{ #category : 'serializing' }
+GsPushDownMethodRefactoring >> analysisJsonString [
+	"The pre-flight payload: a null targetClass (many subclasses), the movable count, a
+	 global decline (if any), and a per-selector {selector, decline} array."
+	| ws |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPutAll: '{"targetClass":null'.
+	ws nextPutAll: ',"globalDecline":';
+		nextPutAll: (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+	ws nextPutAll: ',"movableCount":'; nextPutAll: self movableCount printString.
+	ws nextPutAll: ',"selectors":['.
+	selectors keysAndValuesDo: [:i :sel |
+		i = 1 ifFalse: [ws nextPut: $,].
+		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+		ws nextPutAll: ',"decline":';
+			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPut: $}].
+	ws nextPutAll: ']}'.
+	^ws contents
+]
+
+{ #category : 'serializing' }
+GsPushDownMethodRefactoring >> previewJsonString [
+	^self changeSet jsonString
+]
+
+{ #category : 'serializing' }
+GsPushDownMethodRefactoring >> outOfScopeJsonString [
+	"The scope / precondition payload for the preview panel, in the family's shape. A
+	 hard global decline (which blocks Apply) rides here; per-selector skips ride in
+	 skippedMethods."
+	^'{"references":0,"skipped":', (selectors size - self movableCount) printString,
+	  ',"scope":"class","collision":null,"decline":',
+	  (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]),
+	  '}'
+]
+
+{ #category : 'serializing' }
+GsPushDownMethodRefactoring >> skippedMethodsJsonString [
+	"The declined selectors + reasons, for the preview panel to explain what will NOT
+	 move."
+	| ws first |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	first := true.
+	selectors do: [:sel | | reason |
+		reason := self declineFor: sel.
+		(reason notNil and: [globalDecline isNil]) ifTrue: [
+			first ifFalse: [ws nextPut: $,].
+			first := false.
+			ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+			ws nextPutAll: ',"reason":'; nextPutAll: (self jsonQuote: reason); nextPut: $}]].
+	ws nextPut: $].
+	^ws contents
+]
+
+{ #category : 'paginated preview' }
+GsPushDownMethodRefactoring >> startPreviewToken: token maxBytes: maxBytes [
+	"Build the change set, stash this refactoring in SessionTemps under token, and
+	 answer the first page plus totals and precondition warnings. Nothing is committed."
+	self changeSet.
+	SessionTemps current at: token asSymbol put: self.
+	^'{"token":', (self jsonQuote: token),
+	  ',"total":', self changeSet size printString,
+	  ',"targetClass":null',
+	  ',"movableCount":', self movableCount printString,
+	  ',"outOfScope":', self outOfScopeJsonString,
+	  ',"skippedMethods":', self skippedMethodsJsonString,
+	  ',"page":', (self pageJsonFrom: 1 maxBytes: maxBytes), '}'
+]
+
+{ #category : 'paginated preview' }
+GsPushDownMethodRefactoring >> pageJsonFrom: startIndex maxBytes: maxBytes [
+	"A byte-bounded page of staged changes (with source) from startIndex (1-based). At
+	 least one change is always emitted when any remain."
+	| all ws i |
+	all := self changeSet changes.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	i := startIndex.
+	[i <= all size and: [i = startIndex or: [ws position < maxBytes]]] whileTrue: [
+		i > startIndex ifTrue: [ws nextPut: $,].
+		(all at: i) jsonOn: ws.
+		i := i + 1].
+	ws nextPut: $].
+	^'{"changes":', ws contents,
+	  ',"nextOffset":', i printString,
+	  ',"done":', (i > all size) printString, '}'
+]
+
+{ #category : 'applying' }
+GsPushDownMethodRefactoring >> applyDeselected: deselectedIds [
+	"Apply the staged changes in the stone WITHOUT committing. A deselected id is
+	 skipped. The source removal is guarded (see applyMethodRemove:) so a skipped or
+	 failed subclass add never strands that subclass. Answers {applied, failed:[..]}."
+	| applied failures ids |
+	ids := (deselectedIds ifNil: [#()]) asArray.
+	failures := OrderedCollection new.
+	applied := 0.
+	self changeSet changes do: [:change |
+		(ids includes: change id)
+			ifFalse: [
+				[(self applyChange: change) ifTrue: [applied := applied + 1]]
+				on: Error do: [:e |
+					failures add: (Array with: change id with: change className with: e messageText)]]].
+	^'{"applied":', applied printString,
+	  ',"failed":[',
+	  ((failures collect: [:f |
+		'{"id":', (self jsonQuote: (f at: 1)),
+		',"label":', (self jsonQuote: (f at: 2)),
+		',"error":', (self jsonQuote: (f at: 3)), '}'])
+			inject: '' into: [:acc :s | acc isEmpty ifTrue: [s] ifFalse: [acc, ',', s]]),
+	  ']}'
+]
+
+{ #category : 'applying' }
+GsPushDownMethodRefactoring >> applyChange: aChange [
+	"Answer true when the change was applied, false when it was safely skipped."
+	aChange kind == #methodAdd ifTrue: [^self applyMethodAdd: aChange].
+	aChange kind == #methodRemove ifTrue: [^self applyMethodRemove: aChange].
+	^self error: 'Unexpected change kind for push-down-method: ', aChange kind printString
+]
+
+{ #category : 'applying' }
+GsPushDownMethodRefactoring >> applyMethodAdd: aChange [
+	"Compile the pushed-down method onto a subclass/side. No commit."
+	| cls target |
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].
+	target
+		compileMethod: aChange newSource
+		dictionaries: System myUserProfile symbolList
+		category: (aChange category ifNil: ['as yet unclassified']).
+	^true
+]
+
+{ #category : 'applying' }
+GsPushDownMethodRefactoring >> applyMethodRemove: aChange [
+	"Remove the method from the source -- but ONLY once EVERY immediate subclass
+	 understands the selector on its own (either it received a copy or it already
+	 overrode it), so a deselected or failed add never strands a subclass. No commit."
+	| cls sel |
+	sel := aChange selector asSymbol.
+	(subClasses allSatisfy: [:s | (self behaviorFor: s) includesSelector: sel])
+		ifFalse: [^false].
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	(aChange isMeta ifTrue: [cls class] ifFalse: [cls]) removeSelector: sel.
+	^true
+]
+
+{ #category : 'serializing' }
+GsPushDownMethodRefactoring >> jsonQuote: aString [
+	^'"', (self jsonEscape: aString), '"'
+]
+
+{ #category : 'serializing' }
+GsPushDownMethodRefactoring >> jsonEscape: aString [
+	"JSON string escaping emitting PURE ASCII (control chars and code points above 126
+	 become \\uXXXX), so the client's non-blocking GCI fetch is never handed a Unicode
+	 result."
+	| ws |
+	ws := WriteStream on: String new.
+	aString do: [:ch | | code |
+		code := ch asInteger.
+		ch == $" ifTrue: [ws nextPutAll: '\"']
+		ifFalse: [ch == $\ ifTrue: [ws nextPutAll: '\\']
+		ifFalse: [code = 10 ifTrue: [ws nextPutAll: '\n']
+		ifFalse: [code = 13 ifTrue: [ws nextPutAll: '\r']
+		ifFalse: [code = 9 ifTrue: [ws nextPutAll: '\t']
+		ifFalse: [code < 32
+			ifTrue: [ws nextPutAll: '\u00'; nextPutAll: (self hex2: code)]
+		ifFalse: [code > 126
+			ifTrue: [code > 65535
+				ifTrue: [ws nextPut: $?]
+				ifFalse: [ws nextPutAll: '\u';
+					nextPutAll: (self hex2: code // 256);
+					nextPutAll: (self hex2: code \\ 256)]]
+			ifFalse: [ws nextPut: ch]]]]]]]].
+	^ws contents
+]
+
+{ #category : 'serializing' }
+GsPushDownMethodRefactoring >> hex2: anInteger [
+	| digits |
+	digits := '0123456789abcdef'.
+	^(String with: (digits at: (anInteger // 16) + 1))
+		, (String with: (digits at: (anInteger \\ 16) + 1))
+]

--- a/gs-src/refactoring/engine/GsPushDownMethodRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsPushDownMethodRefactoring.class.st
@@ -9,25 +9,29 @@ one-element collection, so single- and multi-method share one path.
 
 Push-down is the inverse of push-up (M7) and a many-target relative of move-method (M6);
 it reuses the same change kinds and preview/apply/token machinery. Per movable selector it
-stages a #methodAdd on EVERY immediate subclass that does not already override the selector
-(each keeps its own override, and is silently skipped) plus a SINGLE #methodRemove on the
-source. So one pushed-down selector produces N adds + 1 remove (N = the receiving subclass
-count). Both change kinds already exist; no new kind is introduced. Each selector is
-analysed independently; a declined selector is dropped from the change set and reported, so
-a multi-push relocates the movable methods and explains the rest.
+stages a #methodAdd on EVERY immediate subclass plus a SINGLE #methodRemove on the source. A
+subclass that does NOT yet understand the selector gets a plain add; a subclass that already
+OVERRIDES it gets an opt-in OVERWRITE add (staged with the existing override's body + a
+data-loss warning), which the client leaves un-ticked by default so the user consciously
+chooses to replace that override. So one pushed-down selector produces N adds + 1 remove
+(N = the immediate subclass count). Both change kinds already exist; no new kind is
+introduced. Each selector is analysed independently; a declined selector is dropped from the
+change set and reported, so a multi-push relocates the movable methods and explains the rest.
 
 A GLOBAL decline (the source has no subclasses) empties the whole change set. A per-selector
-decline is recorded when: the source method is missing; the method sends super (its meaning
-depends on the source class''s superclass, which changes once the home moves down); or EVERY
-immediate subclass already overrides the selector (nothing to push, and removing it from the
-source would only endanger the source's own direct instances). Instance-variable access needs
-no check: the method already lives on the source, so every accessed ivar is defined on (or
-inherited by) the source, and every subclass inherits those same ivars.
+decline (a HARD skip) is recorded when: the source method is missing; or the method sends
+super (its meaning depends on the source class''s superclass, which changes once the home
+moves down). A class where EVERY immediate subclass already overrides the selector is NOT a
+decline any more -- it is simply an all-overwrite push the user opts into (or leaves entirely
+un-ticked). Instance-variable access needs no check: the method already lives on the source,
+so every accessed ivar is defined on (or inherited by) the source, and every subclass inherits
+those same ivars.
 
 This is the SIMPLEST SOUND variant: the definition is copied into each immediate subclass
-that lacks its own and removed from the source; senders are NOT rewritten and no forwarding
-method is left behind. NOTE the intended semantics: after push-down the source class no
-longer understands the selector, so this is meant for an abstract superclass (or one whose
+(overwriting an override only when the user opts in) and removed from the source; senders are
+NOT rewritten and no forwarding method is left behind. NOTE the intended semantics: after
+push-down the source class no longer understands the selector, so this is meant for an
+abstract superclass (or one whose
 direct instances do not use the method). Building the change set compiles nothing and commits
 nothing; the server-side apply compiles each subclass and removes the source, guarding the
 removal so it fires only once EVERY immediate subclass understands the selector (a
@@ -47,7 +51,8 @@ Class {
 		'changeSet',
 		'analysisDone',
 		'globalDecline',
-		'declines'
+		'declines',
+		'appliedAddSelectors'
 	],
 	#category : 'Refactoring-Core'
 }
@@ -165,8 +170,12 @@ GsPushDownMethodRefactoring >> computeAnalysis [
 { #category : 'private - analysis' }
 GsPushDownMethodRefactoring >> analyzeSelector: aSelector [
 	"Record the decline reason (nil when movable) and the receiving subclasses for one
-	 selector."
-	| method src tree recips |
+	 selector. EVERY immediate subclass is a recipient: those that do not yet understand
+	 the selector get a fresh copy; those that already override it get an opt-in OVERWRITE
+	 (staged with the existing body + a data-loss warning), so a class where every subclass
+	 overrides is no longer a hard decline -- it is just an all-overwrite push the user
+	 opts into. Only a missing source method or a super-send is a hard decline."
+	| method src tree |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	method isNil ifTrue: [
 		^declines at: aSelector put:
@@ -176,11 +185,7 @@ GsPushDownMethodRefactoring >> analyzeSelector: aSelector [
 	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
 		^declines at: aSelector put:
 			'Cannot push down #', aSelector asString, ': it sends super, whose meaning depends on the class''s superclass.'].
-	recips := subClasses reject: [:s | (self behaviorFor: s) includesSelector: aSelector].
-	recips isEmpty ifTrue: [
-		^declines at: aSelector put:
-			'Cannot push down #', aSelector asString, ': every subclass already overrides it.'].
-	recipients at: aSelector put: recips.
+	recipients at: aSelector put: subClasses.
 	declines at: aSelector put: nil
 ]
 
@@ -223,10 +228,36 @@ GsPushDownMethodRefactoring >> declineFor: aSelector [
 
 { #category : 'accessing' }
 GsPushDownMethodRefactoring >> recipientsFor: aSelector [
-	"The immediate subclasses that will receive a copy of aSelector (empty for a declined
-	 or unknown selector)."
+	"The immediate subclasses that will receive aSelector (empty for a declined or unknown
+	 selector). Includes subclasses that already override it -- those receive an opt-in
+	 OVERWRITE rather than a fresh add."
 	self ensureAnalysis.
 	^recipients at: aSelector asSymbol ifAbsent: [#()]
+]
+
+{ #category : 'private - analysis' }
+GsPushDownMethodRefactoring >> existingSourceIn: aSubclass for: aSelector [
+	"If aSubclass ALREADY overrides aSelector on this side, its current source (which
+	 pushing down will OVERWRITE); nil otherwise."
+	| beh |
+	beh := self behaviorFor: aSubclass.
+	(beh includesSelector: aSelector) ifFalse: [^nil].
+	^(beh compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [nil] ifNotNil: [:m | m sourceString]
+]
+
+{ #category : 'preconditions' }
+GsPushDownMethodRefactoring >> overwriteWarningFor: aSelector [
+	"A data-loss summary if pushing aSelector down would OVERWRITE an existing override in
+	 one or more subclasses; nil otherwise. nil for a declined selector or global decline."
+	| overs |
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^nil].
+	(self declineFor: aSelector) notNil ifTrue: [^nil].
+	overs := (self recipientsFor: aSelector) select: [:s | (self behaviorFor: s) includesSelector: aSelector].
+	overs isEmpty ifTrue: [^nil].
+	^'Pushing down overwrites the existing override in ', overs size printString,
+	  ' subclass', (overs size = 1 ifTrue: [''] ifFalse: ['es']), ' -- lost unless left un-ticked.'
 ]
 
 { #category : 'accessing' }
@@ -263,19 +294,32 @@ GsPushDownMethodRefactoring >> buildChangeSet [
 
 { #category : 'building' }
 GsPushDownMethodRefactoring >> stagePushOf: aSelector into: cs [
-	"Stage an add on every receiving subclass, then a single remove from the source."
+	"Stage an add on every receiving subclass -- an OVERWRITE (carrying the existing body +
+	 a data-loss warning) for a subclass that already overrides the selector, a plain add
+	 otherwise -- then a single remove from the source."
 	| method src cat |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	src := method sourceString.
 	cat := self categoryOfSelector: aSelector.
-	(self recipientsFor: aSelector) do: [:sub |
-		cs
-			addMethodAddInDictionary: (self dictNameForClass: sub)
-			className: sub name asString
-			isMeta: isMeta
-			selector: aSelector
-			category: cat
-			newSource: src].
+	(self recipientsFor: aSelector) do: [:sub | | existing |
+		existing := self existingSourceIn: sub for: aSelector.
+		existing isNil
+			ifTrue: [cs
+				addMethodAddInDictionary: (self dictNameForClass: sub)
+				className: sub name asString
+				isMeta: isMeta
+				selector: aSelector
+				category: cat
+				newSource: src]
+			ifFalse: [cs
+				addMethodOverwriteInDictionary: (self dictNameForClass: sub)
+				className: sub name asString
+				isMeta: isMeta
+				selector: aSelector
+				category: cat
+				oldSource: existing
+				newSource: src
+				warning: 'Pushing down overwrites ', sub name asString, '>>', aSelector asString, ' -- its current override is lost.']].
 	cs
 		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
 		className: sourceClass name asString
@@ -302,6 +346,8 @@ GsPushDownMethodRefactoring >> analysisJsonString [
 		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
 		ws nextPutAll: ',"decline":';
 			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPutAll: ',"warning":';
+			nextPutAll: ((self overwriteWarningFor: sel) ifNil: ['null'] ifNotNil: [:w | self jsonQuote: w]).
 		ws nextPut: $}].
 	ws nextPutAll: ']}'.
 	^ws contents
@@ -383,11 +429,15 @@ GsPushDownMethodRefactoring >> applyDeselected: deselectedIds [
 	 skipped. The source removal is guarded (see applyMethodRemove:) so a skipped or
 	 failed subclass add never strands that subclass. Answers {applied, failed:[..]}."
 	| applied failures ids |
-	ids := (deselectedIds ifNil: [#()]) asArray.
+	"Compare ids as Symbols: a deselected id arrives from the client as a String literal,
+	 which on 3.6.x is a Unicode string, and comparing it to the byte-string change id can
+	 raise (the 3.6.2 Unicode-comparison trap). asSymbol canonicalises both sides."
+	ids := ((deselectedIds ifNil: [#()]) collect: [:e | e asSymbol]) asIdentitySet.
 	failures := OrderedCollection new.
 	applied := 0.
+	appliedAddSelectors := Set new.
 	self changeSet changes do: [:change |
-		(ids includes: change id)
+		(ids includes: change id asSymbol)
 			ifFalse: [
 				[(self applyChange: change) ifTrue: [applied := applied + 1]]
 				on: Error do: [:e |
@@ -412,7 +462,10 @@ GsPushDownMethodRefactoring >> applyChange: aChange [
 
 { #category : 'applying' }
 GsPushDownMethodRefactoring >> applyMethodAdd: aChange [
-	"Compile the pushed-down method onto a subclass/side. No commit."
+	"Compile the pushed-down method onto a subclass/side. No commit. Records the selector
+	 as applied so the paired remove fires only when at least one add actually happened
+	 this run (so un-ticking every target is a genuine no-op, even when every subclass
+	 already understood the selector via its own override)."
 	| cls target |
 	cls := environment classNamed: aChange className.
 	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
@@ -421,16 +474,20 @@ GsPushDownMethodRefactoring >> applyMethodAdd: aChange [
 		compileMethod: aChange newSource
 		dictionaries: System myUserProfile symbolList
 		category: (aChange category ifNil: ['as yet unclassified']).
+	appliedAddSelectors add: aChange selector asSymbol.
 	^true
 ]
 
 { #category : 'applying' }
 GsPushDownMethodRefactoring >> applyMethodRemove: aChange [
-	"Remove the method from the source -- but ONLY once EVERY immediate subclass
-	 understands the selector on its own (either it received a copy or it already
-	 overrode it), so a deselected or failed add never strands a subclass. No commit."
+	"Remove the method from the source -- but ONLY once at least one add for this selector
+	 was applied this run AND EVERY immediate subclass understands the selector on its own
+	 (it received a copy or already overrode it). The applied-add clause makes un-ticking
+	 every target a no-op; the all-subclasses clause makes a partial push a copy-down that
+	 leaves the source in place rather than stranding a subclass. No commit."
 	| cls sel |
 	sel := aChange selector asSymbol.
+	(appliedAddSelectors includes: sel) ifFalse: [^false].
 	(subClasses allSatisfy: [:s | (self behaviorFor: s) includesSelector: sel])
 		ifFalse: [^false].
 	cls := environment classNamed: aChange className.

--- a/gs-src/refactoring/engine/GsPushUpMethodRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsPushUpMethodRefactoring.class.st
@@ -15,12 +15,24 @@ is introduced. Each selector is analysed independently; a declined selector is d
 the change set and reported, so a multi-push relocates the movable methods and explains the
 rest.
 
+When the superclass ALREADY implements the selector, the push is NOT declined: it becomes an
+opt-in OVERWRITE change -- the #methodAdd carries the superclass's existing body (for a
+before/after diff) plus a data-loss warning, and the client leaves it un-ticked by default so
+the user consciously chooses to replace the inherited definition (consolidating an inherited
+method by pushing up is a common intent). The paired source #methodRemove is guarded on the
+add having actually been applied THIS run (an applied-add set), NOT on a bare
+includesSelector: -- otherwise a deselected overwrite, whose selector the superclass already
+carries, would wrongly strip the source and lose the subclass version.
+
 A GLOBAL decline (the source has no superclass) empties the whole change set. A per-selector
-decline is recorded when: the source method is missing; the superclass already implements the
-selector (collision -- pushing up would overwrite it); the method sends super (its meaning
-depends on the source class''s superclass, which changes when the home moves up); or the
-method accesses an instance variable the superclass does not define (bytecode-precise via
-instVarsAccessed -- the ivar lives only on the subclass).
+decline (a HARD skip, not an overwrite) is recorded when: the source method is missing; the
+method sends super (its meaning depends on the source class''s superclass, which changes when
+the home moves up); the method accesses an instance variable the superclass does not define
+(bytecode-precise via instVarsAccessed -- the ivar lives only on the subclass); or the method
+references a CLASS variable or POOL variable declared only below the superclass (matched by
+identifier name against the shared-var delta). All three variable cases mean the pushed method
+would not even compile on the superclass. Class-INSTANCE variables are covered by the
+instVarsAccessed check on the metaclass side.
 
 This is the SIMPLEST SOUND variant: the definition is relocated to the superclass and the
 selector kept; siblings that inherited nothing now inherit the pushed-up method, senders are
@@ -41,7 +53,8 @@ Class {
 		'changeSet',
 		'analysisDone',
 		'globalDecline',
-		'declines'
+		'declines',
+		'appliedAddSelectors'
 	],
 	#category : 'Refactoring-Core'
 }
@@ -156,15 +169,17 @@ GsPushUpMethodRefactoring >> computeAnalysis [
 
 { #category : 'private - analysis' }
 GsPushUpMethodRefactoring >> computeDeclineFor: aSelector [
-	"nil if aSelector can be pushed up, otherwise a reason. Checks, in order: method
-	 exists on the source, no collision on the superclass, no super send, and every
-	 accessed instance variable exists on the superclass."
-	| method src tree accessed targetVars missing |
+	"nil if aSelector can be pushed up, otherwise a HARD reason. Checks, in order: the
+	 method exists on the source, it does not send super, every accessed instance variable
+	 exists on the superclass, and no referenced class/pool variable is declared only below
+	 the superclass. A collision (the superclass already implements the selector) is NOT a
+	 hard decline: it becomes an opt-in, data-losing OVERWRITE change (see
+	 overwriteWarningFor:), because consolidating an inherited method by pushing up is often
+	 the intent."
+	| method src tree accessed targetVars missing sharedBelow refNames badShared |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	method isNil ifTrue: [
 		^'Cannot push up #', aSelector asString, ': it is not defined in ', sourceClass name asString, '.'].
-	(self targetBehavior includesSelector: aSelector) ifTrue: [
-		^'Cannot push up #', aSelector asString, ': ', superClass name asString, ' already defines it.'].
 	src := method sourceString.
 	tree := [RBParser parseMethod: src] on: Error do: [:e | nil].
 	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
@@ -175,6 +190,18 @@ GsPushUpMethodRefactoring >> computeDeclineFor: aSelector [
 	missing isEmpty ifFalse: [
 		^'Cannot push up #', aSelector asString, ': it uses instance variable(s) not defined in the superclass (',
 			(self commaList: (missing collect: [:v | v asString])), ').'].
+	"Class variables and pool variables declared only below the superclass (the source's
+	 own, or a pool it alone imports) would be undeclared once the method compiles onto the
+	 superclass. instVarsAccessed does not cover these, so match referenced identifier names
+	 (from the parse tree) against the shared-var delta."
+	sharedBelow := self sharedVarsBelowTarget.
+	sharedBelow isEmpty ifFalse: [
+		refNames := Set new.
+		tree ifNotNil: [tree nodesDo: [:n | n isVariable ifTrue: [refNames add: n name asSymbol]]].
+		badShared := sharedBelow select: [:v | refNames includes: v].
+		badShared isEmpty ifFalse: [
+			^'Cannot push up #', aSelector asString, ': it uses class/pool variable(s) not defined in the superclass (',
+				(self commaList: ((badShared asSortedCollection: [:a :b | a <= b]) asArray collect: [:v | v asString])), ').']].
 	^nil
 ]
 
@@ -183,6 +210,54 @@ GsPushUpMethodRefactoring >> tree: aTree referencesName: aName [
 	"True if aTree or any descendant is a variable node named aName."
 	aTree nodesDo: [:n | (n isVariable and: [n name = aName]) ifTrue: [^true]].
 	^false
+]
+
+{ #category : 'private - analysis' }
+GsPushUpMethodRefactoring >> sharedVarsBelowTarget [
+	"Class-variable + pool-variable names visible to the SOURCE but NOT to the superclass --
+	 i.e. declared on the source (or between it and the superclass) -- as a Set of Symbols. A
+	 pushed-up method referencing any of these would fail to compile on the superclass. Class
+	 variables and pool imports are shared across both sides, so this is independent of isMeta."
+	| below |
+	below := self sharedVarNamesOf: sourceClass.
+	(self sharedVarNamesOf: superClass) do: [:v | below remove: v ifAbsent: []].
+	^below
+]
+
+{ #category : 'private - analysis' }
+GsPushUpMethodRefactoring >> sharedVarNamesOf: aClass [
+	"All class-variable + pool-variable names visible to aClass (own + inherited class vars,
+	 plus every imported pool's keys), as a Set of Symbols. Defensive against a release that
+	 lacks either reflection selector."
+	| names |
+	names := Set new.
+	([aClass allClassVarNames] on: Error do: [:e | #()])
+		do: [:n | names add: n asSymbol].
+	([aClass sharedPools] on: Error do: [:e | #()])
+		do: [:pool | pool keysDo: [:k | names add: k asSymbol]].
+	^names
+]
+
+{ #category : 'private - analysis' }
+GsPushUpMethodRefactoring >> targetExistingSourceFor: aSelector [
+	"If the superclass ALREADY implements aSelector, its current source (which pushing up
+	 will OVERWRITE); nil otherwise. Only meaningful for a movable selector."
+	(self targetBehavior includesSelector: aSelector) ifFalse: [^nil].
+	^(self targetBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [nil] ifNotNil: [:m | m sourceString]
+]
+
+{ #category : 'preconditions' }
+GsPushUpMethodRefactoring >> overwriteWarningFor: aSelector [
+	"A data-loss warning if pushing aSelector up would OVERWRITE a method the superclass
+	 itself defines (its definition is replaced by the pushed-up one); nil otherwise.
+	 nil for a declined selector or a global decline."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^nil].
+	(self declineFor: aSelector) notNil ifTrue: [^nil].
+	(self targetExistingSourceFor: aSelector) isNil ifTrue: [^nil].
+	^'Pushing up overwrites ', superClass name asString, '>>', aSelector asString,
+	  ' -- its current definition is lost.'
 ]
 
 { #category : 'private' }
@@ -261,18 +336,31 @@ GsPushUpMethodRefactoring >> buildChangeSet [
 
 { #category : 'building' }
 GsPushUpMethodRefactoring >> stagePushOf: aSelector into: cs [
-	"Stage the add-on-superclass then the remove-from-source for one movable selector."
-	| method src cat |
+	"Stage the add-on-superclass then the remove-from-source for one movable selector. If
+	 the superclass already implements the selector, the add is an OVERWRITE (carries the
+	 existing body + a data-loss warning) rather than a plain add."
+	| method src cat existing |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	src := method sourceString.
 	cat := self categoryOfSelector: aSelector.
-	cs
-		addMethodAddInDictionary: (self dictNameForClass: superClass)
-		className: superClass name asString
-		isMeta: isMeta
-		selector: aSelector
-		category: cat
-		newSource: src.
+	existing := self targetExistingSourceFor: aSelector.
+	existing isNil
+		ifTrue: [cs
+			addMethodAddInDictionary: (self dictNameForClass: superClass)
+			className: superClass name asString
+			isMeta: isMeta
+			selector: aSelector
+			category: cat
+			newSource: src]
+		ifFalse: [cs
+			addMethodOverwriteInDictionary: (self dictNameForClass: superClass)
+			className: superClass name asString
+			isMeta: isMeta
+			selector: aSelector
+			category: cat
+			oldSource: existing
+			newSource: src
+			warning: (self overwriteWarningFor: aSelector)].
 	cs
 		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
 		className: sourceClass name asString
@@ -300,6 +388,8 @@ GsPushUpMethodRefactoring >> analysisJsonString [
 		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
 		ws nextPutAll: ',"decline":';
 			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPutAll: ',"warning":';
+			nextPutAll: ((self overwriteWarningFor: sel) ifNil: ['null'] ifNotNil: [:w | self jsonQuote: w]).
 		ws nextPut: $}].
 	ws nextPutAll: ']}'.
 	^ws contents
@@ -381,11 +471,15 @@ GsPushUpMethodRefactoring >> applyDeselected: deselectedIds [
 	 skipped. Removals are additionally guarded (see applyMethodRemove:) so a skipped or
 	 failed add never strands a method in neither class. Answers {applied, failed:[..]}."
 	| applied failures ids |
-	ids := (deselectedIds ifNil: [#()]) asArray.
+	"Compare ids as Symbols: a deselected id arrives from the client as a String literal,
+	 which on 3.6.x is a Unicode string, and comparing it to the byte-string change id can
+	 raise (the 3.6.2 Unicode-comparison trap). asSymbol canonicalises both sides."
+	ids := ((deselectedIds ifNil: [#()]) collect: [:e | e asSymbol]) asIdentitySet.
 	failures := OrderedCollection new.
 	applied := 0.
+	appliedAddSelectors := Set new.
 	self changeSet changes do: [:change |
-		(ids includes: change id)
+		(ids includes: change id asSymbol)
 			ifFalse: [
 				[(self applyChange: change) ifTrue: [applied := applied + 1]]
 				on: Error do: [:e |
@@ -410,7 +504,10 @@ GsPushUpMethodRefactoring >> applyChange: aChange [
 
 { #category : 'applying' }
 GsPushUpMethodRefactoring >> applyMethodAdd: aChange [
-	"Compile the pushed-up method onto the superclass/side. No commit."
+	"Compile the pushed-up method onto the superclass/side. No commit. Records the
+	 selector as applied so the paired remove knows the add actually happened (a plain
+	 includesSelector: check cannot tell an applied push from a pre-existing collision
+	 method, so a deselected OVERWRITE must not trigger the remove)."
 	| cls target |
 	cls := environment classNamed: aChange className.
 	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
@@ -419,15 +516,20 @@ GsPushUpMethodRefactoring >> applyMethodAdd: aChange [
 		compileMethod: aChange newSource
 		dictionaries: System myUserProfile symbolList
 		category: (aChange category ifNil: ['as yet unclassified']).
+	appliedAddSelectors add: aChange selector asSymbol.
 	^true
 ]
 
 { #category : 'applying' }
 GsPushUpMethodRefactoring >> applyMethodRemove: aChange [
-	"Remove the method from the source -- but ONLY once the superclass actually holds it,
-	 so a deselected or failed add never leaves the method in neither class. No commit."
+	"Remove the method from the source -- but ONLY once this run actually compiled the
+	 method onto the superclass, so a deselected or failed add never leaves the method in
+	 neither class. Guarding on the applied-add set (not a bare includesSelector: on the
+	 superclass) is what makes a deselected OVERWRITE safe: the superclass already has a
+	 same-selector method, so includesSelector: would wrongly report the push succeeded
+	 and strip the source. No commit."
 	| cls target |
-	(self targetBehavior includesSelector: aChange selector asSymbol) ifFalse: [^false].
+	(appliedAddSelectors includes: aChange selector asSymbol) ifFalse: [^false].
 	cls := environment classNamed: aChange className.
 	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
 	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].

--- a/gs-src/refactoring/engine/GsPushUpMethodRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsPushUpMethodRefactoring.class.st
@@ -1,0 +1,475 @@
+"
+Push one OR MORE methods UP (M7) from a source class to its immediate SUPERCLASS,
+keeping the selector and the method source verbatim and the same side (instance stays
+instance, class stays class -- no side flip). The refactoring is addressed by the source
+class + a COLLECTION of selectors + the source side (isMeta); the target (the superclass)
+is resolved server-side, so the engine -- not the client -- owns the ''which class'' logic
+and can be tested in isolation. Single-method push-up is just a one-element collection, so
+single- and multi-method share one path.
+
+Push-up is the special case of move-method (M6) whose target is the source''s superclass;
+it reuses M6''s change kinds and preview/apply/token machinery verbatim. Per selector it
+stages a #methodAdd on the superclass (compile the same source there, under its original
+category) and a #methodRemove on the source. Both change kinds already exist; no new kind
+is introduced. Each selector is analysed independently; a declined selector is dropped from
+the change set and reported, so a multi-push relocates the movable methods and explains the
+rest.
+
+A GLOBAL decline (the source has no superclass) empties the whole change set. A per-selector
+decline is recorded when: the source method is missing; the superclass already implements the
+selector (collision -- pushing up would overwrite it); the method sends super (its meaning
+depends on the source class''s superclass, which changes when the home moves up); or the
+method accesses an instance variable the superclass does not define (bytecode-precise via
+instVarsAccessed -- the ivar lives only on the subclass).
+
+This is the SIMPLEST SOUND variant: the definition is relocated to the superclass and the
+selector kept; siblings that inherited nothing now inherit the pushed-up method, senders are
+NOT rewritten and no forwarding method is left behind. Building the change set compiles nothing
+and commits nothing; the server-side apply compiles the superclass and removes the source,
+guarding each removal so a deselected/failed add never strands a method in neither class, and
+NEVER commits (the user commits explicitly).
+"
+Class {
+	#name : 'GsPushUpMethodRefactoring',
+	#superclass : 'Object',
+	#instVars : [
+		'environment',
+		'sourceClass',
+		'selectors',
+		'isMeta',
+		'superClass',
+		'changeSet',
+		'analysisDone',
+		'globalDecline',
+		'declines'
+	],
+	#category : 'Refactoring-Core'
+}
+
+{ #category : 'instance creation' }
+GsPushUpMethodRefactoring class >> sourceClass: aClass selectors: aCollection meta: aBool [
+	"Push aCollection of selectors from the aBool side of aClass up to the same side of
+	 aClass's immediate superclass."
+	^self
+		environment: GsRefactoringEnvironment new
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+]
+
+{ #category : 'instance creation' }
+GsPushUpMethodRefactoring class >> environment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool [
+	^self new
+		setEnvironment: anEnvironment
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+]
+
+{ #category : 'preconditions' }
+GsPushUpMethodRefactoring class >> analyzeForClass: aClass selectors: aCollection meta: aBool [
+	"A pre-flight the client runs before opening the preview: the target superclass, a
+	 per-selector decline reason (nil when movable), and the count that will move."
+	^(self
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool) analysisJsonString
+]
+
+{ #category : 'paginated preview' }
+GsPushUpMethodRefactoring class >> pageForToken: token from: startIndex maxBytes: maxBytes [
+	"A page from a previously-started preview (see startPreviewToken:maxBytes:), by
+	 token. Answers an error envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"error":"preview session expired","changes":[],"nextOffset":0,"done":true}']
+		ifNotNil: [:ref | ref pageJsonFrom: startIndex maxBytes: maxBytes]
+]
+
+{ #category : 'paginated preview' }
+GsPushUpMethodRefactoring class >> applyForToken: token deselected: deselectedIds [
+	"Apply a previously-started preview (by token). No commit. Answers an error
+	 envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"applied":0,"failed":[],"error":"preview session expired"}']
+		ifNotNil: [:ref | ref applyDeselected: deselectedIds]
+]
+
+{ #category : 'paginated preview' }
+GsPushUpMethodRefactoring class >> clearToken: token [
+	"Drop a finished preview from SessionTemps."
+	SessionTemps current removeKey: token asSymbol ifAbsent: [].
+	^'ok'
+]
+
+{ #category : 'private' }
+GsPushUpMethodRefactoring >> setEnvironment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool [
+	environment := anEnvironment.
+	sourceClass := aClass.
+	selectors := aCollection collect: [:s | s asSymbol].
+	isMeta := aBool.
+	analysisDone := false
+]
+
+{ #category : 'accessing' }
+GsPushUpMethodRefactoring >> environment [
+	^environment
+]
+
+{ #category : 'accessing' }
+GsPushUpMethodRefactoring >> selectors [
+	^selectors
+]
+
+{ #category : 'private' }
+GsPushUpMethodRefactoring >> sourceBehavior [
+	"The behaviour that holds the methods being pushed: the metaclass for a class-side
+	 source."
+	^isMeta ifTrue: [sourceClass class] ifFalse: [sourceClass]
+]
+
+{ #category : 'private' }
+GsPushUpMethodRefactoring >> targetBehavior [
+	"The behaviour the methods move to (the superclass, same side). Only valid once
+	 analysis has resolved superClass."
+	^isMeta ifTrue: [superClass class] ifFalse: [superClass]
+]
+
+{ #category : 'private - analysis' }
+GsPushUpMethodRefactoring >> ensureAnalysis [
+	analysisDone ifFalse: [
+		analysisDone := true.
+		[self computeAnalysis] on: Error do: [:e |
+			globalDecline := 'The push-up could not be analysed: ', e messageText]]
+]
+
+{ #category : 'private - analysis' }
+GsPushUpMethodRefactoring >> computeAnalysis [
+	"Resolve the target superclass, reject a class with no superclass, then record a
+	 per-selector decline (nil when movable)."
+	globalDecline := nil.
+	declines := Dictionary new.
+	superClass := sourceClass superclass.
+	superClass isNil ifTrue: [
+		^globalDecline := 'Cannot push up: ', sourceClass name asString, ' has no superclass.'].
+	selectors do: [:sel | declines at: sel put: (self computeDeclineFor: sel)]
+]
+
+{ #category : 'private - analysis' }
+GsPushUpMethodRefactoring >> computeDeclineFor: aSelector [
+	"nil if aSelector can be pushed up, otherwise a reason. Checks, in order: method
+	 exists on the source, no collision on the superclass, no super send, and every
+	 accessed instance variable exists on the superclass."
+	| method src tree accessed targetVars missing |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	method isNil ifTrue: [
+		^'Cannot push up #', aSelector asString, ': it is not defined in ', sourceClass name asString, '.'].
+	(self targetBehavior includesSelector: aSelector) ifTrue: [
+		^'Cannot push up #', aSelector asString, ': ', superClass name asString, ' already defines it.'].
+	src := method sourceString.
+	tree := [RBParser parseMethod: src] on: Error do: [:e | nil].
+	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
+		^'Cannot push up #', aSelector asString, ': it sends super, whose meaning depends on the class''s superclass.'].
+	accessed := [method instVarsAccessed] on: Error do: [:e | #()].
+	targetVars := self targetBehavior allInstVarNames collect: [:n | n asSymbol].
+	missing := accessed reject: [:v | targetVars includes: v asSymbol].
+	missing isEmpty ifFalse: [
+		^'Cannot push up #', aSelector asString, ': it uses instance variable(s) not defined in the superclass (',
+			(self commaList: (missing collect: [:v | v asString])), ').'].
+	^nil
+]
+
+{ #category : 'private - analysis' }
+GsPushUpMethodRefactoring >> tree: aTree referencesName: aName [
+	"True if aTree or any descendant is a variable node named aName."
+	aTree nodesDo: [:n | (n isVariable and: [n name = aName]) ifTrue: [^true]].
+	^false
+]
+
+{ #category : 'private' }
+GsPushUpMethodRefactoring >> commaList: aCollection [
+	^aCollection
+		inject: ''
+		into: [:acc :s | acc isEmpty ifTrue: [s] ifFalse: [acc, ', ', s]]
+]
+
+{ #category : 'private' }
+GsPushUpMethodRefactoring >> dictNameForClass: aClass [
+	| dicts |
+	dicts := environment dictionariesDefiningClassNamed: aClass name.
+	^dicts isEmpty ifTrue: [nil] ifFalse: [dicts first name asString]
+]
+
+{ #category : 'private' }
+GsPushUpMethodRefactoring >> categoryOfSelector: aSelector [
+	^((self sourceBehavior categoryOfSelector: aSelector environmentId: 0)
+		ifNil: ['as yet unclassified']) asString
+]
+
+{ #category : 'preconditions' }
+GsPushUpMethodRefactoring >> globalDecline [
+	"nil if the push-up as a whole is viable, otherwise a reason that empties the change
+	 set (the source has no superclass)."
+	self ensureAnalysis.
+	^globalDecline
+]
+
+{ #category : 'preconditions' }
+GsPushUpMethodRefactoring >> declineFor: aSelector [
+	"nil if aSelector will move, otherwise the per-selector (or inherited global)
+	 reason it will not."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^globalDecline].
+	^declines at: aSelector asSymbol ifAbsent: [nil]
+]
+
+{ #category : 'accessing' }
+GsPushUpMethodRefactoring >> superClass [
+	self ensureAnalysis.
+	^superClass
+]
+
+{ #category : 'accessing' }
+GsPushUpMethodRefactoring >> movableSelectors [
+	"The selectors that will actually move, preserving request order."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^#()].
+	^selectors select: [:sel | (declines at: sel ifAbsent: [nil]) isNil]
+]
+
+{ #category : 'accessing' }
+GsPushUpMethodRefactoring >> movableCount [
+	^self movableSelectors size
+]
+
+{ #category : 'building' }
+GsPushUpMethodRefactoring >> changeSet [
+	"The staged, non-committing change set, computed once and cached. Empty on a global
+	 decline; otherwise two changes (add + remove) per movable selector."
+	changeSet isNil ifTrue: [changeSet := self buildChangeSet].
+	^changeSet
+]
+
+{ #category : 'building' }
+GsPushUpMethodRefactoring >> buildChangeSet [
+	| cs |
+	cs := GsRefactoringChangeSet new.
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^cs].
+	self movableSelectors do: [:sel | self stagePushOf: sel into: cs].
+	^cs
+]
+
+{ #category : 'building' }
+GsPushUpMethodRefactoring >> stagePushOf: aSelector into: cs [
+	"Stage the add-on-superclass then the remove-from-source for one movable selector."
+	| method src cat |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	src := method sourceString.
+	cat := self categoryOfSelector: aSelector.
+	cs
+		addMethodAddInDictionary: (self dictNameForClass: superClass)
+		className: superClass name asString
+		isMeta: isMeta
+		selector: aSelector
+		category: cat
+		newSource: src.
+	cs
+		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
+		className: sourceClass name asString
+		isMeta: isMeta
+		selector: aSelector
+		category: cat
+		oldSource: src
+]
+
+{ #category : 'serializing' }
+GsPushUpMethodRefactoring >> analysisJsonString [
+	"The pre-flight payload: the target superclass, the movable count, a global decline
+	 (if any), and a per-selector {selector, decline} array."
+	| ws |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPutAll: '{"targetClass":';
+		nextPutAll: (superClass isNil ifTrue: ['null'] ifFalse: [self jsonQuote: superClass name asString]).
+	ws nextPutAll: ',"globalDecline":';
+		nextPutAll: (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+	ws nextPutAll: ',"movableCount":'; nextPutAll: self movableCount printString.
+	ws nextPutAll: ',"selectors":['.
+	selectors keysAndValuesDo: [:i :sel |
+		i = 1 ifFalse: [ws nextPut: $,].
+		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+		ws nextPutAll: ',"decline":';
+			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPut: $}].
+	ws nextPutAll: ']}'.
+	^ws contents
+]
+
+{ #category : 'serializing' }
+GsPushUpMethodRefactoring >> previewJsonString [
+	^self changeSet jsonString
+]
+
+{ #category : 'serializing' }
+GsPushUpMethodRefactoring >> outOfScopeJsonString [
+	"The scope / precondition payload for the preview panel, in the family's shape. A
+	 hard global decline (which blocks Apply) rides here; per-selector skips ride in
+	 skippedMethods."
+	^'{"references":0,"skipped":', (selectors size - self movableCount) printString,
+	  ',"scope":"class","collision":null,"decline":',
+	  (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]),
+	  '}'
+]
+
+{ #category : 'serializing' }
+GsPushUpMethodRefactoring >> skippedMethodsJsonString [
+	"The declined selectors + reasons, for the preview panel to explain what will NOT
+	 move."
+	| ws first |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	first := true.
+	selectors do: [:sel | | reason |
+		reason := self declineFor: sel.
+		(reason notNil and: [globalDecline isNil]) ifTrue: [
+			first ifFalse: [ws nextPut: $,].
+			first := false.
+			ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+			ws nextPutAll: ',"reason":'; nextPutAll: (self jsonQuote: reason); nextPut: $}]].
+	ws nextPut: $].
+	^ws contents
+]
+
+{ #category : 'paginated preview' }
+GsPushUpMethodRefactoring >> startPreviewToken: token maxBytes: maxBytes [
+	"Build the change set, stash this refactoring in SessionTemps under token, and
+	 answer the first page plus totals and precondition warnings. Nothing is committed."
+	self changeSet.
+	SessionTemps current at: token asSymbol put: self.
+	^'{"token":', (self jsonQuote: token),
+	  ',"total":', self changeSet size printString,
+	  ',"targetClass":', (superClass isNil ifTrue: ['null'] ifFalse: [self jsonQuote: superClass name asString]),
+	  ',"movableCount":', self movableCount printString,
+	  ',"outOfScope":', self outOfScopeJsonString,
+	  ',"skippedMethods":', self skippedMethodsJsonString,
+	  ',"page":', (self pageJsonFrom: 1 maxBytes: maxBytes), '}'
+]
+
+{ #category : 'paginated preview' }
+GsPushUpMethodRefactoring >> pageJsonFrom: startIndex maxBytes: maxBytes [
+	"A byte-bounded page of staged changes (with source) from startIndex (1-based). At
+	 least one change is always emitted when any remain."
+	| all ws i |
+	all := self changeSet changes.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	i := startIndex.
+	[i <= all size and: [i = startIndex or: [ws position < maxBytes]]] whileTrue: [
+		i > startIndex ifTrue: [ws nextPut: $,].
+		(all at: i) jsonOn: ws.
+		i := i + 1].
+	ws nextPut: $].
+	^'{"changes":', ws contents,
+	  ',"nextOffset":', i printString,
+	  ',"done":', (i > all size) printString, '}'
+]
+
+{ #category : 'applying' }
+GsPushUpMethodRefactoring >> applyDeselected: deselectedIds [
+	"Apply the staged changes in the stone WITHOUT committing. A deselected id is
+	 skipped. Removals are additionally guarded (see applyMethodRemove:) so a skipped or
+	 failed add never strands a method in neither class. Answers {applied, failed:[..]}."
+	| applied failures ids |
+	ids := (deselectedIds ifNil: [#()]) asArray.
+	failures := OrderedCollection new.
+	applied := 0.
+	self changeSet changes do: [:change |
+		(ids includes: change id)
+			ifFalse: [
+				[(self applyChange: change) ifTrue: [applied := applied + 1]]
+				on: Error do: [:e |
+					failures add: (Array with: change id with: change className with: e messageText)]]].
+	^'{"applied":', applied printString,
+	  ',"failed":[',
+	  ((failures collect: [:f |
+		'{"id":', (self jsonQuote: (f at: 1)),
+		',"label":', (self jsonQuote: (f at: 2)),
+		',"error":', (self jsonQuote: (f at: 3)), '}'])
+			inject: '' into: [:acc :s | acc isEmpty ifTrue: [s] ifFalse: [acc, ',', s]]),
+	  ']}'
+]
+
+{ #category : 'applying' }
+GsPushUpMethodRefactoring >> applyChange: aChange [
+	"Answer true when the change was applied, false when it was safely skipped."
+	aChange kind == #methodAdd ifTrue: [^self applyMethodAdd: aChange].
+	aChange kind == #methodRemove ifTrue: [^self applyMethodRemove: aChange].
+	^self error: 'Unexpected change kind for push-up-method: ', aChange kind printString
+]
+
+{ #category : 'applying' }
+GsPushUpMethodRefactoring >> applyMethodAdd: aChange [
+	"Compile the pushed-up method onto the superclass/side. No commit."
+	| cls target |
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].
+	target
+		compileMethod: aChange newSource
+		dictionaries: System myUserProfile symbolList
+		category: (aChange category ifNil: ['as yet unclassified']).
+	^true
+]
+
+{ #category : 'applying' }
+GsPushUpMethodRefactoring >> applyMethodRemove: aChange [
+	"Remove the method from the source -- but ONLY once the superclass actually holds it,
+	 so a deselected or failed add never leaves the method in neither class. No commit."
+	| cls target |
+	(self targetBehavior includesSelector: aChange selector asSymbol) ifFalse: [^false].
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].
+	target removeSelector: aChange selector asSymbol.
+	^true
+]
+
+{ #category : 'serializing' }
+GsPushUpMethodRefactoring >> jsonQuote: aString [
+	^'"', (self jsonEscape: aString), '"'
+]
+
+{ #category : 'serializing' }
+GsPushUpMethodRefactoring >> jsonEscape: aString [
+	"JSON string escaping emitting PURE ASCII (control chars and code points above 126
+	 become \\uXXXX), so the client's non-blocking GCI fetch is never handed a Unicode
+	 result."
+	| ws |
+	ws := WriteStream on: String new.
+	aString do: [:ch | | code |
+		code := ch asInteger.
+		ch == $" ifTrue: [ws nextPutAll: '\"']
+		ifFalse: [ch == $\ ifTrue: [ws nextPutAll: '\\']
+		ifFalse: [code = 10 ifTrue: [ws nextPutAll: '\n']
+		ifFalse: [code = 13 ifTrue: [ws nextPutAll: '\r']
+		ifFalse: [code = 9 ifTrue: [ws nextPutAll: '\t']
+		ifFalse: [code < 32
+			ifTrue: [ws nextPutAll: '\u00'; nextPutAll: (self hex2: code)]
+		ifFalse: [code > 126
+			ifTrue: [code > 65535
+				ifTrue: [ws nextPut: $?]
+				ifFalse: [ws nextPutAll: '\u';
+					nextPutAll: (self hex2: code // 256);
+					nextPutAll: (self hex2: code \\ 256)]]
+			ifFalse: [ws nextPut: ch]]]]]]]].
+	^ws contents
+]
+
+{ #category : 'serializing' }
+GsPushUpMethodRefactoring >> hex2: anInteger [
+	| digits |
+	digits := '0123456789abcdef'.
+	^(String with: (digits at: (anInteger // 16) + 1))
+		, (String with: (digits at: (anInteger \\ 16) + 1))
+]

--- a/gs-src/refactoring/engine/GsRefactoringChange.class.st
+++ b/gs-src/refactoring/engine/GsRefactoringChange.class.st
@@ -22,7 +22,8 @@ Class {
 		'newName',
 		'category',
 		'oldSource',
-		'newSource'
+		'newSource',
+		'warning'
 	],
 	#category : 'Refactoring-Core'
 }
@@ -50,6 +51,21 @@ GsRefactoringChange class >> methodAddId: anId dictName: dn className: cn isMeta
 	^self new
 		setId: anId kind: #methodAdd dictName: dn className: cn
 		isMeta: aBool selector: sel category: cat oldSource: nil newSource: ns
+]
+
+{ #category : 'instance creation' }
+GsRefactoringChange class >> methodOverwriteId: anId dictName: dn className: cn isMeta: aBool selector: sel category: cat oldSource: os newSource: ns warning: w [
+	"A method to compile onto a class that ALREADY defines the selector: apply = compile
+	 newSource, exactly like a #methodAdd (the kind IS #methodAdd, so the apply path is
+	 unchanged). Unlike a plain add, oldSource carries the class's EXISTING definition so
+	 the before/after diff shows what is being replaced, and `warning` explains that
+	 applying this change overwrites (loses) that definition. Used by push-up (onto a
+	 superclass that already implements the selector) and push-down (onto a subclass that
+	 already overrides it) as an opt-in, data-losing change."
+	^(self new
+		setId: anId kind: #methodAdd dictName: dn className: cn
+		isMeta: aBool selector: sel category: cat oldSource: os newSource: ns)
+		setWarning: w
 ]
 
 { #category : 'instance creation' }
@@ -179,6 +195,8 @@ GsRefactoringChange >> jsonOn: aStream [
 	self jsonValue: oldSource on: aStream.
 	aStream nextPutAll: ',"newSource":'.
 	self jsonValue: newSource on: aStream.
+	aStream nextPutAll: ',"warning":'.
+	self jsonValue: warning on: aStream.
 	aStream nextPut: $}
 ]
 
@@ -205,6 +223,18 @@ GsRefactoringChange >> newSource [
 { #category : 'accessing' }
 GsRefactoringChange >> oldSource [
 	^oldSource
+]
+
+{ #category : 'accessing' }
+GsRefactoringChange >> warning [
+	"A human-readable data-loss warning for this change (e.g. that it overwrites an
+	 existing method whose definition is lost), or nil when the change is non-destructive."
+	^warning
+]
+
+{ #category : 'private' }
+GsRefactoringChange >> setWarning: aString [
+	warning := aString
 ]
 
 { #category : 'accessing' }

--- a/gs-src/refactoring/engine/GsRefactoringChangeSet.class.st
+++ b/gs-src/refactoring/engine/GsRefactoringChangeSet.class.st
@@ -62,6 +62,22 @@ GsRefactoringChangeSet >> addMethodAddInDictionary: dn className: cn isMeta: aBo
 ]
 
 { #category : 'building' }
+GsRefactoringChangeSet >> addMethodOverwriteInDictionary: dn className: cn isMeta: aBool selector: sel category: cat oldSource: os newSource: ns warning: w [
+	"Stage a method-add onto a class that ALREADY defines the selector (push-up onto a
+	 superclass that implements it, or push-down onto an overriding subclass). Records the
+	 change only; NEVER compiles or commits. Apply compiles newSource exactly like a plain
+	 add (the kind is #methodAdd); oldSource + warning let the client show what will be
+	 overwritten and flag the data loss so the user can opt in. Returns the new
+	 GsRefactoringChange."
+	| change |
+	change := GsRefactoringChange
+		methodOverwriteId: self nextIdString dictName: dn className: cn
+		isMeta: aBool selector: sel category: cat oldSource: os newSource: ns warning: w.
+	changes add: change.
+	^change
+]
+
+{ #category : 'building' }
 GsRefactoringChangeSet >> addMethodRemoveInDictionary: dn className: cn isMeta: aBool selector: sel category: cat oldSource: os [
 	"Stage the removal of a method (inline-method deletes a now-unused target).
 	 Records the change only; NEVER compiles or commits. Apply calls removeSelector:.

--- a/gs-src/refactoring/tests/GsPushDownMethodRefactoringTest.class.st
+++ b/gs-src/refactoring/tests/GsPushDownMethodRefactoringTest.class.st
@@ -1,0 +1,372 @@
+"
+Correctness of the push-down-method refactoring (M8). Push-down relocates one OR MORE
+methods from a source class into its immediate SUBCLASSES, same side, keeping the selector
+and the source verbatim. Per movable selector it stages a #methodAdd on every immediate
+subclass that does not already override the selector (each keeps its own override) plus a
+SINGLE #methodRemove on the source. Nothing is compiled or committed while building; the
+server-side apply compiles the subclasses and removes the source WITHOUT committing.
+
+This suite pins down:
+
+  - a pure method pushes down: one #methodAdd per receiving subclass (verbatim source +
+    category) plus one #methodRemove on the source;
+  - instance-variable access does NOT block a push-down (the subclasses inherit the source's
+    ivars);
+  - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
+    super; or EVERY immediate subclass already overrides the selector;
+  - a subclass that already overrides the selector is silently SKIPPED (no add for it), and
+    the method still pushes into the others;
+  - a class with no subclasses (an impossible push) is a GLOBAL decline that empties the
+    change set;
+  - a class-side method pushes down onto each subclass's class side;
+  - a MULTI-selector push moves the movable ones and reports the declined ones;
+  - the analysis pre-flight reports a null targetClass, a per-selector decline, and a
+    movable count;
+  - building compiles nothing and commits nothing; apply copies the method into each
+    subclass and removes it from the source, guarding the removal so it fires only once
+    every subclass understands the selector (a deselected subclass add leaves the source
+    method in place); apply never commits; a token round-trip works.
+
+setUp builds a throwaway base + two subclasses in UserGlobals; tearDown removes them.
+"
+Class {
+	#name : 'GsPushDownMethodRefactoringTest',
+	#superclass : 'TestCase',
+	#category : 'Refactoring-Tests-Core'
+}
+
+{ #category : 'asserting' }
+GsPushDownMethodRefactoringTest >> assert: aString includesSubstring: aSubstring [
+	self assert: (aString indexOfSubCollection: aSubstring) > 0
+]
+
+{ #category : 'asserting' }
+GsPushDownMethodRefactoringTest >> deny: aString includesSubstring: aSubstring [
+	self assert: (aString indexOfSubCollection: aSubstring) = 0
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> baseFixture [
+	^UserGlobals at: #GsPDBase
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> aFixture [
+	^UserGlobals at: #GsPDA
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> bFixture [
+	^UserGlobals at: #GsPDB
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> compile: aSource in: aClass [
+	[aClass
+		compileMethod: aSource
+		dictionaries: System myUserProfile symbolList
+		category: 'fixture']
+		on: CompileWarning
+		do: [:ex | ex resume: nil]
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> pushSelectors: sels [
+	"Push instance-side sels from GsPDBase down into its subclasses."
+	^GsPushDownMethodRefactoring
+		sourceClass: self baseFixture
+		selectors: sels
+		meta: false
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> push: aSelector [
+	^self pushSelectors: (Array with: aSelector)
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> addChangeFor: aSelector in: aChangeSet [
+	^aChangeSet changes
+		detect: [:c | c kind = #methodAdd and: [c selector = aSelector]]
+		ifNone: [nil]
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> addChangeFor: aSelector inClass: aName in: aChangeSet [
+	^aChangeSet changes
+		detect: [:c | c kind = #methodAdd and: [c selector = aSelector and: [c className = aName]]]
+		ifNone: [nil]
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> removeChangeFor: aSelector in: aChangeSet [
+	^aChangeSet changes
+		detect: [:c | c kind = #methodRemove and: [c selector = aSelector]]
+		ifNone: [nil]
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> addCountFor: aSelector in: aChangeSet [
+	^(aChangeSet changes select: [:c | c kind = #methodAdd and: [c selector = aSelector]]) size
+]
+
+{ #category : 'running' }
+GsPushDownMethodRefactoringTest >> setUp [
+	| base a b |
+	base := Object
+		subclass: 'GsPDBase'
+		instVarNames: #('state')
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	a := base
+		subclass: 'GsPDA'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	b := base
+		subclass: 'GsPDB'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	"--- base instance methods (candidates to push down) ---"
+	self compile: 'pureCompute ^ 40 + 2' in: base.
+	self compile: 'greet ^ ''hi''' in: base.
+	self compile: 'usesState ^ state' in: base.
+	self compile: 'callsSuper ^ super hash' in: base.
+	self compile: 'overriddenByA ^ ''base''' in: base.
+	self compile: 'overriddenByAll ^ ''base''' in: base.
+	"--- A overrides overriddenByA + overriddenByAll; B overrides only overriddenByAll ---"
+	self compile: 'overriddenByA ^ ''a''' in: a.
+	self compile: 'overriddenByAll ^ ''a''' in: a.
+	self compile: 'overriddenByAll ^ ''b''' in: b.
+	"--- class-side method to push down ---"
+	self compile: 'makeOne ^ self new' in: base class
+]
+
+{ #category : 'running' }
+GsPushDownMethodRefactoringTest >> tearDown [
+	#('GsPDA' 'GsPDB' 'GsPDBase')
+		do: [:nm | UserGlobals removeKey: nm asSymbol ifAbsent: []]
+]
+
+{ #category : 'tests - push' }
+GsPushDownMethodRefactoringTest >> testPushesPureMethodStagesAddPerSubclassAndOneRemove [
+	| ref cs |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+
+	"two subclasses both lack it -> 2 adds + 1 remove"
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #pureCompute in: cs) equals: 2.
+	self assert: (self addChangeFor: #pureCompute inClass: 'GsPDA' in: cs) notNil.
+	self assert: (self addChangeFor: #pureCompute inClass: 'GsPDB' in: cs) notNil.
+	self assert: (self removeChangeFor: #pureCompute in: cs) className equals: 'GsPDBase'.
+	self assert: (ref declineFor: #pureCompute) isNil
+]
+
+{ #category : 'tests - push' }
+GsPushDownMethodRefactoringTest >> testPushedAddPreservesSourceAndCategory [
+	| add |
+	add := self addChangeFor: #pureCompute inClass: 'GsPDA' in: (self push: #pureCompute) changeSet.
+
+	self assert: add newSource includesSubstring: '40 + 2'.
+	self assert: add category equals: 'fixture'
+]
+
+{ #category : 'tests - ivar' }
+GsPushDownMethodRefactoringTest >> testIvarReaderPushesDown [
+	| ref |
+	"#usesState reads 'state' on the base; subclasses inherit it -- movable."
+	ref := self push: #usesState.
+
+	self assert: (ref declineFor: #usesState) isNil.
+	self assert: (self addCountFor: #usesState in: ref changeSet) equals: 2
+]
+
+{ #category : 'tests - decline' }
+GsPushDownMethodRefactoringTest >> testNoSubclassesIsGlobalDecline [
+	| ref |
+	"GsPDA is a leaf -- pushing down from it is impossible."
+	ref := GsPushDownMethodRefactoring sourceClass: self aFixture selectors: #(#overriddenByA) meta: false.
+
+	self assert: ref globalDecline notNil.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - decline' }
+GsPushDownMethodRefactoringTest >> testSuperSenderIsDeclined [
+	| ref |
+	ref := self push: #callsSuper.
+
+	self assert: (ref declineFor: #callsSuper) notNil.
+	self assert: (ref declineFor: #callsSuper) includesSubstring: 'super'.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - decline' }
+GsPushDownMethodRefactoringTest >> testEveryoneOverridesIsDeclined [
+	| ref |
+	"#overriddenByAll is overridden by BOTH subclasses -- nothing to push."
+	ref := self push: #overriddenByAll.
+
+	self assert: (ref declineFor: #overriddenByAll) notNil.
+	self assert: (ref declineFor: #overriddenByAll) includesSubstring: 'already overrides'.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - skip' }
+GsPushDownMethodRefactoringTest >> testOverridingSubclassIsSkipped [
+	| ref cs |
+	"#overriddenByA is overridden only by A -- pushes into B only, A is skipped."
+	ref := self push: #overriddenByA.
+	cs := ref changeSet.
+
+	self assert: (ref declineFor: #overriddenByA) isNil.
+	self assert: cs size equals: 2.
+	self assert: (self addCountFor: #overriddenByA in: cs) equals: 1.
+	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDB' in: cs) notNil.
+	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs) isNil
+]
+
+{ #category : 'tests - side' }
+GsPushDownMethodRefactoringTest >> testClassSideMethodPushesDown [
+	| ref cs |
+	ref := GsPushDownMethodRefactoring
+		sourceClass: self baseFixture
+		selectors: (Array with: #makeOne)
+		meta: true.
+	cs := ref changeSet.
+
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #makeOne in: cs) equals: 2.
+	self assert: (self addChangeFor: #makeOne inClass: 'GsPDA' in: cs) isMeta.
+	self assert: (self removeChangeFor: #makeOne in: cs) isMeta
+]
+
+{ #category : 'tests - multi' }
+GsPushDownMethodRefactoringTest >> testMultiPushMovesMovableAndSkipsDeclined [
+	| ref cs |
+	ref := self pushSelectors: #(#pureCompute #callsSuper #greet).
+	cs := ref changeSet.
+
+	"pureCompute + greet each push into 2 subclasses (2 adds + 1 remove each = 6);
+	 callsSuper is skipped"
+	self assert: cs size equals: 6.
+	self assert: (self addCountFor: #pureCompute in: cs) equals: 2.
+	self assert: (self addCountFor: #greet in: cs) equals: 2.
+	self assert: (self addChangeFor: #callsSuper in: cs) isNil.
+	self assert: (ref declineFor: #callsSuper) notNil
+]
+
+{ #category : 'tests - preflight' }
+GsPushDownMethodRefactoringTest >> testAnalysisPreflightReportsPerSelectorAndMovableCount [
+	| json |
+	json := GsPushDownMethodRefactoring
+		analyzeForClass: self baseFixture
+		selectors: #(#pureCompute #callsSuper)
+		meta: false.
+
+	self assert: json includesSubstring: '"targetClass":null'.
+	self assert: json includesSubstring: '"movableCount":1'.
+	self assert: json includesSubstring: '"selector":"pureCompute"'.
+	self assert: json includesSubstring: '"selector":"callsSuper"'
+]
+
+{ #category : 'tests - staging' }
+GsPushDownMethodRefactoringTest >> testBuildingChangeSetCompilesNothingAndDoesNotCommit [
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) changeSet.
+
+	"base still has it; subclasses do not; nothing committed"
+	self assert: (self baseFixture includesSelector: #pureCompute).
+	self deny: (self aFixture includesSelector: #pureCompute).
+	self assert: System needsCommit equals: before
+]
+
+{ #category : 'tests - preview' }
+GsPushDownMethodRefactoringTest >> testPreviewJsonSerializesAddAndRemove [
+	| json |
+	json := (self push: #pureCompute) previewJsonString.
+
+	self assert: json includesSubstring: 'methodAdd'.
+	self assert: json includesSubstring: 'methodRemove'
+]
+
+{ #category : 'tests - preview' }
+GsPushDownMethodRefactoringTest >> testStartPreviewCarriesTotalsAndPage [
+	| json |
+	json := (self push: #pureCompute)
+		startPreviewToken: 'm8Tok' maxBytes: 100000.
+	[self assert: json includesSubstring: '"targetClass":null'.
+	 self assert: json includesSubstring: '"total":3'.
+	 self assert: json includesSubstring: '"movableCount":1'.
+	 self assert: json includesSubstring: '"changes":']
+		ensure: [GsPushDownMethodRefactoring clearToken: 'm8Tok']
+]
+
+{ #category : 'tests - apply' }
+GsPushDownMethodRefactoringTest >> testApplyRelocatesMethodIntoSubclassesAndRemovesFromSource [
+	| json |
+	json := (self push: #pureCompute) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":3'.
+	self assert: (self aFixture includesSelector: #pureCompute).
+	self assert: (self bFixture includesSelector: #pureCompute).
+	self deny: (self baseFixture includesSelector: #pureCompute)
+]
+
+{ #category : 'tests - apply' }
+GsPushDownMethodRefactoringTest >> testApplyDoesNotCommit [
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) applyDeselected: #().
+
+	self assert: System needsCommit equals: before
+]
+
+{ #category : 'tests - apply' }
+GsPushDownMethodRefactoringTest >> testDeselectingOneSubclassAddGuardsTheRemove [
+	"Unticking one subclass's #methodAdd must NOT strand it: the guarded remove is
+	 skipped because not every subclass received the method, so the source keeps it."
+	| ref cs addBId |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+	addBId := (self addChangeFor: #pureCompute inClass: 'GsPDB' in: cs) id.
+	ref applyDeselected: (Array with: addBId).
+
+	self assert: (self baseFixture includesSelector: #pureCompute).
+	self assert: (self aFixture includesSelector: #pureCompute).
+	self deny: (self bFixture includesSelector: #pureCompute)
+]
+
+{ #category : 'tests - apply' }
+GsPushDownMethodRefactoringTest >> testTokenRoundTripStartThenApply [
+	| ref json before |
+	before := System needsCommit.
+	ref := self push: #pureCompute.
+	ref startPreviewToken: 'm8rt' maxBytes: 100000.
+	[json := GsPushDownMethodRefactoring applyForToken: 'm8rt' deselected: #().
+	 self assert: json includesSubstring: '"applied":3'.
+	 self assert: (self aFixture includesSelector: #pureCompute).
+	 self assert: System needsCommit equals: before]
+		ensure: [GsPushDownMethodRefactoring clearToken: 'm8rt']
+]
+
+{ #category : 'tests - apply' }
+GsPushDownMethodRefactoringTest >> testApplyForTokenOnAnExpiredSessionAnswersAnError [
+	self assert: (GsPushDownMethodRefactoring applyForToken: 'nope' deselected: #())
+		includesSubstring: 'expired'
+]
+
+{ #category : 'tests - apply' }
+GsPushDownMethodRefactoringTest >> testPageForTokenOnAnExpiredSessionAnswersAnError [
+	self assert: (GsPushDownMethodRefactoring pageForToken: 'nope' from: 1 maxBytes: 100)
+		includesSubstring: 'expired'
+]

--- a/gs-src/refactoring/tests/GsPushDownMethodRefactoringTest.class.st
+++ b/gs-src/refactoring/tests/GsPushDownMethodRefactoringTest.class.st
@@ -13,9 +13,10 @@ This suite pins down:
   - instance-variable access does NOT block a push-down (the subclasses inherit the source's
     ivars);
   - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
-    super; or EVERY immediate subclass already overrides the selector;
-  - a subclass that already overrides the selector is silently SKIPPED (no add for it), and
-    the method still pushes into the others;
+    super; (a class where EVERY subclass already overrides the selector is NOT declined -- it
+    is an all-overwrite push the user opts into);
+  - a subclass that already overrides the selector gets an opt-in OVERWRITE add (existing
+    body + a data-loss warning), NOT a silent skip, and the others get plain adds;
   - a class with no subclasses (an impossible push) is a GLOBAL decline that empties the
     change set;
   - a class-side method pushes down onto each subclass's class side;
@@ -82,6 +83,13 @@ GsPushDownMethodRefactoringTest >> pushSelectors: sels [
 { #category : 'fixture' }
 GsPushDownMethodRefactoringTest >> push: aSelector [
 	^self pushSelectors: (Array with: aSelector)
+]
+
+{ #category : 'fixture' }
+GsPushDownMethodRefactoringTest >> sourceIn: aClass for: aSelector [
+	"The instance-side source of aSelector in aClass, or '' if absent."
+	^(aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [''] ifNotNil: [:m | m sourceString]
 ]
 
 { #category : 'fixture' }
@@ -196,6 +204,7 @@ GsPushDownMethodRefactoringTest >> testNoSubclassesIsGlobalDecline [
 	ref := GsPushDownMethodRefactoring sourceClass: self aFixture selectors: #(#overriddenByA) meta: false.
 
 	self assert: ref globalDecline notNil.
+	self assert: ref globalDecline includesSubstring: 'subclasses'.
 	self assert: ref changeSet isEmpty
 ]
 
@@ -209,29 +218,69 @@ GsPushDownMethodRefactoringTest >> testSuperSenderIsDeclined [
 	self assert: ref changeSet isEmpty
 ]
 
-{ #category : 'tests - decline' }
-GsPushDownMethodRefactoringTest >> testEveryoneOverridesIsDeclined [
-	| ref |
-	"#overriddenByAll is overridden by BOTH subclasses -- nothing to push."
+{ #category : 'tests - overwrite' }
+GsPushDownMethodRefactoringTest >> testEveryoneOverridesIsMovableAsOverwrites [
+	"#overriddenByAll is overridden by BOTH subclasses -- no longer a decline; it stages an
+	 opt-in overwrite add for each, plus one remove."
+	| ref cs addA addB |
 	ref := self push: #overriddenByAll.
+	cs := ref changeSet.
+	addA := self addChangeFor: #overriddenByAll inClass: 'GsPDA' in: cs.
+	addB := self addChangeFor: #overriddenByAll inClass: 'GsPDB' in: cs.
 
-	self assert: (ref declineFor: #overriddenByAll) notNil.
-	self assert: (ref declineFor: #overriddenByAll) includesSubstring: 'already overrides'.
-	self assert: ref changeSet isEmpty
+	self assert: (ref declineFor: #overriddenByAll) isNil.
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #overriddenByAll in: cs) equals: 2.
+	self assert: addA warning notNil.
+	self assert: addB warning notNil.
+	self assert: (ref overwriteWarningFor: #overriddenByAll) notNil
 ]
 
-{ #category : 'tests - skip' }
-GsPushDownMethodRefactoringTest >> testOverridingSubclassIsSkipped [
-	| ref cs |
-	"#overriddenByA is overridden only by A -- pushes into B only, A is skipped."
+{ #category : 'tests - overwrite' }
+GsPushDownMethodRefactoringTest >> testOverridingSubclassBecomesOverwriteRow [
+	"#overriddenByA is overridden only by A -- B gets a plain add, A gets an opt-in
+	 overwrite (not a silent skip)."
+	| ref cs addA addB |
 	ref := self push: #overriddenByA.
 	cs := ref changeSet.
+	addA := self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs.
+	addB := self addChangeFor: #overriddenByA inClass: 'GsPDB' in: cs.
 
 	self assert: (ref declineFor: #overriddenByA) isNil.
-	self assert: cs size equals: 2.
-	self assert: (self addCountFor: #overriddenByA in: cs) equals: 1.
-	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDB' in: cs) notNil.
-	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs) isNil
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #overriddenByA in: cs) equals: 2.
+	self assert: addA notNil.
+	self assert: addA warning notNil.
+	self assert: addB notNil.
+	self assert: addB warning isNil
+]
+
+{ #category : 'tests - overwrite' }
+GsPushDownMethodRefactoringTest >> testApplyingOverwriteReplacesSubclassOverride [
+	"Opting in to overwrite A's override: A receives the base body, B receives it too, and
+	 the source is removed (every subclass now understands it on its own)."
+	| json |
+	json := (self push: #overriddenByA) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":3'.
+	self assert: (self sourceIn: self aFixture for: #overriddenByA) includesSubstring: 'base'.
+	self assert: (self bFixture includesSelector: #overriddenByA).
+	self deny: (self baseFixture includesSelector: #overriddenByA)
+]
+
+{ #category : 'tests - overwrite' }
+GsPushDownMethodRefactoringTest >> testDeselectingOverwriteKeepsSubclassOverride [
+	"Leaving A's overwrite un-ticked keeps A's own override; B still gets the copy and the
+	 source is removed (A already understands it via its override, B via the copy)."
+	| ref cs addAId |
+	ref := self push: #overriddenByA.
+	cs := ref changeSet.
+	addAId := (self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs) id.
+	ref applyDeselected: (Array with: addAId).
+
+	self deny: (self sourceIn: self aFixture for: #overriddenByA) includesSubstring: 'base'.
+	self assert: (self bFixture includesSelector: #overriddenByA).
+	self deny: (self baseFixture includesSelector: #overriddenByA)
 ]
 
 { #category : 'tests - side' }

--- a/gs-src/refactoring/tests/GsPushUpMethodRefactoringTest.class.st
+++ b/gs-src/refactoring/tests/GsPushUpMethodRefactoringTest.class.st
@@ -11,8 +11,10 @@ This suite pins down:
   - a pure method (no ivar, no super) pushes up to the superclass: a #methodAdd on the
     superclass carrying the verbatim source + category, and a #methodRemove on the source;
   - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
-    super; the superclass already implements the selector (collision -- would overwrite);
-    or the method accesses an instance variable the superclass does not define;
+    super; or the method accesses an instance variable the superclass does not define;
+  - a collision (the superclass already implements the selector) is NOT declined: it stages
+    an opt-in OVERWRITE add carrying the superclass's old body + a data-loss warning, and a
+    deselected overwrite must NOT strip the source (regression guard);
   - a method that reads an ivar the superclass ALSO defines pushes up cleanly; the same
     method is declined when only the subclass declares that ivar;
   - a class with no superclass (an impossible push) is a GLOBAL decline that empties the
@@ -78,6 +80,13 @@ GsPushUpMethodRefactoringTest >> push: aSelector [
 ]
 
 { #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> sourceIn: aClass for: aSelector [
+	"The instance-side source of aSelector in aClass, or '' if absent."
+	^(aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [''] ifNotNil: [:m | m sourceString]
+]
+
+{ #category : 'fixture' }
 GsPushUpMethodRefactoringTest >> addChangeFor: aSelector in: aChangeSet [
 	^aChangeSet changes
 		detect: [:c | c kind = #methodAdd and: [c selector = aSelector]]
@@ -97,14 +106,14 @@ GsPushUpMethodRefactoringTest >> setUp [
 	sup := Object
 		subclass: 'GsPUSuper'
 		instVarNames: #('shared')
-		classVars: #()
+		classVars: #('SharedCVar')
 		classInstVars: #()
 		poolDictionaries: #()
 		inDictionary: UserGlobals.
 	sub := sup
 		subclass: 'GsPUSub'
 		instVarNames: #('own')
-		classVars: #()
+		classVars: #('SubOnlyCVar')
 		classInstVars: #()
 		poolDictionaries: #()
 		inDictionary: UserGlobals.
@@ -113,8 +122,11 @@ GsPushUpMethodRefactoringTest >> setUp [
 	self compile: 'greet ^ ''hi''' in: sub.
 	self compile: 'usesShared ^ shared' in: sub.
 	self compile: 'usesOwn ^ own' in: sub.
+	self compile: 'usesSharedCVar ^ SharedCVar' in: sub.
+	self compile: 'usesSubCVar ^ SubOnlyCVar' in: sub.
 	self compile: 'callsSuper ^ super hash' in: sub.
 	self compile: 'existing ^ 2' in: sub.
+	self compile: 'quoteAndBackslash ^ ''a"b\c''' in: sub.
 	"--- superclass already implements #existing (collision) ---"
 	self compile: 'existing ^ 1' in: sup.
 	"--- class-side method to push up ---"
@@ -164,17 +176,78 @@ GsPushUpMethodRefactoringTest >> testNoSuperclassIsGlobalDecline [
 	ref := GsPushUpMethodRefactoring sourceClass: Object selectors: #(#hash) meta: false.
 
 	self assert: ref globalDecline notNil.
+	self assert: ref globalDecline includesSubstring: 'superclass'.
 	self assert: ref changeSet isEmpty
 ]
 
-{ #category : 'tests - decline' }
-GsPushUpMethodRefactoringTest >> testCollisionIsDeclined [
+{ #category : 'tests - ivar' }
+GsPushUpMethodRefactoringTest >> testSharedClassVarReaderPushesUp [
 	| ref |
-	ref := self push: #existing.
+	"#usesSharedCVar reads SharedCVar, declared on the superclass -- movable."
+	ref := self push: #usesSharedCVar.
 
-	self assert: (ref declineFor: #existing) notNil.
-	self assert: (ref declineFor: #existing) includesSubstring: 'already defines'.
+	self assert: (ref declineFor: #usesSharedCVar) isNil.
+	self assert: ref changeSet size equals: 2
+]
+
+{ #category : 'tests - ivar' }
+GsPushUpMethodRefactoringTest >> testSubclassOnlyClassVarReaderDeclined [
+	| ref |
+	"#usesSubCVar reads SubOnlyCVar, declared only on the subclass -- would not compile on
+	 the superclass, so it is a hard decline (not an overwrite)."
+	ref := self push: #usesSubCVar.
+
+	self assert: (ref declineFor: #usesSubCVar) notNil.
+	self assert: (ref declineFor: #usesSubCVar) includesSubstring: 'class/pool variable'.
 	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - overwrite' }
+GsPushUpMethodRefactoringTest >> testCollisionIsMovableAsOverwrite [
+	"The superclass already defines #existing -- pushing up is NOT declined; it stages an
+	 opt-in overwrite add carrying the superclass's old body + a data-loss warning."
+	| ref cs add |
+	ref := self push: #existing.
+	cs := ref changeSet.
+	add := self addChangeFor: #existing in: cs.
+
+	self assert: (ref declineFor: #existing) isNil.
+	self assert: cs size equals: 2.
+	self assert: add notNil.
+	self assert: add warning notNil.
+	self assert: add warning includesSubstring: 'overwrites'.
+	self assert: add oldSource includesSubstring: '1'.
+	self assert: add newSource includesSubstring: '2'.
+	self assert: (ref overwriteWarningFor: #existing) notNil
+]
+
+{ #category : 'tests - overwrite' }
+GsPushUpMethodRefactoringTest >> testApplyingOverwriteReplacesSuperclassMethod [
+	"Applying the overwrite compiles the pushed body onto the superclass (replacing its old
+	 definition) and removes the source."
+	| json |
+	json := (self push: #existing) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":2'.
+	self assert: (self superFixture includesSelector: #existing).
+	self assert: (self sourceIn: self superFixture for: #existing) includesSubstring: '2'.
+	self deny: (self subFixture includesSelector: #existing)
+]
+
+{ #category : 'tests - overwrite' }
+GsPushUpMethodRefactoringTest >> testDeselectingOverwriteDoesNotStripSource [
+	"Regression: un-ticking the overwrite add must NOT remove the source. The superclass
+	 already defines the selector, so a bare includesSelector: guard would wrongly fire the
+	 remove and lose the subclass version. The applied-add guard prevents that."
+	| ref cs addId |
+	ref := self push: #existing.
+	cs := ref changeSet.
+	addId := (self addChangeFor: #existing in: cs) id.
+	ref applyDeselected: (Array with: addId).
+
+	self assert: (self subFixture includesSelector: #existing).
+	self assert: (self superFixture includesSelector: #existing).
+	self assert: (self sourceIn: self superFixture for: #existing) includesSubstring: '1'
 ]
 
 { #category : 'tests - decline' }
@@ -273,6 +346,49 @@ GsPushUpMethodRefactoringTest >> testPreviewJsonSerializesAddAndRemove [
 
 	self assert: json includesSubstring: 'methodAdd'.
 	self assert: json includesSubstring: 'methodRemove'
+]
+
+{ #category : 'tests - preview' }
+GsPushUpMethodRefactoringTest >> testPreviewJsonEscapesQuoteAndBackslash [
+	"A source containing a double-quote and a backslash must be JSON-escaped by the engine's
+	 jsonEscape: (backslash-quote and backslash-backslash), or the client JSON.parse chokes."
+	| json |
+	json := (self push: #quoteAndBackslash) previewJsonString.
+
+	self assert: json includesSubstring: '\"'.
+	self assert: json includesSubstring: '\\'
+]
+
+{ #category : 'tests - preview' }
+GsPushUpMethodRefactoringTest >> testPaginationSpansMultiplePages [
+	"With a tiny byte budget the preview pages one change at a time: the first page reports
+	 done:false + the next offset, and a later page reports done:true. Exercises the engine's
+	 real byte-bounded slicing, not just a single all-in-one page."
+	| ref first |
+	ref := self pushSelectors: #(#pureCompute #greet #usesShared).
+	ref startPreviewToken: 'm7pg' maxBytes: 1.
+	[first := GsPushUpMethodRefactoring pageForToken: 'm7pg' from: 1 maxBytes: 1.
+	 self assert: first includesSubstring: '"done":false'.
+	 self assert: first includesSubstring: '"nextOffset":2'.
+	 self assert: (GsPushUpMethodRefactoring pageForToken: 'm7pg' from: 6 maxBytes: 1)
+		includesSubstring: '"done":true']
+		ensure: [GsPushUpMethodRefactoring clearToken: 'm7pg']
+]
+
+{ #category : 'tests - creation' }
+GsPushUpMethodRefactoringTest >> testEnvironmentCtorSetsEnvironment [
+	"The environment:sourceClass:selectors:meta: creation path stores the supplied
+	 environment (used for symbol-dict / multi-environment scope) and still builds."
+	| env ref |
+	env := GsRefactoringEnvironment new.
+	ref := GsPushUpMethodRefactoring
+		environment: env
+		sourceClass: self subFixture
+		selectors: #(#pureCompute)
+		meta: false.
+
+	self assert: ref environment == env.
+	self assert: ref changeSet size equals: 2
 ]
 
 { #category : 'tests - preview' }

--- a/gs-src/refactoring/tests/GsPushUpMethodRefactoringTest.class.st
+++ b/gs-src/refactoring/tests/GsPushUpMethodRefactoringTest.class.st
@@ -1,0 +1,346 @@
+"
+Correctness of the push-up-method refactoring (M7). Push-up relocates one OR MORE
+methods from a source class to its immediate SUPERCLASS, same side, keeping the selector
+and the source verbatim. Each selector stages a #methodAdd on the superclass (compile the
+same source there) plus a #methodRemove on the source. Nothing is compiled or committed
+while building; the server-side apply compiles the superclass and removes the source
+WITHOUT committing (the user commits explicitly).
+
+This suite pins down:
+
+  - a pure method (no ivar, no super) pushes up to the superclass: a #methodAdd on the
+    superclass carrying the verbatim source + category, and a #methodRemove on the source;
+  - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
+    super; the superclass already implements the selector (collision -- would overwrite);
+    or the method accesses an instance variable the superclass does not define;
+  - a method that reads an ivar the superclass ALSO defines pushes up cleanly; the same
+    method is declined when only the subclass declares that ivar;
+  - a class with no superclass (an impossible push) is a GLOBAL decline that empties the
+    change set;
+  - a class-side method pushes up to the superclass's class side;
+  - a MULTI-selector push moves the movable ones and reports the declined ones;
+  - the analysis pre-flight reports the target superclass, a per-selector decline, and a
+    movable count;
+  - building compiles nothing and commits nothing; apply relocates the method to the
+    superclass and removes it from the source, guarding the removal so a deselected/failed
+    add never strands the method; apply never commits; a token round-trip works.
+
+setUp builds a throwaway superclass/subclass pair in UserGlobals; tearDown removes them.
+"
+Class {
+	#name : 'GsPushUpMethodRefactoringTest',
+	#superclass : 'TestCase',
+	#category : 'Refactoring-Tests-Core'
+}
+
+{ #category : 'asserting' }
+GsPushUpMethodRefactoringTest >> assert: aString includesSubstring: aSubstring [
+	self assert: (aString indexOfSubCollection: aSubstring) > 0
+]
+
+{ #category : 'asserting' }
+GsPushUpMethodRefactoringTest >> deny: aString includesSubstring: aSubstring [
+	self assert: (aString indexOfSubCollection: aSubstring) = 0
+]
+
+{ #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> superFixture [
+	^UserGlobals at: #GsPUSuper
+]
+
+{ #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> subFixture [
+	^UserGlobals at: #GsPUSub
+]
+
+{ #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> compile: aSource in: aClass [
+	[aClass
+		compileMethod: aSource
+		dictionaries: System myUserProfile symbolList
+		category: 'fixture']
+		on: CompileWarning
+		do: [:ex | ex resume: nil]
+]
+
+{ #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> pushSelectors: sels [
+	"Push instance-side sels from GsPUSub up to GsPUSuper."
+	^GsPushUpMethodRefactoring
+		sourceClass: self subFixture
+		selectors: sels
+		meta: false
+]
+
+{ #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> push: aSelector [
+	^self pushSelectors: (Array with: aSelector)
+]
+
+{ #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> addChangeFor: aSelector in: aChangeSet [
+	^aChangeSet changes
+		detect: [:c | c kind = #methodAdd and: [c selector = aSelector]]
+		ifNone: [nil]
+]
+
+{ #category : 'fixture' }
+GsPushUpMethodRefactoringTest >> removeChangeFor: aSelector in: aChangeSet [
+	^aChangeSet changes
+		detect: [:c | c kind = #methodRemove and: [c selector = aSelector]]
+		ifNone: [nil]
+]
+
+{ #category : 'running' }
+GsPushUpMethodRefactoringTest >> setUp [
+	| sup sub |
+	sup := Object
+		subclass: 'GsPUSuper'
+		instVarNames: #('shared')
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	sub := sup
+		subclass: 'GsPUSub'
+		instVarNames: #('own')
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	"--- subclass instance methods (candidates to push up) ---"
+	self compile: 'pureCompute ^ 40 + 2' in: sub.
+	self compile: 'greet ^ ''hi''' in: sub.
+	self compile: 'usesShared ^ shared' in: sub.
+	self compile: 'usesOwn ^ own' in: sub.
+	self compile: 'callsSuper ^ super hash' in: sub.
+	self compile: 'existing ^ 2' in: sub.
+	"--- superclass already implements #existing (collision) ---"
+	self compile: 'existing ^ 1' in: sup.
+	"--- class-side method to push up ---"
+	self compile: 'buildOne ^ self new' in: sub class
+]
+
+{ #category : 'running' }
+GsPushUpMethodRefactoringTest >> tearDown [
+	#('GsPUSub' 'GsPUSuper')
+		do: [:nm | UserGlobals removeKey: nm asSymbol ifAbsent: []]
+]
+
+{ #category : 'tests - push' }
+GsPushUpMethodRefactoringTest >> testPushesPureMethodStagesAddAndRemove [
+	| ref cs add remove |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+	add := self addChangeFor: #pureCompute in: cs.
+	remove := self removeChangeFor: #pureCompute in: cs.
+
+	self assert: cs size equals: 2.
+	self assert: add notNil.
+	self assert: add className equals: 'GsPUSuper'.
+	self assert: add newSource includesSubstring: '40 + 2'.
+	self assert: remove notNil.
+	self assert: remove className equals: 'GsPUSub'.
+	self assert: (ref declineFor: #pureCompute) isNil
+]
+
+{ #category : 'tests - push' }
+GsPushUpMethodRefactoringTest >> testPushedAddPreservesCategory [
+	| add |
+	add := self addChangeFor: #pureCompute in: (self push: #pureCompute) changeSet.
+
+	self assert: add category equals: 'fixture'
+]
+
+{ #category : 'tests - push' }
+GsPushUpMethodRefactoringTest >> testTargetSuperclassResolved [
+	self assert: (self push: #pureCompute) superClass name asString equals: 'GsPUSuper'
+]
+
+{ #category : 'tests - decline' }
+GsPushUpMethodRefactoringTest >> testNoSuperclassIsGlobalDecline [
+	| ref |
+	"Object has no superclass; pushing up from it is impossible."
+	ref := GsPushUpMethodRefactoring sourceClass: Object selectors: #(#hash) meta: false.
+
+	self assert: ref globalDecline notNil.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - decline' }
+GsPushUpMethodRefactoringTest >> testCollisionIsDeclined [
+	| ref |
+	ref := self push: #existing.
+
+	self assert: (ref declineFor: #existing) notNil.
+	self assert: (ref declineFor: #existing) includesSubstring: 'already defines'.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - decline' }
+GsPushUpMethodRefactoringTest >> testSuperSenderIsDeclined [
+	| ref |
+	ref := self push: #callsSuper.
+
+	self assert: (ref declineFor: #callsSuper) notNil.
+	self assert: (ref declineFor: #callsSuper) includesSubstring: 'super'.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - ivar' }
+GsPushUpMethodRefactoringTest >> testSharedIvarReaderPushesUp [
+	| ref |
+	"#usesShared reads 'shared', which the superclass declares -- movable."
+	ref := self push: #usesShared.
+
+	self assert: (ref declineFor: #usesShared) isNil.
+	self assert: ref changeSet size equals: 2
+]
+
+{ #category : 'tests - ivar' }
+GsPushUpMethodRefactoringTest >> testOwnIvarReaderDeclined [
+	| ref |
+	"#usesOwn reads 'own', declared only on the subclass -- cannot push up."
+	ref := self push: #usesOwn.
+
+	self assert: (ref declineFor: #usesOwn) notNil.
+	self assert: (ref declineFor: #usesOwn) includesSubstring: 'instance variable'.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - side' }
+GsPushUpMethodRefactoringTest >> testClassSideMethodPushesUp [
+	| ref cs add remove |
+	ref := GsPushUpMethodRefactoring
+		sourceClass: self subFixture
+		selectors: (Array with: #buildOne)
+		meta: true.
+	cs := ref changeSet.
+	add := self addChangeFor: #buildOne in: cs.
+	remove := self removeChangeFor: #buildOne in: cs.
+
+	self assert: cs size equals: 2.
+	self assert: add isMeta.
+	self assert: add className equals: 'GsPUSuper'.
+	self assert: remove isMeta.
+	self assert: remove className equals: 'GsPUSub'
+]
+
+{ #category : 'tests - multi' }
+GsPushUpMethodRefactoringTest >> testMultiPushMovesMovableAndSkipsDeclined [
+	| ref cs |
+	ref := self pushSelectors: #(#pureCompute #callsSuper #greet).
+	cs := ref changeSet.
+
+	"pureCompute + greet move (2 changes each); callsSuper is skipped"
+	self assert: cs size equals: 4.
+	self assert: (self addChangeFor: #pureCompute in: cs) notNil.
+	self assert: (self addChangeFor: #greet in: cs) notNil.
+	self assert: (self addChangeFor: #callsSuper in: cs) isNil.
+	self assert: (ref declineFor: #callsSuper) notNil
+]
+
+{ #category : 'tests - preflight' }
+GsPushUpMethodRefactoringTest >> testAnalysisPreflightReportsTargetPerSelectorAndMovableCount [
+	| json |
+	json := GsPushUpMethodRefactoring
+		analyzeForClass: self subFixture
+		selectors: #(#pureCompute #callsSuper)
+		meta: false.
+
+	self assert: json includesSubstring: '"targetClass":"GsPUSuper"'.
+	self assert: json includesSubstring: '"movableCount":1'.
+	self assert: json includesSubstring: '"selector":"pureCompute"'.
+	self assert: json includesSubstring: '"selector":"callsSuper"'
+]
+
+{ #category : 'tests - staging' }
+GsPushUpMethodRefactoringTest >> testBuildingChangeSetCompilesNothingAndDoesNotCommit [
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) changeSet.
+
+	"subclass still has it; superclass does not; nothing committed"
+	self assert: (self subFixture includesSelector: #pureCompute).
+	self deny: (self superFixture includesSelector: #pureCompute).
+	self assert: System needsCommit equals: before
+]
+
+{ #category : 'tests - preview' }
+GsPushUpMethodRefactoringTest >> testPreviewJsonSerializesAddAndRemove [
+	| json |
+	json := (self push: #pureCompute) previewJsonString.
+
+	self assert: json includesSubstring: 'methodAdd'.
+	self assert: json includesSubstring: 'methodRemove'
+]
+
+{ #category : 'tests - preview' }
+GsPushUpMethodRefactoringTest >> testStartPreviewCarriesTotalsAndPage [
+	| json |
+	json := (self push: #pureCompute)
+		startPreviewToken: 'm7Tok' maxBytes: 100000.
+	[self assert: json includesSubstring: '"targetClass":"GsPUSuper"'.
+	 self assert: json includesSubstring: '"total":2'.
+	 self assert: json includesSubstring: '"movableCount":1'.
+	 self assert: json includesSubstring: '"changes":']
+		ensure: [GsPushUpMethodRefactoring clearToken: 'm7Tok']
+]
+
+{ #category : 'tests - apply' }
+GsPushUpMethodRefactoringTest >> testApplyRelocatesMethodAndRemovesFromSource [
+	| json |
+	json := (self push: #pureCompute) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":2'.
+	self assert: (self superFixture includesSelector: #pureCompute).
+	self deny: (self subFixture includesSelector: #pureCompute)
+]
+
+{ #category : 'tests - apply' }
+GsPushUpMethodRefactoringTest >> testApplyDoesNotCommit [
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) applyDeselected: #().
+
+	self assert: System needsCommit equals: before
+]
+
+{ #category : 'tests - apply' }
+GsPushUpMethodRefactoringTest >> testDeselectingAddGuardsTheRemove [
+	"Unticking the #methodAdd must NOT strand the method: the guarded remove is
+	 skipped because the superclass never received the method."
+	| ref cs addId |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+	addId := (self addChangeFor: #pureCompute in: cs) id.
+	ref applyDeselected: (Array with: addId).
+
+	self assert: (self subFixture includesSelector: #pureCompute).
+	self deny: (self superFixture includesSelector: #pureCompute)
+]
+
+{ #category : 'tests - apply' }
+GsPushUpMethodRefactoringTest >> testTokenRoundTripStartThenApply [
+	| ref json before |
+	before := System needsCommit.
+	ref := self push: #pureCompute.
+	ref startPreviewToken: 'm7rt' maxBytes: 100000.
+	[json := GsPushUpMethodRefactoring applyForToken: 'm7rt' deselected: #().
+	 self assert: json includesSubstring: '"applied":2'.
+	 self assert: (self superFixture includesSelector: #pureCompute).
+	 self assert: System needsCommit equals: before]
+		ensure: [GsPushUpMethodRefactoring clearToken: 'm7rt']
+]
+
+{ #category : 'tests - apply' }
+GsPushUpMethodRefactoringTest >> testApplyForTokenOnAnExpiredSessionAnswersAnError [
+	self assert: (GsPushUpMethodRefactoring applyForToken: 'nope' deselected: #())
+		includesSubstring: 'expired'
+]
+
+{ #category : 'tests - apply' }
+GsPushUpMethodRefactoringTest >> testPageForTokenOnAnExpiredSessionAnswersAnError [
+	self assert: (GsPushUpMethodRefactoring pageForToken: 'nope' from: 1 maxBytes: 100)
+		includesSubstring: 'expired'
+]

--- a/package.json
+++ b/package.json
@@ -1175,6 +1175,16 @@
         "icon": "$(edit)"
       },
       {
+        "command": "gemstone.explorer.pushUpMethod",
+        "title": "Push Up…",
+        "category": "GemStone"
+      },
+      {
+        "command": "gemstone.explorer.pushDownMethod",
+        "title": "Push Down…",
+        "category": "GemStone"
+      },
+      {
         "command": "gemstone.renameTemporary",
         "title": "Rename Temporary/Argument…",
         "category": "GemStone",
@@ -1483,6 +1493,14 @@
           "when": "false"
         },
         {
+          "command": "gemstone.explorer.pushUpMethod",
+          "when": "false"
+        },
+        {
+          "command": "gemstone.explorer.pushDownMethod",
+          "when": "false"
+        },
+        {
           "command": "gemstone.explorer.renameClass",
           "when": "false"
         },
@@ -1761,6 +1779,16 @@
           "command": "gemstone.explorer.changeSignature",
           "when": "view == gemstoneExplorerMethods && viewItem =~ /explorerMethod/",
           "group": "3_refactor@1"
+        },
+        {
+          "command": "gemstone.explorer.pushUpMethod",
+          "when": "view == gemstoneExplorerMethods && viewItem =~ /explorerMethod/",
+          "group": "3_refactor@2"
+        },
+        {
+          "command": "gemstone.explorer.pushDownMethod",
+          "when": "view == gemstoneExplorerMethods && viewItem =~ /explorerMethod/",
+          "group": "3_refactor@3"
         },
         {
           "command": "gemstone.explorer.renameClass",

--- a/package.json
+++ b/package.json
@@ -1177,12 +1177,14 @@
       {
         "command": "gemstone.explorer.pushUpMethod",
         "title": "Push Up…",
-        "category": "GemStone"
+        "category": "GemStone",
+        "icon": "$(arrow-up)"
       },
       {
         "command": "gemstone.explorer.pushDownMethod",
         "title": "Push Down…",
-        "category": "GemStone"
+        "category": "GemStone",
+        "icon": "$(arrow-down)"
       },
       {
         "command": "gemstone.renameTemporary",
@@ -1783,12 +1785,12 @@
         {
           "command": "gemstone.explorer.pushUpMethod",
           "when": "view == gemstoneExplorerMethods && viewItem =~ /explorerMethod/",
-          "group": "3_refactor@2"
+          "group": "inline@4"
         },
         {
           "command": "gemstone.explorer.pushDownMethod",
           "when": "view == gemstoneExplorerMethods && viewItem =~ /explorerMethod/",
-          "group": "3_refactor@3"
+          "group": "inline@5"
         },
         {
           "command": "gemstone.explorer.renameClass",

--- a/resources/refactoring/engine-tests.gs
+++ b/resources/refactoring/engine-tests.gs
@@ -288,9 +288,10 @@ This suite pins down:
   - instance-variable access does NOT block a push-down (the subclasses inherit the source''s
     ivars);
   - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
-    super; or EVERY immediate subclass already overrides the selector;
-  - a subclass that already overrides the selector is silently SKIPPED (no add for it), and
-    the method still pushes into the others;
+    super; (a class where EVERY subclass already overrides the selector is NOT declined -- it
+    is an all-overwrite push the user opts into);
+  - a subclass that already overrides the selector gets an opt-in OVERWRITE add (existing
+    body + a data-loss warning), NOT a silent skip, and the others get plain adds;
   - a class with no subclasses (an impossible push) is a GLOBAL decline that empties the
     change set;
   - a class-side method pushes down onto each subclass''s class side;
@@ -332,8 +333,10 @@ This suite pins down:
   - a pure method (no ivar, no super) pushes up to the superclass: a #methodAdd on the
     superclass carrying the verbatim source + category, and a #methodRemove on the source;
   - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
-    super; the superclass already implements the selector (collision -- would overwrite);
-    or the method accesses an instance variable the superclass does not define;
+    super; or the method accesses an instance variable the superclass does not define;
+  - a collision (the superclass already implements the selector) is NOT declined: it stages
+    an opt-in OVERWRITE add carrying the superclass''s old body + a data-loss warning, and a
+    deselected overwrite must NOT strip the source (regression guard);
   - a method that reads an ivar the superclass ALSO defines pushes up cleanly; the same
     method is declined when only the subclass declares that ivar;
   - a class with no superclass (an impossible push) is a GLOBAL decline that empties the
@@ -3510,6 +3513,14 @@ push: aSelector
 
 category: 'fixture'
 method: GsPushDownMethodRefactoringTest
+sourceIn: aClass for: aSelector
+	"The instance-side source of aSelector in aClass, or '' if absent."
+	^(aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [''] ifNotNil: [:m | m sourceString]
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
 addChangeFor: aSelector in: aChangeSet
 	^aChangeSet changes
 		detect: [:c | c kind = #methodAdd and: [c selector = aSelector]]
@@ -3630,6 +3641,7 @@ testNoSubclassesIsGlobalDecline
 	ref := GsPushDownMethodRefactoring sourceClass: self aFixture selectors: #(#overriddenByA) meta: false.
 
 	self assert: ref globalDecline notNil.
+	self assert: ref globalDecline includesSubstring: 'subclasses'.
 	self assert: ref changeSet isEmpty
 %
 
@@ -3644,31 +3656,73 @@ testSuperSenderIsDeclined
 	self assert: ref changeSet isEmpty
 %
 
-category: 'tests - decline'
+category: 'tests - overwrite'
 method: GsPushDownMethodRefactoringTest
-testEveryoneOverridesIsDeclined
-	| ref |
-	"#overriddenByAll is overridden by BOTH subclasses -- nothing to push."
+testEveryoneOverridesIsMovableAsOverwrites
+	"#overriddenByAll is overridden by BOTH subclasses -- no longer a decline; it stages an
+	 opt-in overwrite add for each, plus one remove."
+	| ref cs addA addB |
 	ref := self push: #overriddenByAll.
+	cs := ref changeSet.
+	addA := self addChangeFor: #overriddenByAll inClass: 'GsPDA' in: cs.
+	addB := self addChangeFor: #overriddenByAll inClass: 'GsPDB' in: cs.
 
-	self assert: (ref declineFor: #overriddenByAll) notNil.
-	self assert: (ref declineFor: #overriddenByAll) includesSubstring: 'already overrides'.
-	self assert: ref changeSet isEmpty
+	self assert: (ref declineFor: #overriddenByAll) isNil.
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #overriddenByAll in: cs) equals: 2.
+	self assert: addA warning notNil.
+	self assert: addB warning notNil.
+	self assert: (ref overwriteWarningFor: #overriddenByAll) notNil
 %
 
-category: 'tests - skip'
+category: 'tests - overwrite'
 method: GsPushDownMethodRefactoringTest
-testOverridingSubclassIsSkipped
-	| ref cs |
-	"#overriddenByA is overridden only by A -- pushes into B only, A is skipped."
+testOverridingSubclassBecomesOverwriteRow
+	"#overriddenByA is overridden only by A -- B gets a plain add, A gets an opt-in
+	 overwrite (not a silent skip)."
+	| ref cs addA addB |
 	ref := self push: #overriddenByA.
 	cs := ref changeSet.
+	addA := self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs.
+	addB := self addChangeFor: #overriddenByA inClass: 'GsPDB' in: cs.
 
 	self assert: (ref declineFor: #overriddenByA) isNil.
-	self assert: cs size equals: 2.
-	self assert: (self addCountFor: #overriddenByA in: cs) equals: 1.
-	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDB' in: cs) notNil.
-	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs) isNil
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #overriddenByA in: cs) equals: 2.
+	self assert: addA notNil.
+	self assert: addA warning notNil.
+	self assert: addB notNil.
+	self assert: addB warning isNil
+%
+
+category: 'tests - overwrite'
+method: GsPushDownMethodRefactoringTest
+testApplyingOverwriteReplacesSubclassOverride
+	"Opting in to overwrite A's override: A receives the base body, B receives it too, and
+	 the source is removed (every subclass now understands it on its own)."
+	| json |
+	json := (self push: #overriddenByA) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":3'.
+	self assert: (self sourceIn: self aFixture for: #overriddenByA) includesSubstring: 'base'.
+	self assert: (self bFixture includesSelector: #overriddenByA).
+	self deny: (self baseFixture includesSelector: #overriddenByA)
+%
+
+category: 'tests - overwrite'
+method: GsPushDownMethodRefactoringTest
+testDeselectingOverwriteKeepsSubclassOverride
+	"Leaving A's overwrite un-ticked keeps A's own override; B still gets the copy and the
+	 source is removed (A already understands it via its override, B via the copy)."
+	| ref cs addAId |
+	ref := self push: #overriddenByA.
+	cs := ref changeSet.
+	addAId := (self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs) id.
+	ref applyDeselected: (Array with: addAId).
+
+	self deny: (self sourceIn: self aFixture for: #overriddenByA) includesSubstring: 'base'.
+	self assert: (self bFixture includesSelector: #overriddenByA).
+	self deny: (self baseFixture includesSelector: #overriddenByA)
 %
 
 category: 'tests - side'
@@ -3873,6 +3927,14 @@ push: aSelector
 
 category: 'fixture'
 method: GsPushUpMethodRefactoringTest
+sourceIn: aClass for: aSelector
+	"The instance-side source of aSelector in aClass, or '' if absent."
+	^(aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [''] ifNotNil: [:m | m sourceString]
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
 addChangeFor: aSelector in: aChangeSet
 	^aChangeSet changes
 		detect: [:c | c kind = #methodAdd and: [c selector = aSelector]]
@@ -3894,14 +3956,14 @@ setUp
 	sup := Object
 		subclass: 'GsPUSuper'
 		instVarNames: #('shared')
-		classVars: #()
+		classVars: #('SharedCVar')
 		classInstVars: #()
 		poolDictionaries: #()
 		inDictionary: UserGlobals.
 	sub := sup
 		subclass: 'GsPUSub'
 		instVarNames: #('own')
-		classVars: #()
+		classVars: #('SubOnlyCVar')
 		classInstVars: #()
 		poolDictionaries: #()
 		inDictionary: UserGlobals.
@@ -3910,8 +3972,11 @@ setUp
 	self compile: 'greet ^ ''hi''' in: sub.
 	self compile: 'usesShared ^ shared' in: sub.
 	self compile: 'usesOwn ^ own' in: sub.
+	self compile: 'usesSharedCVar ^ SharedCVar' in: sub.
+	self compile: 'usesSubCVar ^ SubOnlyCVar' in: sub.
 	self compile: 'callsSuper ^ super hash' in: sub.
 	self compile: 'existing ^ 2' in: sub.
+	self compile: 'quoteAndBackslash ^ ''a"b\c''' in: sub.
 	"--- superclass already implements #existing (collision) ---"
 	self compile: 'existing ^ 1' in: sup.
 	"--- class-side method to push up ---"
@@ -3966,18 +4031,83 @@ testNoSuperclassIsGlobalDecline
 	ref := GsPushUpMethodRefactoring sourceClass: Object selectors: #(#hash) meta: false.
 
 	self assert: ref globalDecline notNil.
+	self assert: ref globalDecline includesSubstring: 'superclass'.
 	self assert: ref changeSet isEmpty
 %
 
-category: 'tests - decline'
+category: 'tests - ivar'
 method: GsPushUpMethodRefactoringTest
-testCollisionIsDeclined
+testSharedClassVarReaderPushesUp
 	| ref |
-	ref := self push: #existing.
+	"#usesSharedCVar reads SharedCVar, declared on the superclass -- movable."
+	ref := self push: #usesSharedCVar.
 
-	self assert: (ref declineFor: #existing) notNil.
-	self assert: (ref declineFor: #existing) includesSubstring: 'already defines'.
+	self assert: (ref declineFor: #usesSharedCVar) isNil.
+	self assert: ref changeSet size equals: 2
+%
+
+category: 'tests - ivar'
+method: GsPushUpMethodRefactoringTest
+testSubclassOnlyClassVarReaderDeclined
+	| ref |
+	"#usesSubCVar reads SubOnlyCVar, declared only on the subclass -- would not compile on
+	 the superclass, so it is a hard decline (not an overwrite)."
+	ref := self push: #usesSubCVar.
+
+	self assert: (ref declineFor: #usesSubCVar) notNil.
+	self assert: (ref declineFor: #usesSubCVar) includesSubstring: 'class/pool variable'.
 	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - overwrite'
+method: GsPushUpMethodRefactoringTest
+testCollisionIsMovableAsOverwrite
+	"The superclass already defines #existing -- pushing up is NOT declined; it stages an
+	 opt-in overwrite add carrying the superclass's old body + a data-loss warning."
+	| ref cs add |
+	ref := self push: #existing.
+	cs := ref changeSet.
+	add := self addChangeFor: #existing in: cs.
+
+	self assert: (ref declineFor: #existing) isNil.
+	self assert: cs size equals: 2.
+	self assert: add notNil.
+	self assert: add warning notNil.
+	self assert: add warning includesSubstring: 'overwrites'.
+	self assert: add oldSource includesSubstring: '1'.
+	self assert: add newSource includesSubstring: '2'.
+	self assert: (ref overwriteWarningFor: #existing) notNil
+%
+
+category: 'tests - overwrite'
+method: GsPushUpMethodRefactoringTest
+testApplyingOverwriteReplacesSuperclassMethod
+	"Applying the overwrite compiles the pushed body onto the superclass (replacing its old
+	 definition) and removes the source."
+	| json |
+	json := (self push: #existing) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":2'.
+	self assert: (self superFixture includesSelector: #existing).
+	self assert: (self sourceIn: self superFixture for: #existing) includesSubstring: '2'.
+	self deny: (self subFixture includesSelector: #existing)
+%
+
+category: 'tests - overwrite'
+method: GsPushUpMethodRefactoringTest
+testDeselectingOverwriteDoesNotStripSource
+	"Regression: un-ticking the overwrite add must NOT remove the source. The superclass
+	 already defines the selector, so a bare includesSelector: guard would wrongly fire the
+	 remove and lose the subclass version. The applied-add guard prevents that."
+	| ref cs addId |
+	ref := self push: #existing.
+	cs := ref changeSet.
+	addId := (self addChangeFor: #existing in: cs) id.
+	ref applyDeselected: (Array with: addId).
+
+	self assert: (self subFixture includesSelector: #existing).
+	self assert: (self superFixture includesSelector: #existing).
+	self assert: (self sourceIn: self superFixture for: #existing) includesSubstring: '1'
 %
 
 category: 'tests - decline'
@@ -4084,6 +4214,52 @@ testPreviewJsonSerializesAddAndRemove
 
 	self assert: json includesSubstring: 'methodAdd'.
 	self assert: json includesSubstring: 'methodRemove'
+%
+
+category: 'tests - preview'
+method: GsPushUpMethodRefactoringTest
+testPreviewJsonEscapesQuoteAndBackslash
+	"A source containing a double-quote and a backslash must be JSON-escaped by the engine's
+	 jsonEscape: (backslash-quote and backslash-backslash), or the client JSON.parse chokes."
+	| json |
+	json := (self push: #quoteAndBackslash) previewJsonString.
+
+	self assert: json includesSubstring: '\"'.
+	self assert: json includesSubstring: '\\'
+%
+
+category: 'tests - preview'
+method: GsPushUpMethodRefactoringTest
+testPaginationSpansMultiplePages
+	"With a tiny byte budget the preview pages one change at a time: the first page reports
+	 done:false + the next offset, and a later page reports done:true. Exercises the engine's
+	 real byte-bounded slicing, not just a single all-in-one page."
+	| ref first |
+	ref := self pushSelectors: #(#pureCompute #greet #usesShared).
+	ref startPreviewToken: 'm7pg' maxBytes: 1.
+	[first := GsPushUpMethodRefactoring pageForToken: 'm7pg' from: 1 maxBytes: 1.
+	 self assert: first includesSubstring: '"done":false'.
+	 self assert: first includesSubstring: '"nextOffset":2'.
+	 self assert: (GsPushUpMethodRefactoring pageForToken: 'm7pg' from: 6 maxBytes: 1)
+		includesSubstring: '"done":true']
+		ensure: [GsPushUpMethodRefactoring clearToken: 'm7pg']
+%
+
+category: 'tests - creation'
+method: GsPushUpMethodRefactoringTest
+testEnvironmentCtorSetsEnvironment
+	"The environment:sourceClass:selectors:meta: creation path stores the supplied
+	 environment (used for symbol-dict / multi-environment scope) and still builds."
+	| env ref |
+	env := GsRefactoringEnvironment new.
+	ref := GsPushUpMethodRefactoring
+		environment: env
+		sourceClass: self subFixture
+		selectors: #(#pureCompute)
+		meta: false.
+
+	self assert: ref environment == env.
+	self assert: ref changeSet size equals: 2
 %
 
 category: 'tests - preview'

--- a/resources/refactoring/engine-tests.gs
+++ b/resources/refactoring/engine-tests.gs
@@ -266,6 +266,96 @@ removeallclassmethods GsInlineTemporaryRefactoringTest
 
 doit
 | cls |
+cls := TestCase subclass: 'GsPushDownMethodRefactoringTest'
+  instVarNames: #()
+  classVars: #()
+  classInstVars: #()
+  poolDictionaries: #()
+  inDictionary: UserGlobals.
+cls category: 'Refactoring-Tests-Core'.
+cls comment: '
+Correctness of the push-down-method refactoring (M8). Push-down relocates one OR MORE
+methods from a source class into its immediate SUBCLASSES, same side, keeping the selector
+and the source verbatim. Per movable selector it stages a #methodAdd on every immediate
+subclass that does not already override the selector (each keeps its own override) plus a
+SINGLE #methodRemove on the source. Nothing is compiled or committed while building; the
+server-side apply compiles the subclasses and removes the source WITHOUT committing.
+
+This suite pins down:
+
+  - a pure method pushes down: one #methodAdd per receiving subclass (verbatim source +
+    category) plus one #methodRemove on the source;
+  - instance-variable access does NOT block a push-down (the subclasses inherit the source''s
+    ivars);
+  - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
+    super; or EVERY immediate subclass already overrides the selector;
+  - a subclass that already overrides the selector is silently SKIPPED (no add for it), and
+    the method still pushes into the others;
+  - a class with no subclasses (an impossible push) is a GLOBAL decline that empties the
+    change set;
+  - a class-side method pushes down onto each subclass''s class side;
+  - a MULTI-selector push moves the movable ones and reports the declined ones;
+  - the analysis pre-flight reports a null targetClass, a per-selector decline, and a
+    movable count;
+  - building compiles nothing and commits nothing; apply copies the method into each
+    subclass and removes it from the source, guarding the removal so it fires only once
+    every subclass understands the selector (a deselected subclass add leaves the source
+    method in place); apply never commits; a token round-trip works.
+
+setUp builds a throwaway base + two subclasses in UserGlobals; tearDown removes them.
+'.
+true.
+%
+
+removeallmethods GsPushDownMethodRefactoringTest
+removeallclassmethods GsPushDownMethodRefactoringTest
+
+doit
+| cls |
+cls := TestCase subclass: 'GsPushUpMethodRefactoringTest'
+  instVarNames: #()
+  classVars: #()
+  classInstVars: #()
+  poolDictionaries: #()
+  inDictionary: UserGlobals.
+cls category: 'Refactoring-Tests-Core'.
+cls comment: '
+Correctness of the push-up-method refactoring (M7). Push-up relocates one OR MORE
+methods from a source class to its immediate SUPERCLASS, same side, keeping the selector
+and the source verbatim. Each selector stages a #methodAdd on the superclass (compile the
+same source there) plus a #methodRemove on the source. Nothing is compiled or committed
+while building; the server-side apply compiles the superclass and removes the source
+WITHOUT committing (the user commits explicitly).
+
+This suite pins down:
+
+  - a pure method (no ivar, no super) pushes up to the superclass: a #methodAdd on the
+    superclass carrying the verbatim source + category, and a #methodRemove on the source;
+  - the push is DECLINED (that selector is skipped, with a reason) when: the method sends
+    super; the superclass already implements the selector (collision -- would overwrite);
+    or the method accesses an instance variable the superclass does not define;
+  - a method that reads an ivar the superclass ALSO defines pushes up cleanly; the same
+    method is declined when only the subclass declares that ivar;
+  - a class with no superclass (an impossible push) is a GLOBAL decline that empties the
+    change set;
+  - a class-side method pushes up to the superclass''s class side;
+  - a MULTI-selector push moves the movable ones and reports the declined ones;
+  - the analysis pre-flight reports the target superclass, a per-selector decline, and a
+    movable count;
+  - building compiles nothing and commits nothing; apply relocates the method to the
+    superclass and removes it from the source, guarding the removal so a deselected/failed
+    add never strands the method; apply never commits; a token round-trip works.
+
+setUp builds a throwaway superclass/subclass pair in UserGlobals; tearDown removes them.
+'.
+true.
+%
+
+removeallmethods GsPushUpMethodRefactoringTest
+removeallclassmethods GsPushUpMethodRefactoringTest
+
+doit
+| cls |
 cls := TestCase subclass: 'GsRefactoringChangeSetTest'
   instVarNames: #()
   classVars: #()
@@ -3358,6 +3448,718 @@ category: 'tests - apply'
 method: GsInlineTemporaryRefactoringTest
 testApplyForTokenOnAnExpiredSessionAnswersAnError
 	self assert: (GsInlineTemporaryRefactoring applyForToken: 'nope' deselected: #())
+		includesSubstring: 'expired'
+%
+
+category: 'asserting'
+method: GsPushDownMethodRefactoringTest
+assert: aString includesSubstring: aSubstring
+	self assert: (aString indexOfSubCollection: aSubstring) > 0
+%
+
+category: 'asserting'
+method: GsPushDownMethodRefactoringTest
+deny: aString includesSubstring: aSubstring
+	self assert: (aString indexOfSubCollection: aSubstring) = 0
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+baseFixture
+	^UserGlobals at: #GsPDBase
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+aFixture
+	^UserGlobals at: #GsPDA
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+bFixture
+	^UserGlobals at: #GsPDB
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+compile: aSource in: aClass
+	[aClass
+		compileMethod: aSource
+		dictionaries: System myUserProfile symbolList
+		category: 'fixture']
+		on: CompileWarning
+		do: [:ex | ex resume: nil]
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+pushSelectors: sels
+	"Push instance-side sels from GsPDBase down into its subclasses."
+	^GsPushDownMethodRefactoring
+		sourceClass: self baseFixture
+		selectors: sels
+		meta: false
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+push: aSelector
+	^self pushSelectors: (Array with: aSelector)
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+addChangeFor: aSelector in: aChangeSet
+	^aChangeSet changes
+		detect: [:c | c kind = #methodAdd and: [c selector = aSelector]]
+		ifNone: [nil]
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+addChangeFor: aSelector inClass: aName in: aChangeSet
+	^aChangeSet changes
+		detect: [:c | c kind = #methodAdd and: [c selector = aSelector and: [c className = aName]]]
+		ifNone: [nil]
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+removeChangeFor: aSelector in: aChangeSet
+	^aChangeSet changes
+		detect: [:c | c kind = #methodRemove and: [c selector = aSelector]]
+		ifNone: [nil]
+%
+
+category: 'fixture'
+method: GsPushDownMethodRefactoringTest
+addCountFor: aSelector in: aChangeSet
+	^(aChangeSet changes select: [:c | c kind = #methodAdd and: [c selector = aSelector]]) size
+%
+
+category: 'running'
+method: GsPushDownMethodRefactoringTest
+setUp
+	| base a b |
+	base := Object
+		subclass: 'GsPDBase'
+		instVarNames: #('state')
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	a := base
+		subclass: 'GsPDA'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	b := base
+		subclass: 'GsPDB'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	"--- base instance methods (candidates to push down) ---"
+	self compile: 'pureCompute ^ 40 + 2' in: base.
+	self compile: 'greet ^ ''hi''' in: base.
+	self compile: 'usesState ^ state' in: base.
+	self compile: 'callsSuper ^ super hash' in: base.
+	self compile: 'overriddenByA ^ ''base''' in: base.
+	self compile: 'overriddenByAll ^ ''base''' in: base.
+	"--- A overrides overriddenByA + overriddenByAll; B overrides only overriddenByAll ---"
+	self compile: 'overriddenByA ^ ''a''' in: a.
+	self compile: 'overriddenByAll ^ ''a''' in: a.
+	self compile: 'overriddenByAll ^ ''b''' in: b.
+	"--- class-side method to push down ---"
+	self compile: 'makeOne ^ self new' in: base class
+%
+
+category: 'running'
+method: GsPushDownMethodRefactoringTest
+tearDown
+	#('GsPDA' 'GsPDB' 'GsPDBase')
+		do: [:nm | UserGlobals removeKey: nm asSymbol ifAbsent: []]
+%
+
+category: 'tests - push'
+method: GsPushDownMethodRefactoringTest
+testPushesPureMethodStagesAddPerSubclassAndOneRemove
+	| ref cs |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+
+	"two subclasses both lack it -> 2 adds + 1 remove"
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #pureCompute in: cs) equals: 2.
+	self assert: (self addChangeFor: #pureCompute inClass: 'GsPDA' in: cs) notNil.
+	self assert: (self addChangeFor: #pureCompute inClass: 'GsPDB' in: cs) notNil.
+	self assert: (self removeChangeFor: #pureCompute in: cs) className equals: 'GsPDBase'.
+	self assert: (ref declineFor: #pureCompute) isNil
+%
+
+category: 'tests - push'
+method: GsPushDownMethodRefactoringTest
+testPushedAddPreservesSourceAndCategory
+	| add |
+	add := self addChangeFor: #pureCompute inClass: 'GsPDA' in: (self push: #pureCompute) changeSet.
+
+	self assert: add newSource includesSubstring: '40 + 2'.
+	self assert: add category equals: 'fixture'
+%
+
+category: 'tests - ivar'
+method: GsPushDownMethodRefactoringTest
+testIvarReaderPushesDown
+	| ref |
+	"#usesState reads 'state' on the base; subclasses inherit it -- movable."
+	ref := self push: #usesState.
+
+	self assert: (ref declineFor: #usesState) isNil.
+	self assert: (self addCountFor: #usesState in: ref changeSet) equals: 2
+%
+
+category: 'tests - decline'
+method: GsPushDownMethodRefactoringTest
+testNoSubclassesIsGlobalDecline
+	| ref |
+	"GsPDA is a leaf -- pushing down from it is impossible."
+	ref := GsPushDownMethodRefactoring sourceClass: self aFixture selectors: #(#overriddenByA) meta: false.
+
+	self assert: ref globalDecline notNil.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - decline'
+method: GsPushDownMethodRefactoringTest
+testSuperSenderIsDeclined
+	| ref |
+	ref := self push: #callsSuper.
+
+	self assert: (ref declineFor: #callsSuper) notNil.
+	self assert: (ref declineFor: #callsSuper) includesSubstring: 'super'.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - decline'
+method: GsPushDownMethodRefactoringTest
+testEveryoneOverridesIsDeclined
+	| ref |
+	"#overriddenByAll is overridden by BOTH subclasses -- nothing to push."
+	ref := self push: #overriddenByAll.
+
+	self assert: (ref declineFor: #overriddenByAll) notNil.
+	self assert: (ref declineFor: #overriddenByAll) includesSubstring: 'already overrides'.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - skip'
+method: GsPushDownMethodRefactoringTest
+testOverridingSubclassIsSkipped
+	| ref cs |
+	"#overriddenByA is overridden only by A -- pushes into B only, A is skipped."
+	ref := self push: #overriddenByA.
+	cs := ref changeSet.
+
+	self assert: (ref declineFor: #overriddenByA) isNil.
+	self assert: cs size equals: 2.
+	self assert: (self addCountFor: #overriddenByA in: cs) equals: 1.
+	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDB' in: cs) notNil.
+	self assert: (self addChangeFor: #overriddenByA inClass: 'GsPDA' in: cs) isNil
+%
+
+category: 'tests - side'
+method: GsPushDownMethodRefactoringTest
+testClassSideMethodPushesDown
+	| ref cs |
+	ref := GsPushDownMethodRefactoring
+		sourceClass: self baseFixture
+		selectors: (Array with: #makeOne)
+		meta: true.
+	cs := ref changeSet.
+
+	self assert: cs size equals: 3.
+	self assert: (self addCountFor: #makeOne in: cs) equals: 2.
+	self assert: (self addChangeFor: #makeOne inClass: 'GsPDA' in: cs) isMeta.
+	self assert: (self removeChangeFor: #makeOne in: cs) isMeta
+%
+
+category: 'tests - multi'
+method: GsPushDownMethodRefactoringTest
+testMultiPushMovesMovableAndSkipsDeclined
+	| ref cs |
+	ref := self pushSelectors: #(#pureCompute #callsSuper #greet).
+	cs := ref changeSet.
+
+	"pureCompute + greet each push into 2 subclasses (2 adds + 1 remove each = 6);
+	 callsSuper is skipped"
+	self assert: cs size equals: 6.
+	self assert: (self addCountFor: #pureCompute in: cs) equals: 2.
+	self assert: (self addCountFor: #greet in: cs) equals: 2.
+	self assert: (self addChangeFor: #callsSuper in: cs) isNil.
+	self assert: (ref declineFor: #callsSuper) notNil
+%
+
+category: 'tests - preflight'
+method: GsPushDownMethodRefactoringTest
+testAnalysisPreflightReportsPerSelectorAndMovableCount
+	| json |
+	json := GsPushDownMethodRefactoring
+		analyzeForClass: self baseFixture
+		selectors: #(#pureCompute #callsSuper)
+		meta: false.
+
+	self assert: json includesSubstring: '"targetClass":null'.
+	self assert: json includesSubstring: '"movableCount":1'.
+	self assert: json includesSubstring: '"selector":"pureCompute"'.
+	self assert: json includesSubstring: '"selector":"callsSuper"'
+%
+
+category: 'tests - staging'
+method: GsPushDownMethodRefactoringTest
+testBuildingChangeSetCompilesNothingAndDoesNotCommit
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) changeSet.
+
+	"base still has it; subclasses do not; nothing committed"
+	self assert: (self baseFixture includesSelector: #pureCompute).
+	self deny: (self aFixture includesSelector: #pureCompute).
+	self assert: System needsCommit equals: before
+%
+
+category: 'tests - preview'
+method: GsPushDownMethodRefactoringTest
+testPreviewJsonSerializesAddAndRemove
+	| json |
+	json := (self push: #pureCompute) previewJsonString.
+
+	self assert: json includesSubstring: 'methodAdd'.
+	self assert: json includesSubstring: 'methodRemove'
+%
+
+category: 'tests - preview'
+method: GsPushDownMethodRefactoringTest
+testStartPreviewCarriesTotalsAndPage
+	| json |
+	json := (self push: #pureCompute)
+		startPreviewToken: 'm8Tok' maxBytes: 100000.
+	[self assert: json includesSubstring: '"targetClass":null'.
+	 self assert: json includesSubstring: '"total":3'.
+	 self assert: json includesSubstring: '"movableCount":1'.
+	 self assert: json includesSubstring: '"changes":']
+		ensure: [GsPushDownMethodRefactoring clearToken: 'm8Tok']
+%
+
+category: 'tests - apply'
+method: GsPushDownMethodRefactoringTest
+testApplyRelocatesMethodIntoSubclassesAndRemovesFromSource
+	| json |
+	json := (self push: #pureCompute) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":3'.
+	self assert: (self aFixture includesSelector: #pureCompute).
+	self assert: (self bFixture includesSelector: #pureCompute).
+	self deny: (self baseFixture includesSelector: #pureCompute)
+%
+
+category: 'tests - apply'
+method: GsPushDownMethodRefactoringTest
+testApplyDoesNotCommit
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) applyDeselected: #().
+
+	self assert: System needsCommit equals: before
+%
+
+category: 'tests - apply'
+method: GsPushDownMethodRefactoringTest
+testDeselectingOneSubclassAddGuardsTheRemove
+	"Unticking one subclass's #methodAdd must NOT strand it: the guarded remove is
+	 skipped because not every subclass received the method, so the source keeps it."
+	| ref cs addBId |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+	addBId := (self addChangeFor: #pureCompute inClass: 'GsPDB' in: cs) id.
+	ref applyDeselected: (Array with: addBId).
+
+	self assert: (self baseFixture includesSelector: #pureCompute).
+	self assert: (self aFixture includesSelector: #pureCompute).
+	self deny: (self bFixture includesSelector: #pureCompute)
+%
+
+category: 'tests - apply'
+method: GsPushDownMethodRefactoringTest
+testTokenRoundTripStartThenApply
+	| ref json before |
+	before := System needsCommit.
+	ref := self push: #pureCompute.
+	ref startPreviewToken: 'm8rt' maxBytes: 100000.
+	[json := GsPushDownMethodRefactoring applyForToken: 'm8rt' deselected: #().
+	 self assert: json includesSubstring: '"applied":3'.
+	 self assert: (self aFixture includesSelector: #pureCompute).
+	 self assert: System needsCommit equals: before]
+		ensure: [GsPushDownMethodRefactoring clearToken: 'm8rt']
+%
+
+category: 'tests - apply'
+method: GsPushDownMethodRefactoringTest
+testApplyForTokenOnAnExpiredSessionAnswersAnError
+	self assert: (GsPushDownMethodRefactoring applyForToken: 'nope' deselected: #())
+		includesSubstring: 'expired'
+%
+
+category: 'tests - apply'
+method: GsPushDownMethodRefactoringTest
+testPageForTokenOnAnExpiredSessionAnswersAnError
+	self assert: (GsPushDownMethodRefactoring pageForToken: 'nope' from: 1 maxBytes: 100)
+		includesSubstring: 'expired'
+%
+
+category: 'asserting'
+method: GsPushUpMethodRefactoringTest
+assert: aString includesSubstring: aSubstring
+	self assert: (aString indexOfSubCollection: aSubstring) > 0
+%
+
+category: 'asserting'
+method: GsPushUpMethodRefactoringTest
+deny: aString includesSubstring: aSubstring
+	self assert: (aString indexOfSubCollection: aSubstring) = 0
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
+superFixture
+	^UserGlobals at: #GsPUSuper
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
+subFixture
+	^UserGlobals at: #GsPUSub
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
+compile: aSource in: aClass
+	[aClass
+		compileMethod: aSource
+		dictionaries: System myUserProfile symbolList
+		category: 'fixture']
+		on: CompileWarning
+		do: [:ex | ex resume: nil]
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
+pushSelectors: sels
+	"Push instance-side sels from GsPUSub up to GsPUSuper."
+	^GsPushUpMethodRefactoring
+		sourceClass: self subFixture
+		selectors: sels
+		meta: false
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
+push: aSelector
+	^self pushSelectors: (Array with: aSelector)
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
+addChangeFor: aSelector in: aChangeSet
+	^aChangeSet changes
+		detect: [:c | c kind = #methodAdd and: [c selector = aSelector]]
+		ifNone: [nil]
+%
+
+category: 'fixture'
+method: GsPushUpMethodRefactoringTest
+removeChangeFor: aSelector in: aChangeSet
+	^aChangeSet changes
+		detect: [:c | c kind = #methodRemove and: [c selector = aSelector]]
+		ifNone: [nil]
+%
+
+category: 'running'
+method: GsPushUpMethodRefactoringTest
+setUp
+	| sup sub |
+	sup := Object
+		subclass: 'GsPUSuper'
+		instVarNames: #('shared')
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	sub := sup
+		subclass: 'GsPUSub'
+		instVarNames: #('own')
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: UserGlobals.
+	"--- subclass instance methods (candidates to push up) ---"
+	self compile: 'pureCompute ^ 40 + 2' in: sub.
+	self compile: 'greet ^ ''hi''' in: sub.
+	self compile: 'usesShared ^ shared' in: sub.
+	self compile: 'usesOwn ^ own' in: sub.
+	self compile: 'callsSuper ^ super hash' in: sub.
+	self compile: 'existing ^ 2' in: sub.
+	"--- superclass already implements #existing (collision) ---"
+	self compile: 'existing ^ 1' in: sup.
+	"--- class-side method to push up ---"
+	self compile: 'buildOne ^ self new' in: sub class
+%
+
+category: 'running'
+method: GsPushUpMethodRefactoringTest
+tearDown
+	#('GsPUSub' 'GsPUSuper')
+		do: [:nm | UserGlobals removeKey: nm asSymbol ifAbsent: []]
+%
+
+category: 'tests - push'
+method: GsPushUpMethodRefactoringTest
+testPushesPureMethodStagesAddAndRemove
+	| ref cs add remove |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+	add := self addChangeFor: #pureCompute in: cs.
+	remove := self removeChangeFor: #pureCompute in: cs.
+
+	self assert: cs size equals: 2.
+	self assert: add notNil.
+	self assert: add className equals: 'GsPUSuper'.
+	self assert: add newSource includesSubstring: '40 + 2'.
+	self assert: remove notNil.
+	self assert: remove className equals: 'GsPUSub'.
+	self assert: (ref declineFor: #pureCompute) isNil
+%
+
+category: 'tests - push'
+method: GsPushUpMethodRefactoringTest
+testPushedAddPreservesCategory
+	| add |
+	add := self addChangeFor: #pureCompute in: (self push: #pureCompute) changeSet.
+
+	self assert: add category equals: 'fixture'
+%
+
+category: 'tests - push'
+method: GsPushUpMethodRefactoringTest
+testTargetSuperclassResolved
+	self assert: (self push: #pureCompute) superClass name asString equals: 'GsPUSuper'
+%
+
+category: 'tests - decline'
+method: GsPushUpMethodRefactoringTest
+testNoSuperclassIsGlobalDecline
+	| ref |
+	"Object has no superclass; pushing up from it is impossible."
+	ref := GsPushUpMethodRefactoring sourceClass: Object selectors: #(#hash) meta: false.
+
+	self assert: ref globalDecline notNil.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - decline'
+method: GsPushUpMethodRefactoringTest
+testCollisionIsDeclined
+	| ref |
+	ref := self push: #existing.
+
+	self assert: (ref declineFor: #existing) notNil.
+	self assert: (ref declineFor: #existing) includesSubstring: 'already defines'.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - decline'
+method: GsPushUpMethodRefactoringTest
+testSuperSenderIsDeclined
+	| ref |
+	ref := self push: #callsSuper.
+
+	self assert: (ref declineFor: #callsSuper) notNil.
+	self assert: (ref declineFor: #callsSuper) includesSubstring: 'super'.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - ivar'
+method: GsPushUpMethodRefactoringTest
+testSharedIvarReaderPushesUp
+	| ref |
+	"#usesShared reads 'shared', which the superclass declares -- movable."
+	ref := self push: #usesShared.
+
+	self assert: (ref declineFor: #usesShared) isNil.
+	self assert: ref changeSet size equals: 2
+%
+
+category: 'tests - ivar'
+method: GsPushUpMethodRefactoringTest
+testOwnIvarReaderDeclined
+	| ref |
+	"#usesOwn reads 'own', declared only on the subclass -- cannot push up."
+	ref := self push: #usesOwn.
+
+	self assert: (ref declineFor: #usesOwn) notNil.
+	self assert: (ref declineFor: #usesOwn) includesSubstring: 'instance variable'.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - side'
+method: GsPushUpMethodRefactoringTest
+testClassSideMethodPushesUp
+	| ref cs add remove |
+	ref := GsPushUpMethodRefactoring
+		sourceClass: self subFixture
+		selectors: (Array with: #buildOne)
+		meta: true.
+	cs := ref changeSet.
+	add := self addChangeFor: #buildOne in: cs.
+	remove := self removeChangeFor: #buildOne in: cs.
+
+	self assert: cs size equals: 2.
+	self assert: add isMeta.
+	self assert: add className equals: 'GsPUSuper'.
+	self assert: remove isMeta.
+	self assert: remove className equals: 'GsPUSub'
+%
+
+category: 'tests - multi'
+method: GsPushUpMethodRefactoringTest
+testMultiPushMovesMovableAndSkipsDeclined
+	| ref cs |
+	ref := self pushSelectors: #(#pureCompute #callsSuper #greet).
+	cs := ref changeSet.
+
+	"pureCompute + greet move (2 changes each); callsSuper is skipped"
+	self assert: cs size equals: 4.
+	self assert: (self addChangeFor: #pureCompute in: cs) notNil.
+	self assert: (self addChangeFor: #greet in: cs) notNil.
+	self assert: (self addChangeFor: #callsSuper in: cs) isNil.
+	self assert: (ref declineFor: #callsSuper) notNil
+%
+
+category: 'tests - preflight'
+method: GsPushUpMethodRefactoringTest
+testAnalysisPreflightReportsTargetPerSelectorAndMovableCount
+	| json |
+	json := GsPushUpMethodRefactoring
+		analyzeForClass: self subFixture
+		selectors: #(#pureCompute #callsSuper)
+		meta: false.
+
+	self assert: json includesSubstring: '"targetClass":"GsPUSuper"'.
+	self assert: json includesSubstring: '"movableCount":1'.
+	self assert: json includesSubstring: '"selector":"pureCompute"'.
+	self assert: json includesSubstring: '"selector":"callsSuper"'
+%
+
+category: 'tests - staging'
+method: GsPushUpMethodRefactoringTest
+testBuildingChangeSetCompilesNothingAndDoesNotCommit
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) changeSet.
+
+	"subclass still has it; superclass does not; nothing committed"
+	self assert: (self subFixture includesSelector: #pureCompute).
+	self deny: (self superFixture includesSelector: #pureCompute).
+	self assert: System needsCommit equals: before
+%
+
+category: 'tests - preview'
+method: GsPushUpMethodRefactoringTest
+testPreviewJsonSerializesAddAndRemove
+	| json |
+	json := (self push: #pureCompute) previewJsonString.
+
+	self assert: json includesSubstring: 'methodAdd'.
+	self assert: json includesSubstring: 'methodRemove'
+%
+
+category: 'tests - preview'
+method: GsPushUpMethodRefactoringTest
+testStartPreviewCarriesTotalsAndPage
+	| json |
+	json := (self push: #pureCompute)
+		startPreviewToken: 'm7Tok' maxBytes: 100000.
+	[self assert: json includesSubstring: '"targetClass":"GsPUSuper"'.
+	 self assert: json includesSubstring: '"total":2'.
+	 self assert: json includesSubstring: '"movableCount":1'.
+	 self assert: json includesSubstring: '"changes":']
+		ensure: [GsPushUpMethodRefactoring clearToken: 'm7Tok']
+%
+
+category: 'tests - apply'
+method: GsPushUpMethodRefactoringTest
+testApplyRelocatesMethodAndRemovesFromSource
+	| json |
+	json := (self push: #pureCompute) applyDeselected: #().
+
+	self assert: json includesSubstring: '"applied":2'.
+	self assert: (self superFixture includesSelector: #pureCompute).
+	self deny: (self subFixture includesSelector: #pureCompute)
+%
+
+category: 'tests - apply'
+method: GsPushUpMethodRefactoringTest
+testApplyDoesNotCommit
+	| before |
+	before := System needsCommit.
+	(self push: #pureCompute) applyDeselected: #().
+
+	self assert: System needsCommit equals: before
+%
+
+category: 'tests - apply'
+method: GsPushUpMethodRefactoringTest
+testDeselectingAddGuardsTheRemove
+	"Unticking the #methodAdd must NOT strand the method: the guarded remove is
+	 skipped because the superclass never received the method."
+	| ref cs addId |
+	ref := self push: #pureCompute.
+	cs := ref changeSet.
+	addId := (self addChangeFor: #pureCompute in: cs) id.
+	ref applyDeselected: (Array with: addId).
+
+	self assert: (self subFixture includesSelector: #pureCompute).
+	self deny: (self superFixture includesSelector: #pureCompute)
+%
+
+category: 'tests - apply'
+method: GsPushUpMethodRefactoringTest
+testTokenRoundTripStartThenApply
+	| ref json before |
+	before := System needsCommit.
+	ref := self push: #pureCompute.
+	ref startPreviewToken: 'm7rt' maxBytes: 100000.
+	[json := GsPushUpMethodRefactoring applyForToken: 'm7rt' deselected: #().
+	 self assert: json includesSubstring: '"applied":2'.
+	 self assert: (self superFixture includesSelector: #pureCompute).
+	 self assert: System needsCommit equals: before]
+		ensure: [GsPushUpMethodRefactoring clearToken: 'm7rt']
+%
+
+category: 'tests - apply'
+method: GsPushUpMethodRefactoringTest
+testApplyForTokenOnAnExpiredSessionAnswersAnError
+	self assert: (GsPushUpMethodRefactoring applyForToken: 'nope' deselected: #())
+		includesSubstring: 'expired'
+%
+
+category: 'tests - apply'
+method: GsPushUpMethodRefactoringTest
+testPageForTokenOnAnExpiredSessionAnswersAnError
+	self assert: (GsPushUpMethodRefactoring pageForToken: 'nope' from: 1 maxBytes: 100)
 		includesSubstring: 'expired'
 %
 

--- a/resources/refactoring/engine.gs
+++ b/resources/refactoring/engine.gs
@@ -296,7 +296,7 @@ removeallclassmethods GsInlineTemporaryRefactoring
 doit
 | cls |
 cls := Object subclass: 'GsPushDownMethodRefactoring'
-  instVarNames: #('environment' 'sourceClass' 'selectors' 'isMeta' 'subClasses' 'recipients' 'changeSet' 'analysisDone' 'globalDecline' 'declines')
+  instVarNames: #('environment' 'sourceClass' 'selectors' 'isMeta' 'subClasses' 'recipients' 'changeSet' 'analysisDone' 'globalDecline' 'declines' 'appliedAddSelectors')
   classVars: #()
   classInstVars: #()
   poolDictionaries: #()
@@ -313,25 +313,29 @@ one-element collection, so single- and multi-method share one path.
 
 Push-down is the inverse of push-up (M7) and a many-target relative of move-method (M6);
 it reuses the same change kinds and preview/apply/token machinery. Per movable selector it
-stages a #methodAdd on EVERY immediate subclass that does not already override the selector
-(each keeps its own override, and is silently skipped) plus a SINGLE #methodRemove on the
-source. So one pushed-down selector produces N adds + 1 remove (N = the receiving subclass
-count). Both change kinds already exist; no new kind is introduced. Each selector is
-analysed independently; a declined selector is dropped from the change set and reported, so
-a multi-push relocates the movable methods and explains the rest.
+stages a #methodAdd on EVERY immediate subclass plus a SINGLE #methodRemove on the source. A
+subclass that does NOT yet understand the selector gets a plain add; a subclass that already
+OVERRIDES it gets an opt-in OVERWRITE add (staged with the existing override''s body + a
+data-loss warning), which the client leaves un-ticked by default so the user consciously
+chooses to replace that override. So one pushed-down selector produces N adds + 1 remove
+(N = the immediate subclass count). Both change kinds already exist; no new kind is
+introduced. Each selector is analysed independently; a declined selector is dropped from the
+change set and reported, so a multi-push relocates the movable methods and explains the rest.
 
 A GLOBAL decline (the source has no subclasses) empties the whole change set. A per-selector
-decline is recorded when: the source method is missing; the method sends super (its meaning
-depends on the source class''''s superclass, which changes once the home moves down); or EVERY
-immediate subclass already overrides the selector (nothing to push, and removing it from the
-source would only endanger the source''s own direct instances). Instance-variable access needs
-no check: the method already lives on the source, so every accessed ivar is defined on (or
-inherited by) the source, and every subclass inherits those same ivars.
+decline (a HARD skip) is recorded when: the source method is missing; or the method sends
+super (its meaning depends on the source class''''s superclass, which changes once the home
+moves down). A class where EVERY immediate subclass already overrides the selector is NOT a
+decline any more -- it is simply an all-overwrite push the user opts into (or leaves entirely
+un-ticked). Instance-variable access needs no check: the method already lives on the source,
+so every accessed ivar is defined on (or inherited by) the source, and every subclass inherits
+those same ivars.
 
 This is the SIMPLEST SOUND variant: the definition is copied into each immediate subclass
-that lacks its own and removed from the source; senders are NOT rewritten and no forwarding
-method is left behind. NOTE the intended semantics: after push-down the source class no
-longer understands the selector, so this is meant for an abstract superclass (or one whose
+(overwriting an override only when the user opts in) and removed from the source; senders are
+NOT rewritten and no forwarding method is left behind. NOTE the intended semantics: after
+push-down the source class no longer understands the selector, so this is meant for an
+abstract superclass (or one whose
 direct instances do not use the method). Building the change set compiles nothing and commits
 nothing; the server-side apply compiles each subclass and removes the source, guarding the
 removal so it fires only once EVERY immediate subclass understands the selector (a
@@ -347,7 +351,7 @@ removeallclassmethods GsPushDownMethodRefactoring
 doit
 | cls |
 cls := Object subclass: 'GsPushUpMethodRefactoring'
-  instVarNames: #('environment' 'sourceClass' 'selectors' 'isMeta' 'superClass' 'changeSet' 'analysisDone' 'globalDecline' 'declines')
+  instVarNames: #('environment' 'sourceClass' 'selectors' 'isMeta' 'superClass' 'changeSet' 'analysisDone' 'globalDecline' 'declines' 'appliedAddSelectors')
   classVars: #()
   classInstVars: #()
   poolDictionaries: #()
@@ -370,12 +374,24 @@ is introduced. Each selector is analysed independently; a declined selector is d
 the change set and reported, so a multi-push relocates the movable methods and explains the
 rest.
 
+When the superclass ALREADY implements the selector, the push is NOT declined: it becomes an
+opt-in OVERWRITE change -- the #methodAdd carries the superclass''s existing body (for a
+before/after diff) plus a data-loss warning, and the client leaves it un-ticked by default so
+the user consciously chooses to replace the inherited definition (consolidating an inherited
+method by pushing up is a common intent). The paired source #methodRemove is guarded on the
+add having actually been applied THIS run (an applied-add set), NOT on a bare
+includesSelector: -- otherwise a deselected overwrite, whose selector the superclass already
+carries, would wrongly strip the source and lose the subclass version.
+
 A GLOBAL decline (the source has no superclass) empties the whole change set. A per-selector
-decline is recorded when: the source method is missing; the superclass already implements the
-selector (collision -- pushing up would overwrite it); the method sends super (its meaning
-depends on the source class''''s superclass, which changes when the home moves up); or the
-method accesses an instance variable the superclass does not define (bytecode-precise via
-instVarsAccessed -- the ivar lives only on the subclass).
+decline (a HARD skip, not an overwrite) is recorded when: the source method is missing; the
+method sends super (its meaning depends on the source class''''s superclass, which changes when
+the home moves up); the method accesses an instance variable the superclass does not define
+(bytecode-precise via instVarsAccessed -- the ivar lives only on the subclass); or the method
+references a CLASS variable or POOL variable declared only below the superclass (matched by
+identifier name against the shared-var delta). All three variable cases mean the pushed method
+would not even compile on the superclass. Class-INSTANCE variables are covered by the
+instVarsAccessed check on the metaclass side.
 
 This is the SIMPLEST SOUND variant: the definition is relocated to the superclass and the
 selector kept; siblings that inherited nothing now inherit the pushed-up method, senders are
@@ -393,7 +409,7 @@ removeallclassmethods GsPushUpMethodRefactoring
 doit
 | cls |
 cls := Object subclass: 'GsRefactoringChange'
-  instVarNames: #('id' 'kind' 'dictName' 'className' 'isMeta' 'selector' 'newSelector' 'newName' 'category' 'oldSource' 'newSource')
+  instVarNames: #('id' 'kind' 'dictName' 'className' 'isMeta' 'selector' 'newSelector' 'newName' 'category' 'oldSource' 'newSource' 'warning')
   classVars: #()
   classInstVars: #()
   poolDictionaries: #()
@@ -4619,8 +4635,12 @@ category: 'private - analysis'
 method: GsPushDownMethodRefactoring
 analyzeSelector: aSelector
 	"Record the decline reason (nil when movable) and the receiving subclasses for one
-	 selector."
-	| method src tree recips |
+	 selector. EVERY immediate subclass is a recipient: those that do not yet understand
+	 the selector get a fresh copy; those that already override it get an opt-in OVERWRITE
+	 (staged with the existing body + a data-loss warning), so a class where every subclass
+	 overrides is no longer a hard decline -- it is just an all-overwrite push the user
+	 opts into. Only a missing source method or a super-send is a hard decline."
+	| method src tree |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	method isNil ifTrue: [
 		^declines at: aSelector put:
@@ -4630,11 +4650,7 @@ analyzeSelector: aSelector
 	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
 		^declines at: aSelector put:
 			'Cannot push down #', aSelector asString, ': it sends super, whose meaning depends on the class''s superclass.'].
-	recips := subClasses reject: [:s | (self behaviorFor: s) includesSelector: aSelector].
-	recips isEmpty ifTrue: [
-		^declines at: aSelector put:
-			'Cannot push down #', aSelector asString, ': every subclass already overrides it.'].
-	recipients at: aSelector put: recips.
+	recipients at: aSelector put: subClasses.
 	declines at: aSelector put: nil
 %
 
@@ -4683,10 +4699,38 @@ declineFor: aSelector
 category: 'accessing'
 method: GsPushDownMethodRefactoring
 recipientsFor: aSelector
-	"The immediate subclasses that will receive a copy of aSelector (empty for a declined
-	 or unknown selector)."
+	"The immediate subclasses that will receive aSelector (empty for a declined or unknown
+	 selector). Includes subclasses that already override it -- those receive an opt-in
+	 OVERWRITE rather than a fresh add."
 	self ensureAnalysis.
 	^recipients at: aSelector asSymbol ifAbsent: [#()]
+%
+
+category: 'private - analysis'
+method: GsPushDownMethodRefactoring
+existingSourceIn: aSubclass for: aSelector
+	"If aSubclass ALREADY overrides aSelector on this side, its current source (which
+	 pushing down will OVERWRITE); nil otherwise."
+	| beh |
+	beh := self behaviorFor: aSubclass.
+	(beh includesSelector: aSelector) ifFalse: [^nil].
+	^(beh compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [nil] ifNotNil: [:m | m sourceString]
+%
+
+category: 'preconditions'
+method: GsPushDownMethodRefactoring
+overwriteWarningFor: aSelector
+	"A data-loss summary if pushing aSelector down would OVERWRITE an existing override in
+	 one or more subclasses; nil otherwise. nil for a declined selector or global decline."
+	| overs |
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^nil].
+	(self declineFor: aSelector) notNil ifTrue: [^nil].
+	overs := (self recipientsFor: aSelector) select: [:s | (self behaviorFor: s) includesSelector: aSelector].
+	overs isEmpty ifTrue: [^nil].
+	^'Pushing down overwrites the existing override in ', overs size printString,
+	  ' subclass', (overs size = 1 ifTrue: [''] ifFalse: ['es']), ' -- lost unless left un-ticked.'
 %
 
 category: 'accessing'
@@ -4728,19 +4772,32 @@ buildChangeSet
 category: 'building'
 method: GsPushDownMethodRefactoring
 stagePushOf: aSelector into: cs
-	"Stage an add on every receiving subclass, then a single remove from the source."
+	"Stage an add on every receiving subclass -- an OVERWRITE (carrying the existing body +
+	 a data-loss warning) for a subclass that already overrides the selector, a plain add
+	 otherwise -- then a single remove from the source."
 	| method src cat |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	src := method sourceString.
 	cat := self categoryOfSelector: aSelector.
-	(self recipientsFor: aSelector) do: [:sub |
-		cs
-			addMethodAddInDictionary: (self dictNameForClass: sub)
-			className: sub name asString
-			isMeta: isMeta
-			selector: aSelector
-			category: cat
-			newSource: src].
+	(self recipientsFor: aSelector) do: [:sub | | existing |
+		existing := self existingSourceIn: sub for: aSelector.
+		existing isNil
+			ifTrue: [cs
+				addMethodAddInDictionary: (self dictNameForClass: sub)
+				className: sub name asString
+				isMeta: isMeta
+				selector: aSelector
+				category: cat
+				newSource: src]
+			ifFalse: [cs
+				addMethodOverwriteInDictionary: (self dictNameForClass: sub)
+				className: sub name asString
+				isMeta: isMeta
+				selector: aSelector
+				category: cat
+				oldSource: existing
+				newSource: src
+				warning: 'Pushing down overwrites ', sub name asString, '>>', aSelector asString, ' -- its current override is lost.']].
 	cs
 		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
 		className: sourceClass name asString
@@ -4768,6 +4825,8 @@ analysisJsonString
 		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
 		ws nextPutAll: ',"decline":';
 			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPutAll: ',"warning":';
+			nextPutAll: ((self overwriteWarningFor: sel) ifNil: ['null'] ifNotNil: [:w | self jsonQuote: w]).
 		ws nextPut: $}].
 	ws nextPutAll: ']}'.
 	^ws contents
@@ -4855,11 +4914,15 @@ applyDeselected: deselectedIds
 	 skipped. The source removal is guarded (see applyMethodRemove:) so a skipped or
 	 failed subclass add never strands that subclass. Answers {applied, failed:[..]}."
 	| applied failures ids |
-	ids := (deselectedIds ifNil: [#()]) asArray.
+	"Compare ids as Symbols: a deselected id arrives from the client as a String literal,
+	 which on 3.6.x is a Unicode string, and comparing it to the byte-string change id can
+	 raise (the 3.6.2 Unicode-comparison trap). asSymbol canonicalises both sides."
+	ids := ((deselectedIds ifNil: [#()]) collect: [:e | e asSymbol]) asIdentitySet.
 	failures := OrderedCollection new.
 	applied := 0.
+	appliedAddSelectors := Set new.
 	self changeSet changes do: [:change |
-		(ids includes: change id)
+		(ids includes: change id asSymbol)
 			ifFalse: [
 				[(self applyChange: change) ifTrue: [applied := applied + 1]]
 				on: Error do: [:e |
@@ -4886,7 +4949,10 @@ applyChange: aChange
 category: 'applying'
 method: GsPushDownMethodRefactoring
 applyMethodAdd: aChange
-	"Compile the pushed-down method onto a subclass/side. No commit."
+	"Compile the pushed-down method onto a subclass/side. No commit. Records the selector
+	 as applied so the paired remove fires only when at least one add actually happened
+	 this run (so un-ticking every target is a genuine no-op, even when every subclass
+	 already understood the selector via its own override)."
 	| cls target |
 	cls := environment classNamed: aChange className.
 	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
@@ -4895,17 +4961,21 @@ applyMethodAdd: aChange
 		compileMethod: aChange newSource
 		dictionaries: System myUserProfile symbolList
 		category: (aChange category ifNil: ['as yet unclassified']).
+	appliedAddSelectors add: aChange selector asSymbol.
 	^true
 %
 
 category: 'applying'
 method: GsPushDownMethodRefactoring
 applyMethodRemove: aChange
-	"Remove the method from the source -- but ONLY once EVERY immediate subclass
-	 understands the selector on its own (either it received a copy or it already
-	 overrode it), so a deselected or failed add never strands a subclass. No commit."
+	"Remove the method from the source -- but ONLY once at least one add for this selector
+	 was applied this run AND EVERY immediate subclass understands the selector on its own
+	 (it received a copy or already overrode it). The applied-add clause makes un-ticking
+	 every target a no-op; the all-subclasses clause makes a partial push a copy-down that
+	 leaves the source in place rather than stranding a subclass. No commit."
 	| cls sel |
 	sel := aChange selector asSymbol.
+	(appliedAddSelectors includes: sel) ifFalse: [^false].
 	(subClasses allSatisfy: [:s | (self behaviorFor: s) includesSelector: sel])
 		ifFalse: [^false].
 	cls := environment classNamed: aChange className.
@@ -5081,15 +5151,17 @@ computeAnalysis
 category: 'private - analysis'
 method: GsPushUpMethodRefactoring
 computeDeclineFor: aSelector
-	"nil if aSelector can be pushed up, otherwise a reason. Checks, in order: method
-	 exists on the source, no collision on the superclass, no super send, and every
-	 accessed instance variable exists on the superclass."
-	| method src tree accessed targetVars missing |
+	"nil if aSelector can be pushed up, otherwise a HARD reason. Checks, in order: the
+	 method exists on the source, it does not send super, every accessed instance variable
+	 exists on the superclass, and no referenced class/pool variable is declared only below
+	 the superclass. A collision (the superclass already implements the selector) is NOT a
+	 hard decline: it becomes an opt-in, data-losing OVERWRITE change (see
+	 overwriteWarningFor:), because consolidating an inherited method by pushing up is often
+	 the intent."
+	| method src tree accessed targetVars missing sharedBelow refNames badShared |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	method isNil ifTrue: [
 		^'Cannot push up #', aSelector asString, ': it is not defined in ', sourceClass name asString, '.'].
-	(self targetBehavior includesSelector: aSelector) ifTrue: [
-		^'Cannot push up #', aSelector asString, ': ', superClass name asString, ' already defines it.'].
 	src := method sourceString.
 	tree := [RBParser parseMethod: src] on: Error do: [:e | nil].
 	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
@@ -5100,6 +5172,18 @@ computeDeclineFor: aSelector
 	missing isEmpty ifFalse: [
 		^'Cannot push up #', aSelector asString, ': it uses instance variable(s) not defined in the superclass (',
 			(self commaList: (missing collect: [:v | v asString])), ').'].
+	"Class variables and pool variables declared only below the superclass (the source's
+	 own, or a pool it alone imports) would be undeclared once the method compiles onto the
+	 superclass. instVarsAccessed does not cover these, so match referenced identifier names
+	 (from the parse tree) against the shared-var delta."
+	sharedBelow := self sharedVarsBelowTarget.
+	sharedBelow isEmpty ifFalse: [
+		refNames := Set new.
+		tree ifNotNil: [tree nodesDo: [:n | n isVariable ifTrue: [refNames add: n name asSymbol]]].
+		badShared := sharedBelow select: [:v | refNames includes: v].
+		badShared isEmpty ifFalse: [
+			^'Cannot push up #', aSelector asString, ': it uses class/pool variable(s) not defined in the superclass (',
+				(self commaList: ((badShared asSortedCollection: [:a :b | a <= b]) asArray collect: [:v | v asString])), ').']].
 	^nil
 %
 
@@ -5109,6 +5193,58 @@ tree: aTree referencesName: aName
 	"True if aTree or any descendant is a variable node named aName."
 	aTree nodesDo: [:n | (n isVariable and: [n name = aName]) ifTrue: [^true]].
 	^false
+%
+
+category: 'private - analysis'
+method: GsPushUpMethodRefactoring
+sharedVarsBelowTarget
+	"Class-variable + pool-variable names visible to the SOURCE but NOT to the superclass --
+	 i.e. declared on the source (or between it and the superclass) -- as a Set of Symbols. A
+	 pushed-up method referencing any of these would fail to compile on the superclass. Class
+	 variables and pool imports are shared across both sides, so this is independent of isMeta."
+	| below |
+	below := self sharedVarNamesOf: sourceClass.
+	(self sharedVarNamesOf: superClass) do: [:v | below remove: v ifAbsent: []].
+	^below
+%
+
+category: 'private - analysis'
+method: GsPushUpMethodRefactoring
+sharedVarNamesOf: aClass
+	"All class-variable + pool-variable names visible to aClass (own + inherited class vars,
+	 plus every imported pool's keys), as a Set of Symbols. Defensive against a release that
+	 lacks either reflection selector."
+	| names |
+	names := Set new.
+	([aClass allClassVarNames] on: Error do: [:e | #()])
+		do: [:n | names add: n asSymbol].
+	([aClass sharedPools] on: Error do: [:e | #()])
+		do: [:pool | pool keysDo: [:k | names add: k asSymbol]].
+	^names
+%
+
+category: 'private - analysis'
+method: GsPushUpMethodRefactoring
+targetExistingSourceFor: aSelector
+	"If the superclass ALREADY implements aSelector, its current source (which pushing up
+	 will OVERWRITE); nil otherwise. Only meaningful for a movable selector."
+	(self targetBehavior includesSelector: aSelector) ifFalse: [^nil].
+	^(self targetBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil)
+		ifNil: [nil] ifNotNil: [:m | m sourceString]
+%
+
+category: 'preconditions'
+method: GsPushUpMethodRefactoring
+overwriteWarningFor: aSelector
+	"A data-loss warning if pushing aSelector up would OVERWRITE a method the superclass
+	 itself defines (its definition is replaced by the pushed-up one); nil otherwise.
+	 nil for a declined selector or a global decline."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^nil].
+	(self declineFor: aSelector) notNil ifTrue: [^nil].
+	(self targetExistingSourceFor: aSelector) isNil ifTrue: [^nil].
+	^'Pushing up overwrites ', superClass name asString, '>>', aSelector asString,
+	  ' -- its current definition is lost.'
 %
 
 category: 'private'
@@ -5198,18 +5334,31 @@ buildChangeSet
 category: 'building'
 method: GsPushUpMethodRefactoring
 stagePushOf: aSelector into: cs
-	"Stage the add-on-superclass then the remove-from-source for one movable selector."
-	| method src cat |
+	"Stage the add-on-superclass then the remove-from-source for one movable selector. If
+	 the superclass already implements the selector, the add is an OVERWRITE (carries the
+	 existing body + a data-loss warning) rather than a plain add."
+	| method src cat existing |
 	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
 	src := method sourceString.
 	cat := self categoryOfSelector: aSelector.
-	cs
-		addMethodAddInDictionary: (self dictNameForClass: superClass)
-		className: superClass name asString
-		isMeta: isMeta
-		selector: aSelector
-		category: cat
-		newSource: src.
+	existing := self targetExistingSourceFor: aSelector.
+	existing isNil
+		ifTrue: [cs
+			addMethodAddInDictionary: (self dictNameForClass: superClass)
+			className: superClass name asString
+			isMeta: isMeta
+			selector: aSelector
+			category: cat
+			newSource: src]
+		ifFalse: [cs
+			addMethodOverwriteInDictionary: (self dictNameForClass: superClass)
+			className: superClass name asString
+			isMeta: isMeta
+			selector: aSelector
+			category: cat
+			oldSource: existing
+			newSource: src
+			warning: (self overwriteWarningFor: aSelector)].
 	cs
 		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
 		className: sourceClass name asString
@@ -5238,6 +5387,8 @@ analysisJsonString
 		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
 		ws nextPutAll: ',"decline":';
 			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPutAll: ',"warning":';
+			nextPutAll: ((self overwriteWarningFor: sel) ifNil: ['null'] ifNotNil: [:w | self jsonQuote: w]).
 		ws nextPut: $}].
 	ws nextPutAll: ']}'.
 	^ws contents
@@ -5325,11 +5476,15 @@ applyDeselected: deselectedIds
 	 skipped. Removals are additionally guarded (see applyMethodRemove:) so a skipped or
 	 failed add never strands a method in neither class. Answers {applied, failed:[..]}."
 	| applied failures ids |
-	ids := (deselectedIds ifNil: [#()]) asArray.
+	"Compare ids as Symbols: a deselected id arrives from the client as a String literal,
+	 which on 3.6.x is a Unicode string, and comparing it to the byte-string change id can
+	 raise (the 3.6.2 Unicode-comparison trap). asSymbol canonicalises both sides."
+	ids := ((deselectedIds ifNil: [#()]) collect: [:e | e asSymbol]) asIdentitySet.
 	failures := OrderedCollection new.
 	applied := 0.
+	appliedAddSelectors := Set new.
 	self changeSet changes do: [:change |
-		(ids includes: change id)
+		(ids includes: change id asSymbol)
 			ifFalse: [
 				[(self applyChange: change) ifTrue: [applied := applied + 1]]
 				on: Error do: [:e |
@@ -5356,7 +5511,10 @@ applyChange: aChange
 category: 'applying'
 method: GsPushUpMethodRefactoring
 applyMethodAdd: aChange
-	"Compile the pushed-up method onto the superclass/side. No commit."
+	"Compile the pushed-up method onto the superclass/side. No commit. Records the
+	 selector as applied so the paired remove knows the add actually happened (a plain
+	 includesSelector: check cannot tell an applied push from a pre-existing collision
+	 method, so a deselected OVERWRITE must not trigger the remove)."
 	| cls target |
 	cls := environment classNamed: aChange className.
 	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
@@ -5365,16 +5523,21 @@ applyMethodAdd: aChange
 		compileMethod: aChange newSource
 		dictionaries: System myUserProfile symbolList
 		category: (aChange category ifNil: ['as yet unclassified']).
+	appliedAddSelectors add: aChange selector asSymbol.
 	^true
 %
 
 category: 'applying'
 method: GsPushUpMethodRefactoring
 applyMethodRemove: aChange
-	"Remove the method from the source -- but ONLY once the superclass actually holds it,
-	 so a deselected or failed add never leaves the method in neither class. No commit."
+	"Remove the method from the source -- but ONLY once this run actually compiled the
+	 method onto the superclass, so a deselected or failed add never leaves the method in
+	 neither class. Guarding on the applied-add set (not a bare includesSelector: on the
+	 superclass) is what makes a deselected OVERWRITE safe: the superclass already has a
+	 same-selector method, so includesSelector: would wrongly report the push succeeded
+	 and strip the source. No commit."
 	| cls target |
-	(self targetBehavior includesSelector: aChange selector asSymbol) ifFalse: [^false].
+	(appliedAddSelectors includes: aChange selector asSymbol) ifFalse: [^false].
 	cls := environment classNamed: aChange className.
 	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
 	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].
@@ -5577,6 +5740,8 @@ jsonOn: aStream
 	self jsonValue: oldSource on: aStream.
 	aStream nextPutAll: ',"newSource":'.
 	self jsonValue: newSource on: aStream.
+	aStream nextPutAll: ',"warning":'.
+	self jsonValue: warning on: aStream.
 	aStream nextPut: $}
 %
 
@@ -5607,6 +5772,20 @@ category: 'accessing'
 method: GsRefactoringChange
 oldSource
 	^oldSource
+%
+
+category: 'accessing'
+method: GsRefactoringChange
+warning
+	"A human-readable data-loss warning for this change (e.g. that it overwrites an
+	 existing method whose definition is lost), or nil when the change is non-destructive."
+	^warning
+%
+
+category: 'private'
+method: GsRefactoringChange
+setWarning: aString
+	warning := aString
 %
 
 category: 'accessing'
@@ -5681,6 +5860,22 @@ methodAddId: anId dictName: dn className: cn isMeta: aBool selector: sel categor
 	^self new
 		setId: anId kind: #methodAdd dictName: dn className: cn
 		isMeta: aBool selector: sel category: cat oldSource: nil newSource: ns
+%
+
+category: 'instance creation'
+classmethod: GsRefactoringChange
+methodOverwriteId: anId dictName: dn className: cn isMeta: aBool selector: sel category: cat oldSource: os newSource: ns warning: w
+	"A method to compile onto a class that ALREADY defines the selector: apply = compile
+	 newSource, exactly like a #methodAdd (the kind IS #methodAdd, so the apply path is
+	 unchanged). Unlike a plain add, oldSource carries the class's EXISTING definition so
+	 the before/after diff shows what is being replaced, and `warning` explains that
+	 applying this change overwrites (loses) that definition. Used by push-up (onto a
+	 superclass that already implements the selector) and push-down (onto a subclass that
+	 already overrides it) as an opt-in, data-losing change."
+	^(self new
+		setId: anId kind: #methodAdd dictName: dn className: cn
+		isMeta: aBool selector: sel category: cat oldSource: os newSource: ns)
+		setWarning: w
 %
 
 category: 'instance creation'
@@ -5769,6 +5964,23 @@ addMethodAddInDictionary: dn className: cn isMeta: aBool selector: sel category:
 	change := GsRefactoringChange
 		methodAddId: self nextIdString dictName: dn className: cn
 		isMeta: aBool selector: sel category: cat newSource: ns.
+	changes add: change.
+	^change
+%
+
+category: 'building'
+method: GsRefactoringChangeSet
+addMethodOverwriteInDictionary: dn className: cn isMeta: aBool selector: sel category: cat oldSource: os newSource: ns warning: w
+	"Stage a method-add onto a class that ALREADY defines the selector (push-up onto a
+	 superclass that implements it, or push-down onto an overriding subclass). Records the
+	 change only; NEVER compiles or commits. Apply compiles newSource exactly like a plain
+	 add (the kind is #methodAdd); oldSource + warning let the client show what will be
+	 overwritten and flag the data loss so the user can opt in. Returns the new
+	 GsRefactoringChange."
+	| change |
+	change := GsRefactoringChange
+		methodOverwriteId: self nextIdString dictName: dn className: cn
+		isMeta: aBool selector: sel category: cat oldSource: os newSource: ns warning: w.
 	changes add: change.
 	^change
 %

--- a/resources/refactoring/engine.gs
+++ b/resources/refactoring/engine.gs
@@ -295,6 +295,103 @@ removeallclassmethods GsInlineTemporaryRefactoring
 
 doit
 | cls |
+cls := Object subclass: 'GsPushDownMethodRefactoring'
+  instVarNames: #('environment' 'sourceClass' 'selectors' 'isMeta' 'subClasses' 'recipients' 'changeSet' 'analysisDone' 'globalDecline' 'declines')
+  classVars: #()
+  classInstVars: #()
+  poolDictionaries: #()
+  inDictionary: GsRefactoring.
+cls category: 'Refactoring-Core'.
+cls comment: '
+Push one OR MORE methods DOWN (M8) from a source class into its immediate SUBCLASSES,
+keeping the selector and the method source verbatim and the same side (instance stays
+instance, class stays class -- no side flip). The refactoring is addressed by the source
+class + a COLLECTION of selectors + the source side (isMeta); the targets (the immediate
+subclasses) are resolved server-side, so the engine -- not the client -- owns the ''''which
+classes'''' logic and can be tested in isolation. Single-method push-down is just a
+one-element collection, so single- and multi-method share one path.
+
+Push-down is the inverse of push-up (M7) and a many-target relative of move-method (M6);
+it reuses the same change kinds and preview/apply/token machinery. Per movable selector it
+stages a #methodAdd on EVERY immediate subclass that does not already override the selector
+(each keeps its own override, and is silently skipped) plus a SINGLE #methodRemove on the
+source. So one pushed-down selector produces N adds + 1 remove (N = the receiving subclass
+count). Both change kinds already exist; no new kind is introduced. Each selector is
+analysed independently; a declined selector is dropped from the change set and reported, so
+a multi-push relocates the movable methods and explains the rest.
+
+A GLOBAL decline (the source has no subclasses) empties the whole change set. A per-selector
+decline is recorded when: the source method is missing; the method sends super (its meaning
+depends on the source class''''s superclass, which changes once the home moves down); or EVERY
+immediate subclass already overrides the selector (nothing to push, and removing it from the
+source would only endanger the source''s own direct instances). Instance-variable access needs
+no check: the method already lives on the source, so every accessed ivar is defined on (or
+inherited by) the source, and every subclass inherits those same ivars.
+
+This is the SIMPLEST SOUND variant: the definition is copied into each immediate subclass
+that lacks its own and removed from the source; senders are NOT rewritten and no forwarding
+method is left behind. NOTE the intended semantics: after push-down the source class no
+longer understands the selector, so this is meant for an abstract superclass (or one whose
+direct instances do not use the method). Building the change set compiles nothing and commits
+nothing; the server-side apply compiles each subclass and removes the source, guarding the
+removal so it fires only once EVERY immediate subclass understands the selector (a
+deselected/failed add leaves the source method in place rather than stranding a subclass),
+and NEVER commits (the user commits explicitly).
+'.
+true.
+%
+
+removeallmethods GsPushDownMethodRefactoring
+removeallclassmethods GsPushDownMethodRefactoring
+
+doit
+| cls |
+cls := Object subclass: 'GsPushUpMethodRefactoring'
+  instVarNames: #('environment' 'sourceClass' 'selectors' 'isMeta' 'superClass' 'changeSet' 'analysisDone' 'globalDecline' 'declines')
+  classVars: #()
+  classInstVars: #()
+  poolDictionaries: #()
+  inDictionary: GsRefactoring.
+cls category: 'Refactoring-Core'.
+cls comment: '
+Push one OR MORE methods UP (M7) from a source class to its immediate SUPERCLASS,
+keeping the selector and the method source verbatim and the same side (instance stays
+instance, class stays class -- no side flip). The refactoring is addressed by the source
+class + a COLLECTION of selectors + the source side (isMeta); the target (the superclass)
+is resolved server-side, so the engine -- not the client -- owns the ''''which class'''' logic
+and can be tested in isolation. Single-method push-up is just a one-element collection, so
+single- and multi-method share one path.
+
+Push-up is the special case of move-method (M6) whose target is the source''''s superclass;
+it reuses M6''''s change kinds and preview/apply/token machinery verbatim. Per selector it
+stages a #methodAdd on the superclass (compile the same source there, under its original
+category) and a #methodRemove on the source. Both change kinds already exist; no new kind
+is introduced. Each selector is analysed independently; a declined selector is dropped from
+the change set and reported, so a multi-push relocates the movable methods and explains the
+rest.
+
+A GLOBAL decline (the source has no superclass) empties the whole change set. A per-selector
+decline is recorded when: the source method is missing; the superclass already implements the
+selector (collision -- pushing up would overwrite it); the method sends super (its meaning
+depends on the source class''''s superclass, which changes when the home moves up); or the
+method accesses an instance variable the superclass does not define (bytecode-precise via
+instVarsAccessed -- the ivar lives only on the subclass).
+
+This is the SIMPLEST SOUND variant: the definition is relocated to the superclass and the
+selector kept; siblings that inherited nothing now inherit the pushed-up method, senders are
+NOT rewritten and no forwarding method is left behind. Building the change set compiles nothing
+and commits nothing; the server-side apply compiles the superclass and removes the source,
+guarding each removal so a deselected/failed add never strands a method in neither class, and
+NEVER commits (the user commits explicitly).
+'.
+true.
+%
+
+removeallmethods GsPushUpMethodRefactoring
+removeallclassmethods GsPushUpMethodRefactoring
+
+doit
+| cls |
 cls := Object subclass: 'GsRefactoringChange'
   instVarNames: #('id' 'kind' 'dictName' 'className' 'isMeta' 'selector' 'newSelector' 'newName' 'category' 'oldSource' 'newSource')
   classVars: #()
@@ -4451,6 +4548,937 @@ applyForToken: token deselected: deselectedIds
 
 category: 'paginated preview'
 classmethod: GsInlineTemporaryRefactoring
+clearToken: token
+	"Drop a finished preview from SessionTemps."
+	SessionTemps current removeKey: token asSymbol ifAbsent: [].
+	^'ok'
+%
+
+category: 'private'
+method: GsPushDownMethodRefactoring
+setEnvironment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool
+	environment := anEnvironment.
+	sourceClass := aClass.
+	selectors := aCollection collect: [:s | s asSymbol].
+	isMeta := aBool.
+	analysisDone := false
+%
+
+category: 'accessing'
+method: GsPushDownMethodRefactoring
+environment
+	^environment
+%
+
+category: 'accessing'
+method: GsPushDownMethodRefactoring
+selectors
+	^selectors
+%
+
+category: 'private'
+method: GsPushDownMethodRefactoring
+sourceBehavior
+	"The behaviour that holds the methods being pushed: the metaclass for a class-side
+	 source."
+	^isMeta ifTrue: [sourceClass class] ifFalse: [sourceClass]
+%
+
+category: 'private'
+method: GsPushDownMethodRefactoring
+behaviorFor: aClass
+	"The relevant side of a subclass (its metaclass for a class-side push)."
+	^isMeta ifTrue: [aClass class] ifFalse: [aClass]
+%
+
+category: 'private - analysis'
+method: GsPushDownMethodRefactoring
+ensureAnalysis
+	analysisDone ifFalse: [
+		analysisDone := true.
+		[self computeAnalysis] on: Error do: [:e |
+			globalDecline := 'The push-down could not be analysed: ', e messageText]]
+%
+
+category: 'private - analysis'
+method: GsPushDownMethodRefactoring
+computeAnalysis
+	"Resolve the immediate subclasses, reject a class with none, then record a
+	 per-selector decline (nil when movable) and, for movable selectors, the subclasses
+	 that will receive a copy (those not already overriding it)."
+	globalDecline := nil.
+	declines := Dictionary new.
+	recipients := Dictionary new.
+	subClasses := (sourceClass subclasses ifNil: [#()]) asArray.
+	subClasses isEmpty ifTrue: [
+		^globalDecline := 'Cannot push down: ', sourceClass name asString, ' has no subclasses.'].
+	selectors do: [:sel | self analyzeSelector: sel]
+%
+
+category: 'private - analysis'
+method: GsPushDownMethodRefactoring
+analyzeSelector: aSelector
+	"Record the decline reason (nil when movable) and the receiving subclasses for one
+	 selector."
+	| method src tree recips |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	method isNil ifTrue: [
+		^declines at: aSelector put:
+			'Cannot push down #', aSelector asString, ': it is not defined in ', sourceClass name asString, '.'].
+	src := method sourceString.
+	tree := [RBParser parseMethod: src] on: Error do: [:e | nil].
+	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
+		^declines at: aSelector put:
+			'Cannot push down #', aSelector asString, ': it sends super, whose meaning depends on the class''s superclass.'].
+	recips := subClasses reject: [:s | (self behaviorFor: s) includesSelector: aSelector].
+	recips isEmpty ifTrue: [
+		^declines at: aSelector put:
+			'Cannot push down #', aSelector asString, ': every subclass already overrides it.'].
+	recipients at: aSelector put: recips.
+	declines at: aSelector put: nil
+%
+
+category: 'private - analysis'
+method: GsPushDownMethodRefactoring
+tree: aTree referencesName: aName
+	"True if aTree or any descendant is a variable node named aName."
+	aTree nodesDo: [:n | (n isVariable and: [n name = aName]) ifTrue: [^true]].
+	^false
+%
+
+category: 'private'
+method: GsPushDownMethodRefactoring
+dictNameForClass: aClass
+	| dicts |
+	dicts := environment dictionariesDefiningClassNamed: aClass name.
+	^dicts isEmpty ifTrue: [nil] ifFalse: [dicts first name asString]
+%
+
+category: 'private'
+method: GsPushDownMethodRefactoring
+categoryOfSelector: aSelector
+	^((self sourceBehavior categoryOfSelector: aSelector environmentId: 0)
+		ifNil: ['as yet unclassified']) asString
+%
+
+category: 'preconditions'
+method: GsPushDownMethodRefactoring
+globalDecline
+	"nil if the push-down as a whole is viable, otherwise a reason that empties the
+	 change set (the source has no subclasses)."
+	self ensureAnalysis.
+	^globalDecline
+%
+
+category: 'preconditions'
+method: GsPushDownMethodRefactoring
+declineFor: aSelector
+	"nil if aSelector will move, otherwise the per-selector (or inherited global)
+	 reason it will not."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^globalDecline].
+	^declines at: aSelector asSymbol ifAbsent: [nil]
+%
+
+category: 'accessing'
+method: GsPushDownMethodRefactoring
+recipientsFor: aSelector
+	"The immediate subclasses that will receive a copy of aSelector (empty for a declined
+	 or unknown selector)."
+	self ensureAnalysis.
+	^recipients at: aSelector asSymbol ifAbsent: [#()]
+%
+
+category: 'accessing'
+method: GsPushDownMethodRefactoring
+movableSelectors
+	"The selectors that will actually move, preserving request order."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^#()].
+	^selectors select: [:sel | (declines at: sel ifAbsent: [nil]) isNil]
+%
+
+category: 'accessing'
+method: GsPushDownMethodRefactoring
+movableCount
+	^self movableSelectors size
+%
+
+category: 'building'
+method: GsPushDownMethodRefactoring
+changeSet
+	"The staged, non-committing change set, computed once and cached. Empty on a global
+	 decline; otherwise, per movable selector, one add per receiving subclass plus one
+	 remove from the source."
+	changeSet isNil ifTrue: [changeSet := self buildChangeSet].
+	^changeSet
+%
+
+category: 'building'
+method: GsPushDownMethodRefactoring
+buildChangeSet
+	| cs |
+	cs := GsRefactoringChangeSet new.
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^cs].
+	self movableSelectors do: [:sel | self stagePushOf: sel into: cs].
+	^cs
+%
+
+category: 'building'
+method: GsPushDownMethodRefactoring
+stagePushOf: aSelector into: cs
+	"Stage an add on every receiving subclass, then a single remove from the source."
+	| method src cat |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	src := method sourceString.
+	cat := self categoryOfSelector: aSelector.
+	(self recipientsFor: aSelector) do: [:sub |
+		cs
+			addMethodAddInDictionary: (self dictNameForClass: sub)
+			className: sub name asString
+			isMeta: isMeta
+			selector: aSelector
+			category: cat
+			newSource: src].
+	cs
+		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
+		className: sourceClass name asString
+		isMeta: isMeta
+		selector: aSelector
+		category: cat
+		oldSource: src
+%
+
+category: 'serializing'
+method: GsPushDownMethodRefactoring
+analysisJsonString
+	"The pre-flight payload: a null targetClass (many subclasses), the movable count, a
+	 global decline (if any), and a per-selector {selector, decline} array."
+	| ws |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPutAll: '{"targetClass":null'.
+	ws nextPutAll: ',"globalDecline":';
+		nextPutAll: (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+	ws nextPutAll: ',"movableCount":'; nextPutAll: self movableCount printString.
+	ws nextPutAll: ',"selectors":['.
+	selectors keysAndValuesDo: [:i :sel |
+		i = 1 ifFalse: [ws nextPut: $,].
+		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+		ws nextPutAll: ',"decline":';
+			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPut: $}].
+	ws nextPutAll: ']}'.
+	^ws contents
+%
+
+category: 'serializing'
+method: GsPushDownMethodRefactoring
+previewJsonString
+	^self changeSet jsonString
+%
+
+category: 'serializing'
+method: GsPushDownMethodRefactoring
+outOfScopeJsonString
+	"The scope / precondition payload for the preview panel, in the family's shape. A
+	 hard global decline (which blocks Apply) rides here; per-selector skips ride in
+	 skippedMethods."
+	^'{"references":0,"skipped":', (selectors size - self movableCount) printString,
+	  ',"scope":"class","collision":null,"decline":',
+	  (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]),
+	  '}'
+%
+
+category: 'serializing'
+method: GsPushDownMethodRefactoring
+skippedMethodsJsonString
+	"The declined selectors + reasons, for the preview panel to explain what will NOT
+	 move."
+	| ws first |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	first := true.
+	selectors do: [:sel | | reason |
+		reason := self declineFor: sel.
+		(reason notNil and: [globalDecline isNil]) ifTrue: [
+			first ifFalse: [ws nextPut: $,].
+			first := false.
+			ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+			ws nextPutAll: ',"reason":'; nextPutAll: (self jsonQuote: reason); nextPut: $}]].
+	ws nextPut: $].
+	^ws contents
+%
+
+category: 'paginated preview'
+method: GsPushDownMethodRefactoring
+startPreviewToken: token maxBytes: maxBytes
+	"Build the change set, stash this refactoring in SessionTemps under token, and
+	 answer the first page plus totals and precondition warnings. Nothing is committed."
+	self changeSet.
+	SessionTemps current at: token asSymbol put: self.
+	^'{"token":', (self jsonQuote: token),
+	  ',"total":', self changeSet size printString,
+	  ',"targetClass":null',
+	  ',"movableCount":', self movableCount printString,
+	  ',"outOfScope":', self outOfScopeJsonString,
+	  ',"skippedMethods":', self skippedMethodsJsonString,
+	  ',"page":', (self pageJsonFrom: 1 maxBytes: maxBytes), '}'
+%
+
+category: 'paginated preview'
+method: GsPushDownMethodRefactoring
+pageJsonFrom: startIndex maxBytes: maxBytes
+	"A byte-bounded page of staged changes (with source) from startIndex (1-based). At
+	 least one change is always emitted when any remain."
+	| all ws i |
+	all := self changeSet changes.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	i := startIndex.
+	[i <= all size and: [i = startIndex or: [ws position < maxBytes]]] whileTrue: [
+		i > startIndex ifTrue: [ws nextPut: $,].
+		(all at: i) jsonOn: ws.
+		i := i + 1].
+	ws nextPut: $].
+	^'{"changes":', ws contents,
+	  ',"nextOffset":', i printString,
+	  ',"done":', (i > all size) printString, '}'
+%
+
+category: 'applying'
+method: GsPushDownMethodRefactoring
+applyDeselected: deselectedIds
+	"Apply the staged changes in the stone WITHOUT committing. A deselected id is
+	 skipped. The source removal is guarded (see applyMethodRemove:) so a skipped or
+	 failed subclass add never strands that subclass. Answers {applied, failed:[..]}."
+	| applied failures ids |
+	ids := (deselectedIds ifNil: [#()]) asArray.
+	failures := OrderedCollection new.
+	applied := 0.
+	self changeSet changes do: [:change |
+		(ids includes: change id)
+			ifFalse: [
+				[(self applyChange: change) ifTrue: [applied := applied + 1]]
+				on: Error do: [:e |
+					failures add: (Array with: change id with: change className with: e messageText)]]].
+	^'{"applied":', applied printString,
+	  ',"failed":[',
+	  ((failures collect: [:f |
+		'{"id":', (self jsonQuote: (f at: 1)),
+		',"label":', (self jsonQuote: (f at: 2)),
+		',"error":', (self jsonQuote: (f at: 3)), '}'])
+			inject: '' into: [:acc :s | acc isEmpty ifTrue: [s] ifFalse: [acc, ',', s]]),
+	  ']}'
+%
+
+category: 'applying'
+method: GsPushDownMethodRefactoring
+applyChange: aChange
+	"Answer true when the change was applied, false when it was safely skipped."
+	aChange kind == #methodAdd ifTrue: [^self applyMethodAdd: aChange].
+	aChange kind == #methodRemove ifTrue: [^self applyMethodRemove: aChange].
+	^self error: 'Unexpected change kind for push-down-method: ', aChange kind printString
+%
+
+category: 'applying'
+method: GsPushDownMethodRefactoring
+applyMethodAdd: aChange
+	"Compile the pushed-down method onto a subclass/side. No commit."
+	| cls target |
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].
+	target
+		compileMethod: aChange newSource
+		dictionaries: System myUserProfile symbolList
+		category: (aChange category ifNil: ['as yet unclassified']).
+	^true
+%
+
+category: 'applying'
+method: GsPushDownMethodRefactoring
+applyMethodRemove: aChange
+	"Remove the method from the source -- but ONLY once EVERY immediate subclass
+	 understands the selector on its own (either it received a copy or it already
+	 overrode it), so a deselected or failed add never strands a subclass. No commit."
+	| cls sel |
+	sel := aChange selector asSymbol.
+	(subClasses allSatisfy: [:s | (self behaviorFor: s) includesSelector: sel])
+		ifFalse: [^false].
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	(aChange isMeta ifTrue: [cls class] ifFalse: [cls]) removeSelector: sel.
+	^true
+%
+
+category: 'serializing'
+method: GsPushDownMethodRefactoring
+jsonQuote: aString
+	^'"', (self jsonEscape: aString), '"'
+%
+
+category: 'serializing'
+method: GsPushDownMethodRefactoring
+jsonEscape: aString
+	"JSON string escaping emitting PURE ASCII (control chars and code points above 126
+	 become \\uXXXX), so the client's non-blocking GCI fetch is never handed a Unicode
+	 result."
+	| ws |
+	ws := WriteStream on: String new.
+	aString do: [:ch | | code |
+		code := ch asInteger.
+		ch == $" ifTrue: [ws nextPutAll: '\"']
+		ifFalse: [ch == $\ ifTrue: [ws nextPutAll: '\\']
+		ifFalse: [code = 10 ifTrue: [ws nextPutAll: '\n']
+		ifFalse: [code = 13 ifTrue: [ws nextPutAll: '\r']
+		ifFalse: [code = 9 ifTrue: [ws nextPutAll: '\t']
+		ifFalse: [code < 32
+			ifTrue: [ws nextPutAll: '\u00'; nextPutAll: (self hex2: code)]
+		ifFalse: [code > 126
+			ifTrue: [code > 65535
+				ifTrue: [ws nextPut: $?]
+				ifFalse: [ws nextPutAll: '\u';
+					nextPutAll: (self hex2: code // 256);
+					nextPutAll: (self hex2: code \\ 256)]]
+			ifFalse: [ws nextPut: ch]]]]]]]].
+	^ws contents
+%
+
+category: 'serializing'
+method: GsPushDownMethodRefactoring
+hex2: anInteger
+	| digits |
+	digits := '0123456789abcdef'.
+	^(String with: (digits at: (anInteger // 16) + 1))
+		, (String with: (digits at: (anInteger \\ 16) + 1))
+%
+
+category: 'instance creation'
+classmethod: GsPushDownMethodRefactoring
+sourceClass: aClass selectors: aCollection meta: aBool
+	"Push aCollection of selectors from the aBool side of aClass down into the same side
+	 of aClass's immediate subclasses."
+	^self
+		environment: GsRefactoringEnvironment new
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+%
+
+category: 'instance creation'
+classmethod: GsPushDownMethodRefactoring
+environment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool
+	^self new
+		setEnvironment: anEnvironment
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+%
+
+category: 'preconditions'
+classmethod: GsPushDownMethodRefactoring
+analyzeForClass: aClass selectors: aCollection meta: aBool
+	"A pre-flight the client runs before opening the preview: a per-selector decline
+	 reason (nil when movable) and the count that will move. targetClass is null because
+	 the method lands in many subclasses."
+	^(self
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool) analysisJsonString
+%
+
+category: 'paginated preview'
+classmethod: GsPushDownMethodRefactoring
+pageForToken: token from: startIndex maxBytes: maxBytes
+	"A page from a previously-started preview (see startPreviewToken:maxBytes:), by
+	 token. Answers an error envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"error":"preview session expired","changes":[],"nextOffset":0,"done":true}']
+		ifNotNil: [:ref | ref pageJsonFrom: startIndex maxBytes: maxBytes]
+%
+
+category: 'paginated preview'
+classmethod: GsPushDownMethodRefactoring
+applyForToken: token deselected: deselectedIds
+	"Apply a previously-started preview (by token). No commit. Answers an error
+	 envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"applied":0,"failed":[],"error":"preview session expired"}']
+		ifNotNil: [:ref | ref applyDeselected: deselectedIds]
+%
+
+category: 'paginated preview'
+classmethod: GsPushDownMethodRefactoring
+clearToken: token
+	"Drop a finished preview from SessionTemps."
+	SessionTemps current removeKey: token asSymbol ifAbsent: [].
+	^'ok'
+%
+
+category: 'private'
+method: GsPushUpMethodRefactoring
+setEnvironment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool
+	environment := anEnvironment.
+	sourceClass := aClass.
+	selectors := aCollection collect: [:s | s asSymbol].
+	isMeta := aBool.
+	analysisDone := false
+%
+
+category: 'accessing'
+method: GsPushUpMethodRefactoring
+environment
+	^environment
+%
+
+category: 'accessing'
+method: GsPushUpMethodRefactoring
+selectors
+	^selectors
+%
+
+category: 'private'
+method: GsPushUpMethodRefactoring
+sourceBehavior
+	"The behaviour that holds the methods being pushed: the metaclass for a class-side
+	 source."
+	^isMeta ifTrue: [sourceClass class] ifFalse: [sourceClass]
+%
+
+category: 'private'
+method: GsPushUpMethodRefactoring
+targetBehavior
+	"The behaviour the methods move to (the superclass, same side). Only valid once
+	 analysis has resolved superClass."
+	^isMeta ifTrue: [superClass class] ifFalse: [superClass]
+%
+
+category: 'private - analysis'
+method: GsPushUpMethodRefactoring
+ensureAnalysis
+	analysisDone ifFalse: [
+		analysisDone := true.
+		[self computeAnalysis] on: Error do: [:e |
+			globalDecline := 'The push-up could not be analysed: ', e messageText]]
+%
+
+category: 'private - analysis'
+method: GsPushUpMethodRefactoring
+computeAnalysis
+	"Resolve the target superclass, reject a class with no superclass, then record a
+	 per-selector decline (nil when movable)."
+	globalDecline := nil.
+	declines := Dictionary new.
+	superClass := sourceClass superclass.
+	superClass isNil ifTrue: [
+		^globalDecline := 'Cannot push up: ', sourceClass name asString, ' has no superclass.'].
+	selectors do: [:sel | declines at: sel put: (self computeDeclineFor: sel)]
+%
+
+category: 'private - analysis'
+method: GsPushUpMethodRefactoring
+computeDeclineFor: aSelector
+	"nil if aSelector can be pushed up, otherwise a reason. Checks, in order: method
+	 exists on the source, no collision on the superclass, no super send, and every
+	 accessed instance variable exists on the superclass."
+	| method src tree accessed targetVars missing |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	method isNil ifTrue: [
+		^'Cannot push up #', aSelector asString, ': it is not defined in ', sourceClass name asString, '.'].
+	(self targetBehavior includesSelector: aSelector) ifTrue: [
+		^'Cannot push up #', aSelector asString, ': ', superClass name asString, ' already defines it.'].
+	src := method sourceString.
+	tree := [RBParser parseMethod: src] on: Error do: [:e | nil].
+	(tree notNil and: [self tree: tree referencesName: 'super']) ifTrue: [
+		^'Cannot push up #', aSelector asString, ': it sends super, whose meaning depends on the class''s superclass.'].
+	accessed := [method instVarsAccessed] on: Error do: [:e | #()].
+	targetVars := self targetBehavior allInstVarNames collect: [:n | n asSymbol].
+	missing := accessed reject: [:v | targetVars includes: v asSymbol].
+	missing isEmpty ifFalse: [
+		^'Cannot push up #', aSelector asString, ': it uses instance variable(s) not defined in the superclass (',
+			(self commaList: (missing collect: [:v | v asString])), ').'].
+	^nil
+%
+
+category: 'private - analysis'
+method: GsPushUpMethodRefactoring
+tree: aTree referencesName: aName
+	"True if aTree or any descendant is a variable node named aName."
+	aTree nodesDo: [:n | (n isVariable and: [n name = aName]) ifTrue: [^true]].
+	^false
+%
+
+category: 'private'
+method: GsPushUpMethodRefactoring
+commaList: aCollection
+	^aCollection
+		inject: ''
+		into: [:acc :s | acc isEmpty ifTrue: [s] ifFalse: [acc, ', ', s]]
+%
+
+category: 'private'
+method: GsPushUpMethodRefactoring
+dictNameForClass: aClass
+	| dicts |
+	dicts := environment dictionariesDefiningClassNamed: aClass name.
+	^dicts isEmpty ifTrue: [nil] ifFalse: [dicts first name asString]
+%
+
+category: 'private'
+method: GsPushUpMethodRefactoring
+categoryOfSelector: aSelector
+	^((self sourceBehavior categoryOfSelector: aSelector environmentId: 0)
+		ifNil: ['as yet unclassified']) asString
+%
+
+category: 'preconditions'
+method: GsPushUpMethodRefactoring
+globalDecline
+	"nil if the push-up as a whole is viable, otherwise a reason that empties the change
+	 set (the source has no superclass)."
+	self ensureAnalysis.
+	^globalDecline
+%
+
+category: 'preconditions'
+method: GsPushUpMethodRefactoring
+declineFor: aSelector
+	"nil if aSelector will move, otherwise the per-selector (or inherited global)
+	 reason it will not."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^globalDecline].
+	^declines at: aSelector asSymbol ifAbsent: [nil]
+%
+
+category: 'accessing'
+method: GsPushUpMethodRefactoring
+superClass
+	self ensureAnalysis.
+	^superClass
+%
+
+category: 'accessing'
+method: GsPushUpMethodRefactoring
+movableSelectors
+	"The selectors that will actually move, preserving request order."
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^#()].
+	^selectors select: [:sel | (declines at: sel ifAbsent: [nil]) isNil]
+%
+
+category: 'accessing'
+method: GsPushUpMethodRefactoring
+movableCount
+	^self movableSelectors size
+%
+
+category: 'building'
+method: GsPushUpMethodRefactoring
+changeSet
+	"The staged, non-committing change set, computed once and cached. Empty on a global
+	 decline; otherwise two changes (add + remove) per movable selector."
+	changeSet isNil ifTrue: [changeSet := self buildChangeSet].
+	^changeSet
+%
+
+category: 'building'
+method: GsPushUpMethodRefactoring
+buildChangeSet
+	| cs |
+	cs := GsRefactoringChangeSet new.
+	self ensureAnalysis.
+	globalDecline notNil ifTrue: [^cs].
+	self movableSelectors do: [:sel | self stagePushOf: sel into: cs].
+	^cs
+%
+
+category: 'building'
+method: GsPushUpMethodRefactoring
+stagePushOf: aSelector into: cs
+	"Stage the add-on-superclass then the remove-from-source for one movable selector."
+	| method src cat |
+	method := self sourceBehavior compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
+	src := method sourceString.
+	cat := self categoryOfSelector: aSelector.
+	cs
+		addMethodAddInDictionary: (self dictNameForClass: superClass)
+		className: superClass name asString
+		isMeta: isMeta
+		selector: aSelector
+		category: cat
+		newSource: src.
+	cs
+		addMethodRemoveInDictionary: (self dictNameForClass: sourceClass)
+		className: sourceClass name asString
+		isMeta: isMeta
+		selector: aSelector
+		category: cat
+		oldSource: src
+%
+
+category: 'serializing'
+method: GsPushUpMethodRefactoring
+analysisJsonString
+	"The pre-flight payload: the target superclass, the movable count, a global decline
+	 (if any), and a per-selector {selector, decline} array."
+	| ws |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPutAll: '{"targetClass":';
+		nextPutAll: (superClass isNil ifTrue: ['null'] ifFalse: [self jsonQuote: superClass name asString]).
+	ws nextPutAll: ',"globalDecline":';
+		nextPutAll: (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+	ws nextPutAll: ',"movableCount":'; nextPutAll: self movableCount printString.
+	ws nextPutAll: ',"selectors":['.
+	selectors keysAndValuesDo: [:i :sel |
+		i = 1 ifFalse: [ws nextPut: $,].
+		ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+		ws nextPutAll: ',"decline":';
+			nextPutAll: ((self declineFor: sel) ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]).
+		ws nextPut: $}].
+	ws nextPutAll: ']}'.
+	^ws contents
+%
+
+category: 'serializing'
+method: GsPushUpMethodRefactoring
+previewJsonString
+	^self changeSet jsonString
+%
+
+category: 'serializing'
+method: GsPushUpMethodRefactoring
+outOfScopeJsonString
+	"The scope / precondition payload for the preview panel, in the family's shape. A
+	 hard global decline (which blocks Apply) rides here; per-selector skips ride in
+	 skippedMethods."
+	^'{"references":0,"skipped":', (selectors size - self movableCount) printString,
+	  ',"scope":"class","collision":null,"decline":',
+	  (globalDecline ifNil: ['null'] ifNotNil: [:r | self jsonQuote: r]),
+	  '}'
+%
+
+category: 'serializing'
+method: GsPushUpMethodRefactoring
+skippedMethodsJsonString
+	"The declined selectors + reasons, for the preview panel to explain what will NOT
+	 move."
+	| ws first |
+	self ensureAnalysis.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	first := true.
+	selectors do: [:sel | | reason |
+		reason := self declineFor: sel.
+		(reason notNil and: [globalDecline isNil]) ifTrue: [
+			first ifFalse: [ws nextPut: $,].
+			first := false.
+			ws nextPutAll: '{"selector":'; nextPutAll: (self jsonQuote: sel asString).
+			ws nextPutAll: ',"reason":'; nextPutAll: (self jsonQuote: reason); nextPut: $}]].
+	ws nextPut: $].
+	^ws contents
+%
+
+category: 'paginated preview'
+method: GsPushUpMethodRefactoring
+startPreviewToken: token maxBytes: maxBytes
+	"Build the change set, stash this refactoring in SessionTemps under token, and
+	 answer the first page plus totals and precondition warnings. Nothing is committed."
+	self changeSet.
+	SessionTemps current at: token asSymbol put: self.
+	^'{"token":', (self jsonQuote: token),
+	  ',"total":', self changeSet size printString,
+	  ',"targetClass":', (superClass isNil ifTrue: ['null'] ifFalse: [self jsonQuote: superClass name asString]),
+	  ',"movableCount":', self movableCount printString,
+	  ',"outOfScope":', self outOfScopeJsonString,
+	  ',"skippedMethods":', self skippedMethodsJsonString,
+	  ',"page":', (self pageJsonFrom: 1 maxBytes: maxBytes), '}'
+%
+
+category: 'paginated preview'
+method: GsPushUpMethodRefactoring
+pageJsonFrom: startIndex maxBytes: maxBytes
+	"A byte-bounded page of staged changes (with source) from startIndex (1-based). At
+	 least one change is always emitted when any remain."
+	| all ws i |
+	all := self changeSet changes.
+	ws := WriteStream on: String new.
+	ws nextPut: $[.
+	i := startIndex.
+	[i <= all size and: [i = startIndex or: [ws position < maxBytes]]] whileTrue: [
+		i > startIndex ifTrue: [ws nextPut: $,].
+		(all at: i) jsonOn: ws.
+		i := i + 1].
+	ws nextPut: $].
+	^'{"changes":', ws contents,
+	  ',"nextOffset":', i printString,
+	  ',"done":', (i > all size) printString, '}'
+%
+
+category: 'applying'
+method: GsPushUpMethodRefactoring
+applyDeselected: deselectedIds
+	"Apply the staged changes in the stone WITHOUT committing. A deselected id is
+	 skipped. Removals are additionally guarded (see applyMethodRemove:) so a skipped or
+	 failed add never strands a method in neither class. Answers {applied, failed:[..]}."
+	| applied failures ids |
+	ids := (deselectedIds ifNil: [#()]) asArray.
+	failures := OrderedCollection new.
+	applied := 0.
+	self changeSet changes do: [:change |
+		(ids includes: change id)
+			ifFalse: [
+				[(self applyChange: change) ifTrue: [applied := applied + 1]]
+				on: Error do: [:e |
+					failures add: (Array with: change id with: change className with: e messageText)]]].
+	^'{"applied":', applied printString,
+	  ',"failed":[',
+	  ((failures collect: [:f |
+		'{"id":', (self jsonQuote: (f at: 1)),
+		',"label":', (self jsonQuote: (f at: 2)),
+		',"error":', (self jsonQuote: (f at: 3)), '}'])
+			inject: '' into: [:acc :s | acc isEmpty ifTrue: [s] ifFalse: [acc, ',', s]]),
+	  ']}'
+%
+
+category: 'applying'
+method: GsPushUpMethodRefactoring
+applyChange: aChange
+	"Answer true when the change was applied, false when it was safely skipped."
+	aChange kind == #methodAdd ifTrue: [^self applyMethodAdd: aChange].
+	aChange kind == #methodRemove ifTrue: [^self applyMethodRemove: aChange].
+	^self error: 'Unexpected change kind for push-up-method: ', aChange kind printString
+%
+
+category: 'applying'
+method: GsPushUpMethodRefactoring
+applyMethodAdd: aChange
+	"Compile the pushed-up method onto the superclass/side. No commit."
+	| cls target |
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].
+	target
+		compileMethod: aChange newSource
+		dictionaries: System myUserProfile symbolList
+		category: (aChange category ifNil: ['as yet unclassified']).
+	^true
+%
+
+category: 'applying'
+method: GsPushUpMethodRefactoring
+applyMethodRemove: aChange
+	"Remove the method from the source -- but ONLY once the superclass actually holds it,
+	 so a deselected or failed add never leaves the method in neither class. No commit."
+	| cls target |
+	(self targetBehavior includesSelector: aChange selector asSymbol) ifFalse: [^false].
+	cls := environment classNamed: aChange className.
+	cls isNil ifTrue: [^self error: 'Class not found: ', aChange className].
+	target := aChange isMeta ifTrue: [cls class] ifFalse: [cls].
+	target removeSelector: aChange selector asSymbol.
+	^true
+%
+
+category: 'serializing'
+method: GsPushUpMethodRefactoring
+jsonQuote: aString
+	^'"', (self jsonEscape: aString), '"'
+%
+
+category: 'serializing'
+method: GsPushUpMethodRefactoring
+jsonEscape: aString
+	"JSON string escaping emitting PURE ASCII (control chars and code points above 126
+	 become \\uXXXX), so the client's non-blocking GCI fetch is never handed a Unicode
+	 result."
+	| ws |
+	ws := WriteStream on: String new.
+	aString do: [:ch | | code |
+		code := ch asInteger.
+		ch == $" ifTrue: [ws nextPutAll: '\"']
+		ifFalse: [ch == $\ ifTrue: [ws nextPutAll: '\\']
+		ifFalse: [code = 10 ifTrue: [ws nextPutAll: '\n']
+		ifFalse: [code = 13 ifTrue: [ws nextPutAll: '\r']
+		ifFalse: [code = 9 ifTrue: [ws nextPutAll: '\t']
+		ifFalse: [code < 32
+			ifTrue: [ws nextPutAll: '\u00'; nextPutAll: (self hex2: code)]
+		ifFalse: [code > 126
+			ifTrue: [code > 65535
+				ifTrue: [ws nextPut: $?]
+				ifFalse: [ws nextPutAll: '\u';
+					nextPutAll: (self hex2: code // 256);
+					nextPutAll: (self hex2: code \\ 256)]]
+			ifFalse: [ws nextPut: ch]]]]]]]].
+	^ws contents
+%
+
+category: 'serializing'
+method: GsPushUpMethodRefactoring
+hex2: anInteger
+	| digits |
+	digits := '0123456789abcdef'.
+	^(String with: (digits at: (anInteger // 16) + 1))
+		, (String with: (digits at: (anInteger \\ 16) + 1))
+%
+
+category: 'instance creation'
+classmethod: GsPushUpMethodRefactoring
+sourceClass: aClass selectors: aCollection meta: aBool
+	"Push aCollection of selectors from the aBool side of aClass up to the same side of
+	 aClass's immediate superclass."
+	^self
+		environment: GsRefactoringEnvironment new
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+%
+
+category: 'instance creation'
+classmethod: GsPushUpMethodRefactoring
+environment: anEnvironment sourceClass: aClass selectors: aCollection meta: aBool
+	^self new
+		setEnvironment: anEnvironment
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool
+%
+
+category: 'preconditions'
+classmethod: GsPushUpMethodRefactoring
+analyzeForClass: aClass selectors: aCollection meta: aBool
+	"A pre-flight the client runs before opening the preview: the target superclass, a
+	 per-selector decline reason (nil when movable), and the count that will move."
+	^(self
+		sourceClass: aClass
+		selectors: aCollection
+		meta: aBool) analysisJsonString
+%
+
+category: 'paginated preview'
+classmethod: GsPushUpMethodRefactoring
+pageForToken: token from: startIndex maxBytes: maxBytes
+	"A page from a previously-started preview (see startPreviewToken:maxBytes:), by
+	 token. Answers an error envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"error":"preview session expired","changes":[],"nextOffset":0,"done":true}']
+		ifNotNil: [:ref | ref pageJsonFrom: startIndex maxBytes: maxBytes]
+%
+
+category: 'paginated preview'
+classmethod: GsPushUpMethodRefactoring
+applyForToken: token deselected: deselectedIds
+	"Apply a previously-started preview (by token). No commit. Answers an error
+	 envelope if the preview session has expired."
+	^(SessionTemps current at: token asSymbol ifAbsent: [nil])
+		ifNil: ['{"applied":0,"failed":[],"error":"preview session expired"}']
+		ifNotNil: [:ref | ref applyDeselected: deselectedIds]
+%
+
+category: 'paginated preview'
+classmethod: GsPushUpMethodRefactoring
 clearToken: token
 	"Drop a finished preview from SessionTemps."
 	SessionTemps current removeKey: token asSymbol ifAbsent: [].

--- a/resources/refactoring/manifest.gs
+++ b/resources/refactoring/manifest.gs
@@ -67,6 +67,8 @@ m add: (Array with: 'GsExtractMethodRefactoring' with: 71).
 m add: (Array with: 'GsExtractTemporaryRefactoring' with: 50).
 m add: (Array with: 'GsInlineMethodRefactoring' with: 59).
 m add: (Array with: 'GsInlineTemporaryRefactoring' with: 46).
+m add: (Array with: 'GsPushDownMethodRefactoring' with: 38).
+m add: (Array with: 'GsPushUpMethodRefactoring' with: 39).
 m add: (Array with: 'GsRefactoringChange' with: 25).
 m add: (Array with: 'GsRefactoringChangeSet' with: 17).
 m add: (Array with: 'GsRefactoringEnvironment' with: 16).

--- a/resources/refactoring/manifest.gs
+++ b/resources/refactoring/manifest.gs
@@ -67,10 +67,10 @@ m add: (Array with: 'GsExtractMethodRefactoring' with: 71).
 m add: (Array with: 'GsExtractTemporaryRefactoring' with: 50).
 m add: (Array with: 'GsInlineMethodRefactoring' with: 59).
 m add: (Array with: 'GsInlineTemporaryRefactoring' with: 46).
-m add: (Array with: 'GsPushDownMethodRefactoring' with: 38).
-m add: (Array with: 'GsPushUpMethodRefactoring' with: 39).
-m add: (Array with: 'GsRefactoringChange' with: 25).
-m add: (Array with: 'GsRefactoringChangeSet' with: 17).
+m add: (Array with: 'GsPushDownMethodRefactoring' with: 40).
+m add: (Array with: 'GsPushUpMethodRefactoring' with: 43).
+m add: (Array with: 'GsRefactoringChange' with: 28).
+m add: (Array with: 'GsRefactoringChangeSet' with: 18).
 m add: (Array with: 'GsRefactoringEnvironment' with: 16).
 m add: (Array with: 'GsRenameClassRefactoring' with: 54).
 m add: (Array with: 'GsRenameClassVariableRefactoring' with: 37).


### PR DESCRIPTION
## Summary
Adds **Push Up Method (M7)** and **Push Down Method (M8)** to the server-side RB engine and the GemStone Explorer: relocate a method to its immediate **superclass** (up) or into its immediate **subclasses** (down), same side, via a non-committing paginated preview + server-side apply. Direct cousins of Move Method (M6) — reuse the `#methodAdd` + `#methodRemove` change kinds; no new change kind.

## Behavior
- **Push Up** (inline ▲ on a method row): moves the method to the superclass; siblings inherit it.
- **Push Down** (▼): copies it into each immediate subclass; removed from the source.
- **Opt-in overwrites, data-loss aware:** a collision on push-up (superclass already defines the selector), or an overriding subclass on push-down, is **not** a hard decline — it's an opt-in OVERWRITE row: **un-ticked by default**, flagged with a ⚠ data-loss warning and a before/after diff. "Every subclass overrides" is an all-overwrite push, not a decline.
- **Per-row deselect** on push-down: choose a subset of subclasses (a copy-down; the source is kept unless every subclass is covered — the removal is guarded so nothing is stranded).
- **Reveal + highlight** the moved method after apply (superclass for up; first fresh recipient subclass for down); a now-stale source-method editor no longer yanks the navigator back.
- **Hard declines (unchanged):** super-send; method missing; push-up onto a superclass that lacks an accessed instance/class/pool variable.
- Same-side only (no instance↔class flip). Nothing is ever committed — you commit explicitly.

## Engine
Two focused classes, `GsPushUpMethodRefactoring` / `GsPushDownMethodRefactoring`, resolving targets server-side. The shared `GsRefactoringChange` gains an optional `warning` and an "overwrite" `methodAdd` (carries the existing body for the diff; applies exactly like a plain add). Each source `#methodRemove` is guarded on an *applied-add* set, so a deselected overwrite or an all-un-ticked push never strips the source.

## Tests — 124 new (labeled by layer)
- **[GS SUnit] 48** engine tests — **green on BOTH 3.6.2 and 3.7.5** (27 push-up + 21 push-down): clean push, overwrite, per-subclass skip/overwrite, hard declines, deselect-doesn't-strand, pagination, JSON escaping, `environment:` ctor. Whole engine suite **361/361** both boundaries.
- **[client .ts] 62** unit — preview parser 18, query builders 8, panel HTML 12, panel-show 6, `pushMethod` command orchestrator 13, `ExplorerController.pushMethod` reveal/reload 5.
- **[GCI auto] 11** gated automatic integration (`requireServerPluginFeature`), exercised engine-loaded.
- **[GCI on-demand] 3** e2e (guarded, transient abort).

Full local CI-mirror green: client/server/mcp in both plugin worlds × 3.6.2/3.7.5, plus on-demand GCI green on 3.7.5.

## Also included (unrelated, pre-existing)
`30babb6e` fixes two pre-existing on-demand-GCI test failures on 3.7.5, surfaced only by running that suite engine-loaded: the move-method e2e `System abortTransaction` → `#encodeAsUTF8` abort (the same fix already in the push e2e) and a cold-stone timeout in `querySunit.smoke`. No product-code change; no new tests (fixes only).

Deferred follow-up: a `super`→`self` rewrite option for super-sends (not behavior-safe as an auto-transform).
