### PR TITLE
Ban toBeTruthy/toBeFalsy in vitest tests

### DIFF
--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -3903,7 +3903,7 @@ describe('DebuggerPanel', () => {
         (f: { receiverClass?: string }) => f.receiverClass === 'JasperDebugDemo',
       );
       expect(selfFrames.length).toBeGreaterThan(0);
-      for (const f of selfFrames) expect(Boolean(f.overridable)).toBe(false);
+      for (const f of selfFrames) expect(f.overridable).toBe(false);
     });
 
     it('opens a new-method template for the receiver class + frame selector, with banner help (no init)', async () => {
@@ -4325,7 +4325,7 @@ describe('DebuggerPanel', () => {
         (f: { receiverClass?: string }) => f.receiverClass === 'JasperMakerBase class',
       );
       expect(selfFrames.length).toBeGreaterThan(0);
-      for (const f of selfFrames) expect(Boolean(f.overridable)).toBe(false);
+      for (const f of selfFrames) expect(f.overridable).toBe(false);
     });
 
     it('implementInReceiver opens a CLASS-side new-method template for a metaclass receiver', async () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -3854,7 +3854,7 @@ describe('DebuggerPanel', () => {
 
     it('keeps the Create button suppressed once a create is underway (re-detect returns it)', async () => {
       const panel = openWithDnu();
-      expect(initPayload(panel).dnu).toBeTruthy(); // shown initially
+      expect(initPayload(panel).dnu).toBeDefined(); // shown initially
       sendMessage(panel, { command: 'createDnuMethod' });
       await flush();
       // A refresh while editing must NOT re-offer the button (method-in-progress).
@@ -3903,7 +3903,7 @@ describe('DebuggerPanel', () => {
         (f: { receiverClass?: string }) => f.receiverClass === 'JasperDebugDemo',
       );
       expect(selfFrames.length).toBeGreaterThan(0);
-      for (const f of selfFrames) expect(f.overridable).toBeFalsy();
+      for (const f of selfFrames) expect(Boolean(f.overridable)).toBe(false);
     });
 
     it('opens a new-method template for the receiver class + frame selector, with banner help (no init)', async () => {
@@ -4169,7 +4169,7 @@ describe('DebuggerPanel', () => {
       });
       const payload = initPayload(openPanel());
       expect(payload.subclassResp).toBeUndefined();
-      expect(payload.dnu).toBeTruthy();
+      expect(payload.dnu).toBeDefined();
     });
 
     it('QuickPicks the chain BOUNDED at the abstract definer, then opens a stub', async () => {
@@ -4325,7 +4325,7 @@ describe('DebuggerPanel', () => {
         (f: { receiverClass?: string }) => f.receiverClass === 'JasperMakerBase class',
       );
       expect(selfFrames.length).toBeGreaterThan(0);
-      for (const f of selfFrames) expect(f.overridable).toBeFalsy();
+      for (const f of selfFrames) expect(Boolean(f.overridable)).toBe(false);
     });
 
     it('implementInReceiver opens a CLASS-side new-method template for a metaclass receiver', async () => {

--- a/client/src/__tests__/debuggerView.test.ts
+++ b/client/src/__tests__/debuggerView.test.ts
@@ -1593,7 +1593,7 @@ describe('DebuggerView.renderDnu (create-method-from-DNU)', () => {
     const bar = document.getElementById('dnuBar')!;
     api().renderDnu(bar, { selector: 'fourtyTwo:bar:', className: 'SmallInteger', isMeta: false });
     const btn = bar.querySelector('button.dnu-btn') as HTMLButtonElement;
-    expect(btn).toBeTruthy();
+    expect(btn).not.toBeNull();
     expect(btn.textContent).toBe('Create #fourtyTwo:bar: in SmallInteger');
   });
 
@@ -1630,7 +1630,7 @@ describe('DebuggerView.renderSubclassResp (subclassResponsibility implement acti
     const bar = document.getElementById('dnuBar')!;
     api().renderSubclassResp(bar, { selector: 'foo' });
     const btn = bar.querySelector('button.dnu-btn') as HTMLButtonElement;
-    expect(btn).toBeTruthy();
+    expect(btn).not.toBeNull();
     expect(btn.textContent).toBe('Implement #foo');
   });
 
@@ -1666,7 +1666,7 @@ describe('DebuggerView init — DNU button wiring', () => {
 
   it('a "banner" message sets the error text and clears the Create button (no re-render)', () => {
     const { refs } = setup(STACK, { selector: 'foo:', className: 'Array', isMeta: false });
-    expect(refs.dnuBar!.querySelector('button.dnu-btn')).toBeTruthy();
+    expect(refs.dnuBar!.querySelector('button.dnu-btn')).not.toBeNull();
     window.dispatchEvent(
       new MessageEvent('message', {
         data: { command: 'banner', text: 'Fill in the body, then save (Ctrl+S).' },

--- a/client/src/__tests__/explorerInstVar.test.ts
+++ b/client/src/__tests__/explorerInstVar.test.ts
@@ -74,9 +74,9 @@ describe('ExplorerController add instance variable', () => {
     const validate = opts?.validateInput as (v: string) => string | undefined;
     expect(validate('goodName')).toBeUndefined();
     expect(validate('_ok9')).toBeUndefined();
-    expect(validate('9bad')).toBeDefined();
-    expect(validate('has space')).toBeDefined();
-    expect(validate('  ')).toBeDefined();
+    expect(validate('9bad')).toContain('lowercase');
+    expect(validate('has space')).toContain('lowercase');
+    expect(validate('  ')).toContain('Enter a name');
     // Kept in step with the engine's isValidIvarName: an UPPERCASE first letter reads as a global
     // and must be rejected here too, not just declined after a round trip (#360 item 5). Assert the
     // *word* the engine's testAddDeclinesUppercaseFirstLetter also pins, so the two stay in step and

--- a/client/src/__tests__/explorerInstVar.test.ts
+++ b/client/src/__tests__/explorerInstVar.test.ts
@@ -74,9 +74,9 @@ describe('ExplorerController add instance variable', () => {
     const validate = opts?.validateInput as (v: string) => string | undefined;
     expect(validate('goodName')).toBeUndefined();
     expect(validate('_ok9')).toBeUndefined();
-    expect(validate('9bad')).toBeTruthy();
-    expect(validate('has space')).toBeTruthy();
-    expect(validate('  ')).toBeTruthy();
+    expect(validate('9bad')).toBeDefined();
+    expect(validate('has space')).toBeDefined();
+    expect(validate('  ')).toBeDefined();
     // Kept in step with the engine's isValidIvarName: an UPPERCASE first letter reads as a global
     // and must be rejected here too, not just declined after a round trip (#360 item 5). Assert the
     // *word* the engine's testAddDeclinesUppercaseFirstLetter also pins, so the two stay in step and

--- a/client/src/__tests__/localVersion.test.ts
+++ b/client/src/__tests__/localVersion.test.ts
@@ -418,7 +418,7 @@ describe('VersionManager.fetchAvailableVersions', () => {
       expect(versions).toHaveLength(1);
       expect(versions[0].version).toBe('4.0.0');
       expect(versions[0].extracted).toBe(true);
-      expect(Boolean(versions[0].local)).toBe(false); // a real dir, not a symlink — not "(local)"
+      expect(versions[0].local).toBeUndefined(); // a real dir, not a symlink — never marked "(local)"
       expect(versions[0].date).toBe('2026-07-01');
     },
   );

--- a/client/src/__tests__/localVersion.test.ts
+++ b/client/src/__tests__/localVersion.test.ts
@@ -418,7 +418,7 @@ describe('VersionManager.fetchAvailableVersions', () => {
       expect(versions).toHaveLength(1);
       expect(versions[0].version).toBe('4.0.0');
       expect(versions[0].extracted).toBe(true);
-      expect(versions[0].local).toBeFalsy(); // a real dir, not a symlink — not "(local)"
+      expect(Boolean(versions[0].local)).toBe(false); // a real dir, not a symlink — not "(local)"
       expect(versions[0].date).toBe('2026-07-01');
     },
   );

--- a/client/src/__tests__/osConfigTreeProvider.test.ts
+++ b/client/src/__tests__/osConfigTreeProvider.test.ts
@@ -402,7 +402,7 @@ describe('OsConfigTreeProvider', () => {
         expect(item.label).toContain('not configured');
         expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
         expect(themeIconId(item)).toBe('warning');
-        expect(item.tooltip).toBeTruthy();
+        expect(item.tooltip).toBeDefined();
       });
 
       it('uses "≥ 1" gbLabel in label', () => {

--- a/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
@@ -292,7 +292,7 @@ r := (System myUserProfile symbolList objectNamed: #GsInstVarRefactoringTest) su
       await analyzeInstVar(asyncExec, 'add', BASE, 'mine', userIndex()),
     );
 
-    expect(analysis.decline).toBeTruthy();
+    expect(analysis.decline).toBeDefined();
     expect(analysis.decline).toContain(SUB);
   });
 
@@ -304,6 +304,6 @@ r := (System myUserProfile symbolList objectNamed: #GsInstVarRefactoringTest) su
     const analysis = parseAnalysis(
       await analyzeInstVar(asyncExec, 'add', BASE, 'count', userIndex()),
     );
-    expect(analysis.decline).toBeTruthy();
+    expect(analysis.decline).toBeDefined();
   });
 });

--- a/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
@@ -292,7 +292,6 @@ r := (System myUserProfile symbolList objectNamed: #GsInstVarRefactoringTest) su
       await analyzeInstVar(asyncExec, 'add', BASE, 'mine', userIndex()),
     );
 
-    expect(analysis.decline).toBeDefined();
     expect(analysis.decline).toContain(SUB);
   });
 
@@ -304,6 +303,6 @@ r := (System myUserProfile symbolList objectNamed: #GsInstVarRefactoringTest) su
     const analysis = parseAnalysis(
       await analyzeInstVar(asyncExec, 'add', BASE, 'count', userIndex()),
     );
-    expect(analysis.decline).toBeDefined();
+    expect(analysis.decline).toContain('already has an instance variable');
   });
 });

--- a/client/src/refactoring/__tests__/renameInstVarPreview.test.ts
+++ b/client/src/refactoring/__tests__/renameInstVarPreview.test.ts
@@ -220,12 +220,12 @@ describe('validateNewIvarName', () => {
   });
 
   it('rejects an empty name', () => {
-    expect(validateNewIvarName('   ', 'count')).toBeTruthy();
+    expect(validateNewIvarName('   ', 'count')).toBeDefined();
   });
 
   it('rejects a name that is not a Smalltalk identifier', () => {
-    expect(validateNewIvarName('2tally', 'count')).toBeTruthy();
-    expect(validateNewIvarName('has-dash', 'count')).toBeTruthy();
-    expect(validateNewIvarName('has space', 'count')).toBeTruthy();
+    expect(validateNewIvarName('2tally', 'count')).toBeDefined();
+    expect(validateNewIvarName('has-dash', 'count')).toBeDefined();
+    expect(validateNewIvarName('has space', 'count')).toBeDefined();
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,6 +137,19 @@ export default tseslint.config(
       'vitest/no-interpolation-in-snapshots': 'error',
       'vitest/no-unneeded-async-expect-function': 'error',
       'vitest/prefer-called-exactly-once-with': 'error',
+      // toBeTruthy/toBeFalsy are vague: they pass for any truthy/falsy value,
+      // so a misuse can assert the wrong thing without failing (e.g. a typo'd
+      // getter that returns '' instead of undefined), and a real failure just
+      // reports "expected truthy, got falsy" instead of showing the value.
+      // Ban them and require a matcher that states the actual intent.
+      'vitest/no-restricted-matchers': [
+        'error',
+        {
+          toBeTruthy:
+            'Prefer a specific matcher: toBeDefined(), not.toBeNull(), toBe(true), toContain(...), etc.',
+          toBeFalsy: 'Prefer a specific matcher: toBeUndefined(), toBeNull(), toBe(false), etc.',
+        },
+      ],
       'vitest/require-local-test-context-for-concurrent-snapshots': 'error',
       'vitest/valid-describe-callback': 'error',
       'vitest/valid-expect': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,8 +11,26 @@ import vitest from '@vitest/eslint-plugin';
 // not catch `not.toBeTruthy`, `resolves.toBeTruthy`, etc. Every chain that can
 // reach the matcher has to be listed for the ban to actually hold.
 const RESTRICTED_MODIFIERS = ['', 'not.', 'resolves.', 'rejects.', 'resolves.not.', 'rejects.not.'];
-const banChain = (matcher, message) =>
-  Object.fromEntries(RESTRICTED_MODIFIERS.map((prefix) => [prefix + matcher, message]));
+
+// The advice has to name the matcher that states the intent, which depends on
+// the value's type — so spell the dispatch out rather than saying "be specific"
+// and leaving the reader to pick, since the easiest pick (toBeDefined) is the
+// one that silently changes meaning on a `T | null`.
+const TRUTHY_ADVICE =
+  'Prefer a matcher that states the intent: not.toBeNull() for `T | null`, toBeDefined() for `T | undefined`, toBe(true) for a boolean, toContain(...) for a message.';
+const FALSY_ADVICE =
+  'Prefer a matcher that states the intent: toBeNull(), toBeUndefined(), toBe(false), or toHaveLength(0).';
+
+// A `not.`-bearing chain asserts the opposite of its matcher, so it takes the
+// opposite advice: `not.toBeTruthy()` is a falsy assertion and wants the falsy
+// replacements, not the truthy ones.
+const banChain = (matcher, message, negatedMessage) =>
+  Object.fromEntries(
+    RESTRICTED_MODIFIERS.map((prefix) => [
+      prefix + matcher,
+      prefix.includes('not.') ? negatedMessage : message,
+    ]),
+  );
 
 export default tseslint.config(
   // Keep lint ignores in sync with every `.gitignore` in the repo, instead of
@@ -153,14 +171,8 @@ export default tseslint.config(
       'vitest/no-restricted-matchers': [
         'error',
         {
-          ...banChain(
-            'toBeTruthy',
-            'Prefer a specific matcher: toBeDefined(), not.toBeNull(), toBe(true), toContain(...), etc.',
-          ),
-          ...banChain(
-            'toBeFalsy',
-            'Prefer a specific matcher: toBeUndefined(), toBeNull(), toBe(false), etc.',
-          ),
+          ...banChain('toBeTruthy', TRUTHY_ADVICE, FALSY_ADVICE),
+          ...banChain('toBeFalsy', FALSY_ADVICE, TRUTHY_ADVICE),
         },
       ],
       'vitest/require-local-test-context-for-concurrent-snapshots': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,14 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 import gitignore from 'eslint-config-flat-gitignore';
 import vitest from '@vitest/eslint-plugin';
 
+// `vitest/no-restricted-matchers` matches the *whole* modifier chain, and for a
+// plain matcher name it compares by exact equality — so a `toBeTruthy` key does
+// not catch `not.toBeTruthy`, `resolves.toBeTruthy`, etc. Every chain that can
+// reach the matcher has to be listed for the ban to actually hold.
+const RESTRICTED_MODIFIERS = ['', 'not.', 'resolves.', 'rejects.', 'resolves.not.', 'rejects.not.'];
+const banChain = (matcher, message) =>
+  Object.fromEntries(RESTRICTED_MODIFIERS.map((prefix) => [prefix + matcher, message]));
+
 export default tseslint.config(
   // Keep lint ignores in sync with every `.gitignore` in the repo, instead of
   // a hand-maintained duplicate list that drifts (e.g. missed `.vscode-test/`
@@ -145,9 +153,14 @@ export default tseslint.config(
       'vitest/no-restricted-matchers': [
         'error',
         {
-          toBeTruthy:
+          ...banChain(
+            'toBeTruthy',
             'Prefer a specific matcher: toBeDefined(), not.toBeNull(), toBe(true), toContain(...), etc.',
-          toBeFalsy: 'Prefer a specific matcher: toBeUndefined(), toBeNull(), toBe(false), etc.',
+          ),
+          ...banChain(
+            'toBeFalsy',
+            'Prefer a specific matcher: toBeUndefined(), toBeNull(), toBe(false), etc.',
+          ),
         },
       ],
       'vitest/require-local-test-context-for-concurrent-snapshots': 'error',


### PR DESCRIPTION
## Summary

- `toBeTruthy()`/`toBeFalsy()` are vague matchers: they pass for *any* truthy/falsy value, so a misuse can assert the wrong thing without ever failing (e.g. a typo'd getter returning `''` instead of `undefined` still reads as "falsy"), and when they do fail the message is just "expected truthy, got falsy" instead of showing the actual value.
- Enables `vitest/no-restricted-matchers` to ban both matchers outright, with a message pointing to the intended replacement.
- I initially tried `vitest/prefer-strict-boolean-matchers` (autofixable), but it isn't type-aware — it rewrote every `toBeTruthy`/`toBeFalsy` call to `toBe(true)`/`toBe(false)` regardless of the underlying type, which broke several existing tests (checks against strings, DOM nodes, and optional booleans where `undefined` should count as false). Went with `no-restricted-matchers` instead, which has no autofix, so each site was fixed by hand with the matcher that actually states its intent.
- Fixed the 18 existing call sites this newly caught: `toBeDefined()`/`not.toBeNull()` for presence checks, `Boolean(x).toBe(false)` where an optional boolean's absence should read as false.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:client` (324 files, 4973 tests passing)