### PR TITLE
Issue #352: follow-ups from PR #350 review (V4 move instance variable)

### DIFF
--- a/client/src/__tests__/explorerMoveInstVarPicker.test.ts
+++ b/client/src/__tests__/explorerMoveInstVarPicker.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode'));
+// The controller module pulls in browserQueries (→ native GCI). Stub just the two hierarchy
+// queries the picker calls; nothing else is exercised by pickInstVarMoveTargets.
+vi.mock('../browserQueries', () => ({
+  getClassHierarchy: vi.fn(),
+  getClassDescendantNames: vi.fn(),
+}));
+
+import * as vscode from 'vscode';
+import * as queries from '../browserQueries';
+import { ExplorerController } from '../gemstoneExplorer';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+
+/**
+ * Drives ExplorerController.pickInstVarMoveTargets — the ▲/▼ destination picker behind the
+ * "Move Instance Variable Up/Down…" arrows. Stubs the hierarchy queries and showQuickPick, so it
+ * pins the load-bearing choices (immediate-superclass-first ordering, the two "nowhere to move"
+ * messages, and multi-select on the ▼ path only) without a live tree or stone.
+ */
+
+type Picker = {
+  pickInstVarMoveTargets: (
+    session: ActiveSession,
+    item: { className: string; ivarName: string },
+    direction: 'up' | 'down',
+  ) => Promise<string[] | undefined>;
+};
+
+function makeController(): Picker {
+  const sessionManager = { getSelectedSession: () => ({}) } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.className = 'Mid';
+  ctl.state.dictName = 'UserGlobals';
+  ctl.state.dictIndex = 7;
+  return ctl as unknown as Picker;
+}
+
+const session = {} as ActiveSession;
+const pick = (ctl: Picker, direction: 'up' | 'down'): Promise<string[] | undefined> =>
+  ctl.pickInstVarMoveTargets(session, { className: 'Leaf', ivarName: 'weight' }, direction);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('ExplorerController move-ivar destination picker', () => {
+  describe('▲ up', () => {
+    it('lists ancestors with the immediate superclass first', async () => {
+      // getClassHierarchy returns superclasses root-first; the picker must reverse them.
+      vi.mocked(queries.getClassHierarchy).mockReturnValue([
+        { kind: 'superclass', className: 'Object' },
+        { kind: 'superclass', className: 'Animal' },
+        { kind: 'superclass', className: 'Mid' },
+        { kind: 'subclass', className: 'Grand' },
+      ] as never);
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
+
+      await pick(makeController(), 'up');
+
+      const items = vi.mocked(vscode.window.showQuickPick).mock.calls[0][0] as {
+        label: string;
+        description?: string;
+      }[];
+      expect(items.map((i) => i.label)).toEqual(['Mid', 'Animal', 'Object']);
+      expect(items[0].description).toBe('immediate superclass');
+      expect(items[1].description).toBe('ancestor');
+    });
+
+    it('resolves the hierarchy dict-scoped and single-select (no canPickMany)', async () => {
+      vi.mocked(queries.getClassHierarchy).mockReturnValue([
+        { kind: 'superclass', className: 'Mid' },
+      ] as never);
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValue({ label: 'Mid' });
+
+      const result = await pick(makeController(), 'up');
+
+      expect(queries.getClassHierarchy).toHaveBeenCalledWith(session, 'Leaf', 7);
+      expect(vi.mocked(vscode.window.showQuickPick).mock.calls[0][1]).not.toHaveProperty(
+        'canPickMany',
+      );
+      expect(result).toEqual(['Mid']);
+    });
+
+    it('returns undefined when the user cancels', async () => {
+      vi.mocked(queries.getClassHierarchy).mockReturnValue([
+        { kind: 'superclass', className: 'Mid' },
+      ] as never);
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
+
+      expect(await pick(makeController(), 'up')).toBeUndefined();
+    });
+
+    it('tells the user and picks nothing when the class has no superclass', async () => {
+      vi.mocked(queries.getClassHierarchy).mockReturnValue([] as never);
+
+      const result = await pick(makeController(), 'up');
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Leaf has no superclass to move 'weight' up to"),
+      );
+      expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('▼ down', () => {
+    it('offers every descendant as a multi-select and returns all chosen labels', async () => {
+      vi.mocked(queries.getClassDescendantNames).mockReturnValue([
+        { className: 'LeafA', parentName: 'Mid' },
+        { className: 'LeafB', parentName: 'Mid' },
+      ] as never);
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValue([
+        { label: 'LeafA' },
+        { label: 'LeafB' },
+      ] as never);
+
+      const result = await pick(makeController(), 'down');
+
+      expect(queries.getClassDescendantNames).toHaveBeenCalledWith(session, 'Leaf', 7);
+      expect(vi.mocked(vscode.window.showQuickPick).mock.calls[0][1]).toMatchObject({
+        canPickMany: true,
+      });
+      expect(result).toEqual(['LeafA', 'LeafB']);
+    });
+
+    it('returns undefined when the user picks nothing', async () => {
+      vi.mocked(queries.getClassDescendantNames).mockReturnValue([
+        { className: 'LeafA', parentName: 'Mid' },
+      ] as never);
+      vi.mocked(vscode.window.showQuickPick).mockResolvedValue([] as never);
+
+      expect(await pick(makeController(), 'down')).toBeUndefined();
+    });
+
+    it('tells the user and picks nothing when the class has no subclasses', async () => {
+      vi.mocked(queries.getClassDescendantNames).mockReturnValue([] as never);
+
+      const result = await pick(makeController(), 'down');
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Leaf has no subclasses to move 'weight' down to"),
+      );
+      expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -1395,11 +1395,12 @@ export class ExplorerController {
   }
 
   // Locally-defined instance variable names for a class, memoized per dict load.
-  // {superclass, immediate subclasses} for a class, memoized. Used to gate the ▼ push-down
-  // arrow (no subclasses ⇒ nowhere to push) and to pick the reveal target after a push.
+  // {superclass, immediate subclasses} for a class, memoized. Used to gate the ▼ move-down
+  // arrow (no subclasses ⇒ nowhere to move) and to pick the reveal target after a move.
   // Resolution is first-match (not dict-scoped), matching the Explorer's Hierarchy pane; under a
   // class name shadowed across dictionaries this only affects arrow visibility / reveal target —
-  // the refactoring itself is dict-scoped (pushInstVar threads state.dictIndex) and stays correct.
+  // the refactoring itself stays correct: the source class is resolved dict-scoped, and the engine
+  // binds each chosen destination within the source's own lineage rather than by unscoped name.
   private hierNeighbors(className: string): { superclass?: string; subclasses: string[] } {
     const cached = this.hierNeighborsCache.get(className);
     if (cached) return cached;
@@ -1476,7 +1477,7 @@ export class ExplorerController {
   // push-down to a chosen subset (V3), and move to any hierarchy class (V4). The engine
   // recompiles the affected class definitions (new versions), previews, and applies WITHOUT
   // committing. After a successful apply the class shape changed, so re-cascade the class panes.
-  async pushInstVar(item: IvarItem, direction: 'up' | 'down'): Promise<void> {
+  async moveInstVar(item: IvarItem, direction: 'up' | 'down'): Promise<void> {
     const session = this.session();
     if (!session) return;
 
@@ -3559,20 +3560,20 @@ export function registerGemStoneExplorer(
     vscode.commands.registerCommand('gemstone.explorer.renameIvar', (item?: IvarItem) => {
       if (item instanceof IvarItem) void ctl.renameInstVar(item);
     }),
-    // Push an instance variable up to the superclass (V2) — ivar row context menu.
-    vscode.commands.registerCommand('gemstone.explorer.pushUpInstVar', (item?: IvarItem) => {
+    // Move an instance variable up to a chosen ancestor (▲) — ivar row context menu.
+    vscode.commands.registerCommand('gemstone.explorer.moveUpInstVar', (item?: IvarItem) => {
       if (!(item instanceof IvarItem)) return;
-      void ctl.pushInstVar(item, 'up').catch((e: unknown) => {
+      void ctl.moveInstVar(item, 'up').catch((e: unknown) => {
         const msg = e instanceof Error ? e.message : String(e);
-        void vscode.window.showErrorMessage(`Push up instance variable failed: ${msg}`);
+        void vscode.window.showErrorMessage(`Move up instance variable failed: ${msg}`);
       });
     }),
-    // Push an instance variable down into the subclasses (V3) — ivar row context menu.
-    vscode.commands.registerCommand('gemstone.explorer.pushDownInstVar', (item?: IvarItem) => {
+    // Move an instance variable down into chosen subclasses (▼) — ivar row context menu.
+    vscode.commands.registerCommand('gemstone.explorer.moveDownInstVar', (item?: IvarItem) => {
       if (!(item instanceof IvarItem)) return;
-      void ctl.pushInstVar(item, 'down').catch((e: unknown) => {
+      void ctl.moveInstVar(item, 'down').catch((e: unknown) => {
         const msg = e instanceof Error ? e.message : String(e);
-        void vscode.window.showErrorMessage(`Push down instance variable failed: ${msg}`);
+        void vscode.window.showErrorMessage(`Move down instance variable failed: ${msg}`);
       });
     }),
     // Rename the instance variable at the cursor in a method source editor (the

--- a/client/src/refactoring/__tests__/instVarStructureCommand.test.ts
+++ b/client/src/refactoring/__tests__/instVarStructureCommand.test.ts
@@ -30,8 +30,7 @@ import {
   wordAt,
   saveIfDirty,
 } from '../renameAtCursorShared';
-import { pushInstVar, moveInstVar, convertTempToInstVarCommand } from '../instVarStructureCommand';
-import { PREVIEW_PAGE_BYTES } from '../queries/previewRenameMethod';
+import { moveInstVar, convertTempToInstVarCommand } from '../instVarStructureCommand';
 import type { ActiveSession, SessionManager } from '../../sessionManager';
 
 /**
@@ -64,7 +63,10 @@ const applyResult = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
-const pushUp = (): Promise<boolean> => pushInstVar(session, 'up', 'V2Dog', 'tailLength', 2);
+// Drives the shared runInstVarStructure flow through the live entry point (the general #move);
+// the pre-flight/preview/apply contract below is the same whatever direction or op reaches it.
+const runFlow = (): Promise<boolean> =>
+  moveInstVar(session, 'up', 'V2Dog', 'tailLength', ['V2Animal'], 2);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -72,51 +74,18 @@ beforeEach(() => {
   vi.mocked(saveIfDirty).mockResolvedValue(true);
 });
 
-describe('push instance variable command', () => {
+describe('instance-variable structure command — apply/decline flow', () => {
   it('does not run a pre-flight when the engine is unavailable', async () => {
     vi.mocked(ensureRbSupport).mockResolvedValue(false);
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(queries.analyzeInstVarStructure).not.toHaveBeenCalled();
-  });
-
-  it('always opts into moving simple accessors on a push', async () => {
-    vi.mocked(queries.analyzeInstVarStructure).mockResolvedValue(analysis());
-    vi.mocked(queries.startInstVarStructurePreview).mockResolvedValue(startEnvelope());
-    vi.mocked(showInstVarStructurePanel).mockResolvedValue(applyResult());
-
-    await pushUp();
-
-    // Assert the whole argument list (not a positional index) so inserting or reordering a
-    // parameter fails loudly here instead of silently asserting on the wrong argument.
-    expect(queries.analyzeInstVarStructure).toHaveBeenCalledWith(
-      session,
-      'pushUp',
-      'V2Dog',
-      'tailLength',
-      2,
-      undefined,
-      true,
-      undefined,
-    );
-    expect(queries.startInstVarStructurePreview).toHaveBeenCalledWith(
-      session,
-      'pushUp',
-      'V2Dog',
-      'tailLength',
-      expect.any(String),
-      PREVIEW_PAGE_BYTES,
-      2,
-      undefined,
-      true,
-      undefined,
-    );
   });
 
   it('surfaces a pre-flight failure and never previews', async () => {
     vi.mocked(queries.analyzeInstVarStructure).mockRejectedValue(new Error('kaboom'));
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('kaboom'));
     expect(queries.startInstVarStructurePreview).not.toHaveBeenCalled();
   });
@@ -126,7 +95,7 @@ describe('push instance variable command', () => {
       analysis({ decline: 'it is not an instance variable declared in V2Dog' }),
     );
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(refuse).toHaveBeenCalledWith(expect.stringContaining('not an instance variable'));
     expect(queries.startInstVarStructurePreview).not.toHaveBeenCalled();
   });
@@ -135,7 +104,7 @@ describe('push instance variable command', () => {
     vi.mocked(queries.analyzeInstVarStructure).mockResolvedValue(analysis());
     vi.mocked(queries.startInstVarStructurePreview).mockRejectedValue(new Error('splat'));
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('splat'));
     expect(queries.clearInstVarStructurePreview).toHaveBeenCalled();
     expect(showInstVarStructurePanel).not.toHaveBeenCalled();
@@ -147,7 +116,7 @@ describe('push instance variable command', () => {
       startEnvelope({ outOfScope: { decline: 'still uses it', note: null } }),
     );
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(refuse).toHaveBeenCalledWith(expect.stringContaining('still uses it'));
     expect(showInstVarStructurePanel).not.toHaveBeenCalled();
   });
@@ -156,7 +125,7 @@ describe('push instance variable command', () => {
     vi.mocked(queries.analyzeInstVarStructure).mockResolvedValue(analysis());
     vi.mocked(queries.startInstVarStructurePreview).mockResolvedValue(startEnvelope({ total: 0 }));
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(refuse).toHaveBeenCalledWith(expect.stringContaining('Nothing to change'));
   });
 
@@ -165,7 +134,7 @@ describe('push instance variable command', () => {
     vi.mocked(queries.startInstVarStructurePreview).mockResolvedValue(startEnvelope());
     vi.mocked(showInstVarStructurePanel).mockResolvedValue(undefined);
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
   });
 
@@ -176,7 +145,7 @@ describe('push instance variable command', () => {
       applyResult({ applied: 0, error: 'preview session expired' }),
     );
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
       expect.stringContaining('preview session expired'),
     );
@@ -190,7 +159,7 @@ describe('push instance variable command', () => {
       applyResult({ failed: [{ id: '1', label: 'V2Dog', error: 'boom' }] }),
     );
 
-    expect(await pushUp()).toBe(false);
+    expect(await runFlow()).toBe(false);
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('boom'));
   });
 
@@ -201,7 +170,7 @@ describe('push instance variable command', () => {
       applyResult({ committed: true, migratedFailures: 2 }),
     );
 
-    expect(await pushUp()).toBe(true);
+    expect(await runFlow()).toBe(true);
     const msg = vi.mocked(vscode.window.showInformationMessage).mock.calls[0][0];
     expect(msg).toContain('committed');
     expect(msg).toContain('2 instance');
@@ -228,7 +197,7 @@ describe('move instance variable command', () => {
     );
   });
 
-  it('names the single destination in an up-move heading', async () => {
+  it('names the source class and single destination in an up-move heading', async () => {
     vi.mocked(queries.analyzeInstVarStructure).mockResolvedValue(analysis());
     vi.mocked(queries.startInstVarStructurePreview).mockResolvedValue(startEnvelope());
     vi.mocked(showInstVarStructurePanel).mockResolvedValue(applyResult());
@@ -236,12 +205,34 @@ describe('move instance variable command', () => {
     expect(await moveInstVar(session, 'up', 'V4Leaf', 'shared', ['V4Base'], 2)).toBe(true);
 
     const heading = vi.mocked(showInstVarStructurePanel).mock.calls[0][0];
-    expect(heading).toContain('up to V4Base');
+    expect(heading).toContain("'shared' from V4Leaf up to V4Base");
+  });
+
+  it('names each destination in a down-move heading', async () => {
+    vi.mocked(queries.analyzeInstVarStructure).mockResolvedValue(analysis());
+    vi.mocked(queries.startInstVarStructurePreview).mockResolvedValue(startEnvelope());
+    vi.mocked(showInstVarStructurePanel).mockResolvedValue(applyResult());
+
+    await moveInstVar(session, 'down', 'V4Mid', 'shared', ['V4LeafA', 'V4LeafB'], 2);
+
+    const heading = vi.mocked(showInstVarStructurePanel).mock.calls[0][0];
+    expect(heading).toContain('from V4Mid down to V4LeafA, V4LeafB');
+  });
+
+  it('falls back to a subclass count once there are more destinations than fit', async () => {
+    vi.mocked(queries.analyzeInstVarStructure).mockResolvedValue(analysis());
+    vi.mocked(queries.startInstVarStructurePreview).mockResolvedValue(startEnvelope());
+    vi.mocked(showInstVarStructurePanel).mockResolvedValue(applyResult());
+
+    await moveInstVar(session, 'down', 'V4Mid', 'shared', ['A', 'B', 'C', 'D'], 2);
+
+    const heading = vi.mocked(showInstVarStructurePanel).mock.calls[0][0];
+    expect(heading).toContain('from V4Mid down to 4 subclasses');
   });
 
   it('refuses on a hard decline and never previews', async () => {
     vi.mocked(queries.analyzeInstVarStructure).mockResolvedValue(
-      analysis({ decline: 'GsVSLeaf2 still uses it in 1 of its own method(s): #usesPush.' }),
+      analysis({ decline: 'GsVSTwig still uses it in 1 of its own method(s): #usesPush.' }),
     );
 
     expect(await moveInstVar(session, 'down', 'V4Mid', 'shared', ['V4LeafA'], 2)).toBe(false);

--- a/client/src/refactoring/instVarStructureCommand.ts
+++ b/client/src/refactoring/instVarStructureCommand.ts
@@ -175,34 +175,6 @@ export async function runInstVarStructure(req: IvarStructureRequest): Promise<bo
   return true;
 }
 
-/** V2/V3: push an instance variable up to the superclass / down into the subclasses. */
-export async function pushInstVar(
-  session: ActiveSession,
-  direction: 'up' | 'down',
-  className: string,
-  ivarName: string,
-  dict?: number | string,
-): Promise<boolean> {
-  const op: IvarStructureOp = direction === 'up' ? 'pushUp' : 'pushDown';
-  const heading =
-    direction === 'up'
-      ? `Push instance variable '${ivarName}' up from ${className}`
-      : `Push instance variable '${ivarName}' down from ${className}`;
-
-  // Always carry the ivar's SIMPLE getter/setter accessors along with the declaration — a bare
-  // `^ivar` / `ivar := arg` belongs with the variable it exposes. Anything that isn't a trivial
-  // accessor is never moved, and the preview lists every change so the user can still cancel.
-  return runInstVarStructure({
-    session,
-    op,
-    className,
-    varName: ivarName,
-    heading,
-    dict,
-    moveAccessors: true,
-  });
-}
-
 /** V4: move an instance variable to chosen destination class(es) in the hierarchy — the general
  *  form the Explorer's ▲/▼ arrows drive after the user picks a destination. `direction` is `up`
  *  (a single chosen ancestor) or `down` (one or more chosen descendants). Always carries the
@@ -215,13 +187,16 @@ export async function moveInstVar(
   targets: string[],
   dict?: number | string,
 ): Promise<boolean> {
+  // Name the destinations so the preview title and the "applied N change(s)" toast say where the
+  // ivar went; once there are more names than read cleanly, fall back to a bare count.
+  const namedLimit = 3;
   const where =
     direction === 'up'
       ? `up to ${targets[0] ?? 'superclass'}`
-      : targets.length === 1
-        ? `down to ${targets[0]}`
+      : targets.length >= 1 && targets.length <= namedLimit
+        ? `down to ${targets.join(', ')}`
         : `down to ${targets.length} subclasses`;
-  const heading = `Move instance variable '${ivarName}' ${where}`;
+  const heading = `Move instance variable '${ivarName}' from ${className} ${where}`;
 
   return runInstVarStructure({
     session,

--- a/gs-src/refactoring/engine/GsInstVarStructureRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsInstVarStructureRefactoring.class.st
@@ -126,10 +126,15 @@ GsInstVarStructureRefactoring class >> class: aClass pushDownInstVar: aName [
 GsInstVarStructureRefactoring class >> class: aClass moveInstVar: aName toClasses: classNames direction: aSymbol [
 	"V4 (generalised push up/down): move aClass's own instance variable aName to the named
 	 destination class(es). aSymbol is #up (classNames is a single ancestor of aClass) or #down
-	 (classNames are descendants of aClass, one or many). Names are resolved against the
-	 environment; an unresolved name declines in analysis."
-	| ref env targets |
+	 (classNames are descendants of aClass, one or many). Each name is resolved WITHIN aClass's own
+	 lineage first -- its superclasses for #up, its descendants for #down -- so a name shadowed
+	 across dictionaries binds the class that is genuinely in aClass's hierarchy rather than an
+	 unrelated global first match. A name nowhere in the lineage falls back to a global lookup so
+	 analysis can still report the friendlier 'is not a superclass/subclass' decline; an unresolved
+	 name yields nil and declines as a destination that could not be found."
+	| ref env dir lineage targets |
 	env := GsRefactoringEnvironment new.
+	dir := aSymbol asSymbol.
 	ref := self new
 		setEnvironment: env
 		operation: #move
@@ -137,8 +142,13 @@ GsInstVarStructureRefactoring class >> class: aClass moveInstVar: aName toClasse
 		varName: aName
 		selector: nil
 		meta: false.
-	targets := classNames collect: [:n | env classNamed: n asString].
-	^ref setMoveTargets: targets direction: aSymbol asSymbol
+	lineage := dir == #up
+		ifTrue: [ref ancestorsOf: aClass]
+		ifFalse: [env descendantsOf: aClass].
+	targets := classNames collect: [:n |
+		(lineage detect: [:c | c name asString = n asString] ifNone: [nil])
+			ifNil: [env classNamed: n asString]].
+	^ref setMoveTargets: targets direction: dir
 ]
 
 { #category : 'instance creation' }
@@ -408,7 +418,8 @@ GsInstVarStructureRefactoring >> analyzeMove [
 	 carries it to one OR MORE chosen SUBCLASSES (like V3 push-down, but to a selected subset, and
 	 to any descendant depth). varName must be definingClass's own ivar. On #up the target's
 	 ancestry must not already define the name and no OTHER descendant of the target may own it
-	 (collision on inherit). On #down no descendant of definingClass may already own it. In both
+	 (collision on inherit). On #down no descendant of definingClass may already own it, and no
+	 chosen target may sit under another chosen target (the ancestor target already covers it). In both
 	 directions every class that ends up WITHOUT the ivar must not still use it in its own methods."
 	| def dir sup losing |
 	def := definingClass.
@@ -439,19 +450,25 @@ GsInstVarStructureRefactoring >> analyzeMove [
 					targetClasses do: [:t |
 						(self isAncestor: def of: t) ifFalse: [
 							^decline := 'Cannot move ', varName, ' down: ', t name asString, ' is not a subclass of ', def name asString, '.']].
+					"The picker lists descendants at any depth, so a chosen target can itself sit under
+					 another chosen target. That would declare the ivar on the child while it also inherits
+					 it from the freshly-edited ancestor -- a double declaration GemStone rejects at apply.
+					 The ancestor target already delivers the ivar there by inheritance, so decline rather
+					 than build a plan that fails; the user should drop the redundant target."
+					targetClasses do: [:t | | cover |
+						cover := targetClasses detect: [:other | other ~~ t and: [self isAncestor: other of: t]] ifNone: [nil].
+						cover ifNotNil: [
+							^decline := 'Cannot move ', varName, ' down: ', t name asString, ' is already a subclass of ', cover name asString, ', which was also chosen; drop the redundant target.']].
 					(self anyDescendantOf: def ownsIvar: varName) ifNotNil: [:cls |
 						^decline := 'Cannot move ', varName, ' down: ', cls, ' already declares an instance variable of that name.'].
 					topClass := def]
 				ifFalse: [
 					^decline := 'Cannot move ', varName, ': unknown direction ', dir printString]].
-	newIvarLists at: def name asString put: ((self ownInstVarsOf: def) reject: [:n | n = varName]).
-	targetClasses do: [:t |
-		newIvarLists at: t name asString put: ((self ownInstVarsOf: t) copyWith: varName)].
-	self moveAccessors ifTrue: [self planAccessorMovesFrom: def to: targetClasses].
 	"Every class that ends up without the ivar must not still use it in its own methods (it would
 	 compile against an undeclared variable). On #up nobody loses it (the subtree inherits it from
 	 higher up), so this only bites #down to a subset. definingClass's own simple accessors are
-	 excepted when they are being moved with the ivar."
+	 excepted when they are being moved with the ivar. Checked BEFORE the plan below is recorded so
+	 a declined move leaves the instance with nothing half-built."
 	losing := self classesLosingVar: targetClasses.
 	losing do: [:cls | | users |
 		users := environment instanceMethodsAccessing: varName inClass: cls.
@@ -462,7 +479,11 @@ GsInstVarStructureRefactoring >> analyzeMove [
 		users isEmpty ifFalse: [
 			^decline := 'Cannot move ', varName, ': ', cls name asString,
 				' still uses it in ', users size printString, ' of its own method(s): ',
-				(self selectorListString: users), '.']]
+				(self selectorListString: users), '.']].
+	newIvarLists at: def name asString put: ((self ownInstVarsOf: def) reject: [:n | n = varName]).
+	targetClasses do: [:t |
+		newIvarLists at: t name asString put: ((self ownInstVarsOf: t) copyWith: varName)].
+	self moveAccessors ifTrue: [self planAccessorMovesFrom: def to: targetClasses]
 ]
 
 { #category : 'private - analysis' }
@@ -508,6 +529,17 @@ GsInstVarStructureRefactoring >> anyDescendantOf: aTop ownsIvar: aName [
 	(environment descendantsOf: aTop) do: [:cls |
 		((self ownInstVarsOf: cls) includes: aName) ifTrue: [^cls name asString]].
 	^nil
+]
+
+{ #category : 'private - analysis' }
+GsInstVarStructureRefactoring >> ancestorsOf: aClass [
+	"aClass's proper superclasses, immediate-first. Walks superclass links only, so it needs no
+	 version-specific hierarchy primitive (matching #isAncestor:of:)."
+	| out c |
+	out := OrderedCollection new.
+	c := aClass superclass.
+	[c notNil] whileTrue: [out add: c. c := c superclass].
+	^out
 ]
 
 { #category : 'private - accessors' }

--- a/gs-src/refactoring/tests/GsInstVarStructureRefactoringTest.class.st
+++ b/gs-src/refactoring/tests/GsInstVarStructureRefactoringTest.class.st
@@ -467,6 +467,22 @@ GsInstVarStructureRefactoringTest >> testMoveDownDeclinesWhenAnUnselectedSubtree
 ]
 
 { #category : 'tests - V4 move' }
+GsInstVarStructureRefactoringTest >> testMoveDownDeclinesWhenATargetIsUnderAnotherTarget [
+	"The #down picker lists descendants at any depth, so a user can tick both a class and one of its
+	 own descendants. Moving Base's 'shared' down to BOTH GsVSMid and GsVSLeaf (which descends from
+	 GsVSMid) would declare the ivar on Leaf while it also inherits it from the freshly-edited Mid --
+	 a double declaration GemStone rejects at apply. Analysis declines instead, recording nothing."
+	| ref |
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSBase') moveInstVar: 'shared' toClasses: #('GsVSMid' 'GsVSLeaf') direction: #down.
+
+	self assert: ref decline notNil.
+	self assert: ref decline includesSubstring: 'GsVSLeaf'.
+	self assert: ref decline includesSubstring: 'GsVSMid'.
+	self assert: ref changeSet isEmpty
+]
+
+{ #category : 'tests - V4 move' }
 GsInstVarStructureRefactoringTest >> testMoveDeclinesWhenNotAnOwnIvar [
 	| ref |
 	"'shared' is Base's ivar, only inherited by Mid."

--- a/gs-src/refactoring/tests/GsInstVarStructureRefactoringTest.class.st
+++ b/gs-src/refactoring/tests/GsInstVarStructureRefactoringTest.class.st
@@ -245,7 +245,7 @@ GsInstVarStructureRefactoringTest >> testPushUpDeclinesWhenNotAnOwnIvar [
 { #category : 'tests - V2 push up' }
 GsInstVarStructureRefactoringTest >> testPushUpDeclinesOnSiblingCollision [
 	| ref |
-	"Both Leaf and Leaf2 declare 'dup'; pushing Leaf's up to Mid would collide on Leaf2."
+	"Both Leaf and GsVSTwig declare 'dup'; pushing Leaf's up to Mid would collide on GsVSTwig."
 	ref := GsInstVarStructureRefactoring class: (self classNamed: 'GsVSLeaf') pushUpInstVar: 'dup'.
 
 	self assert: ref decline notNil.
@@ -410,7 +410,7 @@ GsInstVarStructureRefactoringTest >> testMoveUpDeclinesOnMoreThanOneSuperclass [
 
 { #category : 'tests - V4 move' }
 GsInstVarStructureRefactoringTest >> testMoveUpDeclinesOnSiblingCollision [
-	"'dup' is owned by both Leaf and Leaf2; pushing Leaf's up to Mid would collide with Leaf2's
+	"'dup' is owned by both Leaf and GsVSTwig; pushing Leaf's up to Mid would collide with GsVSTwig's
 	 once inherited."
 	| ref |
 	ref := GsInstVarStructureRefactoring
@@ -425,7 +425,7 @@ GsInstVarStructureRefactoringTest >> testMoveUpDeclinesOnSiblingCollision [
 GsInstVarStructureRefactoringTest >> testMoveDownToASelectedSubset [
 	"#down carries the declaration to a CHOSEN subset of subclasses (unlike push-down, which
 	 goes to every immediate subclass). Moving Mid's 'pushable' to only Leaf: Leaf gains it,
-	 Mid and Leaf2 end up without it."
+	 Mid and GsVSTwig end up without it."
 	| json |
 	json := (GsInstVarStructureRefactoring
 		class: (self classNamed: 'GsVSMid') moveInstVar: 'pushable' toClasses: #('GsVSLeaf') direction: #down)
@@ -530,8 +530,8 @@ GsInstVarStructureRefactoringTest >> testMoveUpMovesSimpleAccessorsToAncestor [
 	cs := ref changeSet.
 
 	self assert: ref decline isNil.
-	self assert: (cs changes anySatisfy: [:c | c kind = #methodAdd and: [c className = 'GsVSBase']]).
-	self assert: (cs changes anySatisfy: [:c | c kind = #methodRemove and: [c className = 'GsVSMid']])
+	self assert: (cs changes anySatisfy: [:c | c kind = #methodAdd and: [c className = 'GsVSBase' and: [c selector = #pushable]]]).
+	self assert: (cs changes anySatisfy: [:c | c kind = #methodRemove and: [c className = 'GsVSMid' and: [c selector = #pushable]]])
 ]
 
 { #category : 'tests - V4 move' }

--- a/package.json
+++ b/package.json
@@ -1157,13 +1157,13 @@
         "icon": "$(edit)"
       },
       {
-        "command": "gemstone.explorer.pushUpInstVar",
+        "command": "gemstone.explorer.moveUpInstVar",
         "title": "Move Instance Variable Up…",
         "category": "GemStone",
         "icon": "$(arrow-up)"
       },
       {
-        "command": "gemstone.explorer.pushDownInstVar",
+        "command": "gemstone.explorer.moveDownInstVar",
         "title": "Move Instance Variable Down…",
         "category": "GemStone",
         "icon": "$(arrow-down)"
@@ -1511,11 +1511,11 @@
           "when": "false"
         },
         {
-          "command": "gemstone.explorer.pushUpInstVar",
+          "command": "gemstone.explorer.moveUpInstVar",
           "when": "false"
         },
         {
-          "command": "gemstone.explorer.pushDownInstVar",
+          "command": "gemstone.explorer.moveDownInstVar",
           "when": "false"
         },
         {
@@ -1812,12 +1812,12 @@
           "group": "inline"
         },
         {
-          "command": "gemstone.explorer.pushUpInstVar",
+          "command": "gemstone.explorer.moveUpInstVar",
           "when": "view == gemstoneExplorerClasses && viewItem =~ /^explorerIvar/",
           "group": "inline@2"
         },
         {
-          "command": "gemstone.explorer.pushDownInstVar",
+          "command": "gemstone.explorer.moveDownInstVar",
           "when": "view == gemstoneExplorerClasses && viewItem == explorerIvar",
           "group": "inline@3"
         },

--- a/resources/refactoring/engine-tests.gs
+++ b/resources/refactoring/engine-tests.gs
@@ -3776,7 +3776,7 @@ category: 'tests - V2 push up'
 method: GsInstVarStructureRefactoringTest
 testPushUpDeclinesOnSiblingCollision
 	| ref |
-	"Both Leaf and Leaf2 declare 'dup'; pushing Leaf's up to Mid would collide on Leaf2."
+	"Both Leaf and GsVSTwig declare 'dup'; pushing Leaf's up to Mid would collide on GsVSTwig."
 	ref := GsInstVarStructureRefactoring class: (self classNamed: 'GsVSLeaf') pushUpInstVar: 'dup'.
 
 	self assert: ref decline notNil.
@@ -3956,7 +3956,7 @@ testMoveUpDeclinesOnMoreThanOneSuperclass
 category: 'tests - V4 move'
 method: GsInstVarStructureRefactoringTest
 testMoveUpDeclinesOnSiblingCollision
-	"'dup' is owned by both Leaf and Leaf2; pushing Leaf's up to Mid would collide with Leaf2's
+	"'dup' is owned by both Leaf and GsVSTwig; pushing Leaf's up to Mid would collide with GsVSTwig's
 	 once inherited."
 	| ref |
 	ref := GsInstVarStructureRefactoring
@@ -3972,7 +3972,7 @@ method: GsInstVarStructureRefactoringTest
 testMoveDownToASelectedSubset
 	"#down carries the declaration to a CHOSEN subset of subclasses (unlike push-down, which
 	 goes to every immediate subclass). Moving Mid's 'pushable' to only Leaf: Leaf gains it,
-	 Mid and Leaf2 end up without it."
+	 Mid and GsVSTwig end up without it."
 	| json |
 	json := (GsInstVarStructureRefactoring
 		class: (self classNamed: 'GsVSMid') moveInstVar: 'pushable' toClasses: #('GsVSLeaf') direction: #down)
@@ -4084,8 +4084,8 @@ testMoveUpMovesSimpleAccessorsToAncestor
 	cs := ref changeSet.
 
 	self assert: ref decline isNil.
-	self assert: (cs changes anySatisfy: [:c | c kind = #methodAdd and: [c className = 'GsVSBase']]).
-	self assert: (cs changes anySatisfy: [:c | c kind = #methodRemove and: [c className = 'GsVSMid']])
+	self assert: (cs changes anySatisfy: [:c | c kind = #methodAdd and: [c className = 'GsVSBase' and: [c selector = #pushable]]]).
+	self assert: (cs changes anySatisfy: [:c | c kind = #methodRemove and: [c className = 'GsVSMid' and: [c selector = #pushable]]])
 %
 
 category: 'tests - V4 move'

--- a/resources/refactoring/engine-tests.gs
+++ b/resources/refactoring/engine-tests.gs
@@ -4017,6 +4017,23 @@ testMoveDownDeclinesWhenAnUnselectedSubtreeStillUsesIt
 
 category: 'tests - V4 move'
 method: GsInstVarStructureRefactoringTest
+testMoveDownDeclinesWhenATargetIsUnderAnotherTarget
+	"The #down picker lists descendants at any depth, so a user can tick both a class and one of its
+	 own descendants. Moving Base's 'shared' down to BOTH GsVSMid and GsVSLeaf (which descends from
+	 GsVSMid) would declare the ivar on Leaf while it also inherits it from the freshly-edited Mid --
+	 a double declaration GemStone rejects at apply. Analysis declines instead, recording nothing."
+	| ref |
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSBase') moveInstVar: 'shared' toClasses: #('GsVSMid' 'GsVSLeaf') direction: #down.
+
+	self assert: ref decline notNil.
+	self assert: ref decline includesSubstring: 'GsVSLeaf'.
+	self assert: ref decline includesSubstring: 'GsVSMid'.
+	self assert: ref changeSet isEmpty
+%
+
+category: 'tests - V4 move'
+method: GsInstVarStructureRefactoringTest
 testMoveDeclinesWhenNotAnOwnIvar
 	| ref |
 	"'shared' is Base's ivar, only inherited by Mid."

--- a/resources/refactoring/engine.gs
+++ b/resources/refactoring/engine.gs
@@ -4908,7 +4908,8 @@ analyzeMove
 	 carries it to one OR MORE chosen SUBCLASSES (like V3 push-down, but to a selected subset, and
 	 to any descendant depth). varName must be definingClass's own ivar. On #up the target's
 	 ancestry must not already define the name and no OTHER descendant of the target may own it
-	 (collision on inherit). On #down no descendant of definingClass may already own it. In both
+	 (collision on inherit). On #down no descendant of definingClass may already own it, and no
+	 chosen target may sit under another chosen target (the ancestor target already covers it). In both
 	 directions every class that ends up WITHOUT the ivar must not still use it in its own methods."
 	| def dir sup losing |
 	def := definingClass.
@@ -4939,19 +4940,25 @@ analyzeMove
 					targetClasses do: [:t |
 						(self isAncestor: def of: t) ifFalse: [
 							^decline := 'Cannot move ', varName, ' down: ', t name asString, ' is not a subclass of ', def name asString, '.']].
+					"The picker lists descendants at any depth, so a chosen target can itself sit under
+					 another chosen target. That would declare the ivar on the child while it also inherits
+					 it from the freshly-edited ancestor -- a double declaration GemStone rejects at apply.
+					 The ancestor target already delivers the ivar there by inheritance, so decline rather
+					 than build a plan that fails; the user should drop the redundant target."
+					targetClasses do: [:t | | cover |
+						cover := targetClasses detect: [:other | other ~~ t and: [self isAncestor: other of: t]] ifNone: [nil].
+						cover ifNotNil: [
+							^decline := 'Cannot move ', varName, ' down: ', t name asString, ' is already a subclass of ', cover name asString, ', which was also chosen; drop the redundant target.']].
 					(self anyDescendantOf: def ownsIvar: varName) ifNotNil: [:cls |
 						^decline := 'Cannot move ', varName, ' down: ', cls, ' already declares an instance variable of that name.'].
 					topClass := def]
 				ifFalse: [
 					^decline := 'Cannot move ', varName, ': unknown direction ', dir printString]].
-	newIvarLists at: def name asString put: ((self ownInstVarsOf: def) reject: [:n | n = varName]).
-	targetClasses do: [:t |
-		newIvarLists at: t name asString put: ((self ownInstVarsOf: t) copyWith: varName)].
-	self moveAccessors ifTrue: [self planAccessorMovesFrom: def to: targetClasses].
 	"Every class that ends up without the ivar must not still use it in its own methods (it would
 	 compile against an undeclared variable). On #up nobody loses it (the subtree inherits it from
 	 higher up), so this only bites #down to a subset. definingClass's own simple accessors are
-	 excepted when they are being moved with the ivar."
+	 excepted when they are being moved with the ivar. Checked BEFORE the plan below is recorded so
+	 a declined move leaves the instance with nothing half-built."
 	losing := self classesLosingVar: targetClasses.
 	losing do: [:cls | | users |
 		users := environment instanceMethodsAccessing: varName inClass: cls.
@@ -4962,7 +4969,11 @@ analyzeMove
 		users isEmpty ifFalse: [
 			^decline := 'Cannot move ', varName, ': ', cls name asString,
 				' still uses it in ', users size printString, ' of its own method(s): ',
-				(self selectorListString: users), '.']]
+				(self selectorListString: users), '.']].
+	newIvarLists at: def name asString put: ((self ownInstVarsOf: def) reject: [:n | n = varName]).
+	targetClasses do: [:t |
+		newIvarLists at: t name asString put: ((self ownInstVarsOf: t) copyWith: varName)].
+	self moveAccessors ifTrue: [self planAccessorMovesFrom: def to: targetClasses]
 %
 
 category: 'private - analysis'
@@ -5012,6 +5023,18 @@ anyDescendantOf: aTop ownsIvar: aName
 	(environment descendantsOf: aTop) do: [:cls |
 		((self ownInstVarsOf: cls) includes: aName) ifTrue: [^cls name asString]].
 	^nil
+%
+
+category: 'private - analysis'
+method: GsInstVarStructureRefactoring
+ancestorsOf: aClass
+	"aClass's proper superclasses, immediate-first. Walks superclass links only, so it needs no
+	 version-specific hierarchy primitive (matching #isAncestor:of:)."
+	| out c |
+	out := OrderedCollection new.
+	c := aClass superclass.
+	[c notNil] whileTrue: [out add: c. c := c superclass].
+	^out
 %
 
 category: 'private - accessors'
@@ -5628,10 +5651,15 @@ classmethod: GsInstVarStructureRefactoring
 class: aClass moveInstVar: aName toClasses: classNames direction: aSymbol
 	"V4 (generalised push up/down): move aClass's own instance variable aName to the named
 	 destination class(es). aSymbol is #up (classNames is a single ancestor of aClass) or #down
-	 (classNames are descendants of aClass, one or many). Names are resolved against the
-	 environment; an unresolved name declines in analysis."
-	| ref env targets |
+	 (classNames are descendants of aClass, one or many). Each name is resolved WITHIN aClass's own
+	 lineage first -- its superclasses for #up, its descendants for #down -- so a name shadowed
+	 across dictionaries binds the class that is genuinely in aClass's hierarchy rather than an
+	 unrelated global first match. A name nowhere in the lineage falls back to a global lookup so
+	 analysis can still report the friendlier 'is not a superclass/subclass' decline; an unresolved
+	 name yields nil and declines as a destination that could not be found."
+	| ref env dir lineage targets |
 	env := GsRefactoringEnvironment new.
+	dir := aSymbol asSymbol.
 	ref := self new
 		setEnvironment: env
 		operation: #move
@@ -5639,8 +5667,13 @@ class: aClass moveInstVar: aName toClasses: classNames direction: aSymbol
 		varName: aName
 		selector: nil
 		meta: false.
-	targets := classNames collect: [:n | env classNamed: n asString].
-	^ref setMoveTargets: targets direction: aSymbol asSymbol
+	lineage := dir == #up
+		ifTrue: [ref ancestorsOf: aClass]
+		ifFalse: [env descendantsOf: aClass].
+	targets := classNames collect: [:n |
+		(lineage detect: [:c | c name asString = n asString] ifNone: [nil])
+			ifNil: [env classNamed: n asString]].
+	^ref setMoveTargets: targets direction: dir
 %
 
 category: 'instance creation'

--- a/resources/refactoring/manifest.gs
+++ b/resources/refactoring/manifest.gs
@@ -67,7 +67,7 @@ m add: (Array with: 'GsExtractMethodRefactoring' with: 71).
 m add: (Array with: 'GsExtractTemporaryRefactoring' with: 50).
 m add: (Array with: 'GsInlineMethodRefactoring' with: 59).
 m add: (Array with: 'GsInlineTemporaryRefactoring' with: 46).
-m add: (Array with: 'GsInstVarStructureRefactoring' with: 70).
+m add: (Array with: 'GsInstVarStructureRefactoring' with: 71).
 m add: (Array with: 'GsMoveMethodRefactoring' with: 38).
 m add: (Array with: 'GsPushDownMethodRefactoring' with: 40).
 m add: (Array with: 'GsPushUpMethodRefactoring' with: 43).


### PR DESCRIPTION
Addresses all nine review comments @MatiasFernandez left on PR #350, tracked in #352. Four focused commits, one per concern-area.

## Correctness (engine)
- **#1 — `#down` nested targets.** The ▼ picker lists descendants at any depth, so a user could pick a class *and* one of its own descendants; the ivar was then declared on the child while it also inherited it from the freshly-edited parent — a double declaration GemStone rejects, surfacing as a `"failed"` apply. `analyzeMove` now declines that up front (e.g. *"Cannot move x down: Leaf is already a subclass of Mid, which was also chosen; drop the redundant target."*).
- **#2 — dictionary scoping of destinations.** Destination names were resolved unscoped (global first-match), so a name shadowed across dictionaries could bind the wrong class. They're now resolved **within the source class's own lineage** (superclasses for `#up`, descendants for `#down`) via a new `ancestorsOf:` helper, falling back to a global lookup only so analysis can still report the friendlier "is not a superclass/subclass" decline.
- **#3 — precondition ordering.** The losing-class check ran *after* the plan was half-built; it's hoisted above `newIvarLists`/`planAccessorMovesFrom:` so a decline records nothing by construction (matching `analyzePushDown`).

## Client rename & hygiene
- **#5** — renamed to match the "Move Instance Variable Up/Down…" command titles: Explorer method `pushInstVar`→`moveInstVar`, command IDs `explorer.pushUp/pushDownInstVar`→`explorer.moveUp/moveDownInstVar`, and the "Push … failed" error strings. (Engine `#pushUp`/`#pushDown` ops and their `pushUpInstVar:`/`pushDownInstVar:` selectors are kept as tested special cases.)
- **#4** — deleted the now-dead `pushInstVar` client helper; its op-agnostic flow-contract tests were re-pointed to the live `moveInstVar` path so no coverage was lost.
- **#9** — the move heading now names the source class and lists destinations, falling back to a count past three: *"Move instance variable 'x' from Mid down to Leaf, Twig"* / *"… down to 4 subclasses"*.
- **#2 (comment)** — corrected the stale `hierNeighbors` "dict-scoped … stays correct" comment to describe the lineage-scoped binding.

## Tests
- **#6** — new `explorerMoveInstVarPicker.test.ts` unit-covers the ▲/▼ picker: the immediate-superclass-first `.reverse()`, both "nowhere to move" messages, and `canPickMany` on the ▼ path only.
- **#7** — the move-up accessor test now pins `c selector = #pushable`, so an unrelated selector travelling up can no longer pass.
- **#8** — stale `Leaf2` comments updated to `GsVSTwig`.

## Verification
- RB engine SUnit **49/49 on both 3.6.2 and 3.7.5**.
- Full CI-mirror matrix (both plugin worlds × both boundaries) + on-demand `test:gci`: green for this branch. The only reds are pre-existing/environmental — the documented `encodeAsUTF8` base-image gap in the gci e2e suite and a load-induced ChangeSignature timeout (its SUnit re-run 33/33) — none introduced here.

Closes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
