### PR TITLE
Fix release doc: use npm version instead of hand-editing package-lock.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ CI runs on **GitHub Actions**. The [Health Check workflow](.github/workflows/hea
 
 ## Publishing a release
 
-1. Update the version in `package.json` (and `package-lock.json` — both the top-level `version` and `packages."".version`) and promote the `[Unreleased]` section in `CHANGELOG.md` to a new dated `[X.Y.Z]` heading. Sweep `main` since the last release for merged PRs that didn't add their own changelog entries.
+1. `npm version <X.Y.Z> --no-git-tag-version` — bumps `package.json`'s `version` and `package-lock.json`'s two root fields (`version` and `packages."".version`) atomically. Don't hand-edit these or find-and-replace the version string across the lockfile: the version can collide with an unrelated dependency's own version elsewhere in `package-lock.json` (e.g. `1.8.11` matches `typed-rest-client@1.8.11`), corrupting that entry. `--no-git-tag-version` skips npm's own commit/tag, since steps 3-4 below handle that. Then promote the `[Unreleased]` section in `CHANGELOG.md` to a new dated `[X.Y.Z]` heading. Sweep `main` since the last release for merged PRs that didn't add their own changelog entries.
 2. `npm run compile && npm test`
 3. Commit the version + changelog changes (e.g. `Release X.Y.Z: <one-line summary>`).
 4. `git tag -a vX.Y.Z -m "Release X.Y.Z"` — annotated tag, on the release commit.


### PR DESCRIPTION
## Summary

- During a supply-chain-hardening audit we traced a version mismatch to release commit [`cd0bff1`](https://github.com/GemTalk/Jasper/commit/cd0bff1cc79ffd65825061e7005800fc36f96f25) ("Release 1.6.1"): `package-lock.json`'s version bump was done by hand (a find-and-replace of `1.6.0` → `1.6.1`), and it wasn't scoped to just the two root fields — it also matched two unrelated dependencies pinned at `1.6.0`, `mime@1.6.0` and `sax@1.6.0`, silently rewriting their `version` field to `1.6.1` while their `resolved` URL and `integrity` hash still point at the real `1.6.0` tarball. Both entries are now internally inconsistent in the lockfile on `main` today.
- This isn't a one-off: the collision risk scales with the next release. `1.8.11` (a plausible next patch version) collides with `typed-rest-client@1.8.11`; a `2.0.0` release would match roughly 20 entries across the tree.
- `package-lock.json` should never be edited by hand for exactly this reason. npm already provides `npm version <X.Y.Z> --no-git-tag-version`, which bumps only the two root version fields (`version` and `packages."".version`) atomically and structurally can't reach nested dependency entries.
- Updates [CONTRIBUTING.md](CONTRIBUTING.md)'s release step accordingly, with an inline note on the collision risk and on why `--no-git-tag-version` is required (later steps already commit/tag).

## Test plan

- [x] Verified in a scratch copy that `npm version 1.8.11 --no-git-tag-version` updates only `package.json`'s `version` and `package-lock.json`'s two root fields, leaving the other 739 lockfile entries untouched.
- [x] Docs-only change; no build/test impact expected.
- [x] Separately: fix the drifted `mime`/`sax` entries in `package-lock.json` (not in scope of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)