### PR TITLE
Rule agents into the CI suite, not the gci project

### DIFF
--- a/.claude/rules/client/gci.md
+++ b/.claude/rules/client/gci.md
@@ -12,6 +12,8 @@ The GCI library (`libgcits`) is a platform-native `.so`/`.dylib`/`.dll` bundled 
 
 `docs/3.7/` contains the GCI header files (`gcits.hf`, `gci.ht`, `gcicmn.ht`, `gcits.ht`) — the authoritative reference for GCI function signatures, struct layouts, and constants.
 
-## Running the deep GCI suite (`npm run test:gci`)
+## The on-demand `gci` suite (`npm run test:gci`) — legacy, being retired
 
-The GCI binding tests (`client/src/__tests__/gci/**`) are a separate vitest project named `gci` (in `client/vitest.config.ts`), excluded from `npm test` (which runs the `default` project); run them with `npm run test:gci` (`--project gci`). They read their connection from `.env.test` (`VITE_GEMSTONE_*`, written by `npm run test:server:start`) via `client/src/__tests__/gci/gciTestConfig.ts`; `GCI_LIBRARY_PATH` / `GS_*` shell vars are honored as a fallback for a custom stone. Needs a running stone at localhost.
+`client/src/__tests__/gci/**` is a separate vitest project named `gci` (in `client/vitest.config.ts`), excluded from `npm test` (which runs the `default` project); run it with `npm run test:gci` (`--project gci`). It reads its connection from `.env.test` (`VITE_GEMSTONE_*`, written by `npm run test:server:start`) via `client/src/__tests__/gci/gciTestConfig.ts`; `GCI_LIBRARY_PATH` / `GS_*` shell vars are honored as a fallback for a custom stone. Needs a running stone at localhost.
+
+Because it is excluded from `npm test`, **nothing in this project runs in CI** — it only ever runs on demand, locally. Its tests are being migrated to `useIntegrationTest` integration tests that do run, across the release matrix. Treat the directory as closed: move tests out of it rather than adding to it, and consult "Choosing where a stone-dependent test lives" in `.claude/rules/client/tests.md` for the narrow set of cases that still belong here.

--- a/.claude/rules/client/tests.md
+++ b/.claude/rules/client/tests.md
@@ -42,9 +42,35 @@ Tests run in random order; the seed is printed at the top of the output. Reprodu
 
 ## Integration tests
 
-Tests using `useIntegrationTest` require a live GemStone instance so plain `npm test` needs a running stone. Run `npm run test:server:start` once to provision one; it writes connection details to `.env.test` (which the user may override with `.env.test.local`). CI runs these as a matrix over `client/.gemstone-integration-releases.json`. The deep GCI binding suite (`npm run test:gci`) is separate.
+Tests using `useIntegrationTest` require a live GemStone instance so plain `npm test` needs a running stone. Run `npm run test:server:start` once to provision one; it writes connection details to `.env.test` (which the user may override with `.env.test.local`). CI runs these as a matrix over `client/.gemstone-integration-releases.json`.
 
 GCI session/oop values are koffi `External` pointer wrappers with no enumerable properties, so vitest's deep equality (`toEqual`, and therefore `expect(spy).toHaveBeenCalledWith(someSession, ...)`) cannot tell two *different* sessions or oops apart — it treats any two of them as equal regardless of the underlying native pointer. To assert *which* session/oop a call received, pull the argument out of `spy.mock.calls` and compare with `toBe` (reference equality) instead.
