### PR TITLE
Explorer: class-def/new-class fixes, shadowed-class dict-scoping, Remove Class/Dictionary

### DIFF
--- a/client/src/__tests__/classDefinitionText.test.ts
+++ b/client/src/__tests__/classDefinitionText.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  splitOutCategory,
+  withCategoryLine,
+  classNameFromDefinition,
+  dictNameFromDefinition,
+} from '../classDefinitionText';
+
+const TEMPLATE = `Object subclass: 'Boo'
+  instVarNames: #()
+  classVars: #()
+  classInstVars: #()
+  poolDictionaries: #()
+  inDictionary: MyDict
+  category: 'User Classes'
+  options: #()`;
+
+describe('splitOutCategory', () => {
+  it('removes the category line and returns its value', () => {
+    const { source, category } = splitOutCategory(TEMPLATE);
+
+    expect(category).toBe('User Classes');
+    expect(source).not.toContain('category:');
+    // What remains is the always-valid 7-keyword form.
+    expect(source).toContain('inDictionary: MyDict');
+    expect(source).toContain('options: #()');
+  });
+
+  it('leaves a definition without a category line unchanged', () => {
+    const noCategory = `Object subclass: 'Boo'\n  inDictionary: MyDict\n  options: #()`;
+
+    const { source, category } = splitOutCategory(noCategory);
+
+    expect(category).toBeUndefined();
+    expect(source).toBe(noCategory);
+  });
+
+  it('unescapes doubled single quotes in the category', () => {
+    const src = `Object subclass: 'Boo'\n  category: 'O''Brien-Stuff'\n  options: #()`;
+
+    expect(splitOutCategory(src).category).toBe("O'Brien-Stuff");
+  });
+});
+
+describe('withCategoryLine', () => {
+  it('inserts the category immediately before options:', () => {
+    const def = `Object subclass: 'Boo'\n  inDictionary: MyDict\n  options: #()\n`;
+
+    const out = withCategoryLine(def, 'Collections-Dictionaries');
+
+    expect(out).toContain("  category: 'Collections-Dictionaries'\n  options: #()");
+  });
+
+  it('appends the category when there is no options: line', () => {
+    const def = `nil subclass: 'Object'\n  inDictionary: Globals`;
+
+    const out = withCategoryLine(def, 'Kernel-Objects');
+
+    expect(out.trimEnd().endsWith("  category: 'Kernel-Objects'")).toBe(true);
+  });
+
+  it('escapes single quotes and round-trips through splitOutCategory', () => {
+    const def = `Object subclass: 'Boo'\n  options: #()\n`;
+
+    const shown = withCategoryLine(def, "O'Brien");
+
+    expect(shown).toContain("category: 'O''Brien'");
+    expect(splitOutCategory(shown).category).toBe("O'Brien");
+  });
+
+  it('returns the definition unchanged for an empty category', () => {
+    const def = `Object subclass: 'Boo'\n  options: #()`;
+    expect(withCategoryLine(def, '')).toBe(def);
+  });
+});
+
+describe('classNameFromDefinition', () => {
+  it('reads the class name from the subclass clause', () => {
+    expect(classNameFromDefinition(TEMPLATE)).toBe('Boo');
+    expect(classNameFromDefinition("AbstractDictionary subclass: 'Dictionary'\n …")).toBe(
+      'Dictionary',
+    );
+  });
+
+  it('returns undefined when there is no subclass clause', () => {
+    expect(classNameFromDefinition('42 + 1')).toBeUndefined();
+  });
+});
+
+describe('dictNameFromDefinition', () => {
+  it('reads the dictionary bareword from the inDictionary: clause', () => {
+    expect(dictNameFromDefinition(TEMPLATE)).toBe('MyDict');
+    expect(dictNameFromDefinition("Object subclass: 'Boo'\n  inDictionary: UserGlobals")).toBe(
+      'UserGlobals',
+    );
+  });
+
+  it('reads a dictionary name containing digits and underscores', () => {
+    expect(dictNameFromDefinition('  inDictionary: Issue328_Dict2')).toBe('Issue328_Dict2');
+  });
+
+  it('returns undefined when there is no inDictionary: clause', () => {
+    expect(dictNameFromDefinition("Object subclass: 'Boo'\n  options: #()")).toBeUndefined();
+  });
+});

--- a/client/src/__tests__/explorerCompiledClassJump.test.ts
+++ b/client/src/__tests__/explorerCompiledClassJump.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+vi.mock('../browserQueries', async (orig) => ({
+  ...(await orig()),
+  getClassesWithCategory: vi.fn(() => []),
+  getDictionaryNames: vi.fn(() => ['Globals']),
+  getAllClassNames: vi.fn(() => []),
+}));
+
+import { ExplorerController } from '../gemstoneExplorer';
+import { getClassesWithCategory, getDictionaryNames, getAllClassNames } from '../browserQueries';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+
+function makeController(): ExplorerController {
+  const session = { id: 1 } as ActiveSession;
+  const sessionManager = { getSelectedSession: () => session } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.dictName = 'Globals';
+  ctl.state.dictIndex = 1;
+  return ctl;
+}
+
+const classesInDict = getClassesWithCategory as ReturnType<typeof vi.fn>;
+const dictNames = getDictionaryNames as ReturnType<typeof vi.fn>;
+const allClasses = getAllClassNames as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  classesInDict.mockReturnValue([]);
+  dictNames.mockReturnValue(['Globals']);
+  allClasses.mockReturnValue([]);
+});
+
+// Bug F: after a class is compiled, the explorer should reveal it — in the current
+// dictionary when it lives there, otherwise it should JUMP to the dictionary the
+// class was actually created in (e.g. a new class whose inDictionary: named a
+// different dictionary than the selected one).
+describe('onExternalClassCompiled reveals the compiled class in the right dictionary', () => {
+  it('reveals in the current dictionary when the class lives there', () => {
+    const ctl = makeController();
+    classesInDict.mockReturnValue([{ className: 'Foo', category: '' }]);
+    const reveal = vi.spyOn(ctl as unknown as { revealClass: () => void }, 'revealClass');
+
+    ctl.onExternalClassCompiled(1, 'Foo');
+
+    expect(reveal).toHaveBeenCalledWith('Globals', 1, 'Foo');
+  });
+
+  it('jumps to the dictionary the class was created in when it is not in the current one', () => {
+    const ctl = makeController();
+    classesInDict.mockReturnValue([]); // not in the selected dictionary
+    dictNames.mockReturnValue(['Globals', 'OtherDict']); // OtherDict → 1-based index 2
+    const reveal = vi
+      .spyOn(ctl as unknown as { revealClass: () => void }, 'revealClass')
+      .mockImplementation(() => {});
+
+    ctl.onExternalClassCompiled(1, 'Foo', 'OtherDict');
+
+    expect(reveal).toHaveBeenCalledWith('OtherDict', 2, 'Foo');
+  });
+
+  it('does not reveal when the class cannot be resolved in any dictionary', () => {
+    const ctl = makeController();
+    classesInDict.mockReturnValue([]);
+    dictNames.mockReturnValue(['Globals']); // 'Nope' unresolved
+    allClasses.mockReturnValue([]); // and no global match either
+    const reveal = vi.spyOn(ctl as unknown as { revealClass: () => void }, 'revealClass');
+
+    ctl.onExternalClassCompiled(1, 'Foo', 'Nope');
+
+    expect(reveal).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/explorerQueries.integration.test.ts
+++ b/client/src/__tests__/explorerQueries.integration.test.ts
@@ -220,6 +220,27 @@ describe('explorer queries (integration)', () => {
     });
   });
 
+  describe('getClassCategory', () => {
+    it('returns the class category the definition editor shows on its own line', () => {
+      defineClass(WIDGET, 'JasperIt-Shown');
+
+      expect(q.getClassCategory(session(), WIDGET, userIndex())).toBe('JasperIt-Shown');
+    });
+
+    it('returns empty for a class that cannot be found', () => {
+      expect(q.getClassCategory(session(), 'JasperItNoSuchClass', userIndex())).toBe('');
+    });
+  });
+
+  describe('classExistsInDictionary', () => {
+    it('is true for a class present in the dictionary and false otherwise', () => {
+      defineWidget();
+
+      expect(q.classExistsInDictionary(session(), WIDGET, userIndex())).toBe(true);
+      expect(q.classExistsInDictionary(session(), 'JasperItAbsent', userIndex())).toBe(false);
+    });
+  });
+
   describe('recategorizeMethod', () => {
     it('moves a method into another existing category', () => {
       defineWidget();
@@ -360,6 +381,72 @@ describe('explorer queries (integration)', () => {
       q.moveDictionaryDown(session(), dictIndexOf('JasperItFirst'));
 
       expect(dictIndexOf('JasperItFirst')).toBeGreaterThan(dictIndexOf('JasperItSecond'));
+    });
+  });
+
+  // Shadowed class names — the same name bound in two dictionaries. This session's
+  // Explorer fixes (hierarchy pane, class deletion, and creating a class in a
+  // non-selected dictionary) rely on the query layer resolving by the SELECTED
+  // dictionary index rather than the global first match. These prove that
+  // dict-scoping end-to-end on a live stone.
+  describe('dictionary-scoped resolution for a shadowed class name', () => {
+    const SHADOW = 'JasperItShadowed';
+
+    // Bind SHADOW twice: an Object subclass in UserGlobals and an Array subclass in
+    // a second dictionary. Returns the second dictionary's 1-based index.
+    const defineShadowPair = (): number => {
+      q.compileClassDefinition(
+        session(),
+        `Object subclass: '${SHADOW}' instVarNames: #() classVars: #() ` +
+          `classInstVars: #() poolDictionaries: #() inDictionary: UserGlobals`,
+      );
+      q.addDictionary(session(), 'JasperItShadowDict');
+      const shadowIdx = dictIndexOf('JasperItShadowDict');
+      q.compileClassDefinition(
+        session(),
+        `Array subclass: '${SHADOW}' instVarNames: #() classVars: #() ` +
+          `classInstVars: #() poolDictionaries: #() inDictionary: JasperItShadowDict`,
+      );
+      return shadowIdx;
+    };
+
+    const superclassesOf = (dict: number): string[] =>
+      q
+        .getClassHierarchy(session(), SHADOW, dict)
+        .filter((e) => e.kind === 'superclass')
+        .map((e) => e.className);
+
+    it('getClassHierarchy returns the lineage of the shadow in the given dictionary (G)', () => {
+      const shadowIdx = defineShadowPair();
+
+      // The UserGlobals shadow is a plain Object subclass — no Array in its lineage.
+      expect(superclassesOf(userIndex())).toContain('Object');
+      expect(superclassesOf(userIndex())).not.toContain('Array');
+      // The other dictionary's shadow is an Array subclass — Array is an ancestor.
+      expect(superclassesOf(shadowIdx)).toContain('Array');
+    });
+
+    it('deleteClass removes only the shadow in the targeted dictionary (I)', () => {
+      const shadowIdx = defineShadowPair();
+
+      q.deleteClass(session(), shadowIdx, SHADOW);
+
+      expect(q.classExistsInDictionary(session(), SHADOW, shadowIdx)).toBe(false);
+      expect(q.classExistsInDictionary(session(), SHADOW, userIndex())).toBe(true);
+    });
+
+    it('compileClassDefinition creates the class in the dictionary its inDictionary: names (F)', () => {
+      q.addDictionary(session(), 'JasperItOther');
+      const other = dictIndexOf('JasperItOther');
+
+      q.compileClassDefinition(
+        session(),
+        `Object subclass: '${GADGET}' instVarNames: #() classVars: #() ` +
+          `classInstVars: #() poolDictionaries: #() inDictionary: JasperItOther`,
+      );
+
+      expect(q.classExistsInDictionary(session(), GADGET, other)).toBe(true);
+      expect(q.classExistsInDictionary(session(), GADGET, userIndex())).toBe(false);
     });
   });
 });

--- a/client/src/__tests__/explorerQueries.integration.test.ts
+++ b/client/src/__tests__/explorerQueries.integration.test.ts
@@ -448,5 +448,69 @@ describe('explorer queries (integration)', () => {
       expect(q.classExistsInDictionary(session(), GADGET, other)).toBe(true);
       expect(q.classExistsInDictionary(session(), GADGET, userIndex())).toBe(false);
     });
+
+    // Compile `super subclass: 'name' ... inDictionary: <dict>` (base-kernel selector).
+    const defineIn = (superName: string, name: string, dict: string): void => {
+      q.compileClassDefinition(
+        session(),
+        `${superName} subclass: '${name}' instVarNames: #() classVars: #() ` +
+          `classInstVars: #() poolDictionaries: #() inDictionary: ${dict}`,
+      );
+    };
+
+    // getClassDescendantNames / Remove Class must resolve each subclass by CLASS OBJECT
+    // IDENTITY, so a subclass whose name is also bound (as an unrelated class) in another
+    // dictionary reports its OWN dictionary — never the same-named stranger. (Fixes the
+    // show-stopper on PR #397: a name-keyed lookup would delete the wrong class.)
+    const ROOT = 'JasperItRoot';
+    const LEAF = 'JasperItLeaf';
+
+    it('getClassDescendantNames reports a subclass in its own dictionary, not a same-named stranger', () => {
+      q.addDictionary(session(), 'JasperItAlt');
+      const alt = dictIndexOf('JasperItAlt');
+      defineIn('Object', ROOT, 'UserGlobals');
+      defineIn(ROOT, LEAF, 'UserGlobals'); // the real subclass, in UserGlobals
+      defineIn('Object', LEAF, 'JasperItAlt'); // unrelated class, same name, different dictionary
+
+      const descendants = q.getClassDescendantNames(session(), ROOT, userIndex());
+
+      expect(descendants).toHaveLength(1);
+      expect(descendants[0].className).toBe(LEAF);
+      expect(descendants[0].dictIndex).toBe(userIndex());
+      expect(descendants[0].dictIndex).not.toBe(alt);
+    });
+
+    it('getClassDescendantNames reports a subclass that lives in a different dictionary than its root', () => {
+      q.addDictionary(session(), 'JasperItAlt');
+      const alt = dictIndexOf('JasperItAlt');
+      defineIn('Object', ROOT, 'UserGlobals');
+      defineIn(ROOT, 'JasperItChild', 'JasperItAlt'); // subclass bound in another dictionary
+
+      const descendants = q.getClassDescendantNames(session(), ROOT, userIndex());
+
+      expect(descendants).toHaveLength(1);
+      expect(descendants[0].className).toBe('JasperItChild');
+      expect(descendants[0].dictIndex).toBe(alt);
+    });
+
+    it('deleting a subtree by each descendant’s reported dictionary spares a same-named stranger', () => {
+      q.addDictionary(session(), 'JasperItAlt');
+      const alt = dictIndexOf('JasperItAlt');
+      defineIn('Object', ROOT, 'UserGlobals');
+      defineIn(ROOT, LEAF, 'UserGlobals'); // real subclass
+      defineIn('Object', LEAF, 'JasperItAlt'); // unrelated same-named class
+
+      // Delete the subtree the way Remove Class does: each descendant by its OWN
+      // reported dictionary index, then the root.
+      for (const d of q.getClassDescendantNames(session(), ROOT, userIndex())) {
+        q.deleteClass(session(), d.dictIndex, d.className);
+      }
+      q.deleteClass(session(), userIndex(), ROOT);
+
+      // The real subclass and root are gone; the unrelated same-named class survives.
+      expect(q.classExistsInDictionary(session(), LEAF, userIndex())).toBe(false);
+      expect(q.classExistsInDictionary(session(), ROOT, userIndex())).toBe(false);
+      expect(q.classExistsInDictionary(session(), LEAF, alt)).toBe(true);
+    });
   });
 });

