### PR TITLE
Bump vscode-languageclient to 10 to unblock vsce package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the **GemStone Smalltalk** extension will be documented i
 
 ### Security
 
-- **Patched the `brace-expansion` denial-of-service advisory (GHSA-mh99-v99m-4gvg).** A scoped npm override forces `vscode-languageclient`'s `minimatch` to `^10.2.5` so the only `brace-expansion` in the tree is the patched 5.0.8, avoiding a `vscode-languageclient` major bump that doesn't compile under the repo's module resolution. ([#288](https://github.com/GemTalk/Jasper/pull/288))
+- **Patched the `brace-expansion` denial-of-service advisory (GHSA-mh99-v99m-4gvg) by upgrading `vscode-languageclient` to 10.1.0.** Version 10 is an exports-only package, so `client/tsconfig.json` carries a `paths` mapping for `vscode-languageclient/node` until the repo moves off `node10` module resolution. ([#288](https://github.com/GemTalk/Jasper/pull/288), [#354](https://github.com/GemTalk/Jasper/pull/354))
 
 ## [1.8.9] - 2026-07-22
 

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "selfsigned": "^5.5.0",
-    "vscode-languageclient": "^9.0.0"
+    "vscode-languageclient": "^10.1.0"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -3,7 +3,17 @@
   "compilerOptions": {
     "outDir": "./out",
     "rootDir": "./src",
-    "allowJs": true
+    "allowJs": true,
+    // vscode-languageclient@10 is an exports-only package: it dropped the root-level `node.js` /
+    // `node.d.ts` shims v9 shipped and declares no `main`/`types`, exposing `./node` solely through
+    // the `exports` map. tsconfig.base.json uses `"module": "commonjs"` with no `moduleResolution`,
+    // which implies `node10` — and node10 resolution ignores `exports`, so tsc cannot find
+    // `vscode-languageclient/node`. esbuild (which builds the shipped bundle) does honour
+    // `exports`, so this only ever needed to be a hint for the type checker.
+    // Delete this mapping once the project moves to `moduleResolution: node16`/`bundler`.
+    "paths": {
+      "vscode-languageclient/node": ["../node_modules/vscode-languageclient/lib/node/main"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
       "version": "0.1.0",
       "dependencies": {
         "selfsigned": "^5.5.0",
-        "vscode-languageclient": "^9.0.0"
+        "vscode-languageclient": "^10.1.0"
       },
       "devDependencies": {
         "@types/jsdom": "^28.0.3",
@@ -9693,18 +9693,44 @@
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.91.0"
       }
+    },
+    "node_modules/vscode-languageclient/node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver": {
       "version": "9.0.1",
@@ -9729,9 +9755,9 @@
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {

--- a/package.json
+++ b/package.json
@@ -2362,9 +2362,6 @@
   },
   "overrides": {
     "fast-uri": "^3.1.4",
-    "js-yaml": "^4.3.0",
-    "vscode-languageclient": {
-      "minimatch": "^10.2.5"
-    }
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
Fixes #351

## Summary
- PR #288 patched the `brace-expansion` DoS advisory (GHSA-mh99-v99m-4gvg) with a scoped npm override forcing `vscode-languageclient`'s `minimatch` to `^10.2.5`. That pulled in the patched `brace-expansion` 5.0.8, but v9 declares `minimatch: ^5.1.0`, so npm marked the resolution invalid — `vsce`'s `npm list --production --parseable --depth=99999` check then fails with `ELSPROBLEMS`, aborting packaging and blocking the 1.8.10 release.
- Upgrades `vscode-languageclient` to `10.1.0`, which declares `minimatch: ^10.2.5` itself, so the override is unnecessary and the tree resolves cleanly. `brace-expansion` stays at the patched 5.0.8.
- v10 is exports-only (dropped the root `node.js`/`node.d.ts` shims v9 shipped). Since `client/tsconfig.json` implies `node10` module resolution (which ignores `exports`), added a typecheck-only `paths` mapping for `vscode-languageclient/node` until the repo moves to `moduleResolution: node16`/`bundler`.
- Server stays on `vscode-languageserver` 9 (LSP 3.18 is additive over 3.17; `server.ts` only advertises pre-3.17 capabilities).

## Test plan
- [x] `npm list --production --parseable --depth=99999` exits 0
- [x] `vsce ls` exits 0, lists all files including koffi's prebuilds
- [x] `npm run lint && npm run format:check && npm run compile && npm test`