### PR TITLE
GemStone Explorer: method preview tabs, Methods-pane toggles, and instance-variable method filter (#259)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ acceptance/.features-gen/
 
 # Refactoring design / TDD stage docs — local working notes, kept out of the repo
 gs-src/refactoring/design/
+
+# GCI native-library trace logs from the on-demand `gci` test project. Normally
+# cleaned up after a run, but kept (with the .gci-trace-keep marker) when a gci
+# test fails — so they can linger as untracked files. Never commit them.
+gci*trace.log
+.gci-trace-keep

--- a/client/src/__tests__/explorerHierarchyReveal.test.ts
+++ b/client/src/__tests__/explorerHierarchyReveal.test.ts
@@ -65,3 +65,27 @@ describe('ExplorerController.revealHierarchySelf', () => {
     expect(hierarchy.reveal).not.toHaveBeenCalled();
   });
 });
+
+describe('ExplorerController re-reveals when the Hierarchy pane reappears', () => {
+  it('catches up on a class navigated to while the pane was hidden', async () => {
+    const ctl = makeController();
+    const hierarchy = withHierarchyView(ctl, false);
+    await ctl.revealHierarchySelf();
+    expect(hierarchy.reveal).not.toHaveBeenCalled();
+
+    hierarchy.visible = true;
+    ctl.onHierarchyVisibilityChanged(true);
+
+    await vi.waitFor(() => expect(hierarchy.reveal).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not re-reveal when the pane is being hidden', async () => {
+    const ctl = makeController();
+    const hierarchy = withHierarchyView(ctl, true);
+
+    ctl.onHierarchyVisibilityChanged(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(hierarchy.reveal).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/explorerHierarchyReveal.test.ts
+++ b/client/src/__tests__/explorerHierarchyReveal.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+// The controller pulls in browserQueries (→ native GCI). Stub it; these tests
+// only exercise revealHierarchySelf, which never reaches a query.
+vi.mock('../browserQueries', () => ({}));
+
+import { ExplorerController } from '../gemstoneExplorer';
+import type { ClassHierarchyEntry } from '../queries/getClassHierarchy';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+
+const SESSION = { id: 1 } as ActiveSession;
+
+// revealHierarchySelf reads the private hierarchy chain the load step fills in;
+// seed it directly so the test doesn't need a live query.
+type HierAccess = { hierChain: ClassHierarchyEntry[]; hierSubs: ClassHierarchyEntry[] };
+
+function makeController(): ExplorerController {
+  const sessionManager = { getSelectedSession: () => SESSION } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  const access = ctl as unknown as HierAccess;
+  access.hierChain = [{ className: 'Array', dictName: 'UserGlobals', kind: 'self' }];
+  access.hierSubs = [];
+  return ctl;
+}
+
+// A TreeView-shaped stub whose `visible` flag mirrors whether the pane section
+// is expanded in the sidebar.
+function fakeView(visible = true) {
+  return { reveal: vi.fn(async () => {}), selection: [] as unknown[], description: '', visible };
+}
+
+function withHierarchyView(ctl: ExplorerController, visible: boolean) {
+  const hierarchy = fakeView(visible);
+  ctl.setViews({
+    dict: fakeView(),
+    category: fakeView(),
+    klass: fakeView(),
+    hierarchy,
+    method: fakeView(),
+  } as never);
+  return hierarchy;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ExplorerController.revealHierarchySelf', () => {
+  it('reveals the selected class when the Hierarchy pane is expanded', async () => {
+    const ctl = makeController();
+    const hierarchy = withHierarchyView(ctl, true);
+
+    await ctl.revealHierarchySelf();
+
+    expect(hierarchy.reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not force the Hierarchy pane open when it is collapsed', async () => {
+    const ctl = makeController();
+    const hierarchy = withHierarchyView(ctl, false);
+
+    await ctl.revealHierarchySelf();
+
+    expect(hierarchy.reveal).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/explorerIvarFilter.test.ts
+++ b/client/src/__tests__/explorerIvarFilter.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+// Only getMethodInstVarAccess is exercised here; the controller reads method
+// selectors from its (privately seeded) envLines, not from a query.
+vi.mock('../browserQueries', () => ({
+  getMethodInstVarAccess: vi.fn(() => [
+    { isMeta: false, selector: 'count', reads: ['count'], writes: [] },
+    { isMeta: false, selector: 'count:', reads: [], writes: ['count'] },
+  ]),
+}));
+
+import { Uri, Position, window, __resetConfig, __setConfig } from '../__mocks__/vscode';
+import { ExplorerController, MethodItem, FilterChipItem } from '../gemstoneExplorer';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+import type { EnvCategoryLine } from '../browserQueries';
+
+const GROUP_KEY = 'explorer.groupMethodsByCategory';
+const VIEW_METHODS = 'gemstoneExplorerMethods';
+
+function makeController(): ExplorerController {
+  const session = { id: 1 } as ActiveSession;
+  const sessionManager = { getSelectedSession: () => session } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.dictName = 'UserGlobals';
+  ctl.state.className = 'Demo';
+  ctl.state.dictIndex = 1;
+  (ctl as unknown as { envLines: EnvCategoryLine[] }).envLines = [
+    { isMeta: false, envId: 0, category: 'accessing', selectors: ['count', 'count:', 'size'] },
+  ];
+  return ctl;
+}
+
+function setMethodFilter(ctl: ExplorerController, pattern: string): void {
+  (ctl as unknown as { filters: Map<string, string> }).filters.set(VIEW_METHODS, pattern);
+}
+
+// The method rows only — a filter chip leads the list while filtering.
+function methodItems(ctl: ExplorerController): MethodItem[] {
+  return ctl.methodProvider.getChildren().filter((r): r is MethodItem => r instanceof MethodItem);
+}
+
+function selectors(rows: MethodItem[]): string[] {
+  return rows.map((r) => r.info.selector).sort();
+}
+
+// A minimal TextEditor stand-in for the ivar-highlight decoration path.
+function fakeEditor(uriString: string, text: string) {
+  return {
+    document: {
+      uri: Uri.parse(uriString),
+      getText: () => text,
+      positionAt: (o: number) => new Position(0, o),
+    },
+    setDecorations: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetConfig();
+  __setConfig('gemstone', GROUP_KEY, false); // flat, so getChildren() returns method rows
+});
+
+describe('Methods pane instance-variable filter', () => {
+  it('reads:<ivar> keeps only methods that read the ivar, marked r', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+
+    const rows = methodItems(ctl);
+
+    expect(selectors(rows)).toEqual(['count']);
+    expect(rows[0].description).toBe('r');
+  });
+
+  it('writes:<ivar> keeps only methods that write the ivar, marked w', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'writes:count');
+
+    const rows = methodItems(ctl);
+
+    expect(selectors(rows)).toEqual(['count:']);
+    expect(rows[0].description).toBe('w');
+  });
+
+  it('accesses:<ivar> keeps both readers and writers', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'accesses:count');
+
+    expect(selectors(methodItems(ctl))).toEqual(['count', 'count:']);
+  });
+
+  it('leaves a plain textual filter untouched (no ivar query needed)', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'count');
+
+    const rows = methodItems(ctl);
+
+    expect(selectors(rows)).toEqual(['count', 'count:']);
+    expect(rows.every((r) => r.description === '')).toBe(true);
+  });
+});
+
+describe('Methods pane filter chip', () => {
+  it('leads the list with a distinct filter chip while filtering', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+
+    const [first] = ctl.methodProvider.getChildren();
+
+    expect(first).toBeInstanceOf(FilterChipItem);
+    expect((first as FilterChipItem).description).toBe('reads:count');
+    expect((first as FilterChipItem).viewId).toBe(VIEW_METHODS);
+  });
+
+  it('shows no chip when nothing is filtered', () => {
+    const ctl = makeController();
+
+    const rows = ctl.methodProvider.getChildren();
+
+    expect(rows.some((r) => r instanceof FilterChipItem)).toBe(false);
+  });
+
+  it('clears the pane filter when the chip is cleared', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+
+    ctl.clearFilter(VIEW_METHODS);
+
+    expect(ctl.getFilter(VIEW_METHODS)).toBeUndefined();
+    expect(ctl.methodProvider.getChildren().some((r) => r instanceof FilterChipItem)).toBe(false);
+  });
+
+  it('treats the chip as a root so reveal never targets it', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+    const chip = ctl.methodProvider
+      .getChildren()
+      .find((r): r is FilterChipItem => r instanceof FilterChipItem)!;
+
+    expect(ctl.methodProvider.getParent(chip)).toBeUndefined();
+  });
+});
+
+describe('ExplorerController.filterMethodsByIvar', () => {
+  it('selects the ivar’s own class, seeds the reads: token, and switches to instance side', () => {
+    const ctl = makeController();
+    ctl.setMethodSide(true);
+    const selectClass = vi.spyOn(ctl, 'selectClass').mockImplementation(() => {});
+
+    ctl.filterMethodsByIvar('reads', 'count', 'Other');
+
+    expect(selectClass).toHaveBeenCalledTimes(1);
+    expect(selectClass.mock.calls[0][0].className).toBe('Other');
+    // revealHierarchy=false: switching class for an ivar filter must not open the
+    // (collapsed) Hierarchy pane.
+    expect(selectClass.mock.calls[0][1]).toBe(false);
+    expect(ctl.getFilter(VIEW_METHODS)).toBe('reads:count');
+    expect(ctl.showClassMethods).toBe(false);
+  });
+
+  it('does not re-select the class when the pane already shows it', () => {
+    const ctl = makeController(); // state.className === 'Demo'
+    const selectClass = vi.spyOn(ctl, 'selectClass').mockImplementation(() => {});
+
+    ctl.filterMethodsByIvar('accesses', 'count', 'Demo');
+
+    expect(selectClass).not.toHaveBeenCalled();
+    expect(ctl.getFilter(VIEW_METHODS)).toBe('accesses:count');
+  });
+});
+
+const METHOD_URI = 'gemstone://1/UserGlobals/Demo/instance/accessing/count';
+
+describe('source-editor ivar highlighting', () => {
+  it('resolves the ivar names a method source should highlight under the filter', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+
+    expect(ctl.ivarsToHighlight(Uri.parse(METHOD_URI))).toEqual(['count']);
+  });
+
+  it('highlights nothing for a plain textual filter', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'count');
+
+    expect(ctl.ivarsToHighlight(Uri.parse(METHOD_URI))).toEqual([]);
+  });
+
+  it('highlights nothing for a non-gemstone editor', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+
+    expect(ctl.ivarsToHighlight(Uri.parse('file:///x.st'))).toEqual([]);
+  });
+
+  it('decorates each occurrence of the filtered ivar in the opened source', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+    const editor = fakeEditor(METHOD_URI, 'count\n\t^count');
+
+    (ctl as unknown as { applyIvarHighlight: (e: unknown) => void }).applyIvarHighlight(editor);
+
+    expect(editor.setDecorations).toHaveBeenCalledTimes(1);
+    expect((editor.setDecorations.mock.calls[0][1] as unknown[]).length).toBe(2);
+  });
+
+  it('refreshes highlights across every visible source editor', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+    const editor = fakeEditor(METHOD_URI, 'count\n\t^count');
+    window.visibleTextEditors = [editor];
+
+    try {
+      ctl.refreshIvarHighlights();
+
+      expect(editor.setDecorations).toHaveBeenCalledTimes(1);
+      expect((editor.setDecorations.mock.calls[0][1] as unknown[]).length).toBe(2);
+    } finally {
+      window.visibleTextEditors = [];
+    }
+  });
+});

--- a/client/src/__tests__/explorerIvarFilter.test.ts
+++ b/client/src/__tests__/explorerIvarFilter.test.ts
@@ -12,8 +12,15 @@ vi.mock('../browserQueries', () => ({
 
 import { Uri, Position, window, __resetConfig, __setConfig } from '../__mocks__/vscode';
 import { ExplorerController, MethodItem, FilterChipItem } from '../gemstoneExplorer';
+import { getMethodInstVarAccess } from '../browserQueries';
 import type { SessionManager, ActiveSession } from '../sessionManager';
 import type { EnvCategoryLine } from '../browserQueries';
+
+const ivarQuery = getMethodInstVarAccess as ReturnType<typeof vi.fn>;
+
+function setEnvLines(ctl: ExplorerController, lines: EnvCategoryLine[]): void {
+  (ctl as unknown as { envLines: EnvCategoryLine[] }).envLines = lines;
+}
 
 const GROUP_KEY = 'explorer.groupMethodsByCategory';
 const VIEW_METHODS = 'gemstoneExplorerMethods';
@@ -98,6 +105,24 @@ describe('Methods pane instance-variable filter', () => {
 
     expect(selectors(rows)).toEqual(['count', 'count:']);
     expect(rows.every((r) => r.description === '')).toBe(true);
+  });
+
+  it('reloads the ivar map when the method list is reloaded (no stale cache)', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'reads:count');
+
+    methodItems(ctl); // builds + caches the ivar map
+    const afterFirst = ivarQuery.mock.calls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    // Same class, same filter, but the method list was reloaded (new envLines
+    // array — as after an edit/refresh): the cache must not be reused.
+    setEnvLines(ctl, [
+      { isMeta: false, envId: 0, category: 'accessing', selectors: ['count', 'count:', 'size'] },
+    ]);
+    methodItems(ctl);
+
+    expect(ivarQuery.mock.calls.length).toBeGreaterThan(afterFirst);
   });
 });
 

--- a/client/src/__tests__/explorerMethodFilter.test.ts
+++ b/client/src/__tests__/explorerMethodFilter.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseMethodFilter,
+  methodMatchesFilter,
+  ivarAccessMark,
+  ivarIdentifierRanges,
+} from '../explorerMethodFilter';
+
+describe('parseMethodFilter', () => {
+  it('treats a bare term as the selector prefix', () => {
+    expect(parseMethodFilter('at')).toEqual({ selector: 'at', ivar: [] });
+  });
+
+  it('reads reads:/writes:/accesses: tokens into ivar constraints', () => {
+    expect(parseMethodFilter('reads:count')).toEqual({
+      selector: undefined,
+      ivar: [{ kind: 'reads', pattern: 'count' }],
+    });
+    expect(parseMethodFilter('writes:count')).toEqual({
+      selector: undefined,
+      ivar: [{ kind: 'writes', pattern: 'count' }],
+    });
+    expect(parseMethodFilter('accesses:count')).toEqual({
+      selector: undefined,
+      ivar: [{ kind: 'accesses', pattern: 'count' }],
+    });
+  });
+
+  it('combines a selector prefix with an ivar token', () => {
+    expect(parseMethodFilter('at reads:count')).toEqual({
+      selector: 'at',
+      ivar: [{ kind: 'reads', pattern: 'count' }],
+    });
+  });
+
+  it('is case-insensitive on the token keyword and keeps the ivar wildcard', () => {
+    expect(parseMethodFilter('WRITES:na*')).toEqual({
+      selector: undefined,
+      ivar: [{ kind: 'writes', pattern: 'na*' }],
+    });
+  });
+});
+
+describe('methodMatchesFilter', () => {
+  const access = { reads: ['count'], writes: ['total'] };
+
+  it('matches on the selector prefix alone', () => {
+    expect(methodMatchesFilter(parseMethodFilter('inc'), 'increment', access)).toBe(true);
+    expect(methodMatchesFilter(parseMethodFilter('dec'), 'increment', access)).toBe(false);
+  });
+
+  it('matches a reads: token only against read ivars', () => {
+    expect(methodMatchesFilter(parseMethodFilter('reads:count'), 'increment', access)).toBe(true);
+    expect(methodMatchesFilter(parseMethodFilter('reads:total'), 'increment', access)).toBe(false);
+  });
+
+  it('matches a writes: token only against written ivars', () => {
+    expect(methodMatchesFilter(parseMethodFilter('writes:total'), 'increment', access)).toBe(true);
+    expect(methodMatchesFilter(parseMethodFilter('writes:count'), 'increment', access)).toBe(false);
+  });
+
+  it('matches an accesses: token against reads or writes', () => {
+    expect(methodMatchesFilter(parseMethodFilter('accesses:count'), 'm', access)).toBe(true);
+    expect(methodMatchesFilter(parseMethodFilter('accesses:total'), 'm', access)).toBe(true);
+    expect(methodMatchesFilter(parseMethodFilter('accesses:other'), 'm', access)).toBe(false);
+  });
+
+  it('fails a method with no recorded access under any ivar token', () => {
+    expect(methodMatchesFilter(parseMethodFilter('reads:count'), 'm', undefined)).toBe(false);
+  });
+});
+
+describe('ivarIdentifierRanges', () => {
+  it('finds whole-identifier occurrences and ignores substrings', () => {
+    const text = "describe\n\t^'A shape at ', origin printString, origins";
+
+    const ranges = ivarIdentifierRanges(text, ['origin']);
+
+    expect(ranges.map(([s, e]) => text.slice(s, e))).toEqual(['origin']);
+  });
+
+  it('matches every occurrence of every name', () => {
+    const text = 'count := count + total';
+
+    const ranges = ivarIdentifierRanges(text, ['count', 'total']);
+
+    expect(ranges.map(([s, e]) => text.slice(s, e))).toEqual(['count', 'count', 'total']);
+  });
+
+  it('returns nothing when there are no names', () => {
+    expect(ivarIdentifierRanges('origin', [])).toEqual([]);
+  });
+});
+
+describe('ivarAccessMark', () => {
+  it('is undefined without an ivar token', () => {
+    expect(
+      ivarAccessMark(parseMethodFilter('at'), { reads: ['count'], writes: [] }),
+    ).toBeUndefined();
+  });
+
+  it('marks r / w / rw by what the method does to the named ivar', () => {
+    const f = parseMethodFilter('accesses:count');
+    expect(ivarAccessMark(f, { reads: ['count'], writes: [] })).toBe('r');
+    expect(ivarAccessMark(f, { reads: [], writes: ['count'] })).toBe('w');
+    expect(ivarAccessMark(f, { reads: ['count'], writes: ['count'] })).toBe('rw');
+    expect(ivarAccessMark(f, { reads: ['other'], writes: [] })).toBeUndefined();
+  });
+});

--- a/client/src/__tests__/explorerMethodGrouping.test.ts
+++ b/client/src/__tests__/explorerMethodGrouping.test.ts
@@ -9,7 +9,12 @@ import {
   __resetConfig,
   __setConfig,
 } from '../__mocks__/vscode';
-import { ExplorerController, MethodCategoryItem, MethodItem } from '../gemstoneExplorer';
+import {
+  ExplorerController,
+  MethodCategoryItem,
+  MethodItem,
+  FilterChipItem,
+} from '../gemstoneExplorer';
 import { ALL_METHODS_CATEGORY } from '../systemBrowser';
 import type { SessionManager, ActiveSession } from '../sessionManager';
 import type { EnvCategoryLine } from '../browserQueries';
@@ -114,10 +119,12 @@ describe('Methods pane category grouping', () => {
     const ctl = makeController();
     setMethodFilter(ctl, 'at');
 
-    const children = ctl.methodProvider.getChildren();
+    // The filter chip leads the list; the rest are the pruned category rows.
+    const [chip, ...rest] = ctl.methodProvider.getChildren();
 
-    expect(children.every((c) => c instanceof MethodCategoryItem)).toBe(true);
-    const cats = (children as MethodCategoryItem[]).map((c) => c.category);
+    expect(chip).toBeInstanceOf(FilterChipItem);
+    expect(rest.every((c) => c instanceof MethodCategoryItem)).toBe(true);
+    const cats = (rest as MethodCategoryItem[]).map((c) => c.category);
     expect(cats).toContain('accessing');
     expect(cats).not.toContain('printing');
   });