--- a/client/src/__tests__/explorerRemoveClass.test.ts
+++ b/client/src/__tests__/explorerRemoveClass.test.ts
@@ -5,19 +5,13 @@ vi.mock('../browserQueries', async (orig) => ({
   ...(await orig()),
   canClassBeWritten: vi.fn(() => true),
   getClassDescendantNames: vi.fn(() => []),
-  getAllClassNames: vi.fn(() => []),
   getClassesWithCategory: vi.fn(() => []),
   deleteClass: vi.fn(() => 'Deleted class: X'),
 }));
 
 import { window } from '../__mocks__/vscode';
 import { ExplorerController } from '../gemstoneExplorer';
-import {
-  canClassBeWritten,
-  getClassDescendantNames,
-  getAllClassNames,
-  deleteClass,
-} from '../browserQueries';
+import { canClassBeWritten, getClassDescendantNames, deleteClass } from '../browserQueries';
 import type { SessionManager, ActiveSession } from '../sessionManager';
 
 function makeController(): ExplorerController {
@@ -31,16 +25,25 @@ function makeController(): ExplorerController {
 }
 
 const warn = window.showWarningMessage as ReturnType<typeof vi.fn>;
+const error = window.showErrorMessage as ReturnType<typeof vi.fn>;
 const deleteClassMock = deleteClass as ReturnType<typeof vi.fn>;
 const descendantsMock = getClassDescendantNames as ReturnType<typeof vi.fn>;
-const allClassesMock = getAllClassNames as ReturnType<typeof vi.fn>;
+const writableMock = canClassBeWritten as ReturnType<typeof vi.fn>;
+
+// A descendant now carries the dictionary that binds it (resolved by object identity
+// in the query layer), so removeClass never has to guess by name.
+const descendant = (className: string, dictIndex: number, dictName = 'UserGlobals') => ({
+  className,
+  parentName: 'Doomed',
+  dictIndex,
+  dictName,
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (canClassBeWritten as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  writableMock.mockReturnValue(true);
   deleteClassMock.mockReturnValue('Deleted class: X');
   descendantsMock.mockReturnValue([]);
-  allClassesMock.mockReturnValue([]);
 });
 
 describe('ExplorerController.removeClass', () => {
@@ -52,7 +55,6 @@ describe('ExplorerController.removeClass', () => {
 
     expect(deleteClassMock).toHaveBeenCalledTimes(1);
     expect(deleteClassMock).toHaveBeenCalledWith(expect.anything(), 1, 'Doomed');
-    // The removed class is dropped from selection.
     expect(ctl.state.className).toBeUndefined();
   });
 
@@ -66,18 +68,10 @@ describe('ExplorerController.removeClass', () => {
     expect(ctl.state.className).toBe('Doomed');
   });
 
-  it('removes the whole subtree (all-or-none) when the class has subclasses', async () => {
+  it('removes the whole subtree, deleting each member in its OWN dictionary', async () => {
     const ctl = makeController();
-    descendantsMock.mockReturnValue([
-      { className: 'Sub1', parentName: 'Doomed' },
-      { className: 'Sub2', parentName: 'Sub1' },
-    ]);
-    // Sub2 lives in a different dictionary — each descendant deletes dict-scoped.
-    allClassesMock.mockReturnValue([
-      { className: 'Sub1', dictName: 'UserGlobals', dictIndex: 1 },
-      { className: 'Sub2', dictName: 'OtherDict', dictIndex: 3 },
-      { className: 'Doomed', dictName: 'UserGlobals', dictIndex: 1 },
-    ]);
+    // Sub2 lives in a different dictionary (index 3) than the root (index 1).
+    descendantsMock.mockReturnValue([descendant('Sub1', 1), descendant('Sub2', 3, 'OtherDict')]);
     warn.mockResolvedValueOnce('Remove All');
 
     await ctl.removeClass();
@@ -88,9 +82,48 @@ describe('ExplorerController.removeClass', () => {
     expect(deleteClassMock).toHaveBeenCalledWith(expect.anything(), 1, 'Doomed');
   });
 
+  it('deletes a subclass in its own dictionary even when its name is shadowed elsewhere', async () => {
+    const ctl = makeController();
+    // The real subclass "Shadowed" lives in dict index 3; a different, unrelated class
+    // of the same name lives in dict index 1. The query resolved by object identity,
+    // so the descendant carries dictIndex 3 — deleteClass must target 3, not 1.
+    descendantsMock.mockReturnValue([descendant('Shadowed', 3, 'OtherDict')]);
+    warn.mockResolvedValueOnce('Remove All');
+
+    await ctl.removeClass();
+
+    expect(deleteClassMock).toHaveBeenCalledWith(expect.anything(), 3, 'Shadowed');
+    // Never the shadow in dict 1.
+    expect(deleteClassMock).not.toHaveBeenCalledWith(expect.anything(), 1, 'Shadowed');
+  });
+
+  it('aborts (all-or-none) without deleting when a descendant cannot be located', async () => {
+    const ctl = makeController();
+    descendantsMock.mockReturnValue([descendant('Sub1', 1), descendant('Lost', 0, '')]);
+
+    await ctl.removeClass();
+
+    expect(deleteClassMock).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('all-or-none'));
+    // No confirmation was even offered — we can't deliver the removal.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('aborts (all-or-none) without deleting when a descendant is not writable', async () => {
+    const ctl = makeController();
+    descendantsMock.mockReturnValue([descendant('Sub1', 1), descendant('Locked', 2, 'Kernel')]);
+    // Root writable; the "Locked" descendant is not.
+    writableMock.mockImplementation((_s: unknown, name: string) => name !== 'Locked');
+
+    await ctl.removeClass();
+
+    expect(deleteClassMock).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('Locked'));
+  });
+
   it('cancels the subtree removal when the all-or-none confirmation is dismissed', async () => {
     const ctl = makeController();
-    descendantsMock.mockReturnValue([{ className: 'Sub1', parentName: 'Doomed' }]);
+    descendantsMock.mockReturnValue([descendant('Sub1', 1)]);
     warn.mockResolvedValueOnce(undefined);
 
     await ctl.removeClass();
@@ -98,9 +131,9 @@ describe('ExplorerController.removeClass', () => {
     expect(deleteClassMock).not.toHaveBeenCalled();
   });
 
-  it('refuses to remove a class that cannot be written in this repository', async () => {
+  it('refuses to remove a root class that cannot be written in this repository', async () => {
     const ctl = makeController();
-    (canClassBeWritten as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    writableMock.mockReturnValue(false);
 
     await ctl.removeClass();
 

--- a/client/src/__tests__/explorerRemoveClass.test.ts
+++ b/client/src/__tests__/explorerRemoveClass.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+vi.mock('../browserQueries', async (orig) => ({
+  ...(await orig()),
+  canClassBeWritten: vi.fn(() => true),
+  getClassDescendantNames: vi.fn(() => []),
+  getAllClassNames: vi.fn(() => []),
+  getClassesWithCategory: vi.fn(() => []),
+  deleteClass: vi.fn(() => 'Deleted class: X'),
+}));
+
+import { window } from '../__mocks__/vscode';
+import { ExplorerController } from '../gemstoneExplorer';
+import {
+  canClassBeWritten,
+  getClassDescendantNames,
+  getAllClassNames,
+  deleteClass,
+} from '../browserQueries';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+
+function makeController(): ExplorerController {
+  const session = { id: 1 } as ActiveSession;
+  const sessionManager = { getSelectedSession: () => session } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.dictName = 'UserGlobals';
+  ctl.state.dictIndex = 1;
+  ctl.state.className = 'Doomed';
+  return ctl;
+}
+
+const warn = window.showWarningMessage as ReturnType<typeof vi.fn>;
+const deleteClassMock = deleteClass as ReturnType<typeof vi.fn>;
+const descendantsMock = getClassDescendantNames as ReturnType<typeof vi.fn>;
+const allClassesMock = getAllClassNames as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (canClassBeWritten as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  deleteClassMock.mockReturnValue('Deleted class: X');
+  descendantsMock.mockReturnValue([]);
+  allClassesMock.mockReturnValue([]);
+});
+
+describe('ExplorerController.removeClass', () => {
+  it('deletes a leaf class (no subclasses) dict-scoped after confirmation', async () => {
+    const ctl = makeController();
+    warn.mockResolvedValueOnce('Remove');
+
+    await ctl.removeClass();
+
+    expect(deleteClassMock).toHaveBeenCalledTimes(1);
+    expect(deleteClassMock).toHaveBeenCalledWith(expect.anything(), 1, 'Doomed');
+    // The removed class is dropped from selection.
+    expect(ctl.state.className).toBeUndefined();
+  });
+
+  it('does not delete anything when the confirmation is dismissed', async () => {
+    const ctl = makeController();
+    warn.mockResolvedValueOnce(undefined);
+
+    await ctl.removeClass();
+
+    expect(deleteClassMock).not.toHaveBeenCalled();
+    expect(ctl.state.className).toBe('Doomed');
+  });
+
+  it('removes the whole subtree (all-or-none) when the class has subclasses', async () => {
+    const ctl = makeController();
+    descendantsMock.mockReturnValue([
+      { className: 'Sub1', parentName: 'Doomed' },
+      { className: 'Sub2', parentName: 'Sub1' },
+    ]);
+    // Sub2 lives in a different dictionary — each descendant deletes dict-scoped.
+    allClassesMock.mockReturnValue([
+      { className: 'Sub1', dictName: 'UserGlobals', dictIndex: 1 },
+      { className: 'Sub2', dictName: 'OtherDict', dictIndex: 3 },
+      { className: 'Doomed', dictName: 'UserGlobals', dictIndex: 1 },
+    ]);
+    warn.mockResolvedValueOnce('Remove All');
+
+    await ctl.removeClass();
+
+    expect(deleteClassMock).toHaveBeenCalledTimes(3);
+    expect(deleteClassMock).toHaveBeenCalledWith(expect.anything(), 1, 'Sub1');
+    expect(deleteClassMock).toHaveBeenCalledWith(expect.anything(), 3, 'Sub2');
+    expect(deleteClassMock).toHaveBeenCalledWith(expect.anything(), 1, 'Doomed');
+  });
+
+  it('cancels the subtree removal when the all-or-none confirmation is dismissed', async () => {
+    const ctl = makeController();
+    descendantsMock.mockReturnValue([{ className: 'Sub1', parentName: 'Doomed' }]);
+    warn.mockResolvedValueOnce(undefined);
+
+    await ctl.removeClass();
+
+    expect(deleteClassMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses to remove a class that cannot be written in this repository', async () => {
+    const ctl = makeController();
+    (canClassBeWritten as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    await ctl.removeClass();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('cannot be modified'));
+    expect(deleteClassMock).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/explorerShadowedClassClick.test.ts
+++ b/client/src/__tests__/explorerShadowedClassClick.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('vscode', () => import('../__mocks__/vscode.js'));
+vi.mock('../browserQueries', async (orig) => ({
+  ...(await orig()),
+  getClassHierarchy: vi.fn(() => []),
+}));
+
+import { ExplorerController } from '../gemstoneExplorer';
+import { getClassHierarchy } from '../browserQueries';
+import type { SessionManager, ActiveSession } from '../sessionManager';
+
+function makeController(): ExplorerController {
+  const session = { id: 1 } as ActiveSession;
+  const sessionManager = { getSelectedSession: () => session } as unknown as SessionManager;
+  const ctl = new ExplorerController(sessionManager);
+  ctl.state.dictName = 'Issue328DictB';
+  ctl.state.dictIndex = 2;
+  return ctl;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// Regression for the shadowed-class hierarchy bug: a class of the same name exists
+// in two dictionaries, so both rows share the tree id `k:<className>`. After
+// switching dictionaries, selectDict clears the controller's className while VS Code
+// still shows the row highlighted — so clicking it fires NO onDidChangeSelection.
+// handleClassClick (fired on every click) must re-select the class so the hierarchy
+// reloads for the newly-selected dictionary.
+describe('handleClassClick re-selects a shadowed class after a dictionary switch', () => {
+  it('selects the class when the controller has no class selected (stale highlight)', () => {
+    const ctl = makeController();
+    ctl.state.className = undefined; // as left by selectDict
+    const selectClass = vi.spyOn(ctl, 'selectClass').mockImplementation(() => {});
+
+    ctl.handleClassClick('Issue328Shadow');
+
+    expect(selectClass).toHaveBeenCalledTimes(1);
+    expect(selectClass.mock.calls[0][0].className).toBe('Issue328Shadow');
+  });
+
+  it('does not re-select when the class is already the selected one (no double reload)', () => {
+    const ctl = makeController();
+    ctl.state.className = 'Issue328Shadow';
+    const selectClass = vi.spyOn(ctl, 'selectClass').mockImplementation(() => {});
+
+    ctl.handleClassClick('Issue328Shadow');
+
+    expect(selectClass).not.toHaveBeenCalled();
+  });
+
+  // The Hierarchy pane must scope the lookup to the SELECTED dictionary; otherwise a
+  // shadowed name resolves to the global first match and shows the other class's lineage.
+  it('loads the hierarchy scoped to the selected dictionary index', () => {
+    const ctl = makeController(); // dictIndex = 2 (Issue328DictB)
+    ctl.state.className = 'Issue328Shadow';
+
+    (ctl as unknown as { loadHierarchy: () => void }).loadHierarchy();
+
+    expect(getClassHierarchy).toHaveBeenCalledWith(expect.anything(), 'Issue328Shadow', 2);
+  });
+});

--- a/client/src/__tests__/explorerTreeHelpers.test.ts
+++ b/client/src/__tests__/explorerTreeHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { variableSides, defaultDictionaryIndex } from '../explorerTreeHelpers';
+import { variableSides, defaultDictionaryIndex, categoryContains } from '../explorerTreeHelpers';
 
 describe('variable-side grouping under a class', () => {
   it('shows an instance side then a class side when both kinds exist', () => {
@@ -42,5 +42,24 @@ describe('default dictionary selection on connect', () => {
 
   it('selects nothing when there are no dictionaries', () => {
     expect(defaultDictionaryIndex([])).toBe(-1);
+  });
+});
+
+describe('categoryContains (keep a class selected when its category node is clicked)', () => {
+  it('matches the exact category', () => {
+    expect(categoryContains('User Classes', 'User Classes')).toBe(true);
+  });
+
+  it('matches a class in the dash-segmented subtree', () => {
+    expect(categoryContains('Collections', 'Collections-Dictionaries')).toBe(true);
+  });
+
+  it('does not match a different category or a mere prefix without the dash', () => {
+    expect(categoryContains('User Classes', 'Kernel-Objects')).toBe(false);
+    expect(categoryContains('Coll', 'Collections')).toBe(false);
+  });
+
+  it('does not match when the class has no category', () => {
+    expect(categoryContains('User Classes', undefined)).toBe(false);
   });
 });

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -14,6 +14,9 @@ vi.mock('../browserQueries', () => ({
   getMethodSource: vi.fn(() => 'at: index\n  ^self basicAt: index'),
   getBaseMethodSource: vi.fn(() => 'isVowel\n  ^ base impl'),
   getClassDefinition: vi.fn(() => "Object subclass: 'Array'\n  instVarNames: #()"),
+  getClassCategory: vi.fn(() => ''),
+  classExistsInDictionary: vi.fn(() => false),
+  recategorizeClass: vi.fn(),
   getClassComment: vi.fn(() => 'An ordered collection.'),
   compileMethod: vi.fn(() => 'Compiled: Array >> at:'),
   compileClassDefinition: vi.fn(),
@@ -294,6 +297,18 @@ describe('GemStoneFileSystemProvider', () => {
       expect(content).toContain('inDictionary: UserGlobals');
     });
 
+    it('new-class template always includes an editable category line, defaulting to User Classes when none was selected', () => {
+      const uri = Uri.parse('gemstone://1/UserGlobals/new-class');
+      const content = new TextDecoder().decode(provider.readFile(uri));
+      expect(content).toContain("category: 'User Classes'\n  options: #()");
+    });
+
+    it('new-class template pre-fills the selected category when one was passed', () => {
+      const uri = Uri.parse('gemstone://1/UserGlobals/new-class?category=Kernel-Numbers');
+      const content = new TextDecoder().decode(provider.readFile(uri));
+      expect(content).toContain("category: 'Kernel-Numbers'\n  options: #()");
+    });
+
     it('returns new-method template', () => {
       const uri = Uri.parse('gemstone://1/Globals/Array/instance/accessing/new-method');
       const content = new TextDecoder().decode(provider.readFile(uri));
@@ -475,6 +490,92 @@ describe('GemStoneFileSystemProvider', () => {
       expect(collection.set).toHaveBeenCalledWith(
         newClassUri,
         expect.arrayContaining([expect.objectContaining({ message: 'Class not found' })]),
+      );
+    });
+
+    it('shows the class category on its own line (Class>>definition omits it)', () => {
+      vi.mocked(queries.getClassDefinition).mockReturnValueOnce(
+        "Object subclass: 'Array'\n  inDictionary: Globals\n  options: #()",
+      );
+      vi.mocked(queries.getClassCategory).mockReturnValueOnce('Collections-Ordered');
+
+      const content = new TextDecoder().decode(
+        provider.readFile(Uri.parse('gemstone://1/Globals/Array/definition')),
+      );
+
+      expect(content).toContain("category: 'Collections-Ordered'\n  options: #()");
+      expect(queries.getClassCategory).toHaveBeenCalledWith(expect.anything(), 'Array', 'Globals');
+    });
+
+    it('strips the category line before compiling and applies it via recategorizeClass', () => {
+      const uri = Uri.parse('gemstone://1/UserGlobals/new-class');
+      const source =
+        "Object subclass: 'MyClass'\n  inDictionary: UserGlobals\n  category: 'User Classes'\n  options: #()";
+      vi.mocked(queries.compileClassDefinition).mockReturnValueOnce('MyClass');
+
+      provider.writeFile(uri, encode(source), { create: true, overwrite: true });
+
+      // The compiled source must NOT carry a category: keyword — no base image has
+      // the 8-keyword subclass:…category:options: selector.
+      const compiledSource = vi.mocked(queries.compileClassDefinition).mock.calls[0][1];
+      expect(compiledSource).not.toContain('category:');
+      expect(queries.recategorizeClass).toHaveBeenCalledWith(
+        expect.anything(),
+        'MyClass',
+        'User Classes',
+        'UserGlobals',
+      );
+    });
+
+    it('targets the dictionary named by inDictionary:, not the selected one, for a new class', async () => {
+      // URI dictionary is Globals (the selected one), but the definition names
+      // UserGlobals — the class is created there, so the existence check,
+      // recategorize, and reopened definition tab must all target UserGlobals.
+      const uri = Uri.parse('gemstone://1/Globals/new-class');
+      const source =
+        "Object subclass: 'Fnoodle'\n  inDictionary: UserGlobals\n  category: 'Collections-Internals'\n  options: #()";
+      vi.mocked(queries.compileClassDefinition).mockReturnValueOnce('Fnoodle');
+      const listener = vi.fn();
+      provider.onClassDefinitionCompiled(listener);
+
+      provider.writeFile(uri, encode(source), { create: true, overwrite: true });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(queries.classExistsInDictionary).toHaveBeenCalledWith(
+        expect.anything(),
+        'Fnoodle',
+        'UserGlobals',
+      );
+      expect(queries.recategorizeClass).toHaveBeenCalledWith(
+        expect.anything(),
+        'Fnoodle',
+        'Collections-Internals',
+        'UserGlobals',
+      );
+      const firedUri: Uri = listener.mock.calls[0][0].uri;
+      expect(firedUri.path).toBe('/UserGlobals/Fnoodle/definition/Fnoodle');
+    });
+
+    it('refuses a new-class save that would overwrite an existing class in the dictionary', async () => {
+      const uri = Uri.parse('gemstone://1/UserGlobals/new-class');
+      vi.mocked(queries.classExistsInDictionary).mockReturnValueOnce(true);
+      const listener = vi.fn();
+      provider.onClassDefinitionCompiled(listener);
+
+      provider.writeFile(uri, encode("Object subclass: 'Existing'\n  inDictionary: UserGlobals"), {
+        create: true,
+        overwrite: true,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(queries.compileClassDefinition).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+      const collection = vi.mocked(languages.createDiagnosticCollection).mock.results[0].value;
+      expect(collection.set).toHaveBeenCalledWith(
+        uri,
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringContaining('already exists') }),
+        ]),
       );
     });
 

--- a/client/src/__tests__/gemstoneFileSystemProvider.test.ts
+++ b/client/src/__tests__/gemstoneFileSystemProvider.test.ts
@@ -24,6 +24,12 @@ vi.mock('../browserQueries', () => ({
   canClassBeWritten: vi.fn(() => true),
 }));
 
+// Keep the real gciLog but spy logInfo so the recategorize soft-failure log is observable.
+vi.mock('../gciLog', async (orig) => ({
+  ...(await orig()),
+  logInfo: vi.fn(),
+}));
+
 import {
   Uri,
   FilePermission,
@@ -32,6 +38,7 @@ import {
   TabInputText,
   TabInputTextDiff,
 } from '../__mocks__/vscode';
+import { logInfo } from '../gciLog';
 import {
   GemStoneFileSystemProvider,
   buildMethodUri,
@@ -524,6 +531,41 @@ describe('GemStoneFileSystemProvider', () => {
         'MyClass',
         'User Classes',
         'UserGlobals',
+      );
+    });
+
+    it('clears the category (recategorize with empty) when the category line is removed', () => {
+      // The editor always shows a category: line; deleting it is how the user clears
+      // the category. An absent line must still recategorize (to ''), not be skipped.
+      const uri = Uri.parse('gemstone://1/UserGlobals/new-class');
+      const source = "Object subclass: 'MyClass'\n  inDictionary: UserGlobals\n  options: #()";
+      vi.mocked(queries.compileClassDefinition).mockReturnValueOnce('MyClass');
+      vi.mocked(queries.recategorizeClass).mockReturnValueOnce('Recategorized: MyClass');
+
+      provider.writeFile(uri, encode(source), { create: true, overwrite: true });
+
+      expect(queries.recategorizeClass).toHaveBeenCalledWith(
+        expect.anything(),
+        'MyClass',
+        '',
+        expect.anything(),
+      );
+    });
+
+    it('logs a recategorize soft-failure (returned status) and still reports the save succeeded', () => {
+      const uri = Uri.parse('gemstone://1/UserGlobals/new-class');
+      const source =
+        "Object subclass: 'MyClass'\n  inDictionary: UserGlobals\n  category: 'Widgets'\n  options: #()";
+      vi.mocked(queries.compileClassDefinition).mockReturnValueOnce('MyClass');
+      // recategorizeClass reports a soft failure by RETURNING (not throwing).
+      vi.mocked(queries.recategorizeClass).mockReturnValueOnce('Class not found: MyClass');
+
+      provider.writeFile(uri, encode(source), { create: true, overwrite: true });
+
+      expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('did not apply'));
+      // The soft failure must not block the class creation.
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Class created'),
       );
     });
 

--- a/client/src/__tests__/noHandRolledDictLookup.test.ts
+++ b/client/src/__tests__/noHandRolledDictLookup.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+// client/src — resolved from this test's own location (client/src/__tests__) so cwd
+// doesn't matter. __dirname (not import.meta) because the project compiles to CommonJS.
+const SRC_ROOT = join(__dirname, '..');
+
+function tsSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (
+        entry.name === '__tests__' ||
+        entry.name === '__mocks__' ||
+        entry.name === 'node_modules'
+      ) {
+        continue;
+      }
+      out.push(...tsSourceFiles(full));
+    } else if (
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.d.ts')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// The hand-rolled "resolve a dictionary from a `dict` parameter" snippets that
+// dictLookupExpr (and classLookupExpr, for a class within a dict) exist to replace.
+// These are precise on the `dict` parameter, so legitimate uses don't trip: index-only
+// lookups use `${dictIndex}` / `${srcDictIndex}`, and well-known globals use a literal
+// name (e.g. objectNamed: #'Rowan'). Adding a new one should reuse the shared helper.
+const HAND_ROLLED: RegExp[] = [
+  /symbolList at: \$\{dict\}/,
+  /objectNamed: #'\$\{escapeString\(dict\)\}'/,
+];
+
+describe('no hand-rolled dictionary resolution outside queries/util.ts', () => {
+  it('callers reuse dictLookupExpr / classLookupExpr instead of inlining the dict-by-parameter lookup', () => {
+    const offenders: string[] = [];
+    for (const file of tsSourceFiles(SRC_ROOT)) {
+      // The shared helpers legitimately contain the pattern — that's their home.
+      if (file.endsWith(join('queries', 'util.ts'))) continue;
+      const src = readFileSync(file, 'utf8');
+      if (HAND_ROLLED.some((re) => re.test(src))) offenders.push(file.slice(SRC_ROOT.length + 1));
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/client/src/browserQueries.ts
+++ b/client/src/browserQueries.ts
@@ -22,6 +22,10 @@ import { getMethodCategories as sharedGetMethodCategories } from './queries/getM
 import { getClassEnvironments as sharedGetClassEnvironments } from './queries/getClassEnvironments';
 import { getMethodInstVarAccess as sharedGetMethodInstVarAccess } from './queries/getMethodInstVarAccess';
 import { getClassDefinition as sharedGetClassDefinition } from './queries/getClassDefinition';
+import {
+  getClassCategory as sharedGetClassCategory,
+  classExistsInDictionary as sharedClassExistsInDictionary,
+} from './queries/getClassCategory';
 import { getClassComment as sharedGetClassComment } from './queries/getClassComment';
 import { canClassBeWritten as sharedCanClassBeWritten } from './queries/canClassBeWritten';
 import { getAllClassNames as sharedGetAllClassNames } from './queries/getAllClassNames';
@@ -629,6 +633,22 @@ export function getClassDefinition(
   dict?: number | string,
 ): string {
   return sharedGetClassDefinition(defaultQueryExecutorUsing(session), className, dict);
+}
+
+export function getClassCategory(
+  session: ActiveSession,
+  className: string,
+  dict?: number | string,
+): string {
+  return sharedGetClassCategory(defaultQueryExecutorUsing(session), className, dict);
+}
+
+export function classExistsInDictionary(
+  session: ActiveSession,
+  className: string,
+  dict: number | string,
+): boolean {
+  return sharedClassExistsInDictionary(defaultQueryExecutorUsing(session), className, dict);
 }
 
 export function getClassComment(

--- a/client/src/classDefinitionText.ts
+++ b/client/src/classDefinitionText.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure text helpers for the class-definition editor.
+ *
+ * GemStone's `Class>>definition` never emits a `category:` line, yet every class
+ * belongs to a category — so the editor shows the category on its own line for the
+ * user to see and edit. That line is NOT part of a compilable class-creation
+ * message: the 8-keyword `subclass:…inDictionary:category:options:` selector is
+ * absent on base images (it raises MessageNotUnderstood), so the category cannot
+ * ride in the subclass message. Instead the save path strips the category line,
+ * compiles the remaining (always-valid) definition, and applies the category
+ * separately via `Class>>category:`.
+ *
+ * These helpers keep that split/join pure and unit-testable, out of the
+ * FileSystemProvider.
+ */
+
+// A `category: '<smalltalk-string>'` line (single-quote escapes doubled), possibly
+// indented, on its own line. Anchored per-line so it matches wherever it sits.
+const CATEGORY_LINE = /^[ \t]*category:[ \t]*'((?:[^']|'')*)'[ \t]*\r?\n?/m;
+
+// GemStone's standard default class category. The New Class template always offers
+// an editable category line so the user can set a category regardless of explorer
+// selection; this is the value pre-filled when no category was selected.
+export const DEFAULT_CLASS_CATEGORY = 'User Classes';
+
+/**
+ * Split a class-definition source into the compilable definition (the category
+ * line removed) and the category value it carried (Smalltalk-unescaped), if any.
+ * A source with no category line is returned unchanged with `category` undefined.
+ */
+export function splitOutCategory(source: string): { source: string; category?: string } {
+  const m = CATEGORY_LINE.exec(source);
+  if (!m) return { source };
+  const category = m[1].replace(/''/g, "'");
+  const stripped = source.replace(CATEGORY_LINE, '');
+  return { source: stripped, category };
+}
+
+/**
+ * Insert a `category: '<escaped>'` line into a class definition for display —
+ * immediately before the `options:` line when present (matching the new-class
+ * template's layout), otherwise appended. An empty category yields the definition
+ * unchanged.
+ */
+export function withCategoryLine(definition: string, category: string): string {
+  if (!category) return definition;
+  const line = `  category: '${category.replace(/'/g, "''")}'`;
+  const optionsMatch = /^[ \t]*options:/m.exec(definition);
+  if (!optionsMatch) {
+    return `${definition.replace(/\s*$/, '')}\n${line}\n`;
+  }
+  const at = optionsMatch.index;
+  return `${definition.slice(0, at)}${line}\n${definition.slice(at)}`;
+}
+
+/** The class name a `<Super> subclass: 'Name' …` definition creates, or undefined
+ *  if the source has no recognizable subclass clause. Used to pre-check whether a
+ *  new-class save would collide with an existing class. */
+export function classNameFromDefinition(source: string): string | undefined {
+  const m = /\bsubclass:\s*'((?:[^']|'')*)'/.exec(source);
+  return m ? m[1].replace(/''/g, "'") : undefined;
+}
+
+/** The symbol-dictionary name a `… inDictionary: <Name> …` definition targets, or
+ *  undefined if absent. The value is a bareword (a SymbolDictionary global variable),
+ *  not a quoted string, so the class can be created in a dictionary other than the
+ *  one currently selected in the explorer — callers must target THIS dictionary for
+ *  the post-compile categorize/reveal, not the selected one. */
+export function dictNameFromDefinition(source: string): string | undefined {
+  const m = /\binDictionary:\s*([A-Za-z_]\w*)/.exec(source);
+  return m ? m[1] : undefined;
+}

--- a/client/src/explorerTreeHelpers.ts
+++ b/client/src/explorerTreeHelpers.ts
@@ -38,3 +38,17 @@ export function defaultDictionaryIndex(names: string[]): number {
   const userGlobals = names.indexOf('UserGlobals');
   return userGlobals >= 0 ? userGlobals : 0;
 }
+
+/**
+ * Whether a class whose class-category is `classCategory` is shown under the
+ * selected category node `selectedPath`. A category node shows its own classes AND
+ * everything in its dash-segmented subtree (selecting "Announcements" shows
+ * "Announcements-Core" too), so a class matches when its category equals the path
+ * or begins with `path-`. Used to keep a selected class in sync when its category
+ * node is clicked: the classes pane keeps highlighting the class, so the
+ * controller must not drop it (which would desync New Method / the Hierarchy pane).
+ */
+export function categoryContains(selectedPath: string, classCategory: string | undefined): boolean {
+  if (classCategory === undefined) return false;
+  return classCategory === selectedPath || classCategory.startsWith(`${selectedPath}-`);
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -893,7 +893,10 @@ export function activate(context: vscode.ExtensionContext) {
     gemstoneFs.onClassDefinitionCompiled((e) => {
       const parts = e.uri.path.split('/').map(decodeURIComponent);
       if (parts.length >= 3) {
-        explorer.onClassCompiled(parseInt(e.uri.authority, 10), parts[2]);
+        // parts: ['', dictName, className, 'definition'] — pass the dictName so the
+        // explorer can jump to the dictionary the class was actually created in
+        // (which may differ from the selected one for a new-class inDictionary:).
+        explorer.onClassCompiled(parseInt(e.uri.authority, 10), parts[2], parts[1]);
       }
     }),
   );

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -82,7 +82,7 @@ import {
   validateNewClassVarName,
 } from './refactoring/renameClassVarPreview';
 import { showRenameClassVarPanel } from './refactoring/renameClassVarPanel';
-import { variableSides, defaultDictionaryIndex } from './explorerTreeHelpers';
+import { variableSides, defaultDictionaryIndex, categoryContains } from './explorerTreeHelpers';
 import { emptyVarSideUri } from './explorerVarDecorations';
 import {
   parseClassHistory,
@@ -1081,15 +1081,42 @@ export class ExplorerController {
 
   selectClassCategory(item: ClassCategoryItem): void {
     this.state.classCategory = item.fullPath;
-    this.state.className = undefined;
-    this.envLines = [];
-    this.hierChain = [];
-    this.hierSubs = [];
+    // A category node keeps showing (and the classes pane keeps highlighting) a
+    // selected class that still lives under it. Dropping the controller's className
+    // here would desync from that highlight — the row looks selected, yet New
+    // Method and the Hierarchy pane would report "no class selected". So keep the
+    // current class (and its already-loaded hierarchy) when it remains under this
+    // category; only reset when the class is filtered out of view.
+    const keepClass =
+      this.state.className !== undefined &&
+      categoryContains(item.fullPath, this.categoryOfClass(this.state.className));
+    if (!keepClass) {
+      this.state.className = undefined;
+      this.envLines = [];
+      this.hierChain = [];
+      this.hierSubs = [];
+    }
     this.clearFilters(VIEW_CLASSES, VIEW_METHODS);
     this.classProvider.refresh();
     this.hierarchyProvider.refresh();
     this.methodProvider.refresh();
     this.syncTitles();
+  }
+
+  // The class-category of a class as the classes pane currently knows it, or
+  // undefined if not loaded. Used to decide whether a class stays selected when its
+  // category node is clicked (see selectClassCategory).
+  private categoryOfClass(className: string): string | undefined {
+    return this.classCategoryEntries.find((e) => e.className === className)?.category;
+  }
+
+  // The class currently highlighted in the Classes pane, if any. A fallback for
+  // when the controller's className has been cleared (e.g. by a category click)
+  // but a class row is still visually selected — actions should act on what the
+  // user sees selected. Returns undefined if the selection isn't a class row.
+  private selectedClassInTree(): ClassItem | undefined {
+    const node = this.views?.klass.selection?.[0];
+    return node instanceof ClassItem ? node : undefined;
   }
 
   // Record which side / method-category the user last touched in the Methods
@@ -1430,6 +1457,17 @@ export class ExplorerController {
   // the click; two on the same class within the threshold open its definition.
   private readonly classClicks = new DoubleClickDetector(500);
   handleClassClick(className: string): void {
+    // (Re)select the class even when VS Code's tree still shows it highlighted from
+    // a DIFFERENT dictionary: a same-named class in another dictionary shares this
+    // row's tree id (`k:<className>`), so switching dictionaries leaves the row
+    // highlighted while selectDict cleared the controller's className — and clicking
+    // the already-highlighted row fires no onDidChangeSelection, so the hierarchy
+    // would never reload. classClicked fires on EVERY click, so re-sync here. The
+    // matching guard on the classView selection wiring keeps this to exactly one
+    // selectClass per click.
+    if (className !== this.state.className) {
+      this.selectClass(new ClassItem(className));
+    }
     if (this.classClicks.register(className)) {
       void this.openClassDefinition(new ClassItem(className));
     }
@@ -1458,7 +1496,10 @@ export class ExplorerController {
     }
     let entries: queries.ClassHierarchyEntry[];
     try {
-      entries = queries.getClassHierarchy(session, this.state.className);
+      // Scope the lookup to the selected dictionary: without dictIndex, a class
+      // name shadowed across dictionaries resolves to the global first match, so
+      // the Hierarchy pane would show the OTHER dictionary's class's lineage.
+      entries = queries.getClassHierarchy(session, this.state.className, this.state.dictIndex);
     } catch {
       this.hierChain = [];
       this.hierSubs = [];
@@ -3426,6 +3467,131 @@ export class ExplorerController {
     void vscode.window.setStatusBarMessage(`Removed dictionary ${node.dictName}`, 4000);
   }
 
+  // Remove a class from its dictionary. `item` comes from the inline trash on a
+  // Classes-pane or Hierarchy-pane row; falls back to the selected class. The delete
+  // is dict-scoped (a shadowed name deletes the one the user sees). If the class has
+  // subclasses it's all-or-none: confirm removing the whole subtree, or cancel.
+  // Nothing is committed — the user commits the session.
+  async removeClass(item?: ClassItem | HierarchyItem): Promise<void> {
+    const session = this.session();
+    if (!session) {
+      void vscode.window.showWarningMessage('No active GemStone session.');
+      return;
+    }
+
+    let className: string | undefined;
+    let dictName: string | undefined;
+    let dictIndex: number | undefined;
+    if (item instanceof ClassItem) {
+      className = item.className;
+      dictName = this.state.dictName;
+      dictIndex = this.state.dictIndex;
+    } else if (item instanceof HierarchyItem) {
+      className = item.className;
+      const resolved = this.resolveClassDict(item.className, item.dictName);
+      dictName = resolved?.dictName;
+      dictIndex = resolved?.dictIndex;
+    } else if (this.state.className !== undefined) {
+      className = this.state.className;
+      dictName = this.state.dictName;
+      dictIndex = this.state.dictIndex;
+    }
+    if (className === undefined || dictName === undefined || dictIndex === undefined) {
+      void vscode.window.showWarningMessage('Select a class first.');
+      return;
+    }
+
+    // Kernel/system classes can't be modified in this repository — guard before prompting.
+    if (!queries.canClassBeWritten(session, className, dictIndex)) {
+      void vscode.window.showWarningMessage(`${className} cannot be modified in this repository.`);
+      return;
+    }
+
+    // The transitive subtree, resolved dict-scoped so a shadowed root walks its OWN lineage.
+    const descendants = queries.getClassDescendantNames(session, className, dictIndex);
+
+    if (descendants.length > 0) {
+      const names = descendants.map((d) => d.className);
+      const preview =
+        names.slice(0, 8).join(', ') + (names.length > 8 ? `, …(+${names.length - 8} more)` : '');
+      const confirmed = await vscode.window.showWarningMessage(
+        `Remove ${className} and all ${names.length} of its subclass${names.length === 1 ? '' : 'es'}?`,
+        {
+          modal: true,
+          detail:
+            `Subclasses: ${preview}\n\n` +
+            'This removes the whole subtree — all or none. Nothing is committed until you commit the session.',
+        },
+        'Remove All',
+      );
+      if (confirmed !== 'Remove All') return;
+    } else {
+      const confirmed = await vscode.window.showWarningMessage(
+        `Remove class ${className} from ${dictName}?`,
+        { modal: true, detail: 'Nothing is committed until you commit the session.' },
+        'Remove',
+      );
+      if (confirmed !== 'Remove') return;
+    }
+
+    // Delete each descendant (resolving its own dictionary — a subclass may live in
+    // another one) then the class itself.
+    const targets: { className: string; dictName: string; dictIndex: number }[] = [];
+    if (descendants.length > 0) {
+      const dictOf = new Map<string, { dictName: string; dictIndex: number }>();
+      for (const e of queries.getAllClassNames(session)) {
+        if (!dictOf.has(e.className)) {
+          dictOf.set(e.className, { dictName: e.dictName, dictIndex: e.dictIndex });
+        }
+      }
+      for (const d of descendants) {
+        const where = dictOf.get(d.className);
+        if (where) targets.push({ className: d.className, ...where });
+      }
+    }
+    targets.push({ className, dictName, dictIndex });
+
+    const failures: string[] = [];
+    for (const t of targets) {
+      try {
+        const result = queries.deleteClass(session, t.dictIndex, t.className);
+        if (!result.startsWith('Deleted class:')) failures.push(`${t.className}: ${result}`);
+      } catch (e: unknown) {
+        failures.push(`${t.className}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+
+    // Drop the removed class from selection/hierarchy and reload the current dict's
+    // class list so the pane reflects the deletion.
+    if (this.state.className === className) {
+      this.state.className = undefined;
+      this.envLines = [];
+      this.hierChain = [];
+      this.hierSubs = [];
+    }
+    if (this.state.dictIndex !== undefined) {
+      this.classCategoryEntries = queries.getClassesWithCategory(session, this.state.dictIndex);
+      this.loadDefinedIvarCounts();
+    }
+    this.categoryProvider.refresh();
+    this.classProvider.refresh();
+    this.hierarchyProvider.refresh();
+    this.methodProvider.refresh();
+    this.syncTitles();
+
+    if (failures.length > 0) {
+      void vscode.window.showErrorMessage(`Remove class had errors — ${failures.join('; ')}`);
+    } else if (targets.length > 1) {
+      const n = targets.length - 1;
+      void vscode.window.setStatusBarMessage(
+        `Removed ${className} and ${n} subclass${n === 1 ? '' : 'es'}`,
+        4000,
+      );
+    } else {
+      void vscode.window.setStatusBarMessage(`Removed class ${className}`, 4000);
+    }
+  }
+
   async newClassCategory(): Promise<void> {
     if (this.state.dictName === undefined) {
       void vscode.window.showWarningMessage('Select a dictionary first.');
@@ -3591,6 +3757,13 @@ export class ExplorerController {
         target.computed ? 'as yet unclassified' : target.category,
       );
       return;
+    }
+    if (this.state.className === undefined) {
+      // The controller lost its className (e.g. a category click) but a class row
+      // may still be highlighted — adopt it so "New Method" acts on what the user
+      // sees selected (this also reloads its methods and hierarchy).
+      const fromTree = this.selectedClassInTree();
+      if (fromTree) this.selectClass(fromTree);
     }
     if (this.state.className === undefined) {
       void vscode.window.showWarningMessage('Select a class first.');
@@ -4036,7 +4209,7 @@ export class ExplorerController {
     this.maybeRevealNewMethod();
   }
 
-  onExternalClassCompiled(sessionId: number, className: string): void {
+  onExternalClassCompiled(sessionId: number, className: string, dictName?: string): void {
     const session = this.session();
     if (!session || session.id !== sessionId || this.state.dictIndex === undefined) return;
     this.classCategoryEntries = queries.getClassesWithCategory(session, this.state.dictIndex);
@@ -4050,6 +4223,15 @@ export class ExplorerController {
       this.state.dictName !== undefined
     ) {
       void this.revealClass(this.state.dictName, this.state.dictIndex, className);
+      return;
+    }
+    // Otherwise the class was created in a dictionary other than the selected one
+    // — e.g. a new class whose `inDictionary:` names a different dictionary. Jump
+    // the explorer to where the class actually lives so it's revealed there,
+    // rather than leaving the panes on a dictionary that doesn't contain it.
+    const resolved = this.resolveClassDict(className, dictName);
+    if (resolved) {
+      void this.revealClass(resolved.dictName, resolved.dictIndex, className);
     } else {
       this.syncTitles();
     }
@@ -4317,7 +4499,7 @@ class ClassDropController implements vscode.TreeDragAndDropController<ClassNode>
 // for a live panel refresh.
 export interface ExplorerHandle {
   onMethodCompiled(sessionId: number, className: string): void;
-  onClassCompiled(sessionId: number, className: string): void;
+  onClassCompiled(sessionId: number, className: string, dictName?: string): void;
   onSessionAborted(sessionId: number): void;
 }
 
@@ -4389,9 +4571,11 @@ export function registerGemStoneExplorer(
   });
   classView.onDidChangeSelection((e) => {
     // Only a class row navigates; selecting an ivar child is inert (it's acted on
-    // via its inline pencil, not selection).
+    // via its inline pencil, not selection). Skip when the class is already the
+    // selected one so a click doesn't run selectClass twice — the row's classClicked
+    // command also (re)selects; between the two, exactly one runs per click.
     const node = e.selection[0];
-    if (node instanceof ClassItem) ctl.selectClass(node);
+    if (node instanceof ClassItem && node.className !== ctl.state.className) ctl.selectClass(node);
   });
   hierarchyView.onDidChangeSelection((e) => {
     if (e.selection[0]) ctl.selectHierarchyNode(e.selection[0]);
@@ -4454,6 +4638,14 @@ export function registerGemStoneExplorer(
             `Remove method failed: ${e instanceof Error ? e.message : String(e)}`,
           );
         });
+    }),
+    vscode.commands.registerCommand('gemstone.explorer.removeClass', (node?: unknown) => {
+      const item = node instanceof ClassItem || node instanceof HierarchyItem ? node : undefined;
+      void ctl.removeClass(item).catch((e: unknown) => {
+        void vscode.window.showErrorMessage(
+          `Remove class failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      });
     }),
     // Ctrl/Cmd+Enter in the Methods pane: open the selected method in a new
     // source editor to the side (same as the row's ↗ button). Keybindings don't
@@ -4820,7 +5012,8 @@ export function registerGemStoneExplorer(
 
   return {
     onMethodCompiled: (sessionId, className) => ctl.onExternalMethodCompiled(sessionId, className),
-    onClassCompiled: (sessionId, className) => ctl.onExternalClassCompiled(sessionId, className),
+    onClassCompiled: (sessionId, className, dictName) =>
+      ctl.onExternalClassCompiled(sessionId, className, dictName),
     onSessionAborted: (sessionId) => ctl.onSessionAborted(sessionId),
   };
 }

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -3507,8 +3507,33 @@ export class ExplorerController {
       return;
     }
 
-    // The transitive subtree, resolved dict-scoped so a shadowed root walks its OWN lineage.
+    // The transitive subtree, resolved dict-scoped so a shadowed root walks its OWN
+    // lineage; each descendant carries the dictionary that binds it BY OBJECT IDENTITY
+    // (not by name), so a subclass whose name is shadowed in another dictionary still
+    // resolves to its own class, never a same-named one elsewhere.
     const descendants = queries.getClassDescendantNames(session, className, dictIndex);
+
+    // Resolve and vet the whole subtree BEFORE prompting, so the all-or-none promise
+    // holds: if any member can't be located in a dictionary or can't be written, abort
+    // deleting nothing rather than half-removing the subtree. The root is already
+    // writable-checked above.
+    const targets: { className: string; dictIndex: number }[] = [{ className, dictIndex }];
+    const blockers: string[] = [];
+    for (const d of descendants) {
+      if (d.dictIndex <= 0) {
+        blockers.push(`${d.className} (not found in any dictionary)`);
+      } else if (!queries.canClassBeWritten(session, d.className, d.dictIndex)) {
+        blockers.push(`${d.className} (not writable)`);
+      } else {
+        targets.push({ className: d.className, dictIndex: d.dictIndex });
+      }
+    }
+    if (blockers.length > 0) {
+      void vscode.window.showErrorMessage(
+        `Cannot remove ${className} and its subclasses (all-or-none) — blocked by: ${blockers.join('; ')}.`,
+      );
+      return;
+    }
 
     if (descendants.length > 0) {
       const names = descendants.map((d) => d.className);
@@ -3533,23 +3558,6 @@ export class ExplorerController {
       );
       if (confirmed !== 'Remove') return;
     }
-
-    // Delete each descendant (resolving its own dictionary — a subclass may live in
-    // another one) then the class itself.
-    const targets: { className: string; dictName: string; dictIndex: number }[] = [];
-    if (descendants.length > 0) {
-      const dictOf = new Map<string, { dictName: string; dictIndex: number }>();
-      for (const e of queries.getAllClassNames(session)) {
-        if (!dictOf.has(e.className)) {
-          dictOf.set(e.className, { dictName: e.dictName, dictIndex: e.dictIndex });
-        }
-      }
-      for (const d of descendants) {
-        const where = dictOf.get(d.className);
-        if (where) targets.push({ className: d.className, ...where });
-      }
-    }
-    targets.push({ className, dictName, dictIndex });
 
     const failures: string[] = [];
     for (const t of targets) {

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -5,6 +5,13 @@ import { BrowserQueryError } from './browserQueries';
 import { ExportManager } from './exportManager';
 import { logInfo } from './gciLog';
 import { receiver } from './queries/util';
+import {
+  splitOutCategory,
+  withCategoryLine,
+  classNameFromDefinition,
+  dictNameFromDefinition,
+  DEFAULT_CLASS_CATEGORY,
+} from './classDefinitionText';
 
 // A binary selector can contain '/', but a slash in a URI path segment (raw or
 // %2F-encoded) is collapsed by VS Code's path normalization, losing the
@@ -490,7 +497,11 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     const parsed = parseUri(uri);
 
     if (parsed.kind === 'new-class') {
-      const categoryLine = parsed.category ? `\n  category: '${parsed.category}'` : '';
+      // A new class always gets an editable category line, so the user can set a
+      // category regardless of the explorer's selection. Pre-fill the selected
+      // category when there was one, else GemStone's default 'User Classes'.
+      const category = parsed.category ?? DEFAULT_CLASS_CATEGORY;
+      const categoryLine = `\n  category: '${category.replace(/'/g, "''")}'`;
       const template = `Object subclass: 'NameOfClass'
   instVarNames: #()
   classVars: #()
@@ -534,13 +545,15 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
             );
         break;
       }
-      case 'definition':
-        text = queries.getClassDefinition(
-          session,
-          parsed.className,
-          parsed.dictIndex ?? parsed.dictName,
-        );
+      case 'definition': {
+        // GemStone's `definition` omits the category; show it on its own line so
+        // it's visible and editable (the save path applies it separately).
+        const dictRef = parsed.dictIndex ?? parsed.dictName;
+        const definition = queries.getClassDefinition(session, parsed.className, dictRef);
+        const category = queries.getClassCategory(session, parsed.className, dictRef);
+        text = withCategoryLine(definition, category);
         break;
+      }
       case 'comment':
         text = queries.getClassComment(
           session,
@@ -686,7 +699,52 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     source: string,
     session: ActiveSession,
   ) {
-    const className = queries.compileClassDefinition(session, source);
+    // The editor shows the category on its own line, but no GemStone image can
+    // compile it inside the subclass message (the 8-keyword
+    // subclass:…inDictionary:category:options: selector raises MessageNotUnderstood
+    // on base stones). Strip the category line, compile the always-valid
+    // definition, then apply the category via Class>>category:.
+    const { source: defSource, category } = splitOutCategory(source);
+    // A new-class definition may name a dictionary other than the one selected in
+    // the explorer (the user can edit the `inDictionary:` line). The class is
+    // created wherever that line says, so every post-compile step — existence
+    // check, recategorize, sync, reopen — must target THAT dictionary, not the
+    // selected one (parsed.dictName), or they look the class up in the wrong place
+    // (LookupError / "Class not found").
+    const targetDictName: string =
+      parsed.kind === 'new-class'
+        ? (dictNameFromDefinition(defSource) ?? parsed.dictName)
+        : parsed.dictName;
+    const dictRef: number | string =
+      parsed.kind === 'definition' ? (parsed.dictIndex ?? parsed.dictName) : targetDictName;
+
+    // A NEW-class save must not silently redefine an existing class in the target
+    // dictionary. (Editing an existing class's definition is a deliberate
+    // redefinition, so this guard is new-class only.)
+    if (parsed.kind === 'new-class') {
+      const intended = classNameFromDefinition(defSource);
+      if (intended && queries.classExistsInDictionary(session, intended, dictRef)) {
+        throw new BrowserQueryError(
+          `A class named ${intended} already exists in ${targetDictName} — not overwriting it. ` +
+            `Choose a different name, or edit the existing class from its own definition editor.`,
+        );
+      }
+    }
+
+    const className = queries.compileClassDefinition(session, defSource);
+
+    // Apply the category the subclass message could not carry. A failure here must
+    // not lose the freshly compiled class, so it's logged, not thrown.
+    if (category !== undefined && category.length > 0) {
+      try {
+        queries.recategorizeClass(session, className, category, dictRef);
+      } catch (e: unknown) {
+        logInfo(
+          `[FS] recategorize ${className} → '${category}' failed: ` +
+            `${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    }
 
     // An existing but non-writable class recompiles transiently (like a session
     // method) without persisting, yet GemStone reports success — warn instead
@@ -711,15 +769,16 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
     // Use the name GemStone returned, not parsed.className: for a new-class URI the segment is
     // a placeholder, and editing a definition with a different class name creates a new class —
     // in both cases, parsed.className does not reflect the class that was actually created.
-    void this.exportManager?.syncClass(session, parsed.dictName, className);
+    void this.exportManager?.syncClass(session, targetDictName, className);
 
     // Preserve the dictionary index (when the edited URI carried one) so the
     // reopened definition tab targets the same dictionary and matches the tab
-    // being replaced.
+    // being replaced. For a new class, target the dictionary the definition named
+    // (targetDictName), which may differ from the selected one.
     const dictIndex = parsed.kind === 'definition' ? parsed.dictIndex : undefined;
     const definitionUri = buildClassDefinitionUri(
       parsed.sessionId,
-      parsed.dictName,
+      targetDictName,
       className,
       dictIndex,
     );

--- a/client/src/gemstoneFileSystemProvider.ts
+++ b/client/src/gemstoneFileSystemProvider.ts
@@ -733,17 +733,25 @@ export class GemStoneFileSystemProvider implements vscode.FileSystemProvider {
 
     const className = queries.compileClassDefinition(session, defSource);
 
-    // Apply the category the subclass message could not carry. A failure here must
-    // not lose the freshly compiled class, so it's logged, not thrown.
-    if (category !== undefined && category.length > 0) {
-      try {
-        queries.recategorizeClass(session, className, category, dictRef);
-      } catch (e: unknown) {
-        logInfo(
-          `[FS] recategorize ${className} → '${category}' failed: ` +
-            `${e instanceof Error ? e.message : String(e)}`,
-        );
+    // Apply the category the subclass message could not carry — always, including an
+    // empty value: the editor always shows a `category:` line, so deleting/emptying it
+    // is how the user clears the class's category (skipping the empty case would keep
+    // the old category and read as a reverted edit on reopen). A failure here must not
+    // lose the freshly compiled class, so it's logged, not thrown.
+    const desiredCategory = category ?? '';
+    try {
+      const result = queries.recategorizeClass(session, className, desiredCategory, dictRef);
+      // recategorizeClass reports soft failures (e.g. the class not resolving in
+      // dictRef) by RETURNING a status string rather than throwing — surface it so the
+      // typed category isn't silently dropped behind a "saved" message.
+      if (!result.startsWith('Recategorized:')) {
+        logInfo(`[FS] recategorize ${className} → '${desiredCategory}' did not apply: ${result}`);
       }
+    } catch (e: unknown) {
+      logInfo(
+        `[FS] recategorize ${className} → '${desiredCategory}' failed: ` +
+          `${e instanceof Error ? e.message : String(e)}`,
+      );
     }
 
     // An existing but non-writable class recompiles transiently (like a session

--- a/client/src/queries/__tests__/dictLookup.test.ts
+++ b/client/src/queries/__tests__/dictLookup.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dictLookupExpr } from '../util';
+import { classExistsInDictionary } from '../getClassCategory';
+
+describe('dictLookupExpr', () => {
+  it('resolves a dictionary by 1-based SymbolList index', () => {
+    expect(dictLookupExpr(3)).toBe('System myUserProfile symbolList at: 3');
+  });
+
+  it('resolves a dictionary by name, doubling single quotes', () => {
+    expect(dictLookupExpr("O'Dict")).toBe(
+      "System myUserProfile symbolList objectNamed: #'O''Dict'",
+    );
+  });
+});
+
+describe('classExistsInDictionary (reuses classLookupExpr)', () => {
+  it('resolves the class within the dictionary and checks isBehavior — not a hand-rolled dict lookup', () => {
+    const exec = vi.fn().mockReturnValue('true');
+
+    expect(classExistsInDictionary(exec, 'Foo', 3)).toBe(true);
+
+    const code = exec.mock.calls[0][0] as string;
+    // Goes through the shared class-in-dictionary resolution…
+    expect(code).toContain("(System myUserProfile symbolList at: 3) at: #'Foo' ifAbsent: [nil]");
+    expect(code).toContain('isBehavior');
+    // …and does NOT hand-roll the dict-by-parameter resolution.
+    expect(code).not.toContain('symbolList at: 3 ifAbsent:');
+  });
+
+  it('is false when the class is absent (query returns false)', () => {
+    const exec = vi.fn().mockReturnValue('false');
+    expect(classExistsInDictionary(exec, 'Foo', 'UserGlobals')).toBe(false);
+  });
+});

--- a/client/src/queries/deleteClass.ts
+++ b/client/src/queries/deleteClass.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { escapeString } from './util';
+import { escapeString, dictLookupExpr } from './util';
 
 // Destructive. Not committed automatically. Accepts a dict by 1-based index
 // or by name — required because deletion must target a specific dictionary
@@ -10,10 +10,7 @@ export function deleteClass(
   className: string,
 ): string {
   const esc = escapeString(className);
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| d removed |
 d := ${dictExpr}.
 d ifNil: [^ 'Dictionary not found'].

--- a/client/src/queries/getClassCategory.ts
+++ b/client/src/queries/getClassCategory.ts
@@ -1,0 +1,39 @@
+import { QueryExecutor } from './types';
+import { classLookupExpr, escapeString } from './util';
+
+// The class category of `className` (Class>>category), or '' if the class has none
+// or cannot be found. `dict` scopes the lookup like getClassDefinition. The
+// class-definition editor shows this on its own line (GemStone's own `definition`
+// omits it); see classDefinitionText.ts.
+export function getClassCategory(
+  execute: QueryExecutor,
+  className: string,
+  dict?: number | string,
+): string {
+  const code = `| cls |
+cls := ${classLookupExpr(className, dict)}.
+cls ifNil: [^ 'Class not found: ${escapeString(className)}'].
+(cls category ifNil: ['']) asString`;
+  const result = execute(code);
+  return result.startsWith('Class not found:') ? '' : result;
+}
+
+// True when a class named `className` already exists in the given dictionary — used
+// to refuse a new-class save that would silently redefine (override) an existing
+// class. `dict` is a 1-based symbol-list index or a dictionary name.
+export function classExistsInDictionary(
+  execute: QueryExecutor,
+  className: string,
+  dict: number | string,
+): boolean {
+  const dictExpr =
+    typeof dict === 'number'
+      ? `System myUserProfile symbolList at: ${dict} ifAbsent: [nil]`
+      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const code = `| d v |
+d := ${dictExpr}.
+d ifNil: [^ 'false'].
+v := d at: #'${escapeString(className)}' ifAbsent: [nil].
+(v notNil and: [v isBehavior]) printString`;
+  return execute(code).trim() === 'true';
+}

--- a/client/src/queries/getClassCategory.ts
+++ b/client/src/queries/getClassCategory.ts
@@ -26,14 +26,11 @@ export function classExistsInDictionary(
   className: string,
   dict: number | string,
 ): boolean {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict} ifAbsent: [nil]`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
-  const code = `| d v |
-d := ${dictExpr}.
-d ifNil: [^ 'false'].
-v := d at: #'${escapeString(className)}' ifAbsent: [nil].
-(v notNil and: [v isBehavior]) printString`;
-  return execute(code).trim() === 'true';
+  // Resolve the class within the dictionary via the shared classLookupExpr (which
+  // already handles both the index and the name form and the missing-dictionary
+  // case), then confirm it's actually a class — a plain global of the same name
+  // must not count as "exists". classLookupExpr is a keyword-message expression, so
+  // parenthesize it before sending ifNil:ifNotNil:.
+  const expr = `(${classLookupExpr(className, dict)}) ifNil: [false] ifNotNil: [:v | v isBehavior]`;
+  return execute(`(${expr}) printString`).trim() === 'true';
 }

--- a/client/src/queries/getClassNames.ts
+++ b/client/src/queries/getClassNames.ts
@@ -1,14 +1,11 @@
 import { QueryExecutor } from './types';
-import { escapeString, splitLines } from './util';
+import { splitLines, dictLookupExpr } from './util';
 
 // Accepts a dictionary by 1-based index (canonical for Jasper's IDE) or by
 // name (convenient for MCP clients that don't want to enumerate first).
 // With a name, returns [] if no dict by that name exists.
 export function getClassNames(execute: QueryExecutor, dict: number | string): string[] {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| ws dict |
 dict := ${dictExpr}.
 dict ifNil: [^ ''].

--- a/client/src/queries/getClassesWithCategory.ts
+++ b/client/src/queries/getClassesWithCategory.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { escapeString, splitLines } from './util';
+import { splitLines, dictLookupExpr } from './util';
 
 export interface ClassCategoryEntry {
   className: string;
@@ -15,10 +15,7 @@ export function getClassesWithCategory(
   execute: QueryExecutor,
   dict: number | string,
 ): ClassCategoryEntry[] {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| ws dict |
 dict := ${dictExpr}.
 dict ifNil: [^ ''].

--- a/client/src/queries/getDefinedInstVarCounts.ts
+++ b/client/src/queries/getDefinedInstVarCounts.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { escapeString, splitLines } from './util';
+import { splitLines, dictLookupExpr } from './util';
 
 // className → number of instance variables DEFINED in that class (not inherited),
 // for every class in a dictionary, in a single round trip. The GemStone Explorer
@@ -10,10 +10,7 @@ export function getDefinedInstVarCounts(
   execute: QueryExecutor,
   dict: number | string,
 ): Map<string, number> {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| ws dict |
 dict := ${dictExpr}.
 dict ifNil: [^ ''].

--- a/client/src/queries/getDictionaryClassFileOutOrder.ts
+++ b/client/src/queries/getDictionaryClassFileOutOrder.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { escapeString, splitLines } from './util';
+import { splitLines, dictLookupExpr } from './util';
 
 // Class names in a dictionary, ordered so that a class always appears after any
 // of its superclasses (ascending inheritance depth, then name). Filing the
@@ -12,10 +12,7 @@ export function getDictionaryClassFileOutOrder(
   execute: QueryExecutor,
   dict: number | string,
 ): string[] {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| ws dict |
 dict := ${dictExpr}.
 dict ifNil: [^ ''].

--- a/client/src/queries/getDictionaryEntries.ts
+++ b/client/src/queries/getDictionaryEntries.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from './types';
-import { escapeString } from './util';
+import { dictLookupExpr } from './util';
 
 export interface DictEntry {
   isClass: boolean;
@@ -10,10 +10,7 @@ export interface DictEntry {
 // Accepts a dictionary by 1-based index (Jasper's IDE) or by name (MCP
 // clients). With a name, returns [] if no dict by that name exists.
 export function getDictionaryEntries(execute: QueryExecutor, dict: number | string): DictEntry[] {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| ws dict |
 dict := ${dictExpr}.
 dict ifNil: [^ ''].

--- a/client/src/queries/removeDictionary.ts
+++ b/client/src/queries/removeDictionary.ts
@@ -1,13 +1,10 @@
 import { QueryExecutor } from './types';
-import { escapeString } from './util';
+import { dictLookupExpr } from './util';
 
 // Destructive. Not committed automatically. Accepts a dict by 1-based index
 // or by name.
 export function removeDictionary(execute: QueryExecutor, dict: number | string): string {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| sl d |
 sl := System myUserProfile symbolList.
 d := ${dictExpr}.

--- a/client/src/queries/util.ts
+++ b/client/src/queries/util.ts
@@ -26,6 +26,20 @@ export function compiledMethodExpr(
   return `(${receiver(className, isMeta, dict)} compiledMethodAt: #'${escapeString(selector)}' environmentId: ${environmentId})`;
 }
 
+// A Smalltalk expression resolving the SymbolDictionary identified by `dict` — a
+// 1-based SymbolList index (unambiguous) or a name (first match). Evaluates to the
+// dictionary, or raises/short-circuits per the collection's own semantics if the
+// name/index is absent; callers that pass a possibly-missing name should `ifNil:`.
+// This is the ONE place that knows how to resolve a dictionary within the symbol
+// list — do not hand-roll `System myUserProfile symbolList at:/objectNamed:` for a
+// caller-supplied dict elsewhere (see the duplication guard test). To resolve a
+// CLASS within a dictionary, use classLookupExpr instead.
+export function dictLookupExpr(dict: number | string): string {
+  return typeof dict === 'number'
+    ? `System myUserProfile symbolList at: ${dict}`
+    : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+}
+
 // Compose a Smalltalk expression that resolves a class by name, optionally
 // scoped to a specific dictionary (by 1-based index or by name). Evaluates to
 // the class OOP, or nil if not found. Callers should `ifNil:` to handle the

--- a/client/src/refactoring/__tests__/getClassDescendantNames.test.ts
+++ b/client/src/refactoring/__tests__/getClassDescendantNames.test.ts
@@ -12,15 +12,39 @@ describe('getClassDescendantNames', () => {
     expect(code).toContain('subclassesOf:');
   });
 
-  it('parses each descendant with its immediate parent', () => {
-    const exec = vi.fn().mockReturnValue('LeafA\tMid\nLeafB\tMid\nGrand\tLeafA\n');
+  it('resolves each descendant to its binding dictionary by object identity', () => {
+    const exec = vi.fn().mockReturnValue('');
+
+    getClassDescendantNames(exec, 'Mid');
+
+    // An IdentityDictionary keyed on the class OBJECT (not its name) is what makes a
+    // shadowed subclass name resolve to its own dictionary rather than the first match.
+    const code = exec.mock.calls[0][0] as string;
+    expect(code).toContain('IdentityDictionary');
+    expect(code).toContain('isBehavior');
+  });
+
+  it('parses each descendant with its parent and binding dictionary', () => {
+    const exec = vi
+      .fn()
+      .mockReturnValue(
+        'LeafA\tMid\t1\tUserGlobals\nLeafB\tMid\t3\tOther\nGrand\tLeafA\t1\tUserGlobals\n',
+      );
 
     const result = getClassDescendantNames(exec, 'Mid');
 
     expect(result).toEqual([
-      { className: 'LeafA', parentName: 'Mid' },
-      { className: 'LeafB', parentName: 'Mid' },
-      { className: 'Grand', parentName: 'LeafA' },
+      { className: 'LeafA', parentName: 'Mid', dictIndex: 1, dictName: 'UserGlobals' },
+      { className: 'LeafB', parentName: 'Mid', dictIndex: 3, dictName: 'Other' },
+      { className: 'Grand', parentName: 'LeafA', dictIndex: 1, dictName: 'UserGlobals' },
+    ]);
+  });
+
+  it('reports dictIndex 0 / empty dictName for a descendant bound in no dictionary', () => {
+    const exec = vi.fn().mockReturnValue('Unbound\tMid\t0\t\n');
+
+    expect(getClassDescendantNames(exec, 'Mid')).toEqual([
+      { className: 'Unbound', parentName: 'Mid', dictIndex: 0, dictName: '' },
     ]);
   });
 
@@ -30,11 +54,11 @@ describe('getClassDescendantNames', () => {
     expect(getClassDescendantNames(exec, 'Leaf')).toEqual([]);
   });
 
-  it('tolerates a missing parent field', () => {
+  it('tolerates missing trailing fields', () => {
     const exec = vi.fn().mockReturnValue('Orphan\n');
 
     expect(getClassDescendantNames(exec, 'Root')).toEqual([
-      { className: 'Orphan', parentName: '' },
+      { className: 'Orphan', parentName: '', dictIndex: 0, dictName: '' },
     ]);
   });
 });

--- a/client/src/refactoring/queries/getClassDescendantNames.ts
+++ b/client/src/refactoring/queries/getClassDescendantNames.ts
@@ -1,38 +1,61 @@
 import { QueryExecutor } from '../../queries/types';
 import { classLookupExpr } from '../../queries/util';
 
-/** A descendant class of some class, with its immediate parent (for display context). */
+/** A descendant class of some class, with its immediate parent (for display context)
+ *  and the dictionary that binds it. */
 export interface DescendantClass {
   className: string;
   parentName: string;
+  /** The symbol dictionary that binds this descendant CLASS OBJECT, resolved by
+   *  object identity (not by name) so a caller acting on the descendant — e.g.
+   *  deleting it — targets the right class even when the name is shadowed in another
+   *  dictionary. `dictIndex` is the 1-based SymbolList position; it is 0 (and
+   *  `dictName` empty) when the class is not bound in any dictionary in the list. */
+  dictName: string;
+  dictIndex: number;
 }
 
 // Every transitive subclass of a class, ordered top-down (a class always precedes its own
-// subclasses), each with the name of its immediate superclass for display. Drives the ▼
-// "move instance variable down" picker, where the destination may be any descendant (not just
-// an immediate subclass — the engine handles any depth). The class is resolved through `dict`
-// (a 1-based SymbolList index, canonical for Jasper, or a name) via classLookupExpr, so the
-// same class name in two dictionaries resolves to the object the refactoring uses. A class the
-// dictionary does not bind yields an empty list rather than an error.
+// subclasses), each with the name of its immediate superclass for display and the dictionary
+// that binds the subclass. Drives the ▼ "move instance variable down" picker (destination may be
+// any descendant, any depth) and the Explorer's Remove Class (which deletes the whole subtree).
+// The class is resolved through `dict` (a 1-based SymbolList index, canonical for Jasper, or a
+// name) via classLookupExpr, so the same class name in two dictionaries resolves to the object the
+// caller means. Each descendant's binding dictionary is likewise resolved by OBJECT IDENTITY — a
+// symbol-list scan mapping every class object to the first dictionary that binds it — so a
+// descendant whose name is shadowed elsewhere still reports its own dictionary, not the global
+// first match. A class the dictionary does not bind yields an empty list rather than an error.
 export function getClassDescendantNames(
   execute: QueryExecutor,
   className: string,
   dict?: number | string,
 ): DescendantClass[] {
-  const code = `| organizer cls frontier seen out |
+  const code = `| organizer cls frontier seen out sl classDict |
 cls := ${classLookupExpr(className, dict)}.
 cls isNil ifTrue: [^ ''].
+sl := System myUserProfile symbolList.
+"Map each class OBJECT -> the 1-based index of the first dictionary that binds it, so
+ descendants are resolved by identity rather than by (shadowable) name."
+classDict := IdentityDictionary new.
+1 to: sl size do: [:i | | d |
+  d := sl at: i.
+  d keysAndValuesDo: [:k :v |
+    (v isBehavior and: [(classDict includesKey: v) not])
+      ifTrue: [classDict at: v put: i]]].
 organizer := ClassOrganizer new.
 seen := IdentitySet new.
 frontier := OrderedCollection new.
 frontier addAll: ((organizer subclassesOf: cls) asSortedCollection: [:a :b | a name <= b name]).
 out := WriteStream on: String new.
-[frontier isEmpty] whileFalse: [ | c |
+[frontier isEmpty] whileFalse: [ | c idx |
   c := frontier removeFirst.
   (seen includes: c) ifFalse: [
     seen add: c.
+    idx := classDict at: c ifAbsent: [0].
     out nextPutAll: c name asString; tab;
-      nextPutAll: (c superclass ifNil: [''] ifNotNil: [:s | s name asString]); lf.
+      nextPutAll: (c superclass ifNil: [''] ifNotNil: [:s | s name asString]); tab;
+      nextPutAll: idx printString; tab;
+      nextPutAll: (idx = 0 ifTrue: [''] ifFalse: [(sl at: idx) name asString]); lf.
     frontier addAll: ((organizer subclassesOf: c) asSortedCollection: [:a :b | a name <= b name])]].
 out contents`;
   const raw = execute(code);
@@ -41,7 +64,13 @@ out contents`;
     if (line.length === 0) continue;
     const parts = line.split('\t');
     if (parts.length < 1 || parts[0].length === 0) continue;
-    results.push({ className: parts[0], parentName: parts[1] ?? '' });
+    const dictIndex = parts[2] ? parseInt(parts[2], 10) : 0;
+    results.push({
+      className: parts[0],
+      parentName: parts[1] ?? '',
+      dictName: parts[3] ?? '',
+      dictIndex: Number.isNaN(dictIndex) ? 0 : dictIndex,
+    });
   }
   return results;
 }

--- a/client/src/refactoring/queries/getClassVersions.ts
+++ b/client/src/refactoring/queries/getClassVersions.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from '../../queries/types';
-import { escapeString, splitLines } from '../../queries/util';
+import { splitLines, dictLookupExpr } from '../../queries/util';
 
 /** A class's position in its class history: the 1-based index of the currently
  *  bound version and the total number of versions. Rendered as `[current/total]`. */
@@ -20,10 +20,7 @@ export function getClassVersions(
   execute: QueryExecutor,
   dict: number | string,
 ): Map<string, ClassVersionInfo> {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| ws dict |
 dict := ${dictExpr}.
 dict ifNil: [^ ''].

--- a/client/src/refactoring/queries/getDefinedClassVarCounts.ts
+++ b/client/src/refactoring/queries/getDefinedClassVarCounts.ts
@@ -1,5 +1,5 @@
 import { QueryExecutor } from '../../queries/types';
-import { escapeString, splitLines } from '../../queries/util';
+import { splitLines, dictLookupExpr } from '../../queries/util';
 
 // className → number of class variables DEFINED in that class (not inherited),
 // for every class in a dictionary, in a single round trip. The GemStone Explorer
@@ -11,10 +11,7 @@ export function getDefinedClassVarCounts(
   execute: QueryExecutor,
   dict: number | string,
 ): Map<string, number> {
-  const dictExpr =
-    typeof dict === 'number'
-      ? `System myUserProfile symbolList at: ${dict}`
-      : `System myUserProfile symbolList objectNamed: #'${escapeString(dict)}'`;
+  const dictExpr = dictLookupExpr(dict);
   const code = `| ws dict |
 dict := ${dictExpr}.
 dict ifNil: [^ ''].

--- a/package.json
+++ b/package.json
@@ -1046,6 +1046,12 @@
         "icon": "$(trash)"
       },
       {
+        "command": "gemstone.explorer.removeClass",
+        "title": "Remove Class",
+        "category": "GemStone",
+        "icon": "$(trash)"
+      },
+      {
         "command": "gemstoneExplorerDicts.filter",
         "title": "Filter",
         "category": "GemStone",
@@ -1153,7 +1159,8 @@
       {
         "command": "gemstone.explorer.removeDictionary",
         "title": "Remove Dictionary",
-        "category": "GemStone"
+        "category": "GemStone",
+        "icon": "$(trash)"
       },
       {
         "command": "gemstone.explorer.newClassCategory",
@@ -1745,6 +1752,10 @@
           "when": "false"
         },
         {
+          "command": "gemstone.explorer.removeClass",
+          "when": "false"
+        },
+        {
           "command": "gemstone.rowanRemoveRepo",
           "when": "false"
         },
@@ -1986,7 +1997,7 @@
         {
           "command": "gemstone.explorer.removeDictionary",
           "when": "view == gemstoneExplorerDicts && viewItem == explorerDict",
-          "group": "9_danger@0"
+          "group": "inline"
         },
         {
           "command": "gemstone.explorer.openMethodToSide",
@@ -2134,11 +2145,6 @@
           "group": "inline@6"
         },
         {
-          "command": "gemstone.explorer.removeMethod",
-          "when": "view == gemstoneExplorerMethods && viewItem =~ /^explorerMethod/",
-          "group": "9_danger@0"
-        },
-        {
           "command": "gemstone.explorer.renameClass",
           "when": "view == gemstoneExplorerClasses && viewItem == explorerClass && gemstone.rbSupportAvailable",
           "group": "inline@3"
@@ -2197,6 +2203,16 @@
           "command": "gemstone.generateGrailStub",
           "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
           "group": "2_generate@1"
+        },
+        {
+          "command": "gemstone.explorer.removeClass",
+          "when": "view == gemstoneExplorerClasses && viewItem == explorerClass",
+          "group": "inline@9"
+        },
+        {
+          "command": "gemstone.explorer.removeClass",
+          "when": "view == gemstoneExplorerClassHierarchy && viewItem == explorerHierClass",
+          "group": "inline@9"
         },
         {
           "command": "gemstone.rowanUpdateRepo",


### PR DESCRIPTION
A batch of GemStone Explorer fixes (found while F5-testing) plus a few removal-affordance tweaks. Each item has an ID (A–K) for reference.

## Bug fixes

- **(C)** Saving a class definition errored — the new-class template used the 8-keyword `subclass:…category:options:` selector, which DNUs on base stones. Now strip the category line, compile the always-valid 7-keyword definition, then apply the category via `recategorizeClass`; a new-class save that would overwrite an existing class in the target dictionary is refused.
- **(D)** The class-definition editor now shows the class category on its own line (`Class>>definition` never emits `category:`), spliced in before `options:`.
- **(A)** "Select a class first" toast on New Method after clicking a category node — the class stayed highlighted while the controller had cleared it. Keep the class selected when it remains under the clicked category, plus a New Method fallback that adopts the visibly-selected class.
- **(B)** Hierarchy pane went empty after clicking a category node — same root cause/fix.
- **(E)** The New Class template now always includes an editable `category:` line, defaulting to `'User Classes'` when no category node was selected.
- **(F)** Creating a class in a non-selected dictionary (by editing the `inDictionary:` line): the class *was* created, but recategorize/reopen/reveal used the **selected** dictionary, producing a "Class not found" tab + LookupError and no jump. All post-compile steps now target the dictionary the definition names, and the explorer jumps to it.
- **(G)** For a class name shadowed across dictionaries, the Hierarchy pane showed the wrong (global first-match) class. `loadHierarchy` now scopes `getClassHierarchy` by the selected dictionary index; also fixed a related desync where re-selecting a same-named class in another dictionary fired no reload.

## Features / tweaks

- **(I)** **Remove Class** — a trashcan inline button on both the Classes-pane and Hierarchy-pane class rows. Dict-scoped delete (correct for shadowed names), a can't-be-written guard, and an all-or-none confirmation that removes the whole subclass subtree when the class has subclasses.
- **(J)** **Remove Dictionary** — converted from a right-click menu item to a trashcan inline button (context-menu entry removed).
- **(K)** **Remove Method** — removed the redundant right-click menu item (the inline trashcan button stays), for consistency with the other removable nodes.

## Not included (filed separately)

- **(H)** Class History / revert / remove-version still resolve a shadowed class by unscoped name (engine-side `GsClassHistory`) — needs a dict-scoped engine change, tracked as #396.

## Tests

- **Unit:** `classDefinitionText` (`dictNameFromDefinition`), `gemstoneFileSystemProvider` (category default + cross-dictionary targeting), `explorerShadowedClassClick` (dict-scoped hierarchy + shadowed re-select), `explorerCompiledClassJump` (reveal/jump after compile), `explorerRemoveClass` (leaf / subtree / cancel / guard).
- **Integration (live stone, transient, 3.6.2→3.7.5 matrix):** a "dictionary-scoped resolution for a shadowed class name" block — `getClassHierarchy` lineage, `deleteClass`, and `compileClassDefinition` honoring `inDictionary:`.
- Full client suite: **5094 passed**, lint / prettier / tsc clean.

> **Note:** the full `test-ci-local.sh 3.6.2 3.7.5` CI matrix was not run for this PR (client-only changes, no engine changes); the client suite + live-stone integration are green. Worth a matrix run before merge if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
