### PR TITLE
Fix String tab DNU that silently broke 4 debugger features on 3.6.2 (#272)

### DIFF
--- a/client/src/__tests__/debugQueries.test.ts
+++ b/client/src/__tests__/debugQueries.test.ts
@@ -440,6 +440,63 @@ describe('debugQueries', () => {
     });
   });
 
+  describe('tab separators in generated Smalltalk (3.6.2-compatible via Character tab)', () => {
+    const GS_PROCESS = 0x123n;
+
+    /**
+     * Runs a generator against a session that captures the Smalltalk handed to it
+     * instead of evaluating it, and returns that source for inspection.
+     */
+    function generatedSmalltalkFrom(run: (session: ActiveSession) => void): string {
+      const session = createMockSession();
+      let generated = '';
+      (session.gci as unknown as Record<string, unknown>).executeAndFetchString = vi.fn(
+        (_handle: unknown, code: string) => {
+          generated = code;
+          return '';
+        },
+      );
+
+      run(session);
+
+      return generated;
+    }
+
+    it('delimits the fields of a stack frame method location lookup', () => {
+      const code = generatedSmalltalkFrom((session) => debug.getMethodUriInfo(session, METHOD_OOP));
+
+      expect(code).toContain('(String with: Character tab)');
+      expect(code).not.toContain('String tab');
+    });
+
+    it('delimits the fields of an implementation-candidate class chain lookup', () => {
+      const code = generatedSmalltalkFrom((session) =>
+        debug.getReceiverClassChain(session, RECEIVER_OOP, 'foo'),
+      );
+
+      expect(code).toContain('(String with: Character tab)');
+      expect(code).not.toContain('String tab');
+    });
+
+    it('delimits the fields of a lookup for where a running method is defined', () => {
+      const code = generatedSmalltalkFrom((session) =>
+        debug.getBrowseTarget(session, RECEIVER_OOP, 'foo'),
+      );
+
+      expect(code).toContain('(String with: Character tab)');
+      expect(code).not.toContain('String tab');
+    });
+
+    it('delimits the fields of a missing-method details lookup', () => {
+      const code = generatedSmalltalkFrom((session) =>
+        debug.getDoesNotUnderstandInfo(session, GS_PROCESS),
+      );
+
+      expect(code).toContain('(String with: Character tab)');
+      expect(code).not.toContain('String tab');
+    });
+  });
+
   describe('getInstVarNames', () => {
     it('does not send multi-word selectors', () => {
       const session = createMockSession();

--- a/client/src/debugQueries.ts
+++ b/client/src/debugQueries.ts
@@ -222,10 +222,10 @@ dictName := ''.
 System myUserProfile symbolList do: [:d |
   (d includesKey: baseClass name asSymbol) ifTrue: [dictName := d name]].
 category := (class categoryOfSelector: method selector environmentId: 0) ifNil: ['as yet unclassified'].
-dictName, String tab,
-  baseClass name, String tab,
-  (class isMeta ifTrue: ['class'] ifFalse: ['instance']), String tab,
-  category, String tab,
+dictName, (String with: Character tab),
+  baseClass name, (String with: Character tab),
+  (class isMeta ifTrue: ['class'] ifFalse: ['instance']), (String with: Character tab),
+  category, (String with: Character tab),
   method selector asString`;
 
     const data = executeAndFetchString(session, code);
@@ -301,8 +301,9 @@ rows := OrderedCollection new.
   System myUserProfile symbolList do: [:d |
     (d includesKey: nm asSymbol) ifTrue: [ dn := d name ]].
   impl := cls includesSelector: sel.
-  rows add: nm, String tab, (meta ifTrue: ['class'] ifFalse: ['instance']), String tab, dn,
-    String tab, (impl ifTrue: ['1'] ifFalse: ['0']).
+  rows add: nm, (String with: Character tab),
+    (meta ifTrue: ['class'] ifFalse: ['instance']), (String with: Character tab),
+    dn, (String with: Character tab), (impl ifTrue: ['1'] ifFalse: ['0']).
   cls := cls superclass ].
 rows inject: '' into: [:acc :r | acc isEmpty ifTrue: [r] ifFalse: [acc, (String with: Character lf), r]]`;
 
@@ -371,8 +372,9 @@ def isNil ifTrue: [ '' ] ifFalse: [
   dn := ''.
   System myUserProfile symbolList do: [:d |
     (d includesKey: def theNonMetaClass name asSymbol) ifTrue: [ dn := d name ]].
-  def theNonMetaClass name asString, String tab,
-    (meta ifTrue: ['class'] ifFalse: ['instance']), String tab, dn, String tab,
+  def theNonMetaClass name asString, (String with: Character tab),
+    (meta ifTrue: ['class'] ifFalse: ['instance']), (String with: Character tab),
+    dn, (String with: Character tab),
     ((def categoryOfSelector: sel environmentId: 0) ifNil: ['']) ]`;
 
     const data = executeAndFetchString(session, code);
@@ -452,10 +454,10 @@ dnuTop isNil
     dn := ''.
     System myUserProfile symbolList do: [:d |
       (d includesKey: base name asSymbol) ifTrue: [ dn := d name ] ].
-    base name asString, String tab,
-      (meta ifTrue: ['class'] ifFalse: ['instance']), String tab,
-      dn, String tab,
-      sel asString, String tab,
+    base name asString, (String with: Character tab),
+      (meta ifTrue: ['class'] ifFalse: ['instance']), (String with: Character tab),
+      dn, (String with: Character tab),
+      sel asString, (String with: Character tab),
       (descr at: 2) size printString ]`;
 
     const data = executeAndFetchString(session, code);


### PR DESCRIPTION
Small, low-risk fix for #272.

**What was wrong:** four debugger doit-generators (`getMethodUriInfo`, `getReceiverClassChain`, `getBrowseTarget`, `getDoesNotUnderstandInfo`) built tab separators with `String tab`, which `String class` does not implement on GemStone **3.6.2** (our minimum supported release). Each generator wraps its body in try/catch and returns `undefined`/`[]`, so on 3.6.2 the features silently degraded with no error surfaced — stack-frame method location, implementation-candidate class chain, Browse target, and the doesNotUnderstand details/Create action.

**Fix:** build the tab with `(String with: Character tab)` — the portable idiom already used elsewhere in this file and repo. The generated Smalltalk is byte-identical; only *how* the tab is produced changes.

**Why it's low risk:**
- Mechanical `String tab` → `(String with: Character tab)` swap at 4 sites; no behavior change on 3.7.x (same output), no new dependencies.
- Verified on a live 3.6.2 stone: `String class canUnderstand: #tab` → false, `Character class canUnderstand: #tab` → true, and the portable form yields a one-char tab.
- Adds 4 unit tests (one per generator) that fail against the unfixed source.
- Full `npm test` green; lint / format:check / compile clean.

**Follow-up (not in this PR):** a real 3.6.2 *integration* test — these four are unit-level assertions on the generated source text (the issue notes source-text assertions won't catch a *different* 3.6.2 DNU).

Fixes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
