### PR TITLE
CI gate: catch a semantically-invalid production dependency tree

### DIFF
--- a/.claude/rules/npm-overrides.md
+++ b/.claude/rules/npm-overrides.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "package.json"
+---
+
+# npm `overrides`
+
+An `overrides` entry may only narrow *within* the declaring package's existing range — an out-of-range override breaks `vsce package`. Read [docs/how-to/npm-overrides.md](../../docs/how-to/npm-overrides.md) before adding or editing one.

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -210,6 +210,37 @@ jobs:
           path: test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin.json
           if-no-files-found: ignore
 
+  package-check:
+    name: Verify vsce packaging
+    timeout-minutes: 5
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      # zizmor(unpinned-uses): actions must be pinned to a commit SHA, not
+      # a mutable tag like @v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # zizmor(artipacked): checkout must not persist the token past
+          # this job
+          persist-credentials: false
+      - name: Setup Node.js
+        # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+        # not a mutable tag like @v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      # Runs vsce's full packaging path (esbuild bundle + the production
+      # dependency walk `npm list --production --parseable --depth=99999`).
+      # An `overrides` entry resolved outside its declaring package's range
+      # marks that edge `invalid`, `npm list` exits non-zero, and packaging
+      # aborts — invisible to npm ci / lint / compile / test, and it has
+      # broken a release twice (see issue #351).
+      - name: Verify vsce packaging
+        run: npm run package
+
   # Single stable check for branch protection / the merge queue to require.
   # The matrix job's own check names embed the matrix values, so requiring
   # `test` directly is brittle; this fans them in to one name instead.
@@ -219,7 +250,7 @@ jobs:
   ci-complete:
     name: ci-complete
     if: always()
-    needs: [prepare, lint-workflows, lint, health-check]
+    needs: [prepare, lint-workflows, lint, health-check, package-check]
     runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
@@ -228,11 +259,13 @@ jobs:
           if [ "${{ needs.prepare.result }}" != "success" ] ||
             [ "${{ needs.lint-workflows.result }}" != "success" ] ||
             [ "${{ needs.lint.result }}" != "success" ] ||
-            [ "${{ needs.health-check.result }}" != "success" ]; then
+            [ "${{ needs.health-check.result }}" != "success" ] ||
+            [ "${{ needs.package-check.result }}" != "success" ]; then
             echo "prepare=${{ needs.prepare.result }}"
             echo "lint-workflows=${{ needs.lint-workflows.result }}"
             echo "lint=${{ needs.lint.result }}"
             echo "health-check=${{ needs.health-check.result }}"
+            echo "package-check=${{ needs.package-check.result }}"
             exit 1
           fi
 

--- a/docs/how-to/npm-overrides.md
+++ b/docs/how-to/npm-overrides.md
@@ -1,0 +1,33 @@
+# Using `overrides` in root `package.json`
+
+## The rule
+
+An `overrides` entry may only **narrow** the range the declaring package already permits — it pins a specific version *within* that package's own dependency range, it cannot replace the range with something outside it.
+
+If the version you need to force falls outside the declaring package's existing range, bump the parent package instead of (or as well as) adding/adjusting the override.
+
+## Why
+
+An out-of-range override makes npm mark that edge of the dependency tree `invalid`. `vsce package` refuses to package the extension when `npm ls` reports invalid edges, so a bad override silently breaks packaging rather than failing loudly at the time it's added. This has blocked a release twice.
+
+## How to apply
+
+Before adding or editing an entry in the root `package.json`'s `"overrides"` block:
+
+1. Find the package that actually depends on the module you want to override, and check the range it declares for that dependency (e.g. via `npm ls <package>` or reading its own `package.json`).
+2. Confirm the version you want to pin falls inside that range.
+3. If it doesn't, bump the parent package to a version whose declared range includes the version you need — then add the override only if one is still necessary.
+4. Run `npm run package` (or at least `npm ls`) to confirm no edge comes back `invalid`.
+
+The `package-check` CI job (see `health-check.yml`) exists specifically to catch this class of breakage before it reaches a release.
+
+## Example of the mistake
+
+[Issue #351](https://github.com/GemTalk/Jasper/issues/351): PR #288 added an override forcing `vscode-languageclient`'s `minimatch` to `^10.2.5` to patch a `brace-expansion` advisory. But the pinned `vscode-languageclient@9` declares `minimatch: ^5.1.0`, so `minimatch@10.2.5` fell outside that range and npm marked the edge `invalid`. `vsce package` aborted while walking production dependencies with:
+
+```
+npm error code ELSPROBLEMS
+npm error invalid: minimatch@10.2.5 .../node_modules/minimatch
+```
+
+This silently blocked the release rather than failing at the time the override was added. If you've hit this error, check every entry in `"overrides"` against the rule above. This was the second time this exact pattern broke packaging (the first was the `@hono/node-server` override, reverted in 1.8.9).


### PR DESCRIPTION
## Summary
- Add a `package-check` CI job that runs `npm run package` (vsce's full packaging path), catching the class of failure that has broken `vsce package` on `main` twice (#351), and that `npm ci`/lint/compile/test never touch.
- Document the underlying rule using a Claude rule file: an `overrides` entry may only narrow within the declaring package's existing range.

## Failure screenshot

<img width="1978" height="672" alt="image" src="https://github.com/user-attachments/assets/a719889f-d75f-42ac-bf51-5f1dac24ca23" />


## Test plan
- [x] `npm run lint:github:workflows` — new job's `timeout-minutes` satisfies the enforced-timeout linter
- [x] `npm run lint && npm run format:check && npm run compile && npm test` — full suite passes
- [x] `package-check` appears in GitHub Actions and is wired into `ci-complete` as a required, non-skippable job

🤖 Generated with [Claude Code](https://claude.com/claude-code)
