### PR TITLE
Issue #356: pin lineage-scoped move-destination resolution with a cross-dictionary test

### DIFF
--- a/gs-src/refactoring/tests/GsInstVarStructureRefactoringTest.class.st
+++ b/gs-src/refactoring/tests/GsInstVarStructureRefactoringTest.class.st
@@ -535,6 +535,74 @@ GsInstVarStructureRefactoringTest >> testMoveUpMovesSimpleAccessorsToAncestor [
 ]
 
 { #category : 'tests - V4 move' }
+GsInstVarStructureRefactoringTest >> testMoveUpBindsLineageClassNotASameNamedShadowInAnotherDictionary [
+	"#2 dictionary scoping: a destination name resolves within the source's OWN lineage, not by
+	 unscoped global first-match. Bind an unrelated GsVSBase in a dictionary AHEAD of UserGlobals so a
+	 global lookup returns that shadow (which is not an ancestor of GsVSMid). Moving GsVSMid's own
+	 'mid' up to 'GsVSBase' must still bind the REAL lineage GsVSBase and succeed -- the old unscoped
+	 lookup bound the shadow and declined 'is not a superclass'. This is the exact case the lineage
+	 fix was written for, and the only test that fails if it is reverted (see issue #356)."
+	| shadow ref |
+	shadow := SymbolDictionary new.
+	System myUserProfile insertDictionary: shadow at: 1.
+	[Object
+		subclass: 'GsVSBase'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: shadow.
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSMid') moveInstVar: 'mid' toClasses: #('GsVSBase') direction: #up.
+
+	self assert: ref decline isNil.
+	self assert: ref topClass name asString equals: 'GsVSBase'.
+	self assert: (self editChangeFor: 'GsVSBase' in: ref changeSet) notNil]
+		ensure: [System myUserProfile removeDictionaryAt: 1]
+]
+
+{ #category : 'tests - V4 move' }
+GsInstVarStructureRefactoringTest >> testMoveDownBindsLineageClassNotASameNamedShadowInAnotherDictionary [
+	"#2 dictionary scoping, #down half: the down lineage resolves through the source's DESCENDANTS,
+	 a different code path than #up's ancestor walk. Bind an unrelated GsVSLeaf in a dictionary AHEAD
+	 of UserGlobals so a global lookup returns that shadow (which is not a subclass of GsVSMid).
+	 Moving GsVSMid's own 'pushable' down to 'GsVSLeaf' must still bind the REAL descendant GsVSLeaf
+	 and succeed -- the old unscoped lookup bound the shadow and declined 'is not a subclass'."
+	| shadow ref |
+	shadow := SymbolDictionary new.
+	System myUserProfile insertDictionary: shadow at: 1.
+	[Object
+		subclass: 'GsVSLeaf'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: shadow.
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSMid') moveInstVar: 'pushable' toClasses: #('GsVSLeaf') direction: #down.
+
+	self assert: ref decline isNil.
+	self assert: (self editChangeFor: 'GsVSLeaf' in: ref changeSet) notNil]
+		ensure: [System myUserProfile removeDictionaryAt: 1]
+]
+
+{ #category : 'tests - V4 move' }
+GsInstVarStructureRefactoringTest >> testMoveUpToANonImmediateAncestor [
+	"V4 moves up to ANY chosen ancestor, not just the immediate superclass. GsVSLeaf's 'leaf' moves
+	 up to GsVSBase -- its grandparent, skipping GsVSMid -- so the declaration lands on GsVSBase (from
+	 which GsVSLeaf still inherits it) and leaves GsVSLeaf's own list."
+	| ref cs |
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSLeaf') moveInstVar: 'leaf' toClasses: #('GsVSBase') direction: #up.
+	cs := ref changeSet.
+
+	self assert: ref decline isNil.
+	self assert: ref topClass name asString equals: 'GsVSBase'.
+	self assert: (self editChangeFor: 'GsVSBase' in: cs) notNil.
+	self assert: (self editChangeFor: 'GsVSLeaf' in: cs) notNil
+]
+
+{ #category : 'tests - V4 move' }
 GsInstVarStructureRefactoringTest >> testMoveApplyDoesNotCommit [
 	| before |
 	before := System needsCommit.

--- a/resources/refactoring/engine-tests.gs
+++ b/resources/refactoring/engine-tests.gs
@@ -4090,6 +4090,77 @@ testMoveUpMovesSimpleAccessorsToAncestor
 
 category: 'tests - V4 move'
 method: GsInstVarStructureRefactoringTest
+testMoveUpBindsLineageClassNotASameNamedShadowInAnotherDictionary
+	"#2 dictionary scoping: a destination name resolves within the source's OWN lineage, not by
+	 unscoped global first-match. Bind an unrelated GsVSBase in a dictionary AHEAD of UserGlobals so a
+	 global lookup returns that shadow (which is not an ancestor of GsVSMid). Moving GsVSMid's own
+	 'mid' up to 'GsVSBase' must still bind the REAL lineage GsVSBase and succeed -- the old unscoped
+	 lookup bound the shadow and declined 'is not a superclass'. This is the exact case the lineage
+	 fix was written for, and the only test that fails if it is reverted (see issue #356)."
+	| shadow ref |
+	shadow := SymbolDictionary new.
+	System myUserProfile insertDictionary: shadow at: 1.
+	[Object
+		subclass: 'GsVSBase'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: shadow.
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSMid') moveInstVar: 'mid' toClasses: #('GsVSBase') direction: #up.
+
+	self assert: ref decline isNil.
+	self assert: ref topClass name asString equals: 'GsVSBase'.
+	self assert: (self editChangeFor: 'GsVSBase' in: ref changeSet) notNil]
+		ensure: [System myUserProfile removeDictionaryAt: 1]
+%
+
+category: 'tests - V4 move'
+method: GsInstVarStructureRefactoringTest
+testMoveDownBindsLineageClassNotASameNamedShadowInAnotherDictionary
+	"#2 dictionary scoping, #down half: the down lineage resolves through the source's DESCENDANTS,
+	 a different code path than #up's ancestor walk. Bind an unrelated GsVSLeaf in a dictionary AHEAD
+	 of UserGlobals so a global lookup returns that shadow (which is not a subclass of GsVSMid).
+	 Moving GsVSMid's own 'pushable' down to 'GsVSLeaf' must still bind the REAL descendant GsVSLeaf
+	 and succeed -- the old unscoped lookup bound the shadow and declined 'is not a subclass'."
+	| shadow ref |
+	shadow := SymbolDictionary new.
+	System myUserProfile insertDictionary: shadow at: 1.
+	[Object
+		subclass: 'GsVSLeaf'
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: shadow.
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSMid') moveInstVar: 'pushable' toClasses: #('GsVSLeaf') direction: #down.
+
+	self assert: ref decline isNil.
+	self assert: (self editChangeFor: 'GsVSLeaf' in: ref changeSet) notNil]
+		ensure: [System myUserProfile removeDictionaryAt: 1]
+%
+
+category: 'tests - V4 move'
+method: GsInstVarStructureRefactoringTest
+testMoveUpToANonImmediateAncestor
+	"V4 moves up to ANY chosen ancestor, not just the immediate superclass. GsVSLeaf's 'leaf' moves
+	 up to GsVSBase -- its grandparent, skipping GsVSMid -- so the declaration lands on GsVSBase (from
+	 which GsVSLeaf still inherits it) and leaves GsVSLeaf's own list."
+	| ref cs |
+	ref := GsInstVarStructureRefactoring
+		class: (self classNamed: 'GsVSLeaf') moveInstVar: 'leaf' toClasses: #('GsVSBase') direction: #up.
+	cs := ref changeSet.
+
+	self assert: ref decline isNil.
+	self assert: ref topClass name asString equals: 'GsVSBase'.
+	self assert: (self editChangeFor: 'GsVSBase' in: cs) notNil.
+	self assert: (self editChangeFor: 'GsVSLeaf' in: cs) notNil
+%
+
+category: 'tests - V4 move'
+method: GsInstVarStructureRefactoringTest
 testMoveApplyDoesNotCommit
 	| before |
 	before := System needsCommit.


### PR DESCRIPTION
Follow-up to the review of #353, where @MatiasFernandez noted (approved, non-blocking) that the lineage-scoped move-destination resolution had no test protecting it: every `GsInstVarStructureRefactoringTest` fixture installs into a single `UserGlobals`, so the new lineage `detect:` path and the old unscoped `env classNamed:` global-first path resolved to the same class — a revert to the unscoped lookup would still pass 49/49.

Adds three [GS SUnit] tests. **Test-only; the engine is unchanged.**

## Tests
- **`testMoveUpBindsLineageClassNotASameNamedShadowInAnotherDictionary`** (the #356 core) — binds an unrelated `GsVSBase` in a `SymbolDictionary` inserted ahead of `UserGlobals` so a global first-match lookup returns that shadow, then moves `GsVSMid`'s own `'mid'` up to `'GsVSBase'` and asserts it still binds the **real** lineage `GsVSBase` (`decline` nil, edit targets the real class).
- **`testMoveDownBindsLineageClassNotASameNamedShadowInAnotherDictionary`** — the `#down` half, which resolves through `descendantsOf:` — a different code path than `#up`'s ancestor walk, so a revert of just the down branch needs its own shadow test.
- **`testMoveUpToANonImmediateAncestor`** — covers V4's move-up-to-**any**-ancestor (`GsVSLeaf`'s `'leaf'` up to its grandparent `GsVSBase`, skipping `GsVSMid`), which nothing previously exercised.

Each shadow test builds its second dictionary inside the test and removes it in an `ensure:` block, so it cannot leak into the other tests.

## Verification
- RB engine SUnit **52/52 on both 3.6.2 and 3.7.5** (49 prior + 3 new), and 52/52 in-stone via GCI on a plugin-installed stone.
- **Revert-proof (the point):** temporarily reverting the lineage resolution to the old unscoped lookup makes exactly the two shadow tests **fail** — instead of the old "still passes 49/49". The third test is V4-capability coverage and passes either way, by design.

Closes #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