+
+### Choosing where a stone-dependent test lives
+
+The **default home** is a `*.integration.test.ts` using `useIntegrationTest`, co-located in the `__tests__/` dir next to the code it exercises (raw `GciTsXxx` wrapper tests → `client/src/gciLibrary/__tests__/`). Those run in CI over the whole release matrix, in both passes.
+
+The on-demand `client/src/__tests__/gci/` project **never runs in CI** (see `.claude/rules/client/gci.md`) and is being migrated away. Add a test there only when the harness genuinely cannot host it:
+
+- it must **commit** — the harness aborts every test, and an abort cannot undo a commit;
+- it needs **exclusive access to the stone**, or destroys and restores the whole repository;
+- it drives a **session lifecycle** beyond `login` / `logout` / `withTransientSession` (e.g. many logins with varying flags), or installs process-wide state once for a whole file;
+- it makes a **single blocking GCI call** that can outlast the CI budget and that vitest cannot interrupt, so a hang takes out the whole job;
+- it writes into `process.cwd()` and its cleanup is only registered by the `gci` project.
+
+**These are not reasons** — each already has a mechanism that runs in CI:
+
+- *needs the server plugin in the image* → gate it (see below). CI runs the suite twice, once bare and once with the plugin installed, so both worlds are covered.
+- *needs Rowan or Grail in the image* → probe for it live and `ctx.skip(reason)` when absent, the way `rowanExportFixpoint.integration.test.ts` does with `listRowanProjects(exec).available`. Unlike the server plugin, there is no CI pass with Rowan/Grail installed yet, so such a test currently always skips in CI — that's a known gap, not a reason to write it in `gci/` instead.
+- *needs a class, method, or test-case fixture a bare vendor extent lacks* → create it in the test; the auto-abort rolls it back.
+- *depends on behavior that differs by stone version* → a version-applicability gate resolved off the session, never a hardcoded `stoneVersion` literal.
+- *needs `SystemUser` or different credentials* → `login({ user: 'SystemUser' })`.
+
+A test whose assertion **branches on what the live stone happens to contain** doesn't belong in `gci/` either — it needs a bounded, deterministic fixture. An `if (present) … else …` that asserts both branches passes no matter which one ran, so it can never fail.
+
+A case that can be written with `useIntegrationTest` MUST be written that way, and only that way. Before adding to `gci/`, grep `client/src/**/__tests__/*.integration.test.ts` for a sibling that already covers it and extend that instead. When a file mixes both kinds, split it: the CI-runnable assertions move out, and only the part that cannot run in CI stays behind.
+
+Whenever a test skips, skip it with a reason — `ctx.skip(reason)`. A bare `return` reports as **passed**, which hides the test from CI's skip report, and a bare `ctx.skip()` reports without saying why.
 
 ### Tests that depend on the server plugin
 


### PR DESCRIPTION
Agent-facing context only — no production or test code changes.

While migrating the on-demand `gci` tests into the CI integration suite, the
rules files still read as though `gci/` were a normal place to add a test. An
agent following them would keep writing tests that nobody ever runs, and would
happily write the same case twice, once in each suite.

## What this adds

`.claude/rules/client/tests.md` gains a "Choosing where a stone-dependent test
lives" section that makes `useIntegrationTest` the documented default home and
states the rule plainly: a case that can be written that way MUST be written
that way, and only that way.

It lists the five constraints that genuinely rule the harness out — must
commit, needs exclusive or destructive stone access, drives its own session
lifecycle, makes one un-interruptible blocking call that can outlast the CI
budget, or needs `cwd` cleanup only the `gci` project registers.

Just as important, it lists the near-misses that are **not** reasons, because
each already has a mechanism that runs in CI: needing the server plugin is a
gate, a fixture a bare extent lacks is something the test creates and the
auto-abort rolls back, version-dependent behavior resolves off the session, and
`SystemUser` is a login option. It also bans asserting on whatever the live
stone happens to contain — a branch that asserts both arms can never fail.

`.claude/rules/client/gci.md` reframes the suite as legacy and being retired,
keeping the mechanics needed to actually run it, and points at the rule above
rather than restating the exceptions.

## Placement

The decision rule is client-scoped, so it lives in the path-scoped client rules
file rather than the repo-wide one, which would load stone and GCI detail for
every `server/` and `mcp-server/` test. 

Two incidental cleanups fell out of the no-duplication rule: the "deep GCI
binding suite is separate" aside is gone now that a whole section covers it, and
the koffi deep-equality note moved up so the new section's gating
cross-reference sits next to the gating section it refers to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