@@ -149,10 +156,12 @@ describe('Methods pane category grouping', () => {
     const ctl = makeController();
     setMethodFilter(ctl, 'at');
 
-    const children = ctl.methodProvider.getChildren();
+    // Chip leads; the rest are the flat matching method rows.
+    const [chip, ...rest] = ctl.methodProvider.getChildren();
 
-    expect(children.every((c) => c instanceof MethodItem)).toBe(true);
-    expect((children as MethodItem[]).map((c) => c.info.selector)).toEqual(['at:']);
+    expect(chip).toBeInstanceOf(FilterChipItem);
+    expect(rest.every((c) => c instanceof MethodItem)).toBe(true);
+    expect((rest as MethodItem[]).map((c) => c.info.selector)).toEqual(['at:']);
   });
 
   it('keeps the title-toggle context key in step with the setting', () => {

--- a/client/src/__tests__/explorerMethodGrouping.test.ts
+++ b/client/src/__tests__/explorerMethodGrouping.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+vi.mock('../browserQueries', () => ({}));
+
+import {
+  commands,
+  TreeItemCollapsibleState,
+  __resetConfig,
+  __setConfig,
+} from '../__mocks__/vscode';
+import { ExplorerController, MethodCategoryItem, MethodItem } from '../gemstoneExplorer';
+import { ALL_METHODS_CATEGORY } from '../systemBrowser';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+import type { EnvCategoryLine } from '../browserQueries';
+
+const GROUP_KEY = 'explorer.groupMethodsByCategory';
+
+function makeController(): ExplorerController {
+  const session = { id: 1 } as ActiveSession;
+  const sessionManager = { getSelectedSession: () => session } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.dictName = 'UserGlobals';
+  ctl.state.className = 'Demo';
+  ctl.state.dictIndex = 1;
+  (ctl as unknown as { envLines: EnvCategoryLine[] }).envLines = [
+    { isMeta: false, envId: 0, category: 'accessing', selectors: ['at:', 'size'] },
+    { isMeta: false, envId: 0, category: 'printing', selectors: ['printString'] },
+  ];
+  return ctl;
+}
+
+const executeCommand = commands.executeCommand as ReturnType<typeof vi.fn>;
+
+// The pane filter is private state; set it directly rather than driving the
+// (async, input-box-backed) beginFilter flow.
+function setMethodFilter(ctl: ExplorerController, pattern: string): void {
+  (ctl as unknown as { filters: Map<string, string> }).filters.set(
+    'gemstoneExplorerMethods',
+    pattern,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetConfig();
+});
+
+describe('Methods pane category grouping', () => {
+  it('groups methods under their categories by default', () => {
+    const ctl = makeController();
+
+    const children = ctl.methodProvider.getChildren();
+
+    expect(children.every((c) => c instanceof MethodCategoryItem)).toBe(true);
+    expect((children as MethodCategoryItem[]).map((c) => c.category)).toEqual(
+      expect.arrayContaining([ALL_METHODS_CATEGORY, 'accessing', 'printing']),
+    );
+  });
+
+  it('lists methods flat, with no category rows, when grouping is off', () => {
+    __setConfig('gemstone', GROUP_KEY, false);
+    const ctl = makeController();
+
+    const children = ctl.methodProvider.getChildren();
+
+    expect(children.every((c) => c instanceof MethodItem)).toBe(true);
+    expect((children as MethodItem[]).map((c) => c.info.selector)).toEqual(
+      expect.arrayContaining(['at:', 'size', 'printString']),
+    );
+  });
+
+  it('parents a grouped method row under its category so reveal can locate it', () => {
+    const ctl = makeController();
+    const [accessing] = (ctl.methodProvider.getChildren() as MethodCategoryItem[]).filter(
+      (c) => c.category === 'accessing',
+    );
+    const [method] = ctl.methodProvider.getChildren(accessing) as MethodItem[];
+
+    const parent = ctl.methodProvider.getParent(method);
+
+    expect(parent).toBeInstanceOf(MethodCategoryItem);
+    expect((parent as MethodCategoryItem).category).toBe('accessing');
+  });
+
+  it('gives a flat method row no parent, so it hangs off the root', () => {
+    __setConfig('gemstone', GROUP_KEY, false);
+    const ctl = makeController();
+
+    const [flat] = ctl.methodProvider.getChildren() as MethodItem[];
+
+    expect(flat.displayCategory).toBeUndefined();
+    expect(ctl.methodProvider.getParent(flat)).toBeUndefined();
+  });
+
+  it('reads the group-by-category setting, defaulting to on', () => {
+    const ctl = makeController();
+
+    expect(ctl.groupMethodsByCategory()).toBe(true);
+
+    __setConfig('gemstone', GROUP_KEY, false);
+    expect(ctl.groupMethodsByCategory()).toBe(false);
+  });
+
+  it('persists the choice by writing the setting when toggled', async () => {
+    const ctl = makeController();
+
+    await ctl.setGroupMethodsByCategory(false);
+
+    expect(ctl.groupMethodsByCategory()).toBe(false);
+  });
+
+  it('keeps the category structure when filtering with categories visible', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'at');
+
+    const children = ctl.methodProvider.getChildren();
+
+    expect(children.every((c) => c instanceof MethodCategoryItem)).toBe(true);
+    const cats = (children as MethodCategoryItem[]).map((c) => c.category);
+    expect(cats).toContain('accessing');
+    expect(cats).not.toContain('printing');
+  });
+
+  it('shows only matching selectors under a filtered category', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'at');
+
+    const rows = ctl.methodProvider.getChildren(
+      new MethodCategoryItem(false, 'accessing', false),
+    ) as MethodItem[];
+
+    expect(rows.map((r) => r.info.selector)).toEqual(['at:']);
+  });
+
+  it('expands matching categories while filtering so the matches show', () => {
+    const ctl = makeController();
+    setMethodFilter(ctl, 'at');
+
+    const accessing = (ctl.methodProvider.getChildren() as MethodCategoryItem[]).find(
+      (c) => c.category === 'accessing',
+    );
+
+    expect(accessing?.collapsibleState).toBe(TreeItemCollapsibleState.Expanded);
+  });
+
+  it('still flattens to matching methods when filtering with categories off', () => {
+    __setConfig('gemstone', GROUP_KEY, false);
+    const ctl = makeController();
+    setMethodFilter(ctl, 'at');
+
+    const children = ctl.methodProvider.getChildren();
+
+    expect(children.every((c) => c instanceof MethodItem)).toBe(true);
+    expect((children as MethodItem[]).map((c) => c.info.selector)).toEqual(['at:']);
+  });
+
+  it('keeps the title-toggle context key in step with the setting', () => {
+    __setConfig('gemstone', GROUP_KEY, false);
+    const ctl = makeController();
+
+    ctl.syncMethodGrouping();
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'setContext',
+      'gemstone.explorer.methodsGrouped',
+      false,
+    );
+  });
+});

--- a/client/src/__tests__/explorerMethodSide.test.ts
+++ b/client/src/__tests__/explorerMethodSide.test.ts
@@ -34,6 +34,7 @@ const executeCommand = commands.executeCommand as ReturnType<typeof vi.fn>;
 function attachViews(ctl: ExplorerController, methodSelection: unknown[] = []) {
   const pane = () => ({
     description: '',
+    message: undefined as string | undefined,
     reveal: vi.fn(async () => {}),
     selection: [] as unknown[],
   });
@@ -138,13 +139,13 @@ describe('Methods pane header', () => {
     expect(method.description).toBe('class');
   });
 
-  it('shows the active filter label instead of the side while filtering', () => {
+  it('keeps naming the side in the header while filtering (the filter shows as a chip row)', () => {
     const ctl = makeController();
     const method = attachViews(ctl);
     setMethodFilter(ctl, 'at');
 
     ctl.setMethodSide(true);
 
-    expect(method.description).toBe('Filter: at');
+    expect(method.description).toBe('class');
   });
 });

--- a/client/src/__tests__/explorerMethodSide.test.ts
+++ b/client/src/__tests__/explorerMethodSide.test.ts
@@ -121,6 +121,68 @@ describe('Methods pane instance/class side toggle', () => {
   });
 });
 
+// Capture which side/category New Method files into without driving the real
+// compile: replace the private createNewMethod with a spy and read its args.
+function stubCreateNewMethod(ctl: ExplorerController): ReturnType<typeof vi.fn> {
+  const spy = vi.fn(async () => {});
+  (ctl as unknown as { createNewMethod: typeof spy }).createNewMethod = spy;
+  return spy;
+}
+
+describe('New Method follows the visible side after the title toggle flips', () => {
+  it('files on the default instance side before any selection or toggle', async () => {
+    const ctl = makeController();
+    const create = stubCreateNewMethod(ctl);
+
+    await ctl.newMethod();
+
+    expect(create).toHaveBeenCalledWith(false, 'as yet unclassified');
+  });
+
+  it('files on the class side when the toggle shows class, even after an instance method was selected', async () => {
+    const ctl = makeController();
+    const create = stubCreateNewMethod(ctl);
+    ctl.recordMethodContext(false, 'accessing');
+
+    ctl.setMethodSide(true);
+    await ctl.newMethod();
+
+    expect(create).toHaveBeenCalledWith(true, 'as yet unclassified');
+  });
+
+  it('files on the instance side when the toggle shows instance, even after a class method was selected', async () => {
+    const ctl = makeController();
+    const create = stubCreateNewMethod(ctl);
+    ctl.setMethodSide(true);
+    ctl.recordMethodContext(true, 'instance creation');
+
+    ctl.setMethodSide(false);
+    await ctl.newMethod();
+
+    expect(create).toHaveBeenCalledWith(false, 'as yet unclassified');
+  });
+
+  it('brings the recorded side in step with the visible side and drops the stale category', () => {
+    const ctl = makeController();
+    ctl.recordMethodContext(false, 'accessing');
+
+    ctl.setMethodSide(true);
+
+    expect(ctl.state.selectedIsMeta).toBe(true);
+    expect(ctl.state.selectedMethodCategory).toBeUndefined();
+  });
+
+  it('still reuses the selected category when the visible side never changed', async () => {
+    const ctl = makeController();
+    const create = stubCreateNewMethod(ctl);
+    ctl.recordMethodContext(false, 'accessing');
+
+    await ctl.newMethod();
+
+    expect(create).toHaveBeenCalledWith(false, 'accessing');
+  });
+});
+
 describe('Methods pane header', () => {
   it('names the instance side and does not append the selected selector', () => {
     const ctl = makeController();

--- a/client/src/__tests__/explorerMethodSide.test.ts
+++ b/client/src/__tests__/explorerMethodSide.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+vi.mock('../browserQueries', () => ({}));
+
+import { commands, __resetConfig, __setConfig } from '../__mocks__/vscode';
+import { ExplorerController, MethodCategoryItem, MethodItem } from '../gemstoneExplorer';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+import type { EnvCategoryLine } from '../browserQueries';
+
+const GROUP_KEY = 'explorer.groupMethodsByCategory';
+
+// A class with one instance-side and one class-side method, so switching sides
+// changes which rows the pane produces.
+function makeController(): ExplorerController {
+  const session = { id: 1 } as ActiveSession;
+  const sessionManager = { getSelectedSession: () => session } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.dictName = 'UserGlobals';
+  ctl.state.className = 'Demo';
+  ctl.state.dictIndex = 1;
+  (ctl as unknown as { envLines: EnvCategoryLine[] }).envLines = [
+    { isMeta: false, envId: 0, category: 'accessing', selectors: ['at:'] },
+    { isMeta: true, envId: 0, category: 'instance creation', selectors: ['new'] },
+  ];
+  return ctl;
+}
+
+const executeCommand = commands.executeCommand as ReturnType<typeof vi.fn>;
+
+// Attach a minimal five-pane views mock; setViews() runs syncTitles(), which is
+// what writes each pane's header description. `methodSelection` seeds the Methods
+// view's selection so we can prove the header ignores it.
+function attachViews(ctl: ExplorerController, methodSelection: unknown[] = []) {
+  const pane = () => ({
+    description: '',
+    reveal: vi.fn(async () => {}),
+    selection: [] as unknown[],
+  });
+  const method = { ...pane(), selection: methodSelection };
+  ctl.setViews({
+    dict: pane(),
+    category: pane(),
+    klass: pane(),
+    hierarchy: pane(),
+    method,
+  } as never);
+  return method;
+}
+
+function methodItem(selector: string): MethodItem {
+  return new MethodItem(
+    false,
+    { selector, category: 'accessing', overrideBits: 0, sessionBit: 0 },
+    'accessing',
+  );
+}
+
+function setMethodFilter(ctl: ExplorerController, pattern: string): void {
+  (ctl as unknown as { filters: Map<string, string> }).filters.set(
+    'gemstoneExplorerMethods',
+    pattern,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetConfig();
+});
+
+describe('Methods pane instance/class side toggle', () => {
+  it('shows the instance side by default', () => {
+    const ctl = makeController();
+
+    expect(ctl.showClassMethods).toBe(false);
+    const cats = ctl.methodProvider.getChildren() as MethodCategoryItem[];
+    expect(cats.every((c) => c.isMeta === false)).toBe(true);
+    expect(cats.map((c) => c.category)).toContain('accessing');
+  });
+
+  it('switches the whole pane to the class side when toggled', () => {
+    const ctl = makeController();
+
+    ctl.setMethodSide(true);
+
+    expect(ctl.showClassMethods).toBe(true);
+    const cats = ctl.methodProvider.getChildren() as MethodCategoryItem[];
+    expect(cats.every((c) => c.isMeta === true)).toBe(true);
+    expect(cats.map((c) => c.category)).toContain('instance creation');
+  });
+
+  it('lists only the active side when flattened', () => {
+    __setConfig('gemstone', GROUP_KEY, false);
+    const ctl = makeController();
+
+    ctl.setMethodSide(true);
+
+    const rows = ctl.methodProvider.getChildren() as MethodItem[];
+    expect(rows.map((r) => r.info.selector)).toEqual(['new']);
+  });
+
+  it('renders the instance/class level as a title toggle, so categories are roots', () => {
+    const ctl = makeController();
+
+    const [cat] = ctl.methodProvider.getChildren() as MethodCategoryItem[];
+
+    expect(ctl.methodProvider.getParent(cat)).toBeUndefined();
+  });
+
+  it('mirrors the active side into the context key that picks the visible toggle', () => {
+    const ctl = makeController();
+
+    ctl.setMethodSide(true);
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'setContext',
+      'gemstone.explorer.methodSideIsClass',
+      true,
+    );
+  });
+});
+
+describe('Methods pane header', () => {
+  it('names the instance side and does not append the selected selector', () => {
+    const ctl = makeController();
+
+    const method = attachViews(ctl, [methodItem('at:')]);
+
+    expect(method.description).toBe('instance');
+  });
+
+  it('names the class side after toggling', () => {
+    const ctl = makeController();
+    const method = attachViews(ctl);
+
+    ctl.setMethodSide(true);
+
+    expect(method.description).toBe('class');
+  });
+
+  it('shows the active filter label instead of the side while filtering', () => {
+    const ctl = makeController();
+    const method = attachViews(ctl);
+    setMethodFilter(ctl, 'at');
+
+    ctl.setMethodSide(true);
+
+    expect(method.description).toBe('Filter: at');
+  });
+});

--- a/client/src/__tests__/explorerOpenMethod.test.ts
+++ b/client/src/__tests__/explorerOpenMethod.test.ts
@@ -90,7 +90,7 @@ describe('ExplorerController.openMethod', () => {
   it('opens the method URI built from the node and the current dictionary/class', async () => {
     const ctl = makeController();
 
-    await ctl.openMethod(methodItem({ selector: 'at:', category: 'accessing' }), false);
+    await ctl.openMethod(methodItem({ selector: 'at:', category: 'accessing' }), 'preview');
 
     const opened = openTextDocument.mock.calls[0][0] as vscode.Uri;
     expect(String(opened)).toContain('gemstone://1/UserGlobals/Array/instance/accessing/at');
@@ -100,35 +100,90 @@ describe('ExplorerController.openMethod', () => {
   it('escapes the class side into the URI for a class-side method', async () => {
     const ctl = makeController();
 
-    await ctl.openMethod(methodItem({ selector: 'new' }, true), false);
+    await ctl.openMethod(methodItem({ selector: 'new' }, true), 'preview');
 
     expect(String(openTextDocument.mock.calls[0][0])).toContain(
       'gemstone://1/UserGlobals/Array/class/accessing/new',
     );
   });
 
-  it('single-click opens the method as the transient tab, keeping focus in the tree', async () => {
+  it('single-click opens the method as a preview tab, keeping focus in the tree', async () => {
     const ctl = makeController();
 
-    await ctl.openMethod(methodItem(), false);
+    await ctl.openMethod(methodItem(), 'preview');
+
+    expect(showTextDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ preview: true, preserveFocus: true }),
+    );
+  });
+
+  it('double-click promotes the method to a permanent tab, keeping focus in the tree', async () => {
+    const ctl = makeController();
+
+    await ctl.openMethod(methodItem(), 'keep');
 
     expect(showTextDocument).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ preview: false, preserveFocus: true }),
     );
-    expect(ctl.placement.reusableTab).toBe(String(openTextDocument.mock.calls[0][0]));
+    expect(executeCommand).not.toHaveBeenCalledWith('workbench.action.pinEditor');
   });
 
   it('pin opens the method as a pinned tab', async () => {
     const ctl = makeController();
 
-    await ctl.openMethod(methodItem(), true);
+    await ctl.openMethod(methodItem(), 'pin');
 
     expect(showTextDocument).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ preview: false, preserveFocus: false }),
     );
     expect(executeCommand).toHaveBeenCalledWith('workbench.action.pinEditor');
+  });
+});
+
+describe('MethodItem click wiring', () => {
+  it('routes each click to the double-click hook, carrying the node', () => {
+    const node = methodItem();
+
+    expect(node.command).toMatchObject({
+      command: 'gemstone.explorer.methodClicked',
+      arguments: [node],
+    });
+  });
+});
+
+describe('ExplorerController.handleMethodClick', () => {
+  it('leaves the first click to the single-click preview open', () => {
+    const ctl = makeController();
+    const open = vi.spyOn(ctl, 'openMethod').mockResolvedValue();
+
+    ctl.handleMethodClick(methodItem());
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('promotes the preview to a permanent tab on a double-click of the same method', () => {
+    const ctl = makeController();
+    const open = vi.spyOn(ctl, 'openMethod').mockResolvedValue();
+    const node = methodItem();
+
+    ctl.handleMethodClick(node);
+    ctl.handleMethodClick(node);
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(node, 'keep');
+  });
+
+  it('does not promote when two clicks land on different methods', () => {
+    const ctl = makeController();
+    const open = vi.spyOn(ctl, 'openMethod').mockResolvedValue();
+
+    ctl.handleMethodClick(methodItem({ selector: 'at:' }));
+    ctl.handleMethodClick(methodItem({ selector: 'size' }));
+
+    expect(open).not.toHaveBeenCalled();
   });
 });
 
@@ -154,7 +209,7 @@ describe('ExplorerController.syncToEditor', () => {
     const ctl = makeController();
     const method = withViews(ctl);
     stubResolvableSelector(ctl);
-    await ctl.openMethod(methodItem(), false);
+    await ctl.openMethod(methodItem(), 'preview');
     const openedUri = openTextDocument.mock.calls[0][0] as vscode.Uri;
     method.reveal.mockClear();
 
@@ -184,7 +239,7 @@ describe('ExplorerController.syncToEditor', () => {
   it('still follows a later focus event for a method that was already the active editor', async () => {
     // Discover the exact URI a click on this node builds, via a throwaway controller.
     const probe = makeController();
-    await probe.openMethod(methodItem(), false);
+    await probe.openMethod(methodItem(), 'preview');
     const builtUri = openTextDocument.mock.calls[0][0] as vscode.Uri;
     vi.clearAllMocks();
 
@@ -195,7 +250,7 @@ describe('ExplorerController.syncToEditor', () => {
     const method = withViews(ctl);
     stubResolvableSelector(ctl);
     window.activeTextEditor = { document: { uri: builtUri } };
-    await ctl.openMethod(methodItem(), false);
+    await ctl.openMethod(methodItem(), 'preview');
     method.reveal.mockClear();
 
     await ctl.syncToEditor(builtUri);

--- a/client/src/__tests__/explorerOpenMethod.test.ts
+++ b/client/src/__tests__/explorerOpenMethod.test.ts
@@ -7,7 +7,7 @@ vi.mock('../browserQueries', () => ({}));
 
 import type * as vscode from 'vscode';
 import { ExplorerController, MethodItem } from '../gemstoneExplorer';
-import { Uri, window, commands, workspace } from '../__mocks__/vscode';
+import { Uri, window, commands, workspace, languages } from '../__mocks__/vscode';
 import type { SessionManager, ActiveSession } from '../sessionManager';
 
 // Structural mirror of the (unexported) SelectorInfo the tree items carry.
@@ -115,6 +115,19 @@ describe('ExplorerController.openMethod', () => {
     expect(showTextDocument).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ preview: true, preserveFocus: true }),
+    );
+  });
+
+  it('tags the doc as gemstone-smalltalk before showing it (so CodeLens does not pop in)', async () => {
+    const ctl = makeController();
+    const setLang = languages.setTextDocumentLanguage as ReturnType<typeof vi.fn>;
+
+    await ctl.openMethod(methodItem(), 'preview');
+
+    expect(setLang).toHaveBeenCalledWith(expect.anything(), 'gemstone-smalltalk');
+    // Language is set before the doc is shown in the (reused) preview editor.
+    expect(setLang.mock.invocationCallOrder[0]).toBeLessThan(
+      showTextDocument.mock.invocationCallOrder[0],
     );
   });
 

--- a/client/src/__tests__/explorerOpenToSide.test.ts
+++ b/client/src/__tests__/explorerOpenToSide.test.ts
@@ -17,7 +17,13 @@ function methodDoc(uriString = SOURCE): vscode.TextDocument {
 function setGroups(
   groups: {
     viewColumn?: number;
-    tabs: { uri: string; isDirty?: boolean; isPinned?: boolean; active?: boolean }[];
+    tabs: {
+      uri: string;
+      isDirty?: boolean;
+      isPinned?: boolean;
+      isPreview?: boolean;
+      active?: boolean;
+    }[];
   }[],
 ): void {
   window.tabGroups.all = groups.map((g) => {
@@ -25,6 +31,7 @@ function setGroups(
       input: new TabInputText(Uri.parse(t.uri)),
       isDirty: t.isDirty,
       isPinned: t.isPinned,
+      isPreview: t.isPreview,
     }));
     const activeIndex = g.tabs.findIndex((t) => t.active);
     return {
@@ -49,105 +56,58 @@ describe('openGemstoneDocument', () => {
   });
 
   describe('single-click navigation', () => {
-    it('opens one transient tab in the active group, keeping focus in the tree', async () => {
+    it('opens a preview tab in the active group, keeping focus in the tree', async () => {
       const placement = new SourceEditorPlacement();
 
-      await openGemstoneDocument(methodDoc(), false, placement);
+      await openGemstoneDocument(methodDoc(), 'preview', placement);
 
       expect(showTextDocument).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           viewColumn: ViewColumn.Active,
-          preview: false,
+          preview: true,
           preserveFocus: true,
         }),
       );
-      expect(placement.reusableTab).toBe(SOURCE);
     });
 
-    it('opens the transient tab in the group that already holds our editors', async () => {
+    it('opens the preview tab in the group that already holds our editors', async () => {
       const placement = new SourceEditorPlacement();
       placement.remember(Uri.parse(NAV));
-      placement.reusableTab = NAV;
       setGroups([{ viewColumn: 2, tabs: [{ uri: NAV, active: true }] }]);
 
-      await openGemstoneDocument(methodDoc(), false, placement);
+      await openGemstoneDocument(methodDoc(), 'preview', placement);
+
+      expect(showTextDocument).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ viewColumn: 2, preview: true, preserveFocus: true }),
+      );
+    });
+
+    it('leaves the transient-tab bookkeeping to VS Code — never closes a tab itself', async () => {
+      const placement = new SourceEditorPlacement();
+      placement.remember(Uri.parse(NAV));
+      setGroups([{ viewColumn: 2, tabs: [{ uri: NAV, active: true }] }]);
+
+      await openGemstoneDocument(methodDoc(), 'preview', placement);
+
+      expect(closeTab).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('double-click', () => {
+    it('opens a permanent (non-preview) tab, keeping focus in the tree', async () => {
+      const placement = new SourceEditorPlacement();
+      placement.remember(Uri.parse(NAV));
+      setGroups([{ viewColumn: 2, tabs: [{ uri: NAV, active: true }] }]);
+
+      await openGemstoneDocument(methodDoc(), 'keep', placement);
 
       expect(showTextDocument).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ viewColumn: 2, preview: false, preserveFocus: true }),
       );
-    });
-
-    it('reveals a method already open in our group instead of duplicating it', async () => {
-      const placement = new SourceEditorPlacement();
-      placement.remember(Uri.parse(NAV));
-      placement.remember(Uri.parse(SOURCE));
-      placement.reusableTab = NAV;
-      setGroups([
-        {
-          viewColumn: 2,
-          tabs: [
-            { uri: NAV, active: true },
-            { uri: SOURCE, isPinned: true },
-          ],
-        },
-      ]);
-
-      await openGemstoneDocument(methodDoc(), false, placement);
-
-      expect(showTextDocument).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ viewColumn: 2, preview: false, preserveFocus: true }),
-      );
-      // The transient wasn't replaced and nothing was closed.
-      expect(placement.reusableTab).toBe(NAV);
-      expect(closeTab).not.toHaveBeenCalled();
-    });
-
-    it('closes the previous transient so browsing does not pile up tabs', async () => {
-      const placement = new SourceEditorPlacement();
-      placement.remember(Uri.parse(NAV));
-      placement.reusableTab = NAV;
-      setGroups([{ viewColumn: 2, tabs: [{ uri: NAV, active: true }] }]);
-
-      await openGemstoneDocument(methodDoc(), false, placement);
-
-      expect(closeTab).toHaveBeenCalledTimes(1);
-      expect(placement.reusableTab).toBe(SOURCE);
-    });
-
-    it('keeps the previous transient when it has unsaved edits', async () => {
-      const placement = new SourceEditorPlacement();
-      placement.remember(Uri.parse(NAV));
-      placement.reusableTab = NAV;
-      setGroups([{ viewColumn: 2, tabs: [{ uri: NAV, isDirty: true, active: true }] }]);
-
-      await openGemstoneDocument(methodDoc(), false, placement);
-
-      expect(closeTab).not.toHaveBeenCalled();
-    });
-
-    it('closes the outgoing transient in our column, never a System Browser copy of the same URI', async () => {
-      const placement = new SourceEditorPlacement();
-      placement.remember(Uri.parse(NAV));
-      placement.reusableTab = NAV;
-      placement.reusableColumn = 2;
-      // The same gemstone:// method is open in the System Browser's group (column 1)
-      // and as our transient (column 2). The foreign group is listed first, so a
-      // whole-window scan would reach and close it first.
-      setGroups([
-        { viewColumn: 1, tabs: [{ uri: NAV }] },
-        { viewColumn: 2, tabs: [{ uri: NAV, active: true }] },
-      ]);
-      const foreignTab = window.tabGroups.all[0].tabs[0];
-      const ourTab = window.tabGroups.all[1].tabs[0];
-
-      await openGemstoneDocument(methodDoc(), false, placement);
-
-      expect(closeTab).toHaveBeenCalledTimes(1);
-      expect(closeTab.mock.calls[0][0]).toBe(ourTab);
-      expect(closeTab.mock.calls[0][0]).not.toBe(foreignTab);
+      expect(executeCommand).not.toHaveBeenCalledWith('workbench.action.pinEditor');
     });
   });
 
@@ -155,10 +115,9 @@ describe('openGemstoneDocument', () => {
     it('pins the method as a tab in our group', async () => {
       const placement = new SourceEditorPlacement();
       placement.remember(Uri.parse(NAV));
-      placement.reusableTab = NAV;
       setGroups([{ viewColumn: 2, tabs: [{ uri: NAV, active: true }] }]);
 
-      await openGemstoneDocument(methodDoc(), true, placement);
+      await openGemstoneDocument(methodDoc(), 'pin', placement);
 
       expect(showTextDocument).toHaveBeenCalledWith(
         expect.anything(),
@@ -171,12 +130,11 @@ describe('openGemstoneDocument', () => {
       const placement = new SourceEditorPlacement();
       placement.remember(Uri.parse(NAV));
       placement.remember(Uri.parse(SIDE));
-      placement.reusableTab = NAV;
       setGroups([
         { viewColumn: 2, tabs: [{ uri: NAV }, { uri: SIDE, isPinned: true, active: true }] },
       ]);
 
-      await openGemstoneDocument(methodDoc(), true, placement);
+      await openGemstoneDocument(methodDoc(), 'pin', placement);
 
       expect(showTextDocument).toHaveBeenCalledWith(
         expect.anything(),
@@ -191,17 +149,26 @@ describe('openGemstoneDocument', () => {
       expect(restore?.[1]).toMatchObject({ viewColumn: 2 });
     });
 
-    it('promotes the transient method to a pinned tab and frees the transient slot', async () => {
+    it('restores the browsed method as a preview tab, not promoting it, when pinning another', async () => {
+      const placement = new SourceEditorPlacement();
+      placement.remember(Uri.parse(NAV));
+      placement.remember(Uri.parse(SIDE));
+      setGroups([{ viewColumn: 2, tabs: [{ uri: SIDE, isPreview: true, active: true }] }]);
+
+      await openGemstoneDocument(methodDoc(), 'pin', placement);
+
+      const restore = showTextDocument.mock.calls.find((c) => String(c[0]) === SIDE);
+      expect(restore?.[1]).toMatchObject({ viewColumn: 2, preview: true, preserveFocus: true });
+    });
+
+    it('does not restore the view when the pinned method was the one already showing', async () => {
       const placement = new SourceEditorPlacement();
       placement.remember(Uri.parse(SOURCE));
-      placement.reusableTab = SOURCE;
       setGroups([{ viewColumn: 2, tabs: [{ uri: SOURCE, active: true }] }]);
 
-      await openGemstoneDocument(methodDoc(), true, placement);
+      await openGemstoneDocument(methodDoc(), 'pin', placement);
 
       expect(executeCommand).toHaveBeenCalledWith('workbench.action.pinEditor');
-      expect(placement.reusableTab).toBeUndefined();
-      // The pinned method was already the visible one, so nothing is restored.
       expect(showTextDocument.mock.calls.filter((c) => c[1]?.preserveFocus === true)).toHaveLength(
         0,
       );
@@ -210,7 +177,7 @@ describe('openGemstoneDocument', () => {
     it('opens the first pin in the active group when nothing is open yet', async () => {
       const placement = new SourceEditorPlacement();
 
-      await openGemstoneDocument(methodDoc(), true, placement);
+      await openGemstoneDocument(methodDoc(), 'pin', placement);
 
       expect(showTextDocument).toHaveBeenCalledWith(
         expect.anything(),

--- a/client/src/__tests__/explorerPaneFilterChip.test.ts
+++ b/client/src/__tests__/explorerPaneFilterChip.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+vi.mock('../browserQueries', () => ({
+  getDictionaryNames: vi.fn(() => ['UserGlobals', 'Globals']),
+}));
+
+import { ExplorerController, FilterChipItem } from '../gemstoneExplorer';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+import type { ClassCategoryEntry } from '../browserQueries';
+
+const VIEW_DICTS = 'gemstoneExplorerDicts';
+const VIEW_CATEGORIES = 'gemstoneExplorerCategories';
+const VIEW_CLASSES = 'gemstoneExplorerClasses';
+
+function makeController(): ExplorerController {
+  const session = { id: 1 } as ActiveSession;
+  const sessionManager = { getSelectedSession: () => session } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.dictName = 'Globals';
+  ctl.state.dictIndex = 2;
+  (ctl as unknown as { classCategoryEntries: ClassCategoryEntry[] }).classCategoryEntries = [
+    { category: 'Collections', className: 'Array' },
+    { category: 'Kernel', className: 'Object' },
+  ];
+  return ctl;
+}
+
+function setFilter(ctl: ExplorerController, viewId: string, pattern: string): void {
+  (ctl as unknown as { filters: Map<string, string> }).filters.set(viewId, pattern);
+}
+
+const isChip = (r: unknown): r is FilterChipItem => r instanceof FilterChipItem;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// The chip prepend is shared by all four filterable panes; the Methods pane is
+// covered in explorerIvarFilter — these pin the Dictionaries / Class Categories /
+// Classes rollout so each pane leads with the chip while filtering, hides it
+// otherwise, and never treats it as a navigable parent.
+describe.each([
+  { name: 'Dictionaries', view: VIEW_DICTS, provider: 'dictProvider' as const },
+  { name: 'Class Categories', view: VIEW_CATEGORIES, provider: 'categoryProvider' as const },
+  { name: 'Classes', view: VIEW_CLASSES, provider: 'classProvider' as const },
+])('$name pane filter chip', ({ view, provider }) => {
+  it('leads the root with a filter chip carrying the pane view id while filtering', () => {
+    const ctl = makeController();
+    setFilter(ctl, view, 'a');
+
+    const rows = ctl[provider].getChildren();
+
+    expect(isChip(rows[0])).toBe(true);
+    expect((rows[0] as FilterChipItem).viewId).toBe(view);
+  });
+
+  it('shows no chip when the pane has no filter', () => {
+    const ctl = makeController();
+
+    expect(ctl[provider].getChildren().some(isChip)).toBe(false);
+  });
+
+  it('treats the chip as a root, so reveal never targets it', () => {
+    const ctl = makeController();
+
+    expect(ctl[provider].getParent(new FilterChipItem(view, 'a'))).toBeUndefined();
+  });
+});

--- a/client/src/__tests__/explorerViewRegistration.test.ts
+++ b/client/src/__tests__/explorerViewRegistration.test.ts
@@ -69,3 +69,27 @@ describe('GemStone Explorer Class Hierarchy pane', () => {
     expect(src).toContain(`createTreeView('${HIERARCHY}'`);
   });
 });
+
+// A command referenced from a menu (title bar, row context, palette) but never
+// declared in contributes.commands shows up only at runtime as "command not
+// found". Guard our own gemstone.* commands so a new menu entry can't drift out
+// of sync with its declaration.
+describe('command manifest consistency', () => {
+  const declared = new Set<string>(
+    (pkg.contributes.commands as Array<{ command: string }>).map((c) => c.command),
+  );
+  const menus = pkg.contributes.menus as Record<string, Array<{ command?: string }>>;
+  const menuCommands = new Set<string>();
+  for (const group of Object.values(menus)) {
+    for (const item of group) if (item.command) menuCommands.add(item.command);
+  }
+
+  it('declares every gemstone command that a menu references', () => {
+    const missing = [...menuCommands]
+      .filter((c) => c.startsWith('gemstone'))
+      .filter((c) => !declared.has(c))
+      .sort();
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/client/src/__tests__/explorerViewRegistration.test.ts
+++ b/client/src/__tests__/explorerViewRegistration.test.ts
@@ -48,3 +48,24 @@ describe('GemStone Explorer views are registrable when created', () => {
     },
   );
 });
+
+// The Class Hierarchy pane starts collapsed so it doesn't crowd out the other
+// panes. VS Code only applies a view's declared `visibility` when it has no
+// stored layout for that view id, so the pane id must also stay in sync with
+// the id passed to createTreeView — a mismatch throws "No view is registered".
+const HIERARCHY = 'gemstoneExplorerClassHierarchy';
+
+describe('GemStone Explorer Class Hierarchy pane', () => {
+  it('starts collapsed to leave room for the other panes', () => {
+    const hierarchy = explorerViews.find((v) => v.id === HIERARCHY) as
+      { visibility?: string } | undefined;
+
+    expect(hierarchy?.visibility).toBe('collapsed');
+  });
+
+  it('registers the pane under the id the source creates it with', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, '..', 'gemstoneExplorer.ts'), 'utf-8');
+
+    expect(src).toContain(`createTreeView('${HIERARCHY}'`);
+  });
+});

--- a/client/src/__tests__/explorerViewRegistration.test.ts
+++ b/client/src/__tests__/explorerViewRegistration.test.ts
@@ -93,3 +93,48 @@ describe('command manifest consistency', () => {
     expect(missing).toEqual([]);
   });
 });
+
+// The mirror of the command check above, for view ids. A menu `when` that gates
+// on a `view ==` id no view declares is silently, permanently false — the entry
+// just never appears, with no runtime error. That is exactly how the Insert /
+// Extract Superclass items vanished when the Hierarchy pane was renamed but two
+// of its menu clauses weren't. Guard every view reference so a renamed or
+// mistyped id fails a test instead of quietly dropping a menu item.
+describe('menu view-id consistency', () => {
+  const declaredViews = new Set<string>();
+  for (const views of Object.values(
+    pkg.contributes.views as Record<string, Array<{ id: string }>>,
+  )) {
+    for (const v of views) declaredViews.add(v.id);
+  }
+
+  const whens: string[] = [];
+  for (const group of Object.values(
+    pkg.contributes.menus as Record<string, Array<{ when?: string }>>,
+  )) {
+    for (const item of group) if (item.when) whens.push(item.when);
+  }
+
+  it('references only declared view ids in exact `view ==` menu clauses', () => {
+    const referenced = new Set<string>();
+    for (const when of whens) {
+      for (const m of when.matchAll(/view\s*==\s*([A-Za-z0-9_.]+)/g)) referenced.add(m[1]);
+    }
+
+    const missing = [...referenced].filter((id) => !declaredViews.has(id)).sort();
+
+    expect(missing).toEqual([]);
+  });
+
+  it('uses only `view =~` menu patterns that match at least one declared view', () => {
+    const dead: string[] = [];
+    for (const when of whens) {
+      for (const m of when.matchAll(/view\s*=~\s*\/([^/]+)\//g)) {
+        const re = new RegExp(m[1]);
+        if (![...declaredViews].some((id) => re.test(id))) dead.push(m[1]);
+      }
+    }
+
+    expect(dead).toEqual([]);
+  });
+});

--- a/client/src/__tests__/gemstoneCodeLensProvider.test.ts
+++ b/client/src/__tests__/gemstoneCodeLensProvider.test.ts
@@ -96,6 +96,20 @@ name: aString
       expect(lenses).toHaveLength(2); // 1 method × 2 lenses
     });
 
+    it('returns no lenses for an unsaved new-method template', () => {
+      const doc = {
+        uri: Uri.parse('gemstone://1/UserGlobals/MyClass/instance/accessing/new-method'),
+        getText: () => 'messageSelector\n  ^ self',
+        languageId: 'gemstone-smalltalk',
+        lineAt: vi.fn(),
+        lineCount: 2,
+      } as unknown as TextDocument;
+
+      const lenses = provider.provideCodeLenses(doc);
+
+      expect(lenses).toHaveLength(0);
+    });
+
     it('returns no lenses for empty files', () => {
       const doc = createMockDocument('');
       const lenses = provider.provideCodeLenses(doc);

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -39,6 +39,7 @@ import {
   installStaleGemstoneTabReaper,
   escapeSelectorSlashes,
   parseUri,
+  parseMethodUri,
   listOpenGemstoneTabs,
 } from '../gemstoneFileSystemProvider';
 import { SessionManager } from '../sessionManager';
@@ -998,6 +999,63 @@ describe('GemStoneFileSystemProvider', () => {
         'Globals',
       );
     });
+  });
+});
+
+describe('parseMethodUri', () => {
+  it('returns the method coordinates for a saved method source', () => {
+    const uri = Uri.parse('gemstone://1/Globals/Array/class/creation/new%3A?env=2');
+
+    expect(parseMethodUri(uri)).toEqual({
+      sessionId: 1,
+      dictName: 'Globals',
+      className: 'Array',
+      isMeta: true,
+      selector: 'new:',
+      environmentId: 2,
+      dictIndex: undefined,
+      diffView: false,
+    });
+  });
+
+  it('recovers a selector that contains slashes rather than truncating at the first segment', () => {
+    const uri = buildMethodUri({
+      kind: 'method',
+      sessionId: 1,
+      dictName: 'Globals',
+      className: 'Fraction',
+      isMeta: false,
+      category: 'arithmetic',
+      selector: '/',
+      environmentId: 0,
+    });
+
+    expect(parseMethodUri(uri)?.selector).toBe('/');
+  });
+
+  it('strips the base/session-override diff label and marks the view read-only', () => {
+    const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/size%20%28base%29');
+
+    const ref = parseMethodUri(uri);
+
+    expect(ref?.selector).toBe('size');
+    expect(ref?.diffView).toBe(true);
+  });
+
+  it('rejects a new-method template URI', () => {
+    const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
+
+    expect(parseMethodUri(uri)).toBeNull();
+  });
+
+  it('rejects a class-definition URI', () => {
+    const uri = Uri.parse('gemstone://1/Globals/Array/definition');
+
+    expect(parseMethodUri(uri)).toBeNull();
+  });
+
+  it('rejects a non-gemstone URI', () => {
+    expect(parseMethodUri(Uri.parse('file:///tmp/x.st'))).toBeNull();
   });
 });
 

--- a/client/src/breakpointManager.ts
+++ b/client/src/breakpointManager.ts
@@ -1,13 +1,7 @@
 import * as vscode from 'vscode';
 import { SessionManager, ActiveSession } from './sessionManager';
+import { parseMethodUri } from './gemstoneFileSystemProvider';
 import * as queries from './browserQueries';
-
-interface MethodRef {
-  className: string;
-  isMeta: boolean;
-  selector: string;
-  environmentId: number;
-}
 
 export interface VerifiedBreakpoint {
   stepPoint: number;
@@ -41,8 +35,9 @@ export class BreakpointManager {
     uri: vscode.Uri,
     lines: number[],
   ): VerifiedBreakpoint[] {
-    const method = this.parseMethodUri(uri);
-    if (!method) return lines.map(() => ({ stepPoint: 0, actualLine: 0, verified: false }));
+    const method = parseMethodUri(uri);
+    if (!method || method.diffView)
+      return lines.map(() => ({ stepPoint: 0, actualLine: 0, verified: false }));
 
     try {
       // Clear existing breakpoints on this method
@@ -183,25 +178,6 @@ export class BreakpointManager {
       const lines = allBps.map((bp) => bp.location.range.start.line + 1); // 0-based → 1-based
       this.setBreakpointsForSource(session, uri, lines);
     }
-  }
-
-  private parseMethodUri(uri: vscode.Uri): MethodRef | null {
-    if (uri.scheme !== 'gemstone') return null;
-
-    const parts = uri.path.split('/').map(decodeURIComponent);
-    // parts[0] is '' (leading /)
-    // parts: ['', dictName, className, side, category, selector]
-    if (parts.length < 6) return null;
-
-    const envMatch = uri.query?.match(/env=(\d+)/);
-    const environmentId = envMatch ? parseInt(envMatch[1], 10) : 0;
-
-    return {
-      className: parts[2],
-      isMeta: parts[3] === 'class',
-      selector: parts[5],
-      environmentId,
-    };
   }
 }
 

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -20,6 +20,7 @@ import { getDictionaryEntries as sharedGetDictionaryEntries } from './queries/ge
 import { getGlobalsForDictionary as sharedGetGlobalsForDictionary } from './queries/getGlobalsForDictionary';
 import { getMethodCategories as sharedGetMethodCategories } from './queries/getMethodCategories';
 import { getClassEnvironments as sharedGetClassEnvironments } from './queries/getClassEnvironments';
+import { getMethodInstVarAccess as sharedGetMethodInstVarAccess } from './queries/getMethodInstVarAccess';
 import { getClassDefinition as sharedGetClassDefinition } from './queries/getClassDefinition';
 import { getClassComment as sharedGetClassComment } from './queries/getClassComment';
 import { canClassBeWritten as sharedCanClassBeWritten } from './queries/canClassBeWritten';
@@ -209,6 +210,7 @@ export type { GlobalEntry } from './queries/getGlobalsForDictionary';
 export type { ClassNameEntry } from './queries/getAllClassNames';
 export type { ClassCategoryEntry } from './queries/getClassesWithCategory';
 export type { EnvCategoryLine } from './queries/getClassEnvironments';
+export type { MethodInstVarAccess } from './queries/getMethodInstVarAccess';
 export type { ClassHierarchyEntry } from './queries/getClassHierarchy';
 export type { DescendantClass } from './refactoring/queries/getClassDescendantNames';
 export type { MoveArgs } from './refactoring/queries/previewInstVarStructure';
@@ -559,6 +561,14 @@ export function getClassEnvironments(
     className,
     maxEnv,
   );
+}
+
+export function getMethodInstVarAccess(
+  session: ActiveSession,
+  dictIndex: number,
+  className: string,
+) {
+  return sharedGetMethodInstVarAccess(defaultQueryExecutorUsing(session), dictIndex, className);
 }
 
 export function getMethodSource(

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -577,8 +577,14 @@ export function getMethodInstVarAccess(
   session: ActiveSession,
   dictIndex: number,
   className: string,
+  maxEnv: number,
 ) {
-  return sharedGetMethodInstVarAccess(defaultQueryExecutorUsing(session), dictIndex, className);
+  return sharedGetMethodInstVarAccess(
+    defaultQueryExecutorUsing(session),
+    dictIndex,
+    className,
+    maxEnv,
+  );
 }
 
 export function getMethodSource(

--- a/client/src/explorerMethodFilter.ts
+++ b/client/src/explorerMethodFilter.ts
@@ -1,0 +1,84 @@
+import { filterMatches } from './explorerFilter';
+
+// A parsed Methods-pane filter. The plain (non-token) part is a prefix/`*`
+// pattern on the selector; `reads:`/`writes:`/`accesses:` tokens constrain by
+// which instance variables a method reads or writes.
+export interface MethodFilter {
+  selector?: string;
+  ivar: IvarConstraint[];
+}
+
+export interface IvarConstraint {
+  kind: 'reads' | 'writes' | 'accesses';
+  pattern: string;
+}
+
+const TOKEN = /^(reads|writes|accesses):(.*)$/i;
+
+// Parse a raw filter string. Whitespace separates terms: a `reads:x` / `writes:x`
+// / `accesses:x` term becomes an ivar constraint (x is a prefix/`*` pattern on
+// the ivar name); any other term is the selector prefix (last one wins — a
+// selector carries no spaces, so there is normally at most one).
+export function parseMethodFilter(raw: string): MethodFilter {
+  const ivar: IvarConstraint[] = [];
+  let selector: string | undefined;
+  for (const term of raw.split(/\s+/)) {
+    if (term.length === 0) continue;
+    const m = TOKEN.exec(term);
+    if (m && m[2].length > 0) {
+      ivar.push({ kind: m[1].toLowerCase() as IvarConstraint['kind'], pattern: m[2] });
+    } else {
+      selector = term;
+    }
+  }
+  return { selector, ivar };
+}
+
+type Access = { reads: string[]; writes: string[] } | undefined;
+
+function namesFor(kind: IvarConstraint['kind'], access: Access): string[] {
+  if (kind === 'reads') return access?.reads ?? [];
+  if (kind === 'writes') return access?.writes ?? [];
+  return [...(access?.reads ?? []), ...(access?.writes ?? [])];
+}
+
+// Whether a method matches: its selector against the prefix (if any) AND every
+// ivar constraint against the method's read/write sets.
+export function methodMatchesFilter(
+  filter: MethodFilter,
+  selector: string,
+  access: Access,
+): boolean {
+  if (filter.selector !== undefined && !filterMatches(selector, filter.selector)) return false;
+  return filter.ivar.every((c) =>
+    namesFor(c.kind, access).some((n) => filterMatches(n, c.pattern)),
+  );
+}
+
+// Whole-identifier occurrences of any of `names` in `text`, as [start, end)
+// offset pairs — used to highlight the filtered instance variable(s) in an
+// opened method source. Matches identifier tokens only, so it won't light up a
+// substring inside a larger name (e.g. `origin` inside `origins`).
+export function ivarIdentifierRanges(text: string, names: string[]): Array<[number, number]> {
+  if (names.length === 0) return [];
+  const want = new Set(names);
+  const ranges: Array<[number, number]> = [];
+  const re = /[A-Za-z_][A-Za-z0-9_]*/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (want.has(m[0])) ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+// The r/w/rw marker for a method under an ivar filter — does it read and/or write
+// an ivar the filter names? Undefined when the filter has no ivar constraints.
+export function ivarAccessMark(filter: MethodFilter, access: Access): 'r' | 'w' | 'rw' | undefined {
+  if (filter.ivar.length === 0) return undefined;
+  const patterns = filter.ivar.map((c) => c.pattern);
+  const hit = (names: string[] | undefined): boolean =>
+    (names ?? []).some((n) => patterns.some((p) => filterMatches(n, p)));
+  const r = hit(access?.reads);
+  const w = hit(access?.writes);
+  return r && w ? 'rw' : r ? 'r' : w ? 'w' : undefined;
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -813,11 +813,25 @@ export function activate(context: vscode.ExtensionContext) {
   const hoverProvider = new GemStoneHoverProvider(sessionManager, selectorResolver);
   const completionProvider = new GemStoneCompletionProvider(sessionManager);
   const codeLensProvider = new GemStoneCodeLensProvider(sessionManager);
+  // The senders/implementors CodeLens must attach on a gemstone:// method the
+  // instant it opens. A gemstone doc's language is assigned asynchronously
+  // (onDidOpenTextDocument → setTextDocumentLanguage), so gating the lens on
+  // `language: gemstone-smalltalk` (as providerSelectors does) delays it past the
+  // first paint on a document's first open — the lens then pops in and shoves the
+  // code down. Match on scheme alone so it's present from the first render;
+  // provideCodeLenses returns nothing for non-method gemstone docs anyway.
+  const codeLensSelectors: vscode.DocumentFilter[] = [
+    { scheme: 'gemstone' },
+    { scheme: 'untitled', language: 'gemstone-smalltalk' },
+    { scheme: 'file', language: 'gemstone-smalltalk' },
+    { scheme: 'file', language: 'gemstone-topaz' },
+    { scheme: 'file', language: 'gemstone-tonel' },
+  ];
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider(providerSelectors, definitionProvider),
     vscode.languages.registerHoverProvider(providerSelectors, hoverProvider),
     vscode.languages.registerCompletionItemProvider(providerSelectors, completionProvider),
-    vscode.languages.registerCodeLensProvider(providerSelectors, codeLensProvider),
+    vscode.languages.registerCodeLensProvider(codeLensSelectors, codeLensProvider),
     codeLensProvider, // dispose() cancels pending count lookups + releases the emitter
     // Hosts "Rename Temporary/Argument…" under the native "Refactor…" menu in a
     // saved (scheme:gemstone) method editor.

--- a/client/src/gemstoneCodeLensProvider.ts
+++ b/client/src/gemstoneCodeLensProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { SessionManager, ActiveSession } from './sessionManager';
 import { parseTopazDocument } from './topazFileIn';
 import { extractSelector } from './systemBrowser';
+import { parseMethodUri } from './gemstoneFileSystemProvider';
 import * as queries from './browserQueries';
 
 interface CodeLensData {
@@ -90,25 +91,11 @@ export class GemStoneCodeLensProvider implements vscode.CodeLensProvider, vscode
   }
 
   private provideGemstoneCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
-    const lenses: vscode.CodeLens[] = [];
+    const method = parseMethodUri(document.uri);
+    if (!method) return [];
 
-    try {
-      const uri = document.uri;
-      const parts = uri.path.split('/').map(decodeURIComponent);
-      // Method: /dict/class/side/category/selector (6 parts, first is empty)
-      if (parts.length === 6) {
-        const selector = parts[5];
-        const className = parts[2];
-        const isMeta = parts[3] === 'class';
-
-        const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
-        lenses.push(...this.makeMethodLenses(range, selector, className, isMeta));
-      }
-    } catch {
-      // URI parse error — skip
-    }
-
-    return lenses;
+    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    return this.makeMethodLenses(range, method.selector, method.className, method.isMeta);
   }
 
   // Emit the senders + implementors pair on the same range, in that order.

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -15,6 +15,13 @@ import {
   tabInputUri,
 } from './gemstoneFileSystemProvider';
 import { filterMatches } from './explorerFilter';
+import {
+  parseMethodFilter,
+  methodMatchesFilter as matchesMethodFilter,
+  ivarAccessMark as computeIvarAccessMark,
+  ivarIdentifierRanges,
+  MethodFilter,
+} from './explorerMethodFilter';
 import { DoubleClickDetector } from './explorerDoubleClick';
 import { categoryChildNodes, categoryParentPath, categoryMatches } from './explorerCategories';
 import { registerExplorerOpenEditors } from './explorerOpenEditors';
@@ -85,6 +92,14 @@ const VIEW_CLASSES = 'gemstoneExplorerClasses';
 const VIEW_METHODS = 'gemstoneExplorerMethods';
 // Panes that support the live filter (the Hierarchy pane doesn't).
 const EXPLORER_VIEWS = [VIEW_DICTS, VIEW_CATEGORIES, VIEW_CLASSES, VIEW_METHODS];
+
+// Highlights the filtered instance variable(s) in an opened method source while a
+// reads:/writes:/accesses: filter is active — theme-aware, styled like a search
+// match. One shared type for the extension's lifetime (disposed in activation).
+const ivarHighlightDecoration = vscode.window.createTextEditorDecorationType({
+  backgroundColor: new vscode.ThemeColor('editor.findMatchHighlightBackground'),
+  borderRadius: '2px',
+});
 
 // How the Explorer should open a gemstone:// source editor:
 //   - 'preview': a single-click NAVIGATION open — VS Code's own preview tab (the
@@ -370,6 +385,9 @@ export class MethodItem extends vscode.TreeItem {
     // FileDecoration (the "shown in the active editor" tint) — the label and icon
     // are still set explicitly below, so it doesn't affect how the row renders.
     resourceUri?: vscode.Uri,
+    // Under an active reads:/writes:/accesses: ivar filter, the row's role for the
+    // filtered ivar: 'r' (reads), 'w' (writes), or 'rw' (both). Shown as a glyph.
+    accessMark?: 'r' | 'w' | 'rw',
   ) {
     super(info.selector, vscode.TreeItemCollapsibleState.None);
     this.id = `msel:${isMeta}:${displayCategory ?? ''}:${info.selector}`;
@@ -387,6 +405,7 @@ export class MethodItem extends vscode.TreeItem {
     // Indicators (tree items can't render italics, so we surface override/
     // session state via a compact glyph description + an explanatory tooltip).
     const marks: string[] = [];
+    if (accessMark) marks.push(accessMark);
     if (info.overrideBits & 1) marks.push('▲');
     if (info.overrideBits & 2) marks.push('▼');
     if (info.sessionBit === 1) marks.push('+');
@@ -437,7 +456,27 @@ export class MethodItem extends vscode.TreeItem {
   }
 }
 
-type MethodNode = MethodCategoryItem | MethodItem;
+// A "filter chip" root row shown while a pane's filter is active: a funnel icon,
+// the label "Filter", and the pattern in grey description text — visually
+// distinct from method/selector rows. Clicking it re-opens the filter editor;
+// its inline ✕ clears the filter. Carries the owning view id so one clear
+// command serves every pane.
+export class FilterChipItem extends vscode.TreeItem {
+  constructor(
+    public readonly viewId: string,
+    pattern: string,
+  ) {
+    super('Filter', vscode.TreeItemCollapsibleState.None);
+    this.id = `filterchip:${viewId}`;
+    this.description = pattern;
+    this.iconPath = new vscode.ThemeIcon('filter-filled');
+    this.contextValue = 'explorerFilterChip';
+    this.tooltip = `Active filter: ${pattern} — click to edit, ✕ to clear`;
+    this.command = { command: `${viewId}.filter`, title: '' };
+  }
+}
+
+type MethodNode = MethodCategoryItem | MethodItem | FilterChipItem;
 
 // ── Hierarchy pane ───────────────────────────────────────────────────────────
 // Shows the selected class's lineage: superclasses (root-first) → the class
@@ -567,9 +606,11 @@ function methodSelection(
 // Views the controller updates with the current selection (shown as the greyed
 // description beside each pane title).
 interface ExplorerViews {
-  dict: vscode.TreeView<DictItem>;
-  category: vscode.TreeView<ClassCategoryItem>;
-  klass: vscode.TreeView<ClassNode>;
+  // The filterable panes can each lead with a FilterChipItem row (MethodNode
+  // already includes it).
+  dict: vscode.TreeView<DictItem | FilterChipItem>;
+  category: vscode.TreeView<ClassCategoryItem | FilterChipItem>;
+  klass: vscode.TreeView<ClassNode | FilterChipItem>;
   hierarchy: vscode.TreeView<HierarchyItem>;
   method: vscode.TreeView<MethodNode>;
 }
@@ -602,6 +643,13 @@ export class ExplorerController {
   private classVersions = new Map<string, queries.ClassVersionInfo>();
   // Per-method metadata for the selected class; fetched once per class.
   private envLines: queries.EnvCategoryLine[] = [];
+  // Per-method instance-variable read/write map for the selected class, keyed
+  // `${isMeta}:${selector}`. Lazily loaded (only when a reads:/writes:/accesses:
+  // filter is actually used) and cached per class; see methodIvarAccess.
+  private ivarAccessCache?: {
+    key: string;
+    map: Map<string, queries.MethodInstVarAccess>;
+  };
   private views?: ExplorerViews;
   // Active filter pattern per pane (view id → pattern); empty/absent = no filter.
   private readonly filters = new Map<string, string>();
@@ -675,12 +723,11 @@ export class ExplorerController {
     this.views.klass.description = compose(VIEW_CLASSES, this.state.className);
     this.views.hierarchy.description = this.state.className ?? '';
     // The side (instance/class) is a title toggle rather than a tree row now, so
-    // name it in the header. Don't append the selected selector — the grayed
-    // "instance · roll" just clutters, and the selection is already highlighted in
-    // the tree. A live filter still shows its "Filter: …" label (matching the
-    // other panes), otherwise the header is just the side.
-    const side = this._showClassMethods ? 'class' : 'instance';
-    this.views.method.description = compose(VIEW_METHODS, undefined, side);
+    // keep it in the header description; don't append the selected selector (the
+    // grayed "instance · roll" just clutters, and the selection is already
+    // highlighted in the tree). The active filter is shown by the filter-chip row
+    // at the top of the tree (see MethodProvider), not in the header.
+    this.views.method.description = this._showClassMethods ? 'class' : 'instance';
   }
 
   getFilter(viewId: string): string | undefined {
@@ -713,6 +760,8 @@ export class ExplorerController {
     );
     this.providerFor(viewId).refresh();
     this.syncTitles();
+    // A changed Methods filter changes which ivar (if any) is highlighted.
+    if (viewId === VIEW_METHODS) this.refreshIvarHighlights();
   }
 
   clearFilter(viewId: string): void {
@@ -740,6 +789,24 @@ export class ExplorerController {
       box.dispose();
     });
     box.show();
+  }
+
+  // From an instance-variable row's context menu: filter the Methods pane to the
+  // methods that read / write / reference that ivar, by seeding the matching
+  // reads:/writes:/accesses: token. Selects the ivar's OWN class first (selecting
+  // an ivar row is otherwise inert, so the pane could still be showing another
+  // class — which would filter the wrong method list and find nothing), then
+  // switches to the instance side, since instance variables are only accessed by
+  // instance-side methods. `selectClass` clears the Methods filter, so seed the
+  // token after it.
+  filterMethodsByIvar(
+    kind: 'reads' | 'writes' | 'accesses',
+    ivarName: string,
+    className: string,
+  ): void {
+    if (className !== this.state.className) this.selectClass(new ClassItem(className), false);
+    this.setMethodSide(false);
+    this.setFilterState(VIEW_METHODS, `${kind}:${ivarName}`);
   }
 
   applyFilter(names: string[], viewId: string): string[] {
@@ -1098,7 +1165,10 @@ export class ExplorerController {
     }
   }
 
-  selectClass(item: ClassItem): void {
+  // `revealHierarchy` false loads the hierarchy data but doesn't reveal (and thus
+  // can't force-open) the Hierarchy pane — used when selecting the class is a
+  // side effect (e.g. filtering methods by one of its ivars), not a navigation.
+  selectClass(item: ClassItem, revealHierarchy = true): void {
     this.state.className = item.className;
     this.state.selectedSelector = undefined;
     this.state.selectedIsMeta = undefined;
@@ -1115,7 +1185,7 @@ export class ExplorerController {
     this.loadHierarchy();
     this.methodProvider.refresh();
     this.hierarchyProvider.refresh();
-    void this.revealHierarchySelf();
+    if (revealHierarchy) void this.revealHierarchySelf();
     this.syncTitles();
     // NOTE: a plain class click no longer auto-opens the definition editor —
     // that cluttered the editor area with a definition tab per class browsed.
@@ -2618,7 +2688,9 @@ export class ExplorerController {
     // matches are visible without hand-expanding each folder.
     const hasMatch = (category: string) =>
       filter === undefined ||
-      this.selectorsFor(isMeta, category).some((info) => filterMatches(info.selector, filter));
+      this.selectorsFor(isMeta, category).some((info) =>
+        this.methodMatchesFilter(isMeta, info.selector, filter),
+      );
     const expanded = filter !== undefined;
     if (filter !== undefined) combined = combined.filter(hasMatch);
     const items: MethodCategoryItem[] = [];
@@ -2642,8 +2714,116 @@ export class ExplorerController {
   // category grouping is off, or when a filter is narrowing the list.
   flatMethods(isMeta: boolean, filter?: string): MethodItem[] {
     return this.selectorsFor(isMeta, ALL_METHODS_CATEGORY)
-      .filter((info) => filter === undefined || filterMatches(info.selector, filter))
-      .map((info) => new MethodItem(isMeta, info, undefined, this.methodSourceUri(isMeta, info)));
+      .filter(
+        (info) => filter === undefined || this.methodMatchesFilter(isMeta, info.selector, filter),
+      )
+      .map(
+        (info) =>
+          new MethodItem(
+            isMeta,
+            info,
+            undefined,
+            this.methodSourceUri(isMeta, info),
+            this.ivarAccessMark(isMeta, info.selector, filter),
+          ),
+      );
+  }
+
+  // Lazily load + cache the per-method instance-variable read/write map for the
+  // current class. Called only when a reads:/writes:/accesses: filter is active,
+  // so plain textual filters never pay for the extra round trip.
+  private methodIvarAccess(): Map<string, queries.MethodInstVarAccess> {
+    const session = this.session();
+    const { className, dictName, dictIndex } = this.state;
+    if (!session || className === undefined || dictIndex === undefined) return new Map();
+    const key = `${session.id}:${dictName}:${dictIndex}:${className}`;
+    if (this.ivarAccessCache?.key === key) return this.ivarAccessCache.map;
+    const map = new Map<string, queries.MethodInstVarAccess>();
+    for (const r of queries.getMethodInstVarAccess(session, dictIndex, className)) {
+      map.set(`${r.isMeta}:${r.selector}`, r);
+    }
+    this.ivarAccessCache = { key, map };
+    return map;
+  }
+
+  // Parse cache — the same raw filter string is matched against every row, so
+  // parse it once per distinct string.
+  private parsedFilter?: { raw: string; filter: MethodFilter };
+  private parseFilter(raw: string): MethodFilter {
+    if (this.parsedFilter?.raw !== raw) this.parsedFilter = { raw, filter: parseMethodFilter(raw) };
+    return this.parsedFilter.filter;
+  }
+
+  // Whether a method row passes the active filter — the selector prefix plus any
+  // reads:/writes:/accesses: ivar tokens. The ivar map is only consulted (and
+  // hence only loaded) when the filter actually carries an ivar token.
+  methodMatchesFilter(isMeta: boolean, selector: string, raw: string): boolean {
+    const filter = this.parseFilter(raw);
+    if (filter.ivar.length === 0) {
+      return filter.selector === undefined || filterMatches(selector, filter.selector);
+    }
+    const access = this.methodIvarAccess().get(`${isMeta}:${selector}`);
+    return matchesMethodFilter(filter, selector, access);
+  }
+
+  // The r/w/rw glyph a method row should show under an active ivar filter, or
+  // undefined when the filter has no ivar token (nothing to mark).
+  ivarAccessMark(isMeta: boolean, selector: string, raw?: string): 'r' | 'w' | 'rw' | undefined {
+    if (raw === undefined) return undefined;
+    const filter = this.parseFilter(raw);
+    if (filter.ivar.length === 0) return undefined;
+    const access = this.methodIvarAccess().get(`${isMeta}:${selector}`);
+    return computeIvarAccessMark(filter, access);
+  }
+
+  // The instance-variable names to highlight in a method-source editor: the ivars
+  // the method actually reads/writes that match an active reads:/writes:/accesses:
+  // token. Empty unless a gemstone:// method source and an ivar filter line up.
+  ivarsToHighlight(uri: vscode.Uri): string[] {
+    if (uri.scheme !== 'gemstone') return [];
+    const raw = this.filters.get(VIEW_METHODS);
+    if (raw === undefined) return [];
+    const filter = this.parseFilter(raw);
+    if (filter.ivar.length === 0) return [];
+    // parts: ['', dictName, className, side, category, selector...]
+    const parts = uri.path.split('/').map((p) => decodeURIComponent(p));
+    if (parts.length < 6) return [];
+    const isMeta = parts[3] === 'class';
+    const selector = unescapeSelectorSlashes(parts.slice(5).join('/'));
+    const access = this.methodIvarAccess().get(`${isMeta}:${selector}`);
+    if (!access) return [];
+    const patterns = filter.ivar.map((c) => c.pattern);
+    return [...new Set([...access.reads, ...access.writes])].filter((n) =>
+      patterns.some((p) => filterMatches(n, p)),
+    );
+  }
+
+  // Highlight (or clear) the filtered ivar identifiers in one editor. When there's
+  // nothing to highlight (the common case — no active ivar filter) just clear,
+  // without reading the document text, so this stays off the editor-open hot path
+  // (it runs on every activation, alongside the async CodeLens render).
+  private applyIvarHighlight(editor?: vscode.TextEditor): void {
+    if (!editor) return;
+    const names = this.ivarsToHighlight(editor.document.uri);
+    if (names.length === 0) {
+      editor.setDecorations(ivarHighlightDecoration, []);
+      return;
+    }
+    const ranges = ivarIdentifierRanges(editor.document.getText(), names).map(
+      ([s, e]) => new vscode.Range(editor.document.positionAt(s), editor.document.positionAt(e)),
+    );
+    editor.setDecorations(ivarHighlightDecoration, ranges);
+  }
+
+  // Re-apply ivar highlighting across every open source editor — after opening a
+  // method or changing the filter, so highlights track the active ivar filter.
+  refreshIvarHighlights(): void {
+    for (const editor of vscode.window.visibleTextEditors) this.applyIvarHighlight(editor);
+  }
+
+  // Highlight in whichever editor just became active (tab switch).
+  highlightActiveEditor(editor?: vscode.TextEditor): void {
+    this.applyIvarHighlight(editor);
   }
 
   // Flip the persistent group-by-category setting (from the title-bar toggle).
@@ -2807,10 +2987,22 @@ export class ExplorerController {
       this.selfOpenedUris.add(uriStr);
     }
     const doc = await vscode.workspace.openTextDocument(uri);
+    // Assign the language BEFORE the doc enters the (reused) preview editor. A
+    // gemstone doc is otherwise language-tagged asynchronously
+    // (onDidOpenTextDocument → setTextDocumentLanguage) — i.e. *after* it's shown —
+    // and that post-show flip re-tokenizes and re-queries CodeLens, which makes the
+    // senders/implementors lens pop in and shove the source down on each new
+    // method. Setting it up front keeps the doc stable when it's shown.
+    if (doc.languageId !== 'gemstone-smalltalk') {
+      await vscode.languages.setTextDocumentLanguage(doc, 'gemstone-smalltalk');
+    }
     // Single-click opens a preview tab and a double-click promotes it to a
     // permanent one (focus stays in the tree so type-to-filter / arrow-nav keep
     // working); the 📌 action pins a real tab so methods can be compared.
     await openGemstoneDocument(doc, mode, this.placement);
+    // Under an active ivar filter, highlight the filtered ivar in the just-opened
+    // source (it may not be the active editor, so refresh all visible editors).
+    this.refreshIvarHighlights();
   }
 
   // Remove a method from its class (the row's 🗑 button). Destructive, so it
@@ -3778,7 +3970,20 @@ abstract class RefreshableProvider<T> implements vscode.TreeDataProvider<T> {
   }
 }
 
-class DictProvider extends RefreshableProvider<DictItem> {
+// Lead a pane's root rows with a filter chip when a filter is active, so every
+// filterable pane shows (and can clear) its filter the same way (see
+// FilterChipItem / MethodProvider). Panes render the chip identically because the
+// chip carries its own view id.
+function withFilterChip<T>(
+  viewId: string,
+  ctl: ExplorerController,
+  rows: T[],
+): (T | FilterChipItem)[] {
+  const filter = ctl.getFilter(viewId);
+  return filter === undefined ? rows : [new FilterChipItem(viewId, filter), ...rows];
+}
+
+class DictProvider extends RefreshableProvider<DictItem | FilterChipItem> {
   constructor(private readonly ctl: ExplorerController) {
     super();
   }
@@ -3786,52 +3991,62 @@ class DictProvider extends RefreshableProvider<DictItem> {
   getParent(): DictItem | undefined {
     return undefined;
   }
-  getChildren(element?: DictItem): DictItem[] {
+  getChildren(element?: DictItem | FilterChipItem): (DictItem | FilterChipItem)[] {
     if (element) return [];
     const session = this.ctl.session();
     if (!session) return [];
-    return queries
+    const rows = queries
       .getDictionaryNames(session)
       .map((name, i) => new DictItem(name, i + 1))
       .filter((d) => filterMatches(d.dictName, this.ctl.getFilter(VIEW_DICTS)));
+    return withFilterChip(VIEW_DICTS, this.ctl, rows);
   }
 }
 
-class CategoryProvider extends RefreshableProvider<ClassCategoryItem> {
+class CategoryProvider extends RefreshableProvider<ClassCategoryItem | FilterChipItem> {
   constructor(private readonly ctl: ExplorerController) {
     super();
   }
-  getParent(element: ClassCategoryItem): ClassCategoryItem | undefined {
+  getParent(element: ClassCategoryItem | FilterChipItem): ClassCategoryItem | undefined {
+    if (element instanceof FilterChipItem) return undefined;
     return this.ctl.categoryParent(element.fullPath);
   }
-  getChildren(element?: ClassCategoryItem): ClassCategoryItem[] {
-    if (this.ctl.state.dictName === undefined) return [];
-    // While filtering, drop the tree and list matching full category paths flat.
-    if (!element && this.ctl.categoryFilterActive()) {
-      return this.ctl.filteredCategoryPaths().map((p) => new ClassCategoryItem(p, p, false));
+  getChildren(
+    element?: ClassCategoryItem | FilterChipItem,
+  ): (ClassCategoryItem | FilterChipItem)[] {
+    if (this.ctl.state.dictName === undefined || element instanceof FilterChipItem) return [];
+    if (!element) {
+      // While filtering, drop the tree and list matching full category paths flat.
+      const rows = this.ctl.categoryFilterActive()
+        ? this.ctl.filteredCategoryPaths().map((p) => new ClassCategoryItem(p, p, false))
+        : this.ctl
+            .categoryChildren(undefined)
+            .map((n) => new ClassCategoryItem(n.segment, n.fullPath, n.hasChildren));
+      return withFilterChip(VIEW_CATEGORIES, this.ctl, rows);
     }
     return this.ctl
-      .categoryChildren(element?.fullPath)
+      .categoryChildren(element.fullPath)
       .map((n) => new ClassCategoryItem(n.segment, n.fullPath, n.hasChildren));
   }
 }
 
-class ClassProvider extends RefreshableProvider<ClassNode> {
+class ClassProvider extends RefreshableProvider<ClassNode | FilterChipItem> {
   constructor(private readonly ctl: ExplorerController) {
     super();
   }
-  getParent(element: ClassNode): ClassNode | undefined {
+  getParent(element: ClassNode | FilterChipItem): ClassNode | undefined {
     if (element instanceof IvarItem) return new VarSideItem(element.className, false);
     if (element instanceof ClassVarItem) return new VarSideItem(element.className, true);
     if (element instanceof VarSideItem) return new ClassItem(element.className);
     return undefined;
   }
-  getChildren(element?: ClassNode): ClassNode[] {
-    if (this.ctl.state.dictName === undefined) return [];
+  getChildren(element?: ClassNode | FilterChipItem): (ClassNode | FilterChipItem)[] {
+    if (this.ctl.state.dictName === undefined || element instanceof FilterChipItem) return [];
     if (!element) {
-      return this.ctl
+      const rows = this.ctl
         .classNames()
         .map((n) => new ClassItem(n, this.ctl.classHasDefinedVars(n), this.ctl.classVersion(n)));
+      return withFilterChip(VIEW_CLASSES, this.ctl, rows);
     }
     // A class expands to an "instance" and/or "class" variable-side node (like the
     // Methods pane's sides), each shown only when that side has variables.
@@ -3886,7 +4101,7 @@ class MethodProvider extends RefreshableProvider<MethodNode> {
         element.displayCategory === SESSION_METHODS_CATEGORY;
       return new MethodCategoryItem(element.isMeta, element.displayCategory, computed);
     }
-    // Category rows are roots (the side is a title toggle, not a tree level).
+    // Category rows and the filter chip are roots.
     return undefined;
   }
   getChildren(element?: MethodNode): MethodNode[] {
@@ -3899,14 +4114,22 @@ class MethodProvider extends RefreshableProvider<MethodNode> {
       // methodCategories). An empty filter is a no-op.
       const isMeta = this.ctl.showClassMethods;
       const filter = this.ctl.getFilter(VIEW_METHODS);
-      if (!this.ctl.groupMethodsByCategory()) return this.ctl.flatMethods(isMeta, filter);
-      return this.ctl.methodCategories(isMeta, filter);
+      const rows: MethodNode[] = !this.ctl.groupMethodsByCategory()
+        ? this.ctl.flatMethods(isMeta, filter)
+        : this.ctl.methodCategories(isMeta, filter);
+      // While filtering, lead with a filter chip (funnel row + inline ✕) so the
+      // active filter reads distinctly from the method rows and can be cleared here.
+      return filter === undefined ? rows : [new FilterChipItem(VIEW_METHODS, filter), ...rows];
     }
     if (element instanceof MethodCategoryItem) {
       const filter = this.ctl.getFilter(VIEW_METHODS);
       return this.ctl
         .selectorsFor(element.isMeta, element.category)
-        .filter((info) => filter === undefined || filterMatches(info.selector, filter))
+        .filter(
+          (info) =>
+            filter === undefined ||
+            this.ctl.methodMatchesFilter(element.isMeta, info.selector, filter),
+        )
         .map(
           (info) =>
             new MethodItem(
@@ -3914,6 +4137,7 @@ class MethodProvider extends RefreshableProvider<MethodNode> {
               info,
               element.category,
               this.ctl.methodSourceUri(element.isMeta, info),
+              this.ctl.ivarAccessMark(element.isMeta, info.selector, filter),
             ),
         );
     }
@@ -4055,10 +4279,12 @@ export function registerGemStoneExplorer(
   });
 
   dictView.onDidChangeSelection((e) => {
-    if (e.selection[0]) ctl.selectDict(e.selection[0]);
+    const node = e.selection[0];
+    if (node instanceof DictItem) ctl.selectDict(node);
   });
   categoryView.onDidChangeSelection((e) => {
-    if (e.selection[0]) ctl.selectClassCategory(e.selection[0]);
+    const node = e.selection[0];
+    if (node instanceof ClassCategoryItem) ctl.selectClassCategory(node);
   });
   classView.onDidChangeSelection((e) => {
     // Only a class row navigates; selecting an ivar child is inert (it's acted on
@@ -4107,6 +4333,14 @@ export function registerGemStoneExplorer(
     // only when that pane has an active filter.
     ...EXPLORER_VIEWS.map((viewId) =>
       vscode.commands.registerCommand(`${viewId}.clearFilter`, () => ctl.clearFilter(viewId)),
+    ),
+    // The filter-chip row's inline ✕ — clears the filter for whichever pane the
+    // chip belongs to (it carries its own view id).
+    vscode.commands.registerCommand(
+      'gemstone.explorer.clearFilterChip',
+      (item?: FilterChipItem) => {
+        if (item instanceof FilterChipItem) ctl.clearFilter(item.viewId);
+      },
     ),
     vscode.commands.registerCommand('gemstone.explorer.openMethodToSide', (node: MethodItem) => {
       if (node instanceof MethodItem) void ctl.openMethod(node, 'pin');
@@ -4207,6 +4441,22 @@ export function registerGemStoneExplorer(
     vscode.commands.registerCommand('gemstone.explorer.renameIvar', (item?: IvarItem) => {
       if (item instanceof IvarItem) void ctl.renameInstVar(item);
     }),
+    // Filter the Methods pane to the readers / writers / references of an ivar
+    // (its row's context menu) — seeds a reads:/writes:/accesses: token.
+    vscode.commands.registerCommand('gemstone.explorer.filterReadersOfIvar', (item?: IvarItem) => {
+      if (item instanceof IvarItem) ctl.filterMethodsByIvar('reads', item.ivarName, item.className);
+    }),
+    vscode.commands.registerCommand('gemstone.explorer.filterWritersOfIvar', (item?: IvarItem) => {
+      if (item instanceof IvarItem)
+        ctl.filterMethodsByIvar('writes', item.ivarName, item.className);
+    }),
+    vscode.commands.registerCommand(
+      'gemstone.explorer.filterReferencesToIvar',
+      (item?: IvarItem) => {
+        if (item instanceof IvarItem)
+          ctl.filterMethodsByIvar('accesses', item.ivarName, item.className);
+      },
+    ),
     // Add / remove an instance variable (V1).
     vscode.commands.registerCommand('gemstone.explorer.addInstVar', (item?: unknown) => {
       if (item instanceof VarSideItem) void ctl.addInstVarFromSide(item);
@@ -4438,8 +4688,10 @@ export function registerGemStoneExplorer(
     // Editor-focus → navigator: when a gemstone:// method/class editor gains
     // focus, cascade the panels to its location.
     vscode.window.onDidChangeActiveTextEditor((editor) => {
+      ctl.highlightActiveEditor(editor);
       if (editor) void ctl.syncToEditor(editor.document.uri);
     }),
+    ivarHighlightDecoration,
   );
 
   return {

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -86,61 +86,59 @@ const VIEW_METHODS = 'gemstoneExplorerMethods';
 // Panes that support the live filter (the Hierarchy pane doesn't).
 const EXPLORER_VIEWS = [VIEW_DICTS, VIEW_CATEGORIES, VIEW_CLASSES, VIEW_METHODS];
 
+// How the Explorer should open a gemstone:// source editor:
+//   - 'preview': a single-click NAVIGATION open — VS Code's own preview tab (the
+//     one italic, reused tab per group that the next preview replaces; pinned and
+//     permanent tabs are left alone). Focus stays in the tree so type-to-filter /
+//     arrow-nav keep working.
+//   - 'keep': a double-click open — the same doc re-shown as a permanent (non-
+//     preview) tab, promoting the preview in place so a later single click won't
+//     replace it.
+//   - 'pin': the 📌 action — a pinned tab added to the group WITHOUT stealing the
+//     view (the tab you were reading stays showing).
+export type OpenSourceMode = 'preview' | 'keep' | 'pin';
+
 // Open a gemstone:// source document in the editor area. All of this Explorer's
 // source editors live as tabs in ONE group (see NOTES-editor-placement.md), so the
-// transient tab and every pinned tab sit next to each other in one row:
-//   - NAVIGATION (single click): the ONE transient (unpinned) tab, reused — a new
-//     click replaces it; pinned tabs are left alone. Already-open tab → just reveal.
-//   - PIN (the 📌 action): the method becomes a PINNED tab in that same group, added
-//     WITHOUT stealing the view (the tab you were reading stays showing).
-// `placement` scopes this to editors this Explorer opened, so it never invades the
-// System Browser's group (see sourceEditorPlacement.ts).
+// preview tab and every pinned tab sit next to each other in one row. `placement`
+// scopes this to editors this Explorer opened, so it never invades the System
+// Browser's group (see sourceEditorPlacement.ts).
 // Exported for unit testing the placement rules.
 export async function openGemstoneDocument(
   doc: vscode.TextDocument,
-  pin: boolean,
+  mode: OpenSourceMode,
   placement: SourceEditorPlacement,
 ): Promise<void> {
-  const uriStr = doc.uri.toString();
   const sourceColumn = placement.sourceColumn();
   const targetColumn = sourceColumn ?? vscode.ViewColumn.Active;
 
-  if (!pin) {
-    // NAVIGATION. If the method is already a tab in our group (transient or pinned),
-    // reveal it — no duplicate, and pinned tabs stay pinned. (A real tab, not
-    // preview:true, because a preview swap scrolls the Methods tree.)
-    if (sourceColumn !== undefined && columnHoldsUri(sourceColumn, uriStr)) {
-      await vscode.window.showTextDocument(doc, {
-        viewColumn: sourceColumn,
-        preview: false,
-        preserveFocus: true,
-      });
-      return;
-    }
-    // Otherwise open it as the ONE transient tab, replacing the previous transient
-    // (unless it's pinned or dirty). Pinned tabs are untouched.
-    const previous = placement.reusableTab;
-    const previousColumn = placement.reusableColumn;
-    const editor = await vscode.window.showTextDocument(doc, {
+  if (mode !== 'pin') {
+    // NAVIGATION. Let VS Code's native preview tab do the transient-tab
+    // bookkeeping — one reusable preview tab per group, replaced by the next
+    // preview, leaving pinned/permanent tabs alone. A single click ('preview')
+    // opens that preview tab; a double click ('keep') re-shows the same doc as a
+    // permanent tab, promoting the preview in place. Either way focus stays in the
+    // tree. Preview being per-group means we never disturb the System Browser's
+    // own group.
+    await vscode.window.showTextDocument(doc, {
       viewColumn: targetColumn,
-      preview: false,
+      preview: mode === 'preview',
       preserveFocus: true,
     });
     placement.remember(doc.uri);
-    placement.reusableTab = uriStr;
-    placement.reusableColumn = editor.viewColumn ?? targetColumn;
-    // Close the OUTGOING transient in the column WE opened it into — never scan the
-    // whole window, or the same URI open in the System Browser's group gets closed.
-    if (previous && previous !== uriStr)
-      closeDisposableTab(previous, previousColumn ?? targetColumn);
     return;
   }
 
   // PIN. Bring the method into our group and pin it, WITHOUT stealing the view: note
   // what's showing, add + pin the tab, then restore what was showing so a new pin
   // just parks a background tab beside the one you're reading. Pinning the method
-  // that's currently the transient simply promotes it to a pinned tab.
-  const showing = sourceColumn !== undefined ? activeUriInColumn(sourceColumn) : undefined;
+  // that's currently the preview simply promotes it to a pinned tab.
+  const uriStr = doc.uri.toString();
+  const showingTab =
+    sourceColumn !== undefined
+      ? vscode.window.tabGroups.all.find((g) => g.viewColumn === sourceColumn)?.activeTab
+      : undefined;
+  const showing = showingTab ? tabInputUri(showingTab)?.toString() : undefined;
   await vscode.window.showTextDocument(doc, {
     viewColumn: targetColumn,
     preview: false,
@@ -148,46 +146,14 @@ export async function openGemstoneDocument(
   });
   await vscode.commands.executeCommand('workbench.action.pinEditor');
   placement.remember(doc.uri);
-  if (placement.reusableTab === uriStr) placement.reusableTab = undefined;
   if (sourceColumn !== undefined && showing !== undefined && showing !== uriStr) {
+    // Restore whatever was showing in its ORIGINAL preview/permanent state — a pin
+    // action must not silently promote the preview method you were just browsing.
     await vscode.window.showTextDocument(vscode.Uri.parse(showing), {
       viewColumn: sourceColumn,
-      preview: false,
+      preview: showingTab?.isPreview ?? false,
       preserveFocus: true,
     });
-  }
-}
-
-// The URI showing in a given view-column's group (its active tab), or undefined.
-function activeUriInColumn(column: number): string | undefined {
-  const group = vscode.window.tabGroups.all.find((g) => g.viewColumn === column);
-  return group?.activeTab ? tabInputUri(group.activeTab)?.toString() : undefined;
-}
-
-// Does the group in this view-column currently hold a tab for this URI?
-function columnHoldsUri(column: number, uriStr: string): boolean {
-  const group = vscode.window.tabGroups.all.find((g) => g.viewColumn === column);
-  return group?.tabs.some((tab) => tabInputUri(tab)?.toString() === uriStr) ?? false;
-}
-
-// Close the single reusable source tab a prior single-click opened, but only if
-// the user isn't working in it: a dirty tab has unsaved edits and a pinned tab was
-// deliberately kept — both are cases where a preview tab would likewise have
-// promoted itself to permanent rather than being replaced.
-//
-// Scoped to OUR column: the outgoing transient always lives in the group we open
-// into, and the same gemstone:// URI can also be open in the System Browser's own
-// group. Scanning every group and matching on the URI alone would let us close
-// that foreign copy — exactly the cross-browser interference SourceEditorPlacement
-// exists to prevent.
-function closeDisposableTab(uriStr: string, column: vscode.ViewColumn): void {
-  const group = vscode.window.tabGroups.all.find((g) => g.viewColumn === column);
-  if (!group) return;
-  for (const tab of group.tabs) {
-    if (tabInputUri(tab)?.toString() !== uriStr) continue;
-    if (tab.isDirty || tab.isPinned) return;
-    void vscode.window.tabGroups.close(tab);
-    return;
   }
 }
 
@@ -476,6 +442,16 @@ export class MethodItem extends vscode.TreeItem {
     } else {
       this.iconPath = new vscode.ThemeIcon('symbol-method');
     }
+
+    // Fires on every click (a re-click of the already-selected row too, which
+    // onDidChangeSelection misses). Selection still drives the single-click
+    // preview open; the controller uses this hook's timing to detect a
+    // double-click and promote that preview to a permanent tab.
+    this.command = {
+      command: 'gemstone.explorer.methodClicked',
+      title: '',
+      arguments: [this],
+    };
   }
 }
 
@@ -1255,7 +1231,7 @@ export class ExplorerController {
     const uri = buildClassCommentUri(session.id, dictName, className, dictIndex);
     this.selfOpenedUris.add(uri.toString());
     const doc = await vscode.workspace.openTextDocument(uri);
-    await openGemstoneDocument(doc, pin, this.placement);
+    await openGemstoneDocument(doc, pin ? 'pin' : 'preview', this.placement);
   }
 
   // Generate an editable Grail `.py` stub for a class. Invoked from the Classes-
@@ -1348,7 +1324,7 @@ export class ExplorerController {
     const uri = buildClassDefinitionUri(session.id, dictName, className, dictIndex);
     this.selfOpenedUris.add(uri.toString());
     const doc = await vscode.workspace.openTextDocument(uri);
-    await openGemstoneDocument(doc, pin, this.placement);
+    await openGemstoneDocument(doc, pin ? 'pin' : 'preview', this.placement);
   }
 
   // Manual double-click detection for the Classes pane: VS Code trees have no
@@ -1358,6 +1334,17 @@ export class ExplorerController {
   handleClassClick(className: string): void {
     if (this.classClicks.register(className)) {
       void this.openClassDefinition(new ClassItem(className));
+    }
+  }
+
+  // Same manual double-click detection for the Methods pane: a single click
+  // already opened the method as a preview tab (via onDidChangeSelection); a
+  // double-click on the same row promotes it to a permanent tab so a later
+  // single click elsewhere won't replace it.
+  private readonly methodClicks = new DoubleClickDetector(500);
+  handleMethodClick(node: MethodItem): void {
+    if (this.methodClicks.register(`${node.isMeta}:${node.info.selector}`)) {
+      void this.openMethod(node, 'keep');
     }
   }
 
@@ -1426,6 +1413,10 @@ export class ExplorerController {
   // in sync with the Classes pane.
   async revealHierarchySelf(): Promise<void> {
     if (this.hierChain.length === 0) return;
+    // Don't reveal when the Hierarchy pane is collapsed — reveal() would force
+    // VS Code to expand the section, defeating the collapsed-by-default layout
+    // and re-opening the pane every time the user selects a class.
+    if (!this.views?.hierarchy.visible) return;
     const lastIdx = this.hierChain.length - 1;
     const e = this.hierChain[lastIdx];
     const self = new HierarchyItem(
@@ -2726,7 +2717,7 @@ export class ExplorerController {
     });
   }
 
-  async openMethod(node: MethodItem, pin = false): Promise<void> {
+  async openMethod(node: MethodItem, mode: OpenSourceMode = 'preview'): Promise<void> {
     const session = this.session();
     if (!session || this.state.dictName === undefined || this.state.className === undefined) {
       return;
@@ -2759,10 +2750,10 @@ export class ExplorerController {
       this.selfOpenedUris.add(uriStr);
     }
     const doc = await vscode.workspace.openTextDocument(uri);
-    // Single-click reuses one source tab (focus stays in the tree so type-to-filter
-    // / arrow-nav keep working); open-to-side pins a real tab in a balanced
-    // neighbouring group so methods can be compared.
-    await openGemstoneDocument(doc, pin, this.placement);
+    // Single-click opens a preview tab and a double-click promotes it to a
+    // permanent one (focus stays in the tree so type-to-filter / arrow-nav keep
+    // working); the 📌 action pins a real tab so methods can be compared.
+    await openGemstoneDocument(doc, mode, this.placement);
   }
 
   // Remove a method from its class (the row's 🗑 button). Destructive, so it
@@ -3350,14 +3341,14 @@ export class ExplorerController {
       this.state.dictIndex,
     );
     const doc = await vscode.workspace.openTextDocument(uri);
+    // A preview tab, like a single-click navigation open: the next preview
+    // replaces it, and it counts as the navigation editor (remembered below) so
+    // "open to the side" doesn't mistake its group for the side group.
     await vscode.window.showTextDocument(doc, {
       viewColumn: vscode.ViewColumn.Active,
       preview: true,
     });
     this.placement.remember(uri);
-    // Count the new-method template as the navigation editor, not a side pane, so
-    // "open to the side" doesn't mistake its group for the side group.
-    this.placement.reusableTab = uri.toString();
   }
 
   // After a method compiles on the class we're showing, select a just-created
@@ -4025,7 +4016,7 @@ export function registerGemStoneExplorer(
     treeDataProvider: ctl.classProvider,
     dragAndDropController: new ClassDropController(ctl),
   });
-  const hierarchyView = vscode.window.createTreeView('gemstoneExplorerHierarchy', {
+  const hierarchyView = vscode.window.createTreeView('gemstoneExplorerClassHierarchy', {
     treeDataProvider: ctl.hierarchyProvider,
   });
   const methodView = vscode.window.createTreeView('gemstoneExplorerMethods', {
@@ -4099,7 +4090,7 @@ export function registerGemStoneExplorer(
       vscode.commands.registerCommand(`${viewId}.clearFilter`, () => ctl.clearFilter(viewId)),
     ),
     vscode.commands.registerCommand('gemstone.explorer.openMethodToSide', (node: MethodItem) => {
-      if (node instanceof MethodItem) void ctl.openMethod(node, true);
+      if (node instanceof MethodItem) void ctl.openMethod(node, 'pin');
     }),
     vscode.commands.registerCommand('gemstone.explorer.removeMethod', (node?: MethodItem) => {
       if (node instanceof MethodItem)
@@ -4114,7 +4105,7 @@ export function registerGemStoneExplorer(
     // pass the tree selection, so read it from the view here.
     vscode.commands.registerCommand('gemstone.explorer.openSelectedMethodToSide', () => {
       const node = methodView.selection[0];
-      if (node instanceof MethodItem) void ctl.openMethod(node, true);
+      if (node instanceof MethodItem) void ctl.openMethod(node, 'pin');
     }),
     // Find Class: cascade the panes to a class by name (from the Classes pane
     // title button or the command palette).
@@ -4157,6 +4148,10 @@ export function registerGemStoneExplorer(
     // Per-click hook powering double-click-to-open-definition.
     vscode.commands.registerCommand('gemstone.explorer.classClicked', (className?: string) => {
       if (typeof className === 'string') ctl.handleClassClick(className);
+    }),
+    // Per-click hook powering double-click-to-promote-the-preview-tab.
+    vscode.commands.registerCommand('gemstone.explorer.methodClicked', (node?: MethodItem) => {
+      if (node instanceof MethodItem) ctl.handleMethodClick(node);
     }),
     // Generate a Grail (.py) stub for a class — Classes/Hierarchy menus and the
     // Command Palette all route here.

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -651,9 +651,13 @@ export class ExplorerController {
   private envLines: queries.EnvCategoryLine[] = [];
   // Per-method instance-variable read/write map for the selected class, keyed
   // `${isMeta}:${selector}`. Lazily loaded (only when a reads:/writes:/accesses:
-  // filter is actually used) and cached per class; see methodIvarAccess.
+  // filter is actually used); see methodIvarAccess. Cache validity is tied to the
+  // `envLines` array *identity* — envLines is replaced on every method-list reload
+  // (class switch, refresh, post-edit reloadIfCurrent), so a changed reference
+  // means the class's methods may have changed and the map must be rebuilt. This
+  // auto-invalidates without having to touch each envLines-assignment site.
   private ivarAccessCache?: {
-    key: string;
+    envLines: queries.EnvCategoryLine[];
     map: Map<string, queries.MethodInstVarAccess>;
   };
   private views?: ExplorerViews;
@@ -753,17 +757,12 @@ export class ExplorerController {
     }
   }
 
-  // Set (or clear, with an empty pattern) a pane's filter: updates the map, the
-  // `gemstone.explorerFiltered.<viewId>` context key that shows/hides its Clear
-  // button, then refreshes the pane and titles.
+  // Set (or clear, with an empty pattern) a pane's filter: update the map, then
+  // refresh the pane and titles. Clearing is offered via the in-pane filter chip
+  // (see FilterChipItem), so no context key is needed to gate a title Clear button.
   private setFilterState(viewId: string, pattern: string | undefined): void {
     if (pattern) this.filters.set(viewId, pattern);
     else this.filters.delete(viewId);
-    void vscode.commands.executeCommand(
-      'setContext',
-      `gemstone.explorerFiltered.${viewId}`,
-      !!pattern,
-    );
     this.providerFor(viewId).refresh();
     this.syncTitles();
     // A changed Methods filter changes which ivar (if any) is highlighted.
@@ -2764,15 +2763,15 @@ export class ExplorerController {
   // so plain textual filters never pay for the extra round trip.
   private methodIvarAccess(): Map<string, queries.MethodInstVarAccess> {
     const session = this.session();
-    const { className, dictName, dictIndex } = this.state;
+    const { className, dictIndex } = this.state;
     if (!session || className === undefined || dictIndex === undefined) return new Map();
-    const key = `${session.id}:${dictName}:${dictIndex}:${className}`;
-    if (this.ivarAccessCache?.key === key) return this.ivarAccessCache.map;
+    // Valid as long as the method list (envLines) hasn't been reloaded since.
+    if (this.ivarAccessCache?.envLines === this.envLines) return this.ivarAccessCache.map;
     const map = new Map<string, queries.MethodInstVarAccess>();
-    for (const r of queries.getMethodInstVarAccess(session, dictIndex, className)) {
+    for (const r of queries.getMethodInstVarAccess(session, dictIndex, className, this.maxEnv())) {
       map.set(`${r.isMeta}:${r.selector}`, r);
     }
-    this.ivarAccessCache = { key, map };
+    this.ivarAccessCache = { envLines: this.envLines, map };
     return map;
   }
 
@@ -4359,8 +4358,8 @@ export function registerGemStoneExplorer(
     ...EXPLORER_VIEWS.map((viewId) =>
       vscode.commands.registerCommand(`${viewId}.filter`, () => ctl.beginFilter(viewId)),
     ),
-    // Clear buttons: shown (via the gemstone.explorerFiltered.<viewId> context key)
-    // only when that pane has an active filter.
+    // Per-pane clear-filter command (palette / programmatic). The in-pane filter
+    // chip's ✕ is the primary affordance now (see clearFilterChip below).
     ...EXPLORER_VIEWS.map((viewId) =>
       vscode.commands.registerCommand(`${viewId}.clearFilter`, () => ctl.clearFilter(viewId)),
     ),

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -332,37 +332,19 @@ type ClassNode = ClassItem | VarSideItem | IvarItem | ClassVarItem;
 
 // Method pane is a 3-level tree: side ▸ method-category ▸ selector.
 // Exported for unit tests that drive the New Method / category flows.
-export class MethodSideItem extends vscode.TreeItem {
-  constructor(public readonly isMeta: boolean) {
-    // Instance side opens expanded (so ALL METHODS shows immediately); the
-    // class side starts collapsed to keep the default view focused.
-    super(
-      isMeta ? 'class' : 'instance',
-      isMeta ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.Expanded,
-    );
-    this.id = `mside:${isMeta}`;
-    // Both instance/class side headers use the class icon — distinct from the
-    // per-method rows (symbol-method) so a header doesn't read as a method.
-    this.iconPath = new vscode.ThemeIcon('symbol-class');
-    // Hosts the per-side "+" (add method category) inline action — a distinct
-    // value per side so each shows its own titled command. Deliberately does NOT
-    // contain the substring "explorerMethod" so it can't match the method-row
-    // menu regexes (/^explorerMethod/, /explorerMethod/).
-    this.contextValue = isMeta ? 'explorerSideClass' : 'explorerSideInstance';
-  }
-}
-
 export class MethodCategoryItem extends vscode.TreeItem {
   constructor(
     public readonly isMeta: boolean,
     public readonly category: string,
     public readonly computed: boolean,
+    // Open the node up front. ALL METHODS always does (it's the landing view);
+    // the rest do while a filter is active, so matches show without expanding
+    // every folder by hand.
+    forceExpanded = false,
   ) {
-    // ALL METHODS is the default landing view — expand it so selecting a class
-    // immediately lists every method.
     super(
       category,
-      category === ALL_METHODS_CATEGORY
+      category === ALL_METHODS_CATEGORY || forceExpanded
         ? vscode.TreeItemCollapsibleState.Expanded
         : vscode.TreeItemCollapsibleState.Collapsed,
     );
@@ -378,8 +360,8 @@ export class MethodCategoryItem extends vscode.TreeItem {
 
 export class MethodItem extends vscode.TreeItem {
   // `displayCategory` is the category node this row is shown *under* (a real
-  // category, ALL METHODS, SESSION METHODS, or undefined when flattened by a
-  // filter). It's needed so MethodProvider.getParent can walk up for reveal().
+  // category, ALL METHODS, SESSION METHODS, or undefined when category grouping is
+  // off). It's needed so MethodProvider.getParent can walk up for reveal().
   constructor(
     public readonly isMeta: boolean,
     public readonly info: SelectorInfo,
@@ -455,7 +437,7 @@ export class MethodItem extends vscode.TreeItem {
   }
 }
 
-type MethodNode = MethodSideItem | MethodCategoryItem | MethodItem;
+type MethodNode = MethodCategoryItem | MethodItem;
 
 // ── Hierarchy pane ───────────────────────────────────────────────────────────
 // Shows the selected class's lineage: superclasses (root-first) → the class
@@ -692,23 +674,13 @@ export class ExplorerController {
     this.views.category.description = compose(VIEW_CATEGORIES, this.state.classCategory);
     this.views.klass.description = compose(VIEW_CLASSES, this.state.className);
     this.views.hierarchy.description = this.state.className ?? '';
-    // The Methods header reflects what is *currently* selected in the tree — not
-    // the last method that happened to be opened. So when the filter input is
-    // cleared (backspaced to empty) or dismissed with nothing selected, the
-    // header goes blank — matching the other three panes — rather than a stale
-    // selector or a redundant class name. See `currentMethodSelector`.
-    this.views.method.description = compose(VIEW_METHODS, this.currentMethodSelector());
-  }
-
-  // The selector of the method row currently selected in the Methods pane, or
-  // undefined when nothing (or a non-method row) is selected. Reads the live
-  // TreeView selection so it can't go stale. Falls back to the last-opened
-  // selector only when the view can't report a selection (e.g. under test mocks).
-  private currentMethodSelector(): string | undefined {
-    const selection = this.views?.method.selection;
-    if (!selection) return this.state.selectedSelector;
-    const item = selection.find((n) => n instanceof MethodItem);
-    return item?.info.selector;
+    // The side (instance/class) is a title toggle rather than a tree row now, so
+    // name it in the header. Don't append the selected selector — the grayed
+    // "instance · roll" just clutters, and the selection is already highlighted in
+    // the tree. A live filter still shows its "Filter: …" label (matching the
+    // other panes), otherwise the header is just the side.
+    const side = this._showClassMethods ? 'class' : 'instance';
+    this.views.method.description = compose(VIEW_METHODS, undefined, side);
   }
 
   getFilter(viewId: string): string | undefined {
@@ -932,16 +904,7 @@ export class ExplorerController {
       const info = this.selectorsFor(revealMethod.isMeta, ALL_METHODS_CATEGORY).find(
         (i) => i.selector === revealMethod.selector,
       );
-      if (info) {
-        try {
-          await this.views?.method.reveal(
-            new MethodItem(revealMethod.isMeta, info, info.category),
-            { select: true, focus: false, expand: true },
-          );
-        } catch {
-          /* ignore */
-        }
-      }
+      if (info) await this.revealMethodRow(revealMethod.isMeta, info);
     }
   }
 
@@ -2639,20 +2602,114 @@ export class ExplorerController {
 
   // Method categories for one side, with the computed ALL/SESSION rows on top,
   // plus any just-created (still empty) categories from the + button.
-  methodCategories(isMeta: boolean): MethodCategoryItem[] {
+  methodCategories(isMeta: boolean, filter?: string): MethodCategoryItem[] {
     const lines = this.envLines.filter((l) => l.isMeta === isMeta);
     const real = [...new Set(lines.map((l) => l.category).filter((c) => c && c.length))];
     const fresh = [...this.newMethodCategories[isMeta ? 'meta' : 'instance']].filter(
       (c) => !real.includes(c),
     );
-    const combined = [...real, ...fresh].sort((a, b) => a.localeCompare(b));
+    let combined = [...real, ...fresh].sort((a, b) => a.localeCompare(b));
     if (lines.length === 0 && combined.length === 0) return [];
     const hasSession = lines.some(
       (l) => l.sessionMethodBits && Object.keys(l.sessionMethodBits).length > 0,
     );
-    const items = [new MethodCategoryItem(isMeta, ALL_METHODS_CATEGORY, true)];
-    if (hasSession) items.push(new MethodCategoryItem(isMeta, SESSION_METHODS_CATEGORY, true));
-    return items.concat(combined.map((c) => new MethodCategoryItem(isMeta, c, false)));
+    // With a filter set and categories visible, keep the category structure but
+    // drop categories with no matching selector, and expand what remains so the
+    // matches are visible without hand-expanding each folder.
+    const hasMatch = (category: string) =>
+      filter === undefined ||
+      this.selectorsFor(isMeta, category).some((info) => filterMatches(info.selector, filter));
+    const expanded = filter !== undefined;
+    if (filter !== undefined) combined = combined.filter(hasMatch);
+    const items: MethodCategoryItem[] = [];
+    if (hasMatch(ALL_METHODS_CATEGORY))
+      items.push(new MethodCategoryItem(isMeta, ALL_METHODS_CATEGORY, true, expanded));
+    if (hasSession && hasMatch(SESSION_METHODS_CATEGORY))
+      items.push(new MethodCategoryItem(isMeta, SESSION_METHODS_CATEGORY, true, expanded));
+    return items.concat(combined.map((c) => new MethodCategoryItem(isMeta, c, false, expanded)));
+  }
+
+  // Whether the Methods pane groups selectors under their categories. Off = a
+  // flat list of the class's methods (the category tree level is dropped). Backed
+  // by a setting so the title-bar toggle both flips the view AND persists it.
+  groupMethodsByCategory(): boolean {
+    return vscode.workspace
+      .getConfiguration('gemstone')
+      .get<boolean>('explorer.groupMethodsByCategory', true);
+  }
+
+  // All of one side's methods as flat rows (no category parent) — used when
+  // category grouping is off, or when a filter is narrowing the list.
+  flatMethods(isMeta: boolean, filter?: string): MethodItem[] {
+    return this.selectorsFor(isMeta, ALL_METHODS_CATEGORY)
+      .filter((info) => filter === undefined || filterMatches(info.selector, filter))
+      .map((info) => new MethodItem(isMeta, info, undefined, this.methodSourceUri(isMeta, info)));
+  }
+
+  // Flip the persistent group-by-category setting (from the title-bar toggle).
+  // Writing the setting fires the config-change listener that calls
+  // syncMethodGrouping, so the view and the saved preference stay in step.
+  async setGroupMethodsByCategory(group: boolean): Promise<void> {
+    await vscode.workspace
+      .getConfiguration('gemstone')
+      .update('explorer.groupMethodsByCategory', group, vscode.ConfigurationTarget.Global);
+  }
+
+  // Keep the `gemstone.explorer.methodsGrouped` context key (which title toggle
+  // shows) in step with the setting, and re-render the pane.
+  syncMethodGrouping(): void {
+    void vscode.commands.executeCommand(
+      'setContext',
+      'gemstone.explorer.methodsGrouped',
+      this.groupMethodsByCategory(),
+    );
+    this.methodProvider.refresh();
+  }
+
+  // Which method side the Methods pane shows — instance (default) or class. The
+  // pane shows ONE side at a time; this is a per-session toggle from the title bar
+  // that carries across class selections until flipped or the window reloads.
+  private _showClassMethods = false;
+  get showClassMethods(): boolean {
+    return this._showClassMethods;
+  }
+
+  // Switch the pane to a side, re-rendering only when it actually changed. Called
+  // by the title toggle and before revealing a row that lives on the other side.
+  setMethodSide(isMeta: boolean): void {
+    const changed = this._showClassMethods !== isMeta;
+    this._showClassMethods = isMeta;
+    this.syncMethodSide();
+    if (changed) {
+      this.methodProvider.refresh();
+      this.syncTitles();
+    }
+  }
+
+  // Mirror the active side into the `gemstone.explorer.methodSideIsClass` context
+  // key that selects which title toggle (Show Class / Show Instance) is visible.
+  syncMethodSide(): void {
+    void vscode.commands.executeCommand(
+      'setContext',
+      'gemstone.explorer.methodSideIsClass',
+      this._showClassMethods,
+    );
+  }
+
+  // Reveal + select a method row, honoring the pane's current view state: switch
+  // to the method's side (the pane shows one side at a time) and drop the category
+  // parent when grouping is off, so the built node's id matches the rendered row.
+  private async revealMethodRow(isMeta: boolean, info: SelectorInfo): Promise<void> {
+    this.setMethodSide(isMeta);
+    const displayCategory = this.groupMethodsByCategory() ? info.category : undefined;
+    try {
+      await this.views?.method.reveal(
+        new MethodItem(isMeta, info, displayCategory, this.methodSourceUri(isMeta, info)),
+        { select: true, focus: false, expand: true },
+      );
+    } catch {
+      /* ignore */
+    }
   }
 
   // Selectors under a category (real or computed) with per-method metadata.
@@ -2945,15 +3002,8 @@ export class ExplorerController {
         (i) => i.selector === opts.revealMethod!.selector,
       );
       if (info) {
-        try {
-          await this.views?.method.reveal(
-            new MethodItem(opts.revealMethod.isMeta, info, info.category),
-            { select: true, focus: false, expand: true },
-          );
-          this.syncTitles();
-        } catch {
-          /* ignore */
-        }
+        await this.revealMethodRow(opts.revealMethod.isMeta, info);
+        this.syncTitles();
       }
     }
   }
@@ -3015,15 +3065,8 @@ export class ExplorerController {
           (i) => i.selector === revealMethod.selector,
         );
         if (info) {
-          try {
-            await this.views?.method.reveal(
-              new MethodItem(revealMethod.isMeta, info, info.category),
-              { select: true, focus: false, expand: true },
-            );
-            this.syncTitles();
-          } catch {
-            /* ignore */
-          }
+          await this.revealMethodRow(revealMethod.isMeta, info);
+          this.syncTitles();
         }
       }
       return;
@@ -3261,22 +3304,10 @@ export class ExplorerController {
       void vscode.window.showWarningMessage('Select a class first.');
       return;
     }
-    // Palette: honor the last-touched side, else ask so either an instance or a
-    // class method can be created regardless of what's selected.
-    let isMeta: boolean;
-    if (this.state.selectedIsMeta !== undefined) {
-      isMeta = this.state.selectedIsMeta;
-    } else {
-      const pick = await vscode.window.showQuickPick(
-        [
-          { label: 'Instance method', meta: false },
-          { label: 'Class method', meta: true },
-        ],
-        { placeHolder: `New method on ${this.state.className}` },
-      );
-      if (!pick) return;
-      isMeta = pick.meta;
-    }
+    // Honor the last-touched side, else default to the side the Methods pane is
+    // currently showing (the instance/class title toggle) — a new method lands on
+    // the side you're looking at.
+    const isMeta = this.state.selectedIsMeta ?? this.showClassMethods;
     const category =
       this.state.selectedIsMeta === isMeta && this.state.selectedMethodCategory
         ? this.state.selectedMethodCategory
@@ -3369,13 +3400,7 @@ export class ExplorerController {
     );
     if (!added) return;
     this.pendingNewMethod = undefined;
-    this.views?.method
-      .reveal(new MethodItem(pending.isMeta, added, added.category), {
-        select: true,
-        focus: false,
-        expand: true,
-      })
-      .then(undefined, () => {});
+    void this.revealMethodRow(pending.isMeta, added);
   }
 
   // ── Drag & drop ─────────────────────────────────────────────────────────────
@@ -3849,49 +3874,39 @@ class MethodProvider extends RefreshableProvider<MethodNode> {
   constructor(private readonly ctl: ExplorerController) {
     super();
   }
-  // Walk up the side ▸ category ▸ selector tree so TreeView.reveal can locate a
-  // method row (used by editor-focus → navigator sync). Nodes match by their
-  // stable ids, so freshly-built parents resolve to the rendered ones.
+  // Walk up the category ▸ selector tree so TreeView.reveal can locate a method
+  // row (used by editor-focus → navigator sync). The instance/class side is a
+  // title-bar toggle, not a tree level, so a category is a root. Nodes match by
+  // their stable ids, so freshly-built parents resolve to the rendered ones.
   getParent(element: MethodNode): MethodNode | undefined {
     if (element instanceof MethodItem) {
-      if (element.displayCategory === undefined) return new MethodSideItem(element.isMeta);
+      if (element.displayCategory === undefined) return undefined;
       const computed =
         element.displayCategory === ALL_METHODS_CATEGORY ||
         element.displayCategory === SESSION_METHODS_CATEGORY;
       return new MethodCategoryItem(element.isMeta, element.displayCategory, computed);
     }
-    if (element instanceof MethodCategoryItem) return new MethodSideItem(element.isMeta);
+    // Category rows are roots (the side is a title toggle, not a tree level).
     return undefined;
   }
   getChildren(element?: MethodNode): MethodNode[] {
     if (this.ctl.state.className === undefined) return [];
 
     if (!element) {
-      return [new MethodSideItem(false), new MethodSideItem(true)];
-    }
-    if (element instanceof MethodSideItem) {
-      // With a filter active, drop the category grouping and show matching
-      // selectors directly under each side — "everything starting with r".
+      // Roots are the active side's rows. Filtering respects the grouping setting:
+      // categories off → a flat list of matching selectors; categories on → the
+      // category structure, pruned to categories that contain a match (see
+      // methodCategories). An empty filter is a no-op.
+      const isMeta = this.ctl.showClassMethods;
       const filter = this.ctl.getFilter(VIEW_METHODS);
-      if (filter) {
-        return this.ctl
-          .selectorsFor(element.isMeta, ALL_METHODS_CATEGORY)
-          .filter((info) => filterMatches(info.selector, filter))
-          .map(
-            (info) =>
-              new MethodItem(
-                element.isMeta,
-                info,
-                undefined,
-                this.ctl.methodSourceUri(element.isMeta, info),
-              ),
-          );
-      }
-      return this.ctl.methodCategories(element.isMeta);
+      if (!this.ctl.groupMethodsByCategory()) return this.ctl.flatMethods(isMeta, filter);
+      return this.ctl.methodCategories(isMeta, filter);
     }
     if (element instanceof MethodCategoryItem) {
+      const filter = this.ctl.getFilter(VIEW_METHODS);
       return this.ctl
         .selectorsFor(element.isMeta, element.category)
+        .filter((info) => filter === undefined || filterMatches(info.selector, filter))
         .map(
           (info) =>
             new MethodItem(
@@ -4005,6 +4020,11 @@ export function registerGemStoneExplorer(
     );
   };
   syncActiveContext();
+  // Seed the Methods-pane grouping context key (which title toggle shows) from the
+  // saved setting, and keep it in step if the setting changes elsewhere.
+  ctl.syncMethodGrouping();
+  // Seed the instance/class side context key (defaults to instance).
+  ctl.syncMethodSide();
 
   const dictView = vscode.window.createTreeView('gemstoneExplorerDicts', {
     treeDataProvider: ctl.dictProvider,
@@ -4051,14 +4071,13 @@ export function registerGemStoneExplorer(
   });
   methodView.onDidChangeSelection((e) => {
     const node = e.selection[0];
-    // Record the side / category context so New Method(-Category) default there.
+    // Record the category context so New Method(-Category) defaults there. The
+    // side is the title-bar toggle now, not a selectable row.
     if (node instanceof MethodItem) {
       ctl.recordMethodContext(node.isMeta, node.info.category);
       void ctl.openMethod(node);
     } else if (node instanceof MethodCategoryItem) {
       ctl.recordMethodContext(node.isMeta, node.computed ? undefined : node.category);
-    } else if (node instanceof MethodSideItem) {
-      ctl.recordMethodContext(node.isMeta, undefined);
     }
   });
 
@@ -4153,6 +4172,28 @@ export function registerGemStoneExplorer(
     vscode.commands.registerCommand('gemstone.explorer.methodClicked', (node?: MethodItem) => {
       if (node instanceof MethodItem) ctl.handleMethodClick(node);
     }),
+    // Methods-pane title toggle: group under categories, or list methods flat.
+    // Both write the persistent setting; the config listener re-renders the pane.
+    vscode.commands.registerCommand(
+      'gemstone.explorer.groupMethodsByCategory',
+      () => void ctl.setGroupMethodsByCategory(true),
+    ),
+    vscode.commands.registerCommand(
+      'gemstone.explorer.showMethodsFlat',
+      () => void ctl.setGroupMethodsByCategory(false),
+    ),
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('gemstone.explorer.groupMethodsByCategory'))
+        ctl.syncMethodGrouping();
+    }),
+    // Methods-pane title toggle: show the instance side or the class side (the
+    // pane shows one at a time; the side level is no longer a tree row).
+    vscode.commands.registerCommand('gemstone.explorer.showClassMethods', () =>
+      ctl.setMethodSide(true),
+    ),
+    vscode.commands.registerCommand('gemstone.explorer.showInstanceMethods', () =>
+      ctl.setMethodSide(false),
+    ),
     // Generate a Grail (.py) stub for a class — Classes/Hierarchy menus and the
     // Command Palette all route here.
     vscode.commands.registerCommand(
@@ -4355,8 +4396,14 @@ export function registerGemStoneExplorer(
     vscode.commands.registerCommand('gemstone.explorer.newClassMethodCategory', () =>
       ctl.newMethodCategory(true),
     ),
+    // Methods-pane title "+": add a category to whichever side the pane is
+    // currently showing (the instance/class level is a title toggle now).
+    vscode.commands.registerCommand('gemstone.explorer.newMethodCategory', () =>
+      ctl.newMethodCategory(ctl.showClassMethods),
+    ),
     // From a category row, file the new method straight into that category;
-    // from the palette (no item), infer side + category from the selection.
+    // from the palette / title bar (no item), infer side + category from the
+    // active side and selection.
     vscode.commands.registerCommand('gemstone.explorer.newMethod', (item?: MethodCategoryItem) =>
       ctl.newMethod(item instanceof MethodCategoryItem ? item : undefined),
     ),

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -11,9 +11,11 @@ import {
   buildNewMethodUri,
   buildMethodUri,
   parseUri,
+  parseMethodUri,
   listOpenGemstoneTabs,
   tabInputUri,
 } from './gemstoneFileSystemProvider';
+import type { ParsedUri } from './gemstoneFileSystemProvider';
 import { filterMatches } from './explorerFilter';
 import {
   parseMethodFilter,
@@ -1471,6 +1473,16 @@ export class ExplorerController {
     }
   }
 
+  // Re-reveal the current class when the Hierarchy pane reappears. reveals are
+  // skipped while the pane is hidden — either collapsed, or the whole Explorer
+  // container is off-screen (revealHierarchySelf's visible guard) — so a class
+  // navigated to while it was hidden would otherwise leave the pane on a stale
+  // selection until the next navigation. Only acts on becoming visible, so it
+  // never forces a deliberately-collapsed pane open.
+  onHierarchyVisibilityChanged(visible: boolean): void {
+    if (visible) void this.revealHierarchySelf();
+  }
+
   hierarchyParent(element: HierarchyItem): HierarchyItem | undefined {
     if (element.role === 'subclass') {
       const selfIdx = this.hierChain.length - 1;
@@ -2814,12 +2826,9 @@ export class ExplorerController {
     if (raw === undefined) return [];
     const filter = this.parseFilter(raw);
     if (filter.ivar.length === 0) return [];
-    // parts: ['', dictName, className, side, category, selector...]
-    const parts = uri.path.split('/').map((p) => decodeURIComponent(p));
-    if (parts.length < 6) return [];
-    const isMeta = parts[3] === 'class';
-    const selector = unescapeSelectorSlashes(parts.slice(5).join('/'));
-    const access = this.methodIvarAccess().get(`${isMeta}:${selector}`);
+    const method = parseMethodUri(uri);
+    if (!method) return [];
+    const access = this.methodIvarAccess().get(`${method.isMeta}:${method.selector}`);
     if (!access) return [];
     const patterns = filter.ivar.map((c) => c.pattern);
     return [...new Set([...access.reads, ...access.writes])].filter((n) =>
@@ -2890,6 +2899,11 @@ export class ExplorerController {
     this._showClassMethods = isMeta;
     this.syncMethodSide();
     if (changed) {
+      // Keep the recorded selection side in step with the visible side so New
+      // Method lands on the side you're now looking at (the old selection is on
+      // the other side); its category no longer applies, so drop it too.
+      this.state.selectedIsMeta = isMeta;
+      this.state.selectedMethodCategory = undefined;
       this.methodProvider.refresh();
       this.syncTitles();
     }
@@ -3246,20 +3260,19 @@ export class ExplorerController {
     const session = this.session();
     if (!session || String(session.id) !== uri.authority) return;
 
-    const parts = uri.path.split('/').map((p) => decodeURIComponent(p));
-    // parts: ['', dictName, className, side|'definition', category, selector...]
-    const dictName = parts[1];
-    const className = parts[2];
-    if (!dictName || !className || className === 'new-class') return;
-
-    let revealMethod: { selector: string; isMeta: boolean } | undefined;
-    if (parts.length >= 6) {
-      const selector = unescapeSelectorSlashes(parts.slice(5).join('/'));
-      if (selector === 'new-method') return; // unsaved template
-      revealMethod = { selector, isMeta: parts[3] === 'class' };
-    } else if (parts[3] !== 'definition') {
-      return; // not a recognizable method/definition URI
+    // Only a saved method or a class definition drives the navigator; a comment
+    // or a new-* template (and anything unparseable) is left alone.
+    let parsed: ParsedUri;
+    try {
+      parsed = parseUri(uri);
+    } catch {
+      return;
     }
+    if (parsed.kind !== 'method' && parsed.kind !== 'definition') return;
+    const { dictName, className } = parsed;
+
+    const revealMethod =
+      parsed.kind === 'method' ? { selector: parsed.selector, isMeta: parsed.isMeta } : undefined;
 
     // Already showing this class: just (re)reveal the method row / refresh title.
     if (this.state.className === className && this.state.dictName === dictName) {
@@ -4147,8 +4160,9 @@ class MethodProvider extends RefreshableProvider<MethodNode> {
         ? this.ctl.flatMethods(isMeta, filter)
         : this.ctl.methodCategories(isMeta, filter);
       // While filtering, lead with a filter chip (funnel row + inline ✕) so the
-      // active filter reads distinctly from the method rows and can be cleared here.
-      return filter === undefined ? rows : [new FilterChipItem(VIEW_METHODS, filter), ...rows];
+      // active filter reads distinctly from the method rows and can be cleared
+      // here — the same helper the other three panes use.
+      return withFilterChip(VIEW_METHODS, this.ctl, rows);
     }
     if (element instanceof MethodCategoryItem) {
       const filter = this.ctl.getFilter(VIEW_METHODS);
@@ -4324,6 +4338,7 @@ export function registerGemStoneExplorer(
   hierarchyView.onDidChangeSelection((e) => {
     if (e.selection[0]) ctl.selectHierarchyNode(e.selection[0]);
   });
+  hierarchyView.onDidChangeVisibility((e) => ctl.onHierarchyVisibilityChanged(e.visible));
   methodView.onDidChangeSelection((e) => {
     const node = e.selection[0];
     // Record the category context so New Method(-Category) defaults there. The

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -158,6 +158,48 @@ export function parseUri(uri: vscode.Uri): ParsedUri {
   throw vscode.FileSystemError.FileNotFound(uri);
 }
 
+// A saved method's coordinates, recovered from its gemstone:// source URI.
+export interface MethodUriRef {
+  sessionId: number;
+  dictName: string;
+  className: string;
+  isMeta: boolean;
+  selector: string;
+  environmentId: number;
+  dictIndex?: number;
+  // True for a read-only base / session-override diff view (its selector has
+  // already been un-labelled). Callers that mutate the method — e.g. setting a
+  // breakpoint — skip these; read-only consumers (highlighting, code lenses)
+  // ignore the flag and use the real selector.
+  diffView: boolean;
+}
+
+// Parse a gemstone:// method-source URI into its method coordinates, or null
+// when the URI isn't a saved method: a non-gemstone scheme, a definition /
+// comment / new-* template, or an unparseable path. The one reverse of the
+// method-URI format, so callers don't re-split the path by hand and re-acquire
+// the slash-selector and diff-label bugs that hand-rolled parse carries.
+export function parseMethodUri(uri: vscode.Uri): MethodUriRef | null {
+  if (uri.scheme !== 'gemstone') return null;
+  let parsed: ParsedUri;
+  try {
+    parsed = parseUri(uri);
+  } catch {
+    return null;
+  }
+  if (parsed.kind !== 'method') return null;
+  return {
+    sessionId: parsed.sessionId,
+    dictName: parsed.dictName,
+    className: parsed.className,
+    isMeta: parsed.isMeta,
+    selector: parsed.selector,
+    environmentId: parsed.environmentId,
+    dictIndex: parsed.dictIndex,
+    diffView: parsed.diffView ?? false,
+  };
+}
+
 export function buildNewMethodUri(
   sessionId: number,
   dictName: string,

--- a/client/src/queries/__tests__/getMethodInstVarAccess.integration.test.ts
+++ b/client/src/queries/__tests__/getMethodInstVarAccess.integration.test.ts
@@ -1,0 +1,57 @@
+// Integration test for getMethodInstVarAccess against a live stone. Confirms the
+// synthesized Smalltalk actually runs and that GsNMethod>>instVarsRead /
+// instVarsWritten report reader / writer / both / neither correctly — over the
+// whole release matrix (3.6.2 and 3.7.5). No server plugin needed: this is
+// base-image reflection, so it runs in both the bare and plugin CI passes.
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
+
+import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
+import { GciLibrary } from '../../gciLibrary';
+import * as q from '../../browserQueries';
+import type { ActiveSession } from '../../sessionManager';
+
+describe('getMethodInstVarAccess (integration)', () => {
+  let gci: GciLibrary;
+  let handle: unknown;
+  useIntegrationTest((testContext) => {
+    gci = testContext.gciLibrary;
+    handle = testContext.session;
+  });
+
+  const session = (): ActiveSession => ({ id: 1, gci, handle }) as unknown as ActiveSession;
+
+  const CLS = 'IvarAccessDemo';
+
+  // A transient fixture (rolled back by the harness's abort) with one method per
+  // access shape. Selector spellings are unique to the fixture.
+  const defineFixture = (): void => {
+    q.compileClassDefinition(
+      session(),
+      `Object subclass: '${CLS}' instVarNames: #( count name ) classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    const m = (src: string): void => {
+      q.compileMethod(session(), CLS, false, 'accessing', src);
+    };
+    m('ivaCount\n\t^count'); // reads count
+    m('ivaSetCount: aValue\n\tcount := aValue'); // writes count
+    m('ivaBump\n\tcount := count + 1'); // reads + writes count
+    m("ivaGreeting\n\t^'hi'"); // touches no ivar
+  };
+
+  const dictIndex = (): number => q.getDictionaryNames(session()).indexOf('UserGlobals') + 1;
+
+  it('reports each method reader / writer / both / neither', () => {
+    defineFixture();
+
+    const rows = q.getMethodInstVarAccess(session(), dictIndex(), CLS);
+    const by = (selector: string) => rows.find((r) => !r.isMeta && r.selector === selector);
+
+    expect(by('ivaCount')).toMatchObject({ reads: ['count'], writes: [] });
+    expect(by('ivaSetCount:')).toMatchObject({ reads: [], writes: ['count'] });
+    expect(by('ivaBump')).toMatchObject({ reads: ['count'], writes: ['count'] });
+    // A method that touches no instance variable is omitted entirely.
+    expect(by('ivaGreeting')).toBeUndefined();
+  });
+});

--- a/client/src/queries/__tests__/getMethodInstVarAccess.integration.test.ts
+++ b/client/src/queries/__tests__/getMethodInstVarAccess.integration.test.ts
@@ -45,7 +45,7 @@ describe('getMethodInstVarAccess (integration)', () => {
   it('reports each method reader / writer / both / neither', () => {
     defineFixture();
 
-    const rows = q.getMethodInstVarAccess(session(), dictIndex(), CLS);
+    const rows = q.getMethodInstVarAccess(session(), dictIndex(), CLS, 0);
     const by = (selector: string) => rows.find((r) => !r.isMeta && r.selector === selector);
 
     expect(by('ivaCount')).toMatchObject({ reads: ['count'], writes: [] });

--- a/client/src/queries/__tests__/getMethodInstVarAccess.test.ts
+++ b/client/src/queries/__tests__/getMethodInstVarAccess.test.ts
@@ -11,6 +11,7 @@ describe('getMethodInstVarAccess', () => {
       vi.fn<QueryExecutor>(() => raw),
       1,
       'Association',
+      0,
     );
 
     expect(rows).toEqual([
@@ -28,6 +29,7 @@ describe('getMethodInstVarAccess', () => {
       vi.fn<QueryExecutor>(() => raw),
       1,
       'C',
+      0,
     );
 
     expect(rows).toEqual([{ isMeta: false, selector: 'key', reads: ['key'], writes: [] }]);

--- a/client/src/queries/__tests__/getMethodInstVarAccess.test.ts
+++ b/client/src/queries/__tests__/getMethodInstVarAccess.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryExecutor } from '../types';
+import { getMethodInstVarAccess } from '../getMethodInstVarAccess';
+
+describe('getMethodInstVarAccess', () => {
+  it('parses reader, writer, multi-ivar, and class-side rows', () => {
+    const raw =
+      '0\tkey\tkey\t\n' + '0\tkey:\t\tkey\n' + '0\t=\tkey,value\t\n' + '1\tnew\t\tcount\n';
+
+    const rows = getMethodInstVarAccess(
+      vi.fn<QueryExecutor>(() => raw),
+      1,
+      'Association',
+    );
+
+    expect(rows).toEqual([
+      { isMeta: false, selector: 'key', reads: ['key'], writes: [] },
+      { isMeta: false, selector: 'key:', reads: [], writes: ['key'] },
+      { isMeta: false, selector: '=', reads: ['key', 'value'], writes: [] },
+      { isMeta: true, selector: 'new', reads: [], writes: ['count'] },
+    ]);
+  });
+
+  it('skips blank and malformed lines', () => {
+    const raw = '\n0\tkey\tkey\t\nnotenoughtabs\n';
+
+    const rows = getMethodInstVarAccess(
+      vi.fn<QueryExecutor>(() => raw),
+      1,
+      'C',
+    );
+
+    expect(rows).toEqual([{ isMeta: false, selector: 'key', reads: ['key'], writes: [] }]);
+  });
+});

--- a/client/src/queries/getMethodInstVarAccess.ts
+++ b/client/src/queries/getMethodInstVarAccess.ts
@@ -18,27 +18,34 @@ export function getMethodInstVarAccess(
   execute: QueryExecutor,
   dictIndex: number,
   className: string,
+  maxEnv: number,
 ): MethodInstVarAccess[] {
   // One line per accessing method: <isMeta 0|1> TAB <selector> TAB
   // <reads, comma-joined> TAB <writes, comma-joined>. Names come straight from
   // the compiled method, so they include in-scope inherited ivars by name.
+  // Scans environments 0..maxEnv (matching the method list); a selector is
+  // reported once per side, the first environment that defines it winning.
   const code = `| class stream |
 class := (System myUserProfile symbolList at: ${dictIndex}) at: #'${escapeString(className)}'.
 stream := WriteStream on: Unicode7 new.
 { class. class class. } doWithIndex: [:eachClass :idx |
-  | isMeta |
+  | isMeta seen |
   isMeta := idx = 2.
-  eachClass selectors asSortedCollection do: [:sel |
-    | m rd wr |
-    m := eachClass compiledMethodAt: sel environmentId: 0 otherwise: nil.
-    m ifNotNil: [
-      rd := m instVarsRead. wr := m instVarsWritten.
-      (rd isEmpty and: [wr isEmpty]) ifFalse: [
-        stream nextPutAll: (isMeta ifTrue: ['1'] ifFalse: ['0']); tab; nextPutAll: sel; tab.
-        rd asSortedCollection do: [:n | stream nextPutAll: n] separatedBy: [stream nextPut: $,].
-        stream tab.
-        wr asSortedCollection do: [:n | stream nextPutAll: n] separatedBy: [stream nextPut: $,].
-        stream lf ] ] ] ].
+  seen := IdentitySet new.
+  0 to: ${maxEnv} do: [:env |
+    (eachClass _unifiedCategorys: env) valuesDo: [:selectors |
+      selectors do: [:sel |
+        (seen includes: sel) ifFalse: [ | m rd wr |
+          seen add: sel.
+          m := eachClass compiledMethodAt: sel environmentId: env otherwise: nil.
+          m ifNotNil: [
+            rd := m instVarsRead. wr := m instVarsWritten.
+            (rd isEmpty and: [wr isEmpty]) ifFalse: [
+              stream nextPutAll: (isMeta ifTrue: ['1'] ifFalse: ['0']); tab; nextPutAll: sel; tab.
+              rd asSortedCollection do: [:n | stream nextPutAll: n] separatedBy: [stream nextPut: $,].
+              stream tab.
+              wr asSortedCollection do: [:n | stream nextPutAll: n] separatedBy: [stream nextPut: $,].
+              stream lf ] ] ] ] ] ] ].
 stream contents`;
 
   const raw = execute(code);

--- a/client/src/queries/getMethodInstVarAccess.ts
+++ b/client/src/queries/getMethodInstVarAccess.ts
@@ -1,0 +1,60 @@
+import { QueryExecutor } from './types';
+import { escapeString } from './util';
+
+// Per-method instance-variable access for a class: which instance variables each
+// method reads and which it writes, straight from the compiler
+// (`GsNMethod>>instVarsRead` / `instVarsWritten`). Both sides are reported; a
+// class-side method's sets are its class-instance variables. Methods that touch
+// no instance variable are omitted (they can't match a reads:/writes: filter).
+// Drives the Methods-pane reads:/writes:/accesses: filter tokens.
+export interface MethodInstVarAccess {
+  isMeta: boolean;
+  selector: string;
+  reads: string[];
+  writes: string[];
+}
+
+export function getMethodInstVarAccess(
+  execute: QueryExecutor,
+  dictIndex: number,
+  className: string,
+): MethodInstVarAccess[] {
+  // One line per accessing method: <isMeta 0|1> TAB <selector> TAB
+  // <reads, comma-joined> TAB <writes, comma-joined>. Names come straight from
+  // the compiled method, so they include in-scope inherited ivars by name.
+  const code = `| class stream |
+class := (System myUserProfile symbolList at: ${dictIndex}) at: #'${escapeString(className)}'.
+stream := WriteStream on: Unicode7 new.
+{ class. class class. } doWithIndex: [:eachClass :idx |
+  | isMeta |
+  isMeta := idx = 2.
+  eachClass selectors asSortedCollection do: [:sel |
+    | m rd wr |
+    m := eachClass compiledMethodAt: sel environmentId: 0 otherwise: nil.
+    m ifNotNil: [
+      rd := m instVarsRead. wr := m instVarsWritten.
+      (rd isEmpty and: [wr isEmpty]) ifFalse: [
+        stream nextPutAll: (isMeta ifTrue: ['1'] ifFalse: ['0']); tab; nextPutAll: sel; tab.
+        rd asSortedCollection do: [:n | stream nextPutAll: n] separatedBy: [stream nextPut: $,].
+        stream tab.
+        wr asSortedCollection do: [:n | stream nextPutAll: n] separatedBy: [stream nextPut: $,].
+        stream lf ] ] ] ].
+stream contents`;
+
+  const raw = execute(code);
+
+  const results: MethodInstVarAccess[] = [];
+  for (const line of raw.split('\n')) {
+    if (line.length === 0) continue;
+    const parts = line.split('\t');
+    if (parts.length < 4) continue;
+    const split = (s: string): string[] => (s.length > 0 ? s.split(',') : []);
+    results.push({
+      isMeta: parts[0] === '1',
+      selector: parts[1],
+      reads: split(parts[2]),
+      writes: split(parts[3]),
+    });
+  }
+  return results;
+}

--- a/client/src/refactoring/__tests__/refactoringChangeSignature.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringChangeSignature.integration.test.ts
@@ -103,6 +103,8 @@ describe('change method signature (integration)', () => {
     expect(enginePresent()).toBe(q.checkRefactoringSupportAvailable(session()));
   });
 
+  // One blocking exec runs an entire in-stone SUnit suite; under a busy shared
+  // stone that can exceed vitest's default 5s and flake a push. Give it room.
   it('runs the change-signature GS SUnit suite in-stone with zero failures', (ctx) => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
@@ -112,7 +114,7 @@ r := (System myUserProfile symbolList objectNamed: #GsChangeSignatureRefactoring
 (r failures size + r errors size) printString`;
 
     expect(exec(code).trim()).toBe('0');
-  });
+  }, 30_000);
 
   it('pre-flight analyses the method arity and argument names', async (ctx) => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());

--- a/client/src/selectorBreakpointManager.ts
+++ b/client/src/selectorBreakpointManager.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { SessionManager, ActiveSession } from './sessionManager';
+import { parseMethodUri, MethodUriRef } from './gemstoneFileSystemProvider';
 import * as queries from './browserQueries';
 import { StepPointSelectorInfo } from './browserQueries';
 
@@ -8,13 +9,6 @@ interface TrackedSelectorBreakpoint {
   selectorOffset: number;
   selectorLength: number;
   selectorText: string;
-}
-
-interface MethodRef {
-  className: string;
-  isMeta: boolean;
-  selector: string;
-  environmentId: number;
 }
 
 const decorationType = vscode.window.createTextEditorDecorationType({
@@ -53,8 +47,8 @@ export class SelectorBreakpointManager {
 
     const uri = editor.document.uri;
     const uriKey = uri.toString();
-    const method = this.parseMethodUri(uri);
-    if (!method) return;
+    const method = parseMethodUri(uri);
+    if (!method || method.diffView) return;
 
     const infos = this.getSelectorInfos(session, uri, method, editor.document.getText());
     if (!infos || infos.length === 0) {
@@ -177,7 +171,7 @@ export class SelectorBreakpointManager {
   private getSelectorInfos(
     session: ActiveSession,
     uri: vscode.Uri,
-    method: MethodRef,
+    method: MethodUriRef,
     source?: string,
   ): StepPointSelectorInfo[] | null {
     const uriKey = uri.toString();
@@ -210,19 +204,6 @@ export class SelectorBreakpointManager {
         this.refreshDecorations(editor);
       }
     }
-  }
-
-  private parseMethodUri(uri: vscode.Uri): MethodRef | null {
-    if (uri.scheme !== 'gemstone') return null;
-    const parts = uri.path.split('/').map(decodeURIComponent);
-    if (parts.length < 6) return null;
-    const envMatch = uri.query?.match(/env=(\d+)/);
-    return {
-      className: parts[2],
-      isMeta: parts[3] === 'class',
-      selector: parts[5],
-      environmentId: envMatch ? parseInt(envMatch[1], 10) : 0,
-    };
   }
 }
 

--- a/client/src/sourceEditorPlacement.ts
+++ b/client/src/sourceEditorPlacement.ts
@@ -17,19 +17,6 @@ import { tabInputUri } from './gemstoneFileSystemProvider';
 export class SourceEditorPlacement {
   private readonly owned = new Set<string>();
 
-  // URI (string) of the one reusable, non-preview source tab this browser keeps
-  // for single-click navigation, if any. The next single-click closes it instead
-  // of piling up tabs. We can't use a real preview tab for this — opening one
-  // scrolls the navigator tree (see openGemstoneDocument) — so we mimic its
-  // "single throwaway editor" behavior ourselves.
-  reusableTab?: string;
-
-  // The view-column the reusable tab was actually opened into. Recorded from the
-  // opened editor (not inferred from the URI), because the SAME gemstone:// method
-  // URI can be open in another browser's group too — so when we close the outgoing
-  // transient we must target the column WE put it in, never a foreign copy.
-  reusableColumn?: number;
-
   // `createHome` builds this browser's source region from scratch (e.g. a group
   // below its webview) and returns the column to open into. Required only when
   // homeColumn() is used.
@@ -68,7 +55,7 @@ export class SourceEditorPlacement {
   }
 
   /**
-   * The one editor group that holds this browser's source editors — the transient
+   * The one editor group that holds this browser's source editors — the preview
    * tab and every pinned tab live together here, so they read as one row of tabs.
    * Undefined until the first open, when the caller uses the active group.
    */

--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
             "minimum": 0,
             "description": "Maximum method dictionary environment to show in the browser (0 = standard Smalltalk only, 2 = show environments 0–2)"
           },
+          "gemstone.explorer.groupMethodsByCategory": {
+            "type": "boolean",
+            "default": true,
+            "description": "Group methods in the GemStone Explorer's Methods pane under their categories. Turn off to list a class's methods flat, without the category level. Toggle quickly from the Methods pane title bar."
+          },
           "gemstone.sessionMode": {
             "type": "string",
             "enum": [
@@ -1084,6 +1089,30 @@
         "icon": "$(clear-all)"
       },
       {
+        "command": "gemstone.explorer.showMethodsFlat",
+        "title": "Show Methods Without Categories",
+        "category": "GemStone",
+        "icon": "$(list-flat)"
+      },
+      {
+        "command": "gemstone.explorer.groupMethodsByCategory",
+        "title": "Group Methods by Category",
+        "category": "GemStone",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "gemstone.explorer.showClassMethods",
+        "title": "Show Class-Side Methods",
+        "category": "GemStone",
+        "icon": "$(symbol-class)"
+      },
+      {
+        "command": "gemstone.explorer.showInstanceMethods",
+        "title": "Show Instance-Side Methods",
+        "category": "GemStone",
+        "icon": "$(symbol-method)"
+      },
+      {
         "command": "gemstone.explorer.findClass",
         "title": "Find Class in Browser Panels",
         "category": "GemStone",
@@ -1121,6 +1150,12 @@
       {
         "command": "gemstone.explorer.newClassMethodCategory",
         "title": "New Class Method Category",
+        "category": "GemStone",
+        "icon": "$(new-folder)"
+      },
+      {
+        "command": "gemstone.explorer.newMethodCategory",
+        "title": "New Method Category",
         "category": "GemStone",
         "icon": "$(new-folder)"
       },
@@ -1743,42 +1778,72 @@
         },
         {
           "command": "gemstoneExplorerDicts.filter",
-          "when": "view == gemstoneExplorerDicts && focusedView == gemstoneExplorerDicts",
+          "when": "view == gemstoneExplorerDicts",
           "group": "navigation@0"
         },
         {
           "command": "gemstoneExplorerCategories.filter",
-          "when": "view == gemstoneExplorerCategories && focusedView == gemstoneExplorerCategories",
+          "when": "view == gemstoneExplorerCategories",
           "group": "navigation@0"
         },
         {
           "command": "gemstoneExplorerClasses.filter",
-          "when": "view == gemstoneExplorerClasses && focusedView == gemstoneExplorerClasses",
+          "when": "view == gemstoneExplorerClasses",
           "group": "navigation@0"
         },
         {
           "command": "gemstoneExplorerMethods.filter",
-          "when": "view == gemstoneExplorerMethods && focusedView == gemstoneExplorerMethods",
+          "when": "view == gemstoneExplorerMethods",
           "group": "navigation@0"
         },
         {
+          "command": "gemstone.explorer.showClassMethods",
+          "when": "view == gemstoneExplorerMethods && !gemstone.explorer.methodSideIsClass",
+          "group": "navigation@1"
+        },
+        {
+          "command": "gemstone.explorer.showInstanceMethods",
+          "when": "view == gemstoneExplorerMethods && gemstone.explorer.methodSideIsClass",
+          "group": "navigation@1"
+        },
+        {
+          "command": "gemstone.explorer.showMethodsFlat",
+          "when": "view == gemstoneExplorerMethods && gemstone.explorer.methodsGrouped",
+          "group": "navigation@2"
+        },
+        {
+          "command": "gemstone.explorer.groupMethodsByCategory",
+          "when": "view == gemstoneExplorerMethods && !gemstone.explorer.methodsGrouped",
+          "group": "navigation@2"
+        },
+        {
+          "command": "gemstone.explorer.newMethodCategory",
+          "when": "view == gemstoneExplorerMethods",
+          "group": "navigation@4"
+        },
+        {
+          "command": "gemstone.explorer.newMethod",
+          "when": "view == gemstoneExplorerMethods",
+          "group": "navigation@5"
+        },
+        {
           "command": "gemstoneExplorerDicts.clearFilter",
-          "when": "view == gemstoneExplorerDicts && focusedView == gemstoneExplorerDicts && gemstone.explorerFiltered.gemstoneExplorerDicts",
+          "when": "view == gemstoneExplorerDicts && gemstone.explorerFiltered.gemstoneExplorerDicts",
           "group": "navigation@1"
         },
         {
           "command": "gemstoneExplorerCategories.clearFilter",
-          "when": "view == gemstoneExplorerCategories && focusedView == gemstoneExplorerCategories && gemstone.explorerFiltered.gemstoneExplorerCategories",
+          "when": "view == gemstoneExplorerCategories && gemstone.explorerFiltered.gemstoneExplorerCategories",
           "group": "navigation@1"
         },
         {
           "command": "gemstoneExplorerClasses.clearFilter",
-          "when": "view == gemstoneExplorerClasses && focusedView == gemstoneExplorerClasses && gemstone.explorerFiltered.gemstoneExplorerClasses",
+          "when": "view == gemstoneExplorerClasses && gemstone.explorerFiltered.gemstoneExplorerClasses",
           "group": "navigation@1"
         },
         {
           "command": "gemstoneExplorerMethods.clearFilter",
-          "when": "view == gemstoneExplorerMethods && focusedView == gemstoneExplorerMethods && gemstone.explorerFiltered.gemstoneExplorerMethods",
+          "when": "view == gemstoneExplorerMethods && gemstone.explorerFiltered.gemstoneExplorerMethods",
           "group": "navigation@1"
         },
         {
@@ -1957,26 +2022,6 @@
           "command": "gemstone.explorer.renameMethod",
           "when": "view == gemstoneExplorerMethods && viewItem =~ /explorerMethod/",
           "group": "inline"
-        },
-        {
-          "command": "gemstone.explorer.newInstanceMethodCategory",
-          "when": "view == gemstoneExplorerMethods && viewItem == explorerSideInstance",
-          "group": "inline@1"
-        },
-        {
-          "command": "gemstone.explorer.newInstanceMethod",
-          "when": "view == gemstoneExplorerMethods && viewItem == explorerSideInstance",
-          "group": "inline@2"
-        },
-        {
-          "command": "gemstone.explorer.newClassMethodCategory",
-          "when": "view == gemstoneExplorerMethods && viewItem == explorerSideClass",
-          "group": "inline@1"
-        },
-        {
-          "command": "gemstone.explorer.newClassMethod",
-          "when": "view == gemstoneExplorerMethods && viewItem == explorerSideClass",
-          "group": "inline@2"
         },
         {
           "command": "gemstone.explorer.renameMethodCategory",

--- a/package.json
+++ b/package.json
@@ -2001,7 +2001,7 @@
         },
         {
           "command": "gemstone.explorer.clearFilterChip",
-          "when": "viewItem == explorerFilterChip",
+          "when": "view =~ /^gemstoneExplorer/ && viewItem == explorerFilterChip",
           "group": "inline"
         },
         {
@@ -2151,12 +2151,12 @@
         },
         {
           "command": "gemstone.explorer.insertSuperclass",
-          "when": "view == gemstoneExplorerHierarchy && viewItem == explorerHierClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "3_refactor@2"
         },
         {
           "command": "gemstone.explorer.extractSuperclass",
-          "when": "view == gemstoneExplorerHierarchy && viewItem == explorerHierClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "3_refactor@3"
         },
         {

--- a/package.json
+++ b/package.json
@@ -393,12 +393,13 @@
           "size": 3
         },
         {
-          "id": "gemstoneExplorerHierarchy",
+          "id": "gemstoneExplorerClassHierarchy",
           "name": "Hierarchy",
           "type": "tree",
           "icon": "$(type-hierarchy)",
           "when": "gemstone.explorerActive",
-          "size": 2
+          "size": 2,
+          "visibility": "collapsed"
         },
         {
           "id": "gemstoneExplorerMethods",
@@ -2034,22 +2035,22 @@
         },
         {
           "command": "gemstone.explorer.openHierarchyDefinition",
-          "when": "view == gemstoneExplorerHierarchy && viewItem == explorerHierClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "inline@1"
         },
         {
           "command": "gemstone.explorer.openHierarchyComment",
-          "when": "view == gemstoneExplorerHierarchy && viewItem == explorerHierClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "inline@2"
         },
         {
           "command": "gemstone.explorer.renameClass",
-          "when": "view == gemstoneExplorerHierarchy && viewItem == explorerHierClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "inline@3"
         },
         {
           "command": "gemstone.explorer.classHistory",
-          "when": "view == gemstoneExplorerHierarchy && viewItem == explorerHierClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "3_refactor@1"
         },
         {
@@ -2059,7 +2060,7 @@
         },
         {
           "command": "gemstone.generateGrailStub",
-          "when": "view == gemstoneExplorerHierarchy && viewItem == explorerHierClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "2_generate@1"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1089,6 +1089,12 @@
         "icon": "$(clear-all)"
       },
       {
+        "command": "gemstone.explorer.clearFilterChip",
+        "title": "Clear Filter",
+        "category": "GemStone",
+        "icon": "$(close)"
+      },
+      {
         "command": "gemstone.explorer.showMethodsFlat",
         "title": "Show Methods Without Categories",
         "category": "GemStone",
@@ -1099,6 +1105,21 @@
         "title": "Group Methods by Category",
         "category": "GemStone",
         "icon": "$(list-tree)"
+      },
+      {
+        "command": "gemstone.explorer.filterReadersOfIvar",
+        "title": "Filter Methods: Readers",
+        "category": "GemStone"
+      },
+      {
+        "command": "gemstone.explorer.filterWritersOfIvar",
+        "title": "Filter Methods: Writers",
+        "category": "GemStone"
+      },
+      {
+        "command": "gemstone.explorer.filterReferencesToIvar",
+        "title": "Filter Methods: References",
+        "category": "GemStone"
       },
       {
         "command": "gemstone.explorer.showClassMethods",
@@ -1827,26 +1848,6 @@
           "group": "navigation@5"
         },
         {
-          "command": "gemstoneExplorerDicts.clearFilter",
-          "when": "view == gemstoneExplorerDicts && gemstone.explorerFiltered.gemstoneExplorerDicts",
-          "group": "navigation@1"
-        },
-        {
-          "command": "gemstoneExplorerCategories.clearFilter",
-          "when": "view == gemstoneExplorerCategories && gemstone.explorerFiltered.gemstoneExplorerCategories",
-          "group": "navigation@1"
-        },
-        {
-          "command": "gemstoneExplorerClasses.clearFilter",
-          "when": "view == gemstoneExplorerClasses && gemstone.explorerFiltered.gemstoneExplorerClasses",
-          "group": "navigation@1"
-        },
-        {
-          "command": "gemstoneExplorerMethods.clearFilter",
-          "when": "view == gemstoneExplorerMethods && gemstone.explorerFiltered.gemstoneExplorerMethods",
-          "group": "navigation@1"
-        },
-        {
           "command": "gemstone.explorer.newDictionary",
           "when": "view == gemstoneExplorerDicts",
           "group": "navigation@6"
@@ -1979,9 +1980,29 @@
           "group": "inline@2"
         },
         {
+          "command": "gemstone.explorer.clearFilterChip",
+          "when": "viewItem == explorerFilterChip",
+          "group": "inline"
+        },
+        {
           "command": "gemstone.explorer.renameIvar",
           "when": "view == gemstoneExplorerClasses && viewItem =~ /^explorerIvar/",
           "group": "inline"
+        },
+        {
+          "command": "gemstone.explorer.filterReadersOfIvar",
+          "when": "view == gemstoneExplorerClasses && viewItem =~ /^explorerIvar/",
+          "group": "1_filter@1"
+        },
+        {
+          "command": "gemstone.explorer.filterWritersOfIvar",
+          "when": "view == gemstoneExplorerClasses && viewItem =~ /^explorerIvar/",
+          "group": "1_filter@2"
+        },
+        {
+          "command": "gemstone.explorer.filterReferencesToIvar",
+          "when": "view == gemstoneExplorerClasses && viewItem =~ /^explorerIvar/",
+          "group": "1_filter@3"
         },
         {
           "command": "gemstone.explorer.moveUpInstVar",


### PR DESCRIPTION
## Summary
A batch of GemStone Explorer improvements, culminating in #259 item 2a (filter methods by instance-variable readers/writers). Client-side only, plus one read-only reflection query — no RB engine or server-plugin change.

## Highlights

### Method source editors — native preview tabs
- Single-click a method opens a VS Code **preview** tab (reused/replaced by the next click); **double-click** promotes it to a permanent tab; the 📌 action pins a tab. Replaces the hand-rolled transient-tab machinery.
- Fixed the senders/implementors **CodeLens pop-in** that shoved the source down on a method's first open (register the provider by scheme, and tag the doc `gemstone-smalltalk` before it enters the reused preview editor, avoiding the post-show language flip that re-queried CodeLens).

### Hierarchy pane
- Collapsed by default (more room for the other panes) and no longer force-opened when selecting a class/method or filtering by an ivar.

### Methods pane — leaner tree
- **Instance/class side** is now a title-bar toggle rather than a tree level.
- **Category grouping** is a title-bar toggle backed by `gemstone.explorer.groupMethodsByCategory` (lists methods flat when off). Filtering respects it.

### #259 Filtered searches
- **2a — filter methods by instance-variable access**: `reads:` / `writes:` / `accesses:<ivar>` filter tokens (`*` wildcard, composable with a selector prefix); right-click an instance-variable row → **Filter: Readers / Writers / References**; `r` / `w` / `rw` glyphs on matching rows; the filtered ivar highlighted in the opened source. Backed by a new `getMethodInstVarAccess` query (`GsNMethod>>instVarsRead` / `instVarsWritten`, scanning environments `0..maxEnv`).
- **Filter chip**: while a pane is filtered, its list leads with a distinct funnel-icon chip (pattern in grey + inline ✕), replacing the title-bar Clear button — rolled out to all four filterable panes (Dictionaries, Class Categories, Classes, Methods).
- Items 1 (filter classes by name) and 2b (quick method search) are the existing pane filters, now always-visible. **Item 2c (methods extended in packages) is split to #382** — deferred until Rowan package support is available.

### Housekeeping
- gitignore the GCI trace-log artifacts a failed `gci`-project run leaves behind.
- Give the flaky change-signature in-stone SUnit test a generous timeout (it was intermittently failing the pre-push gate under a busy shared stone).

## Testing
Client unit suite (including a live matrix integration test for the ivar query) + full lint + format + compile, all green. A `/review` pass over the diff found no HIGH issues; its one MED (ivar-access cache going stale after a method edit) and the actionable LOWs are fixed in this branch.

Addresses #259 (items 1, 2a, 2b); item 2c → #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
