### PR TITLE
Enable a first batch of vitest lint rules

### DIFF
--- a/client/src/__tests__/extensionCommandGuards.test.ts
+++ b/client/src/__tests__/extensionCommandGuards.test.ts
@@ -26,7 +26,7 @@ describe('extension command handlers guard against undefined node', () => {
         unguarded.push({ line: i + 1, text: text.trim() });
       }
     });
-    expect(unguarded, 'unguarded node.kind reads:\n' + JSON.stringify(unguarded, null, 2)).toEqual(
+    expect(unguarded, `unguarded node.kind reads:\n${JSON.stringify(unguarded, null, 2)}`).toEqual(
       [],
     );
   });

--- a/client/src/__tests__/gciVersionGated.test.ts
+++ b/client/src/__tests__/gciVersionGated.test.ts
@@ -112,12 +112,7 @@ describe('GemStone 3.6.2 compatibility gate', () => {
 
     expect(
       offenders,
-      offenders.length === 0
-        ? ''
-        : `Production code uses GCI function(s) that do NOT exist in GemStone 3.6.2:\n${detail}\n\n` +
-            `These will throw on a 3.6.2 server. If you intend to require GemStone 3.7+ for ` +
-            `this path, consciously add the name(s) to ALLOWED_POST_362 in ` +
-            `client/src/__tests__/gciVersionGated.test.ts.`,
+      `Production code uses GCI function(s) that do NOT exist in GemStone 3.6.2:\n${detail}\n\nThese will throw on a 3.6.2 server. If you intend to require GemStone 3.7+ for this path, consciously add the name(s) to ALLOWED_POST_362 in client/src/__tests__/gciVersionGated.test.ts.`,
     ).toEqual([]);
   });
 });

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -2695,7 +2695,7 @@ describe('SystemBrowser', () => {
     });
   });
 
-  describe('navigateToClass', () => {
+  describe('navigateToClass updating the target panel', () => {
     beforeEach(() => {
       SystemBrowser.show(session, exportManager);
       messageHandler({ command: 'ready' });

--- a/client/src/queries/rowan/__tests__/rowanExportFixpoint.integration.test.ts
+++ b/client/src/queries/rowan/__tests__/rowanExportFixpoint.integration.test.ts
@@ -123,7 +123,7 @@ describe('Rowan export is a deterministic reload-faithful fixpoint', () => {
       expect(exec(createCode(home)).trim()).toBe('ok');
 
       const a = exportRowanProject(exec, PROJECT, targetA);
-      expect(a.success, a.detail).toBe(true);
+      expect(a.success, `${a.detail}`).toBe(true);
 
       expect(exec(`Rowan gemstoneTools topaz unloadProjectNamed: '${PROJECT}'. 'ok'`).trim()).toBe(
         'ok',
@@ -138,7 +138,7 @@ describe('Rowan export is a deterministic reload-faithful fixpoint', () => {
       expect(listRowanProjects(exec).projects.some((p) => p.name === PROJECT)).toBe(true);
 
       const c = exportRowanProject(exec, PROJECT, targetC);
-      expect(c.success, c.detail).toBe(true);
+      expect(c.success, `${c.detail}`).toBe(true);
 
       const treeA = readTree(targetA);
       const treeC = readTree(targetC);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import globals from 'globals';
 import eslintComments from '@eslint-community/eslint-plugin-eslint-comments';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import gitignore from 'eslint-config-flat-gitignore';
+import vitest from '@vitest/eslint-plugin';
 
 export default tseslint.config(
   // Keep lint ignores in sync with every `.gitignore` in the repo, instead of
@@ -110,6 +111,30 @@ export default tseslint.config(
     // which still applies) and browser globals (added here) to satisfy `no-undef`.
     files: ['client/src/__tests__/vitest.windowSetup.cjs'],
     languageOptions: { globals: { ...globals.browser } },
+  },
+  {
+    // Vitest-specific best-practice rules, scoped to test files across all
+    // workspaces. Only a subset of `vitest.configs.recommended` is enabled:
+    // the rest (expect-expect, no-conditional-expect, no-standalone-expect,
+    // no-mocks-import, no-disabled-tests) currently have real violations
+    // across ~90 test files that need separate triage before they can be
+    // turned on.
+    files: ['**/__tests__/**/*.test.ts'],
+    plugins: { vitest },
+    rules: {
+      'vitest/no-commented-out-tests': 'error',
+      'vitest/no-focused-tests': 'error',
+      'vitest/no-identical-title': 'error',
+      'vitest/no-import-node-test': 'error',
+      'vitest/no-interpolation-in-snapshots': 'error',
+      'vitest/no-unneeded-async-expect-function': 'error',
+      'vitest/prefer-called-exactly-once-with': 'error',
+      'vitest/require-local-test-context-for-concurrent-snapshots': 'error',
+      'vitest/valid-describe-callback': 'error',
+      'vitest/valid-expect': 'error',
+      'vitest/valid-expect-in-promise': 'error',
+      'vitest/valid-title': 'error',
+    },
   },
   // Disables stylistic ESLint rules that would conflict with Prettier; must stay last.
   eslintConfigPrettier,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@eslint/js": "^9.19.0",
         "@playwright/test": "^1.61.1",
         "@types/node": "^22.15",
+        "@vitest/eslint-plugin": "^1.6.24",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.28.1",
@@ -1370,6 +1371,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.2"
       },
@@ -1909,6 +1911,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1926,6 +1929,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1943,6 +1947,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1960,6 +1965,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1977,6 +1983,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1994,6 +2001,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2011,6 +2019,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2028,6 +2037,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2045,6 +2055,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2062,6 +2073,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2079,6 +2091,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2096,6 +2109,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2110,6 +2124,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -2132,6 +2147,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2149,6 +2165,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2903,6 +2920,37 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.6.24",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.24.tgz",
+      "integrity": "sha512-U5isuChJ58H1M6oRGaIotYbH2gM1rhzKUjtiarqpLNG/3+fzXIXs5RyTLrYQJmQPnXbvIMPFvI9z8ufpFZc8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.58.0",
+        "@typescript-eslint/utils": "^8.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "*",
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -5190,6 +5238,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -5488,6 +5537,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/htmlparser2": {
@@ -5965,6 +6029,21 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/jsdom/node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
@@ -6415,6 +6494,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6436,6 +6516,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6457,6 +6538,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6478,6 +6560,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6499,6 +6582,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6520,6 +6604,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6541,6 +6626,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6562,6 +6648,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6583,6 +6670,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6604,6 +6692,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6625,6 +6714,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -581,7 +581,7 @@
           {
             "id": "serverSupport",
             "title": "Install optional server support",
-            "description": "Jasper can install two optional server-side supports: the Enhanced Inspector (rich object views, GemStone 3.7.5+) and the refactoring engine (rename instance variable, and more). On connect it offers to install whatever a stone is missing; the `gemstone.serverSupport.autoInstall` setting (ask / always / never) controls that.\n[Install GemStone Support\u2026](command:gemstone.installServerSupport)",
+            "description": "Jasper can install two optional server-side supports: the Enhanced Inspector (rich object views, GemStone 3.7.5+) and the refactoring engine (rename instance variable, and more). On connect it offers to install whatever a stone is missing; the `gemstone.serverSupport.autoInstall` setting (ask / always / never) controls that.\n[Install GemStone Support…](command:gemstone.installServerSupport)",
             "media": {
               "markdown": "resources/walkthrough/enhancedInspector.md"
             },
@@ -2301,6 +2301,7 @@
     "@eslint/js": "^9.19.0",
     "@playwright/test": "^1.61.1",
     "@types/node": "^22.15",
+    "@vitest/eslint-plugin": "^1.6.24",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
## Goal
I found a few issues in tests that can be prevented by enabling recommended lint rules. This is a PR enabling a batch of rules that are not currently failing or which are simple to fix; there's an extra set of rules that will require some cleanup before enabling them

## Changes
- Adds `@vitest/eslint-plugin` and enables the subset of its recommended rules (plus `valid-expect` and `no-identical-title`) that already pass cleanly across the whole test suite — 12 of the 17 recommended rules.
- Fixes the 5 violations those last two rules surfaced: three `expect()` calls whose custom message wasn't a plain string/template literal (the rule requires that shape), and one duplicate `describe('navigateToClass', ...)` block, renamed to reflect what it actually covers.
- The remaining 5 recommended rules (`expect-expect`, `no-conditional-expect`, `no-standalone-expect`, `no-mocks-import`, `no-disabled-tests`) have ~250 pre-existing violations across ~90 test files and need separate triage before they can be turned on — left disabled for now.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile`
- [x] `npm test`