### PR TITLE
Move the partial-apply gci test into the CI integration suite

### DIFF
--- a/client/src/__tests__/gci/gciInstVar.e2e.test.ts
+++ b/client/src/__tests__/gci/gciInstVar.e2e.test.ts
@@ -20,16 +20,21 @@ import { parseStartPreview, parseApplyResult } from '../../refactoring/instVarRe
  * On-demand GCI e2e for the COMMITTING paths of the add / remove instance-variable (V1)
  * refactoring, over the real GCI transport (`npm run test:gci`).
  *
- * WHY THIS IS STILL AN on-demand gci SUITE: every non-committing scenario has moved to the
- * automatic integration suite, which runs in CI across the release matrix — see
+ * WHY THIS IS STILL AN on-demand gci SUITE: every scenario the harness can host has moved to
+ * the automatic integration suite, which runs in CI across the release matrix — see
  * `refactoring/__tests__/refactoringInstVar.integration.test.ts` (add, remove + selective
- * copy-forward, shadowed-temporary prediction, decline duplicate, decline a name a subclass
- * declares, plus the engine's GS SUnit suite). What remains here are the three scenarios that
- * COMMIT: `useIntegrationTest` aborts after every test to keep tests isolated, and an abort
- * cannot undo a commit, so these can only move once the CI migration settles a
- * commit-and-compensate story for the harness (a transient session, or a test that commits its
- * own cleanup). That is a policy call about the harness's "never commit" invariant, not a
- * technical blocker.
+ * copy-forward, partial apply without abort, shadowed-temporary prediction, decline duplicate,
+ * decline a name a subclass declares, plus the engine's GS SUnit suite). What remains here are
+ * the two scenarios on which the ENGINE commits:
+ * `GsInstVarRefactoring>>applyDeselected:options:migrate:deleteHistory:` calls
+ * `commitStructuralThenMigrate:` once the structural apply has succeeded, whenever `migrate` or
+ * `deleteHistory` is requested, because `migrateInstancesTo:` needs a clean transaction.
+ * `useIntegrationTest` aborts after every test
+ * to keep tests isolated, and an abort cannot undo a commit, so these can only move once the CI
+ * migration settles a commit-and-compensate story for the harness (a transient session, or a
+ * test that commits its own cleanup). That is a policy call about the harness's "never commit"
+ * invariant, not a technical blocker. Note the discriminator is what the PRODUCTION code does,
+ * not what the test does: a test that merely commits its own fixture belongs in the harness.
  *
  * Guarded on the refactoring engine being installed (the queries reference the in-stone
  * `GsInstVarRefactoring`); the tests skip, with a reason, otherwise. Each test is self-cleaning
@@ -168,65 +173,6 @@ describe('instance-variable refactoring, committing paths (gci e2e)', () => {
       expect(exec(`${CLS} classHistory size printString`).trim()).toBe('1');
     } finally {
       exec(`UserGlobals removeKey: #${CLS} ifAbsent: []. System commitTransaction. 'ok'`);
-    }
-  });
-
-  // A mid-apply failure, end to end against a COMMITTED fixture: the engine must stop at the
-  // first failure, leave the transaction alone (it never aborts — that would discard the user's
-  // other in-flight work), and report the partial state for the client's abort recommendation.
-  it('stops at the first failure and reports the partial apply without aborting', async (ctx) => {
-    if (!enginePresent) return ctx.skip('GsInstVarRefactoring is not installed on this stone');
-
-    const RB_BASE = 'GciIvRbBase';
-    const RB_SUB = 'GciIvRbSub';
-    try {
-      q.compileClassDefinition(
-        session,
-        `Object subclass: '${RB_BASE}' instVarNames: #(x) classVars: #() ` +
-          'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
-      );
-      q.compileClassDefinition(
-        session,
-        `${RB_BASE} subclass: '${RB_SUB}' instVarNames: #() classVars: #() ` +
-          'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
-      );
-      // A method that WOULD be dropped by the apply, so a bogus `dropped` report is detectable.
-      q.compileMethod(session, RB_SUB, false, 'accessing', 'shadowIt | tally | ^tally');
-      exec("System commitTransaction. 'ok'"); // clean session — the engine may now abort
-
-      const start = parseStartPreview(
-        await startInstVarPreview(
-          asyncExec,
-          'add',
-          RB_BASE,
-          'tally',
-          'gci-iv-rollback',
-          PREVIEW_PAGE_BYTES,
-          userIndex(),
-        ),
-      );
-      expect(start.total).toBe(2); // base + sub are both staged
-
-      // Break the SECOND change after the preview was staged: the base will version fine, then
-      // the sub will fail with 'Class not found'. Committed so the session stays clean.
-      exec(`UserGlobals removeKey: #${RB_SUB} ifAbsent: []. System commitTransaction. 'ok'`);
-
-      const result = parseApplyResult(
-        await applyInstVar(asyncExec, 'gci-iv-rollback', [], null, false, false),
-      );
-
-      expect(result.failed.length).toBe(1);
-      expect(result.applied).toBe(1); // the base applied; the sub failed; nothing after it ran
-      expect(result.partiallyApplied).toBe(true);
-      expect(result.committed).toBe(false);
-      // The decisive check: the engine did NOT abort, so the base's new version is still staged
-      // in the transaction — which is exactly why the client tells the user to abort it.
-      expect(hasIvar(RB_BASE, 'tally')).toBe(true);
-    } finally {
-      exec(
-        `#(#${RB_SUB} #${RB_BASE}) do: [:s | UserGlobals removeKey: s ifAbsent: []]. ` +
-          "System commitTransaction. 'ok'",
-      );
     }
   });
 });

--- a/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
@@ -22,11 +22,12 @@ import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
  *  2. A client round trip through the real query builders + parsers: add an ivar and
  *     confirm the class carries it; remove one that methods use and confirm those methods
  *     are reported (will-not-recompile) and dropped while an unrelated method survives;
- *     predict a shadowed temporary; and decline a name a subclass already declares.
+ *     stop at the first failure of a partial apply without aborting; predict a shadowed
+ *     temporary; and decline a name a subclass already declares.
  *
- * The committing paths (migrate instances, delete history, and a mid-apply failure over a
- * committed fixture) cannot live here — the harness aborts after every test and an abort
- * cannot undo a commit — so they stay in `__tests__/gci/gciInstVar.e2e.test.ts`.
+ * The committing paths (migrate instances, delete history) cannot live here — on those the
+ * engine itself commits, and the harness aborts after every test, which cannot undo a commit
+ * — so they stay in `__tests__/gci/gciInstVar.e2e.test.ts`.
  *
  * Gated via the shared server-plugin feature gate; the engine-dependent tests run in the
  * plugin-installed pass and skip, with a reason, against a bare stone. Fully transient:
@@ -173,6 +174,65 @@ r := (System myUserProfile symbolList objectNamed: #GsInstVarRefactoringTest) su
     // so it must survive onto the new class version and must not be reported as dropped.
     expect(includesSelector(BASE, 'getOther')).toBe(true);
     expect(result.dropped.map((m) => m.selector)).not.toContain('getOther');
+  });
+
+  it('stops at the first failure and reports the partial apply without aborting', async (ctx) => {
+    requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
+
+    // Its own fixture, kept apart from the shared one: this test deletes the subclass.
+    const FAIL_BASE = 'XIvItFailBase';
+    const FAIL_SUB = 'XIvItFailSub';
+    q.compileClassDefinition(
+      session(),
+      `Object subclass: '${FAIL_BASE}' instVarNames: #(x) classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    q.compileClassDefinition(
+      session(),
+      `${FAIL_BASE} subclass: '${FAIL_SUB}' instVarNames: #() classVars: #() ` +
+        'classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals',
+    );
+    // A method that WOULD be dropped by the apply, so a bogus `dropped` report is detectable.
+    q.compileMethod(session(), FAIL_SUB, false, 'accessing', 'shadowIt | tally | ^tally');
+    // A pre-existing method on the base, unrelated to `tally`, so its copy-forward survival
+    // on the class that actually re-versions during this partial apply is exercised too —
+    // not just on a clean, fully-successful apply.
+    q.compileMethod(session(), FAIL_BASE, false, 'accessing', 'keepMe\n\t^ x');
+
+    const start = parseStartPreview(
+      await startInstVarPreview(
+        asyncExec,
+        'add',
+        FAIL_BASE,
+        'tally',
+        'xivit-partial-apply',
+        PREVIEW_PAGE_BYTES,
+        userIndex(),
+      ),
+    );
+    expect(start.total).toBe(2); // base + sub are both staged
+
+    // Break the SECOND change after the preview was staged: the base will version fine, then
+    // the sub will fail with 'Class not found'. The session sees its own uncommitted removal.
+    exec(`UserGlobals removeKey: #${FAIL_SUB} ifAbsent: []. 'ok'`);
+
+    const result = parseApplyResult(
+      await applyInstVar(asyncExec, 'xivit-partial-apply', [], null, false, false),
+    );
+
+    expect(result.failed.length).toBe(1);
+    expect(result.failed[0].label).toBe(FAIL_SUB);
+    expect(result.applied).toBe(1); // the base applied; the sub failed; nothing after it ran
+    expect(result.dropped).toEqual([]); // shadowIt never ran, so it must not be reported dropped
+    expect(result.partiallyApplied).toBe(true);
+    expect(result.committed).toBe(false);
+    // The decisive check: the engine did NOT abort, so the base's new version is still staged
+    // in the transaction — which is exactly why the client tells the user to abort it.
+    expect(hasIvar(FAIL_BASE, 'tally')).toBe(true);
+    // Copy-forward survival on the class that actually succeeded mid-partial-apply: `keepMe`
+    // predates this apply and never referenced `tally`, so it must ride along onto the base's
+    // new version just as it would on a clean, fully-successful apply.
+    expect(includesSelector(FAIL_BASE, 'keepMe')).toBe(true);
   });
 
   it('warns up front that a method whose temp shadows the new variable will not recompile', async (ctx) => {


### PR DESCRIPTION
Moves one test out of the on-demand `gci` project (which never runs in CI) into the integration suite, which runs across the release matrix in both CI passes.

It was parked in `gci/` on the premise that it had to commit. It does not: it drives `applyInstVar` with `migrate=false, deleteHistory=false`, and `GsInstVarRefactoring>>applyDeselected:options:migrate:deleteHistory:` only calls `commitStructuralThenMigrate:` when `migrate` or `deleteHistory` is requested — so the engine never commits on this path. Its three `System commitTransaction` calls were incidental scaffolding:

- the post-fixture commit was annotated *"clean session — the engine may now abort"*, even though the test's whole point is that the engine never aborts;
- the mid-test `UserGlobals removeKey:` needs no commit — a session sees its own uncommitted removals;
- the `finally` block existed only to undo the other two.

## Changes

- **Moved** `stops at the first failure and reports the partial apply without aborting` into `refactoringInstVar.integration.test.ts` (7 → 8 tests): reuses that file's existing helpers, gated with `requireServerPluginFeature(pluginFeatures.refactoring, …)`, no commits, no `try/finally`, no hardcoded `stoneVersion` literal, ASCII-only Smalltalk for the 3.6.2 floor. Its own `XIvItFailBase`/`XIvItFailSub` fixture, kept apart from the shared one since the test deletes its subclass.
- **Reduced** `gciInstVar.e2e.test.ts` to its 2 remaining tests, whose doc comment now names `commitStructuralThenMigrate:` as the reason they stay: the **engine** commits on their paths, so their assertions exist because of that commit and no test rewrite removes it.
- **Corrected** the integration file's doc comment, which listed the mid-apply-failure case among what cannot live there.

## Verification

Run against **GemStone 3.6.2** (the matrix floor) with the server plugin installed.

- Target file: 8 passed, 0 failed. Both instVar files under `--project gci`: 3 passed, 0 failed.
- Full gate: `npm run lint`, `npm run format:check` and `npm run compile` clean; `npm test` → 4951 client / 322 server / 92 mcp-server passing, only the 10 pre-existing client skips.
- Confirmed transient: on a freshly reset stone the run leaves zero committed residue when probed from a new session, and it passes twice consecutively on a dirty stone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
