### PR TITLE
Deduplicate ownInstVarsOf: / allInstVarsOf: onto GsRefactoringEnvironment (#401)

### DIFF
--- a/gs-src/refactoring/engine/GsExtractSuperclassRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsExtractSuperclassRefactoring.class.st
@@ -153,16 +153,6 @@ GsExtractSuperclassRefactoring >> sharedParent [
 ]
 
 { #category : 'private' }
-GsExtractSuperclassRefactoring >> ownInstVarsOf: aClass [
-	^aClass instVarNames collect: [:e | e asString]
-]
-
-{ #category : 'private' }
-GsExtractSuperclassRefactoring >> allInstVarsOf: aClass [
-	^aClass allInstVarNames collect: [:e | e asString]
-]
-
-{ #category : 'private' }
 GsExtractSuperclassRefactoring >> sourceOf: aSelector in: aClass [
 	| m |
 	m := aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
@@ -229,8 +219,8 @@ GsExtractSuperclassRefactoring >> validateHoistInstVars [
 	 created and some reparents done -- the half-applied state the user then has to abort. The
 	 class comment sells these as global declines that empty the change set, so it belongs here."
 	| own supAll |
-	own := self ownInstVarsOf: anchorClass.
-	supAll := self allInstVarsOf: sharedParent.
+	own := environment ownInstVarNamesOf: anchorClass.
+	supAll := environment allInstVarNamesOf: sharedParent.
 	hoistInstVars do: [:v |
 		(own includes: v) ifFalse: [
 			^decline := 'Cannot hoist instance variable ', v, ': it is not declared in ', anchorClass name asString, '.'].
@@ -248,7 +238,7 @@ GsExtractSuperclassRefactoring >> descendantDeclaring: anIvarName [
 	extractedClasses do: [:cls |
 		(environment descendantsOf: cls) do: [:d |
 			((extractedClasses includes: d) not
-				and: [(self ownInstVarsOf: d) includes: anIvarName])
+				and: [(environment ownInstVarNamesOf: d) includes: anIvarName])
 					ifTrue: [^d]]].
 	^nil
 ]
@@ -273,7 +263,7 @@ GsExtractSuperclassRefactoring >> visibleIvarSymbolsWith: anIvarList [
 	| visible |
 	visible := Set new.
 	anIvarList do: [:v | visible add: v asSymbol].
-	(self allInstVarsOf: sharedParent) do: [:v | visible add: v asSymbol].
+	(environment allInstVarNamesOf: sharedParent) do: [:v | visible add: v asSymbol].
 	^visible
 ]
 
@@ -389,11 +379,11 @@ GsExtractSuperclassRefactoring >> candidateInstVars [
 	self ensureAnalysis.
 	result := OrderedCollection new.
 	decline notNil ifTrue: [^result].
-	(self ownInstVarsOf: anchorClass) do: [:v | | all |
-		((self allInstVarsOf: sharedParent) includes: v)
+	(environment ownInstVarNamesOf: anchorClass) do: [:v | | all |
+		((environment allInstVarNamesOf: sharedParent) includes: v)
 			ifTrue: [result add: (Array with: v with: #unhoistable)]
 			ifFalse: [
-				all := extractedClasses allSatisfy: [:c | (self ownInstVarsOf: c) includes: v].
+				all := extractedClasses allSatisfy: [:c | (environment ownInstVarNamesOf: c) includes: v].
 				result add: (Array with: v with: (all ifTrue: [#identical] ifFalse: [#partial]))]].
 	^result
 ]
@@ -402,9 +392,9 @@ GsExtractSuperclassRefactoring >> candidateInstVars [
 GsExtractSuperclassRefactoring >> identicalCandidateIvarNames [
 	"The own ivars of the anchor that every extracted class also owns -- the ones hoisted by
 	 default -- as an Array of Strings. Used to classify method hoistability optimistically."
-	^(self ownInstVarsOf: anchorClass) select: [:v |
-		((self allInstVarsOf: sharedParent) includes: v) not
-			and: [extractedClasses allSatisfy: [:c | (self ownInstVarsOf: c) includes: v]]]
+	^(environment ownInstVarNamesOf: anchorClass) select: [:v |
+		((environment allInstVarNamesOf: sharedParent) includes: v) not
+			and: [extractedClasses allSatisfy: [:c | (environment ownInstVarNamesOf: c) includes: v]]]
 ]
 
 { #category : 'classification' }
@@ -450,7 +440,7 @@ GsExtractSuperclassRefactoring >> stageExtractedEdit: aClass into: cs [
 	 dropped from its own list."
 	| oldDef newList |
 	oldDef := aClass definition.
-	newList := (self ownInstVarsOf: aClass) reject: [:n | hoistInstVars includes: n].
+	newList := (environment ownInstVarNamesOf: aClass) reject: [:n | hoistInstVars includes: n].
 	cs
 		addClassDefinitionEditInDictionary: (self dictNameForClass: aClass)
 		className: aClass name asString
@@ -724,8 +714,8 @@ GsExtractSuperclassRefactoring >> applyClassChange: aChange [
 		ifTrue: [newClass]
 		ifFalse: [oldToNew at: old superclass ifAbsent: [old superclass]].
 	list := isExtracted
-		ifTrue: [(self ownInstVarsOf: old) reject: [:n | hoistInstVars includes: n]]
-		ifFalse: [self ownInstVarsOf: old].
+		ifTrue: [(environment ownInstVarNamesOf: old) reject: [:n | hoistInstVars includes: n]]
+		ifFalse: [environment ownInstVarNamesOf: old].
 	skip := isExtracted ifTrue: [hoistMethods] ifFalse: [#()].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list.
 	self copyMethodsFrom: old to: new skipping: skip.

--- a/gs-src/refactoring/engine/GsInstVarRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsInstVarRefactoring.class.st
@@ -152,14 +152,6 @@ GsInstVarRefactoring >> optionsOf: aClass [
 ]
 
 { #category : 'private' }
-GsInstVarRefactoring >> allClassVarsOf: aClass [
-	"aClass's own and inherited class-variable names, as a Set of Strings. Used to decline an
-	 #add whose name would shadow a class variable inside method bodies. Shared with V8 split --
-	 the walk itself lives on the environment so both refactorings ask the same question."
-	^environment classVarNamesVisibleTo: aClass
-]
-
-{ #category : 'private' }
 GsInstVarRefactoring >> isValidIvarName: aString [
 	"A syntactically valid Smalltalk instance-variable name: a LOWERCASE letter or an underscore,
 	 followed by letters, digits, or underscores.
@@ -207,7 +199,7 @@ GsInstVarRefactoring >> analyzeAdd [
 		^decline := 'Cannot add ', varName printString, ': an instance-variable name must start with a lowercase letter or an underscore, followed by letters, digits, or underscores.'].
 	((environment allInstVarNamesOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': ', definingClass name asString, ' already has an instance variable of that name.'].
-	((self allClassVarsOf: definingClass) includes: varName) ifTrue: [
+	((environment classVarNamesVisibleTo: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': a class variable of that name is visible to ', definingClass name asString, ', which it would shadow.'].
 	"A subclass that already declares varName as its OWN instance variable would end up with two
 	 of that name once the new one is inherited. That fails mid-apply (error 2271), so decline up

--- a/gs-src/refactoring/engine/GsInstVarRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsInstVarRefactoring.class.st
@@ -146,17 +146,6 @@ GsInstVarRefactoring >> varName [
 ]
 
 { #category : 'private' }
-GsInstVarRefactoring >> ownInstVarsOf: aClass [
-	"aClass's OWN instance-variable names (not inherited), as an Array of Strings."
-	^aClass instVarNames collect: [:e | e asString]
-]
-
-{ #category : 'private' }
-GsInstVarRefactoring >> allInstVarsOf: aClass [
-	^aClass allInstVarNames collect: [:e | e asString]
-]
-
-{ #category : 'private' }
 GsInstVarRefactoring >> optionsOf: aClass [
 	"aClass's own class-creation options, as an Array of Strings (e.g. #('selfCanBeSpecial'))."
 	^(aClass _optionsArray ifNil: [#()]) collect: [:e | e asString]
@@ -216,7 +205,7 @@ GsInstVarRefactoring >> analyzeAdd [
 	| conflicts names |
 	(self isValidIvarName: varName) ifFalse: [
 		^decline := 'Cannot add ', varName printString, ': an instance-variable name must start with a lowercase letter or an underscore, followed by letters, digits, or underscores.'].
-	((self allInstVarsOf: definingClass) includes: varName) ifTrue: [
+	((environment allInstVarNamesOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': ', definingClass name asString, ' already has an instance variable of that name.'].
 	((self allClassVarsOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': a class variable of that name is visible to ', definingClass name asString, ', which it would shadow.'].
@@ -232,7 +221,7 @@ GsInstVarRefactoring >> analyzeAdd [
 			(conflicts size = 1 ifTrue: [' already declares'] ifFalse: [' already declare']),
 			' an instance variable of that name; adding it to ', definingClass name asString,
 			' would duplicate that variable.'].
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) copyWith: varName).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) copyWith: varName).
 	self computeAffectedFrom: (Array with: definingClass).
 	self recordWillNotRecompileShadowedBy: definingClass
 ]
@@ -241,9 +230,9 @@ GsInstVarRefactoring >> analyzeAdd [
 GsInstVarRefactoring >> analyzeRemove [
 	"V1 remove: varName must be an OWN instance variable of definingClass. Every method (defining
 	 class and descendants) that accesses it will lose it -- those are the willNotRecompile set."
-	((self ownInstVarsOf: definingClass) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: definingClass) includes: varName) ifFalse: [
 		^decline := 'Cannot remove ', varName, ': it is not an instance variable declared in ', definingClass name asString, '.'].
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) reject: [:n | n = varName]).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) reject: [:n | n = varName]).
 	self computeAffectedFrom: (Array with: definingClass).
 	self recordWillNotRecompileLosing: definingClass
 ]
@@ -368,7 +357,7 @@ GsInstVarRefactoring >> previewDefinitionFor: aClass oldDef: defString [
 	 are not surfaced for editing in the panel."
 	^self replaceListClause: 'instVarNames:'
 		in: defString
-		with: (newIvarLists at: aClass name asString ifAbsent: [self ownInstVarsOf: aClass])
+		with: (newIvarLists at: aClass name asString ifAbsent: [environment ownInstVarNamesOf: aClass])
 ]
 
 { #category : 'building' }
@@ -630,7 +619,7 @@ GsInstVarRefactoring >> applyClassChange: aChange [
 	old := environment classNamed: aChange className.
 	old isNil ifTrue: [^self error: 'Class not found: ', aChange className].
 	parentNew := oldToNew at: old superclass ifAbsent: [old superclass].
-	list := newIvarLists at: aChange className ifAbsent: [self ownInstVarsOf: old].
+	list := newIvarLists at: aChange className ifAbsent: [environment ownInstVarNamesOf: old].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list options: (self optionsForApply: old).
 	"Count it as applied HERE, the moment the version is staged -- before copyMethodsFrom:, which
 	 could raise. If it does, this class's new version is already a real staged mutation, so the

--- a/gs-src/refactoring/engine/GsInstVarStructureRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsInstVarStructureRefactoring.class.st
@@ -289,17 +289,6 @@ GsInstVarStructureRefactoring >> topClass [
 	^topClass
 ]
 
-{ #category : 'private' }
-GsInstVarStructureRefactoring >> ownInstVarsOf: aClass [
-	"aClass's OWN instance-variable names (not inherited), as an Array of Strings."
-	^aClass instVarNames collect: [:e | e asString]
-]
-
-{ #category : 'private' }
-GsInstVarStructureRefactoring >> allInstVarsOf: aClass [
-	^aClass allInstVarNames collect: [:e | e asString]
-]
-
 { #category : 'private - analysis' }
 GsInstVarStructureRefactoring >> ensureAnalysis [
 	analysisDone ifFalse: [
@@ -334,7 +323,7 @@ GsInstVarStructureRefactoring >> analyzeConvertTemp [
 		 method can't reference it), and this engine only edits instance-side ivar lists. Decline
 		 rather than corrupt (add an unreachable ivar + recompile the class method against it)."
 		^decline := 'Cannot convert #', varName, ': converting a temporary in a class-side method to an instance variable is not supported.'].
-	((self allInstVarsOf: definingClass) includes: varName) ifTrue: [
+	((environment allInstVarNamesOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot convert #', varName, ': it is already an instance variable of ', definingClass name asString, '.'].
 	behavior := methodMeta ifTrue: [definingClass class] ifFalse: [definingClass].
 	method := behavior compiledMethodAt: methodSelector environmentId: 0 otherwise: nil.
@@ -355,7 +344,7 @@ GsInstVarStructureRefactoring >> analyzeConvertTemp [
 		newDecl,
 		(src copyFrom: tree body rightBar + 1 to: src size).
 	methodRewrite := Array with: definingClass name asString with: methodSelector with: methodMeta with: src with: newSrc.
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) copyWith: varName)
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) copyWith: varName)
 ]
 
 { #category : 'private - analysis' }
@@ -364,18 +353,18 @@ GsInstVarStructureRefactoring >> analyzePushUp [
 	 ancestors) must not already define it; and no OTHER descendant of that superclass may
 	 own a same-named ivar (it would collide with the newly inherited one)."
 	| sup |
-	((self ownInstVarsOf: definingClass) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: definingClass) includes: varName) ifFalse: [
 		^decline := 'Cannot push up ', varName, ': it is not an instance variable declared in ', definingClass name asString, '.'].
 	sup := definingClass superclass.
 	sup isNil ifTrue: [
 		^decline := 'Cannot push up ', varName, ': ', definingClass name asString, ' has no superclass.'].
-	((self allInstVarsOf: sup) includes: varName) ifTrue: [
+	((environment allInstVarNamesOf: sup) includes: varName) ifTrue: [
 		^decline := 'Cannot push up ', varName, ': ', sup name asString, ' already defines an instance variable of that name.'].
 	(self otherDescendant: definingClass ofTop: sup ownsIvar: varName) ifNotNil: [:cls |
 		^decline := 'Cannot push up ', varName, ': ', cls, ' also declares an instance variable of that name, which would collide once it is inherited.'].
 	topClass := sup.
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) reject: [:n | n = varName]).
-	newIvarLists at: sup name asString put: ((self ownInstVarsOf: sup) copyWith: varName).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) reject: [:n | n = varName]).
+	newIvarLists at: sup name asString put: ((environment ownInstVarNamesOf: sup) copyWith: varName).
 	self moveAccessors ifTrue: [self planAccessorMovesFrom: definingClass to: (Array with: sup)]
 ]
 
@@ -385,7 +374,7 @@ GsInstVarStructureRefactoring >> analyzePushDown [
 	 access it (removing it would leave them undeclared); it must have subclasses; and no
 	 proper descendant may already own a same-named ivar (it would collide once inherited)."
 	| subs users |
-	((self ownInstVarsOf: definingClass) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: definingClass) includes: varName) ifFalse: [
 		^decline := 'Cannot push down ', varName, ': it is not an instance variable declared in ', definingClass name asString, '.'].
 	subs := (definingClass subclasses ifNil: [#()]) asArray.
 	subs isEmpty ifTrue: [
@@ -404,9 +393,9 @@ GsInstVarStructureRefactoring >> analyzePushDown [
 	(self anyDescendantOf: definingClass ownsIvar: varName) ifNotNil: [:cls |
 		^decline := 'Cannot push down ', varName, ': ', cls, ' already declares an instance variable of that name.'].
 	topClass := definingClass.
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) reject: [:n | n = varName]).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) reject: [:n | n = varName]).
 	subs do: [:sub |
-		newIvarLists at: sub name asString put: ((self ownInstVarsOf: sub) copyWith: varName)].
+		newIvarLists at: sub name asString put: ((environment ownInstVarNamesOf: sub) copyWith: varName)].
 	self moveAccessors ifTrue: [self planAccessorMovesFrom: definingClass to: subs]
 ]
 
@@ -424,7 +413,7 @@ GsInstVarStructureRefactoring >> analyzeMove [
 	| def dir sup losing |
 	def := definingClass.
 	dir := moveDirection.
-	((self ownInstVarsOf: def) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: def) includes: varName) ifFalse: [
 		^decline := 'Cannot move ', varName, ': it is not an instance variable declared in ', def name asString, '.'].
 	(targetClasses isNil or: [targetClasses isEmpty]) ifTrue: [
 		^decline := 'Cannot move ', varName, ': no destination class was chosen.'].
@@ -439,7 +428,7 @@ GsInstVarStructureRefactoring >> analyzeMove [
 			sup := targetClasses first.
 			(self isAncestor: sup of: def) ifFalse: [
 				^decline := 'Cannot move ', varName, ' up: ', sup name asString, ' is not a superclass of ', def name asString, '.'].
-			((self allInstVarsOf: sup) includes: varName) ifTrue: [
+			((environment allInstVarNamesOf: sup) includes: varName) ifTrue: [
 				^decline := 'Cannot move ', varName, ' up: ', sup name asString, ' already defines an instance variable of that name.'].
 			(self otherDescendant: def ofTop: sup ownsIvar: varName) ifNotNil: [:cls |
 				^decline := 'Cannot move ', varName, ' up: ', cls, ' also declares an instance variable of that name, which would collide once it is inherited.'].
@@ -480,9 +469,9 @@ GsInstVarStructureRefactoring >> analyzeMove [
 			^decline := 'Cannot move ', varName, ': ', cls name asString,
 				' still uses it in ', users size printString, ' of its own method(s): ',
 				(self selectorListString: users), '.']].
-	newIvarLists at: def name asString put: ((self ownInstVarsOf: def) reject: [:n | n = varName]).
+	newIvarLists at: def name asString put: ((environment ownInstVarNamesOf: def) reject: [:n | n = varName]).
 	targetClasses do: [:t |
-		newIvarLists at: t name asString put: ((self ownInstVarsOf: t) copyWith: varName)].
+		newIvarLists at: t name asString put: ((environment ownInstVarNamesOf: t) copyWith: varName)].
 	self moveAccessors ifTrue: [self planAccessorMovesFrom: def to: targetClasses]
 ]
 
@@ -518,7 +507,7 @@ GsInstVarStructureRefactoring >> otherDescendant: aSkip ofTop: aTop ownsIvar: aN
 	"The name of a descendant of aTop (other than aSkip) that owns an ivar named aName, or
 	 nil."
 	(environment descendantsOf: aTop) do: [:cls |
-		(cls ~~ aSkip and: [(self ownInstVarsOf: cls) includes: aName])
+		(cls ~~ aSkip and: [(environment ownInstVarNamesOf: cls) includes: aName])
 			ifTrue: [^cls name asString]].
 	^nil
 ]
@@ -527,7 +516,7 @@ GsInstVarStructureRefactoring >> otherDescendant: aSkip ofTop: aTop ownsIvar: aN
 GsInstVarStructureRefactoring >> anyDescendantOf: aTop ownsIvar: aName [
 	"The name of any descendant of aTop that owns an ivar named aName, or nil."
 	(environment descendantsOf: aTop) do: [:cls |
-		((self ownInstVarsOf: cls) includes: aName) ifTrue: [^cls name asString]].
+		((environment ownInstVarNamesOf: cls) includes: aName) ifTrue: [^cls name asString]].
 	^nil
 ]
 
@@ -949,7 +938,7 @@ GsInstVarStructureRefactoring >> applyClassChange: aChange [
 	old := environment classNamed: aChange className.
 	old isNil ifTrue: [^self error: 'Class not found: ', aChange className].
 	parentNew := oldToNew at: old superclass ifAbsent: [old superclass].
-	list := newIvarLists at: aChange className ifAbsent: [self ownInstVarsOf: old].
+	list := newIvarLists at: aChange className ifAbsent: [environment ownInstVarNamesOf: old].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list.
 	self copyMethodsFrom: old to: new.
 	oldToNew at: old put: new

--- a/gs-src/refactoring/engine/GsRefactoringEnvironment.class.st
+++ b/gs-src/refactoring/engine/GsRefactoringEnvironment.class.st
@@ -151,7 +151,7 @@ GsRefactoringEnvironment >> descendantsOf: aClass declaringInstVar: aName [
 	 Shared by every refactoring that introduces an instance variable on an existing class (V1 add,
 	 V8 split), so the check and its cross-version behaviour live in one place. Read-only."
 	^(self descendantsOf: aClass)
-		select: [:d | ((d instVarNames ifNil: [#()]) collect: [:e | e asString]) includes: aName]
+		select: [:d | (self ownInstVarNamesOf: d) includes: aName]
 ]
 
 { #category : 'enumerating' }
@@ -166,6 +166,31 @@ GsRefactoringEnvironment >> classVarNamesVisibleTo: aClass [
 		(cls classVarNames ifNil: [#()]) do: [:n | result add: n asString].
 		cls := cls superclass].
 	^result
+]
+
+{ #category : 'instance variables' }
+GsRefactoringEnvironment >> ownInstVarNamesOf: aClass [
+	"aClass's OWN instance-variable names (not inherited), as an Array of Strings, in
+	 declaration order -- which is the order a class-creation change must preserve.
+
+	 Strings, not the Symbols #instVarNames answers, because every caller compares them
+	 against a name that arrived as a String from the client. Comparing a Symbol against
+	 such a String can silently answer false on 3.6.x (the Unicode-comparison trap), so
+	 normalising here is what makes those comparisons hold across releases.
+
+	 Shared by every refactoring that reasons about instance-variable structure --
+	 add/remove, push up/down/move, extract superclass, split class -- so the
+	 normalisation lives in one place. Read-only."
+	^(aClass instVarNames ifNil: [#()]) collect: [:e | e asString]
+]
+
+{ #category : 'instance variables' }
+GsRefactoringEnvironment >> allInstVarNamesOf: aClass [
+	"aClass's own AND inherited instance-variable names, as an Array of Strings, inherited
+	 first -- the slot order of an instance. Callers use it to ask whether a name is already
+	 visible to aClass (its own or any superclass's). See #ownInstVarNamesOf: for why these
+	 are Strings. Read-only."
+	^(aClass allInstVarNames ifNil: [#()]) collect: [:e | e asString]
 ]
 
 { #category : 'accessing' }

--- a/gs-src/refactoring/engine/GsRefactoringEnvironment.class.st
+++ b/gs-src/refactoring/engine/GsRefactoringEnvironment.class.st
@@ -149,9 +149,15 @@ GsRefactoringEnvironment >> descendantsOf: aClass declaringInstVar: aName [
 	 classes have already been versioned. Callers decline up front and name the offenders instead.
 
 	 Shared by every refactoring that introduces an instance variable on an existing class (V1 add,
-	 V8 split), so the check and its cross-version behaviour live in one place. Read-only."
+	 V8 split), so the check and its cross-version behaviour live in one place. Read-only.
+
+	 aName is normalised to a String because #ownInstVarNamesOf: answers Strings; a caller passing a
+	 Symbol would otherwise hit the same 3.6.x Unicode-comparison trap on the argument side and get a
+	 silently empty answer. Both #instVarNameArgument callers already accept either, so we match that."
+	| name |
+	name := aName asString.
 	^(self descendantsOf: aClass)
-		select: [:d | (self ownInstVarNamesOf: d) includes: aName]
+		select: [:d | (self ownInstVarNamesOf: d) includes: name]
 ]
 
 { #category : 'enumerating' }
@@ -180,7 +186,11 @@ GsRefactoringEnvironment >> ownInstVarNamesOf: aClass [
 
 	 Shared by every refactoring that reasons about instance-variable structure --
 	 add/remove, push up/down/move, extract superclass, split class -- so the
-	 normalisation lives in one place. Read-only."
+	 normalisation lives in one place. Read-only.
+
+	 The ifNil: guard is defensive only: a live class always answers an Array from #instVarNames, so
+	 nil is not expected to be reachable here. It mirrors the guard #descendantsOf:declaringInstVar:
+	 already carried and keeps the answer an empty Array rather than raising if that ever changes."
 	^(aClass instVarNames ifNil: [#()]) collect: [:e | e asString]
 ]
 

--- a/gs-src/refactoring/engine/GsSplitClassRefactoring.class.st
+++ b/gs-src/refactoring/engine/GsSplitClassRefactoring.class.st
@@ -110,16 +110,6 @@ GsSplitClassRefactoring >> movableSelectors [
 ]
 
 { #category : 'private' }
-GsSplitClassRefactoring >> ownInstVarsOf: aClass [
-	^aClass instVarNames collect: [:e | e asString]
-]
-
-{ #category : 'private' }
-GsSplitClassRefactoring >> allInstVarsOf: aClass [
-	^aClass allInstVarNames collect: [:e | e asString]
-]
-
-{ #category : 'private' }
 GsSplitClassRefactoring >> sourceOf: aSelector in: aClass [
 	| m |
 	m := aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
@@ -275,12 +265,12 @@ GsSplitClassRefactoring >> computeAnalysis [
 		^decline := 'Cannot split: a class named ', newName, ' already exists.'].
 	extractIvars isEmpty ifTrue: [
 		^decline := 'Cannot split: no instance variables were chosen to extract.'].
-	own := self ownInstVarsOf: sourceClass.
+	own := environment ownInstVarNamesOf: sourceClass.
 	extractIvars do: [:v |
 		(own includes: v) ifFalse: [
 			^decline := 'Cannot split: ', v, ' is not an instance variable of ', sourceClass name asString, '.']].
 	componentIvarName := self decapitalize: newName.
-	((self allInstVarsOf: sourceClass) includes: componentIvarName) ifTrue: [
+	((environment allInstVarNamesOf: sourceClass) includes: componentIvarName) ifTrue: [
 		^decline := 'Cannot split: the source already has an instance variable named ', componentIvarName, '.'].
 	"The component ivar is a NEW instance variable on the source, so it faces the same two
 	 collisions V1 add declines -- a class variable it would shadow, and a subclass that already
@@ -415,7 +405,7 @@ GsSplitClassRefactoring >> buildChangeSet [
 
 { #category : 'building' }
 GsSplitClassRefactoring >> retainedOwnIvars [
-	^(self ownInstVarsOf: sourceClass) reject: [:n | extractIvars includes: n]
+	^(environment ownInstVarNamesOf: sourceClass) reject: [:n | extractIvars includes: n]
 ]
 
 { #category : 'building' }
@@ -554,7 +544,7 @@ GsSplitClassRefactoring >> candidatesJsonString [
 	ws nextPutAll: '{"sourceClass":'; nextPutAll: (self jsonQuote: sourceClass name asString).
 	ws nextPutAll: ',"instVars":['.
 	first := true.
-	(self ownInstVarsOf: sourceClass) do: [:v |
+	(environment ownInstVarNamesOf: sourceClass) do: [:v |
 		first ifFalse: [ws nextPut: $,]. first := false.
 		ws nextPutAll: '{"name":'; nextPutAll: (self jsonQuote: v); nextPut: $}].
 	ws nextPutAll: ']}'.
@@ -667,7 +657,7 @@ GsSplitClassRefactoring >> applyClassChange: aChange [
 		ifFalse: [oldToNew at: old superclass ifAbsent: [old superclass]].
 	list := isSource
 		ifTrue: [self sourceIvarsAfterSplit]
-		ifFalse: [self ownInstVarsOf: old].
+		ifFalse: [environment ownInstVarNamesOf: old].
 	skip := isSource ifTrue: [movableSelectors] ifFalse: [#()].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list.
 	self copyMethodsFrom: old to: new skipping: skip.

--- a/gs-src/refactoring/tests/GsRefactoringEnvironmentTest.class.st
+++ b/gs-src/refactoring/tests/GsRefactoringEnvironmentTest.class.st
@@ -3,10 +3,13 @@ Correctness of the read-only all-dictionaries environment: class resolution
 and enumeration span every dictionary (not just UserGlobals); instance-variable
 access is found for reads and writes across a class hierarchy and excludes
 methods that never touch the variable; the instance-variable name argument
-accepts a String or a Symbol; and the queries never dirty the transaction.
+accepts a String or a Symbol; the own/all instance-variable-name queries answer
+Strings in declaration order and separate a class's own slots from its inherited
+ones; and the queries never dirty the transaction.
 
 setUp builds a throwaway three-class hierarchy in UserGlobals and tearDown
-removes it, so the assertions have known, self-contained answers.
+removes it, so the assertions have known, self-contained answers. The subclass
+declares its own instance variable so own-vs-inherited is distinguishable.
 "
 Class {
 	#name : 'GsRefactoringEnvironmentTest',
@@ -23,8 +26,9 @@ GsRefactoringEnvironmentTest >> noAccessFixture [
 GsRefactoringEnvironmentTest >> setUp [
 	"A tiny throwaway hierarchy so the instance-variable queries have known,
 	 self-contained answers: a superclass defining 'alpha' with a reader, a
-	 writer and a non-accessing method; a subclass that reads the inherited
-	 'alpha'; and a sibling subclass that never touches it."
+	 writer and a non-accessing method; a subclass declaring its own 'beta' and
+	 'gamma' that reads the inherited 'alpha'; and a sibling subclass that declares
+	 nothing and never touches it."
 	| supr sl |
 	sl := System myUserProfile symbolList.
 	supr := Object
@@ -39,7 +43,7 @@ GsRefactoringEnvironmentTest >> setUp [
 	supr compileMethod: 'noTouch ^42' dictionaries: sl category: 'tests'.
 	(supr
 		subclass: 'GsRefEnvFixtureSub'
-		instVarNames: #()
+		instVarNames: #('beta' 'gamma')
 		classVars: #()
 		classInstVars: #()
 		poolDictionaries: #()
@@ -82,12 +86,43 @@ GsRefactoringEnvironmentTest >> testAllClassesSpansEveryDictionaryWithoutDuplica
 ]
 
 { #category : 'tests' }
+GsRefactoringEnvironmentTest >> testAllInstVarNamesListsInheritedNamesBeforeOwnOnes [
+	"Inherited first, then the class's own -- the slot order of an instance, which a
+	 class-creation change has to reproduce."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: (env allInstVarNamesOf: self superFixture) asArray
+		equals: #('alpha').
+	self assert: (env allInstVarNamesOf: self subFixture) asArray
+		equals: #('alpha' 'beta' 'gamma')
+]
+
+{ #category : 'tests' }
+GsRefactoringEnvironmentTest >> testAllInstVarNamesOfAClassWithNoInstVarsIsEmpty [
+	self assert: (GsRefactoringEnvironment new allInstVarNamesOf: Object) isEmpty
+]
+
+{ #category : 'tests' }
 GsRefactoringEnvironmentTest >> testClassNamedResolvesClassesFromAnyDictionary [
 	| env |
 	env := GsRefactoringEnvironment new.
 
 	self assert: (env classNamed: #Object) == Object.
 	self assert: (env classNamed: #GsRefEnvFixtureSuper) == self superFixture
+]
+
+{ #category : 'tests' }
+GsRefactoringEnvironmentTest >> testDescendantsDeclaringInstVarFindsOnlyTheRedeclaringSubclasses [
+	"The V1-add / V8-split collision check: only a descendant that declares the name as its
+	 OWN instance variable counts. 'beta' is declared by the subclass; 'alpha' is declared by
+	 the superclass itself and merely inherited, so no descendant answers for it."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: ((env descendantsOf: self superFixture declaringInstVar: 'beta')
+		collect: [:c | c name asString]) asArray equals: #('GsRefEnvFixtureSub').
+	self assert: (env descendantsOf: self superFixture declaringInstVar: 'alpha') isEmpty
 ]
 
 { #category : 'tests' }
@@ -142,6 +177,44 @@ GsRefactoringEnvironmentTest >> testInstVarNameArgumentAcceptsAStringOrASymbol [
 ]
 
 { #category : 'tests' }
+GsRefactoringEnvironmentTest >> testInstVarNameQueriesAnswerStringsNotSymbols [
+	"#instVarNames / #allInstVarNames answer Symbols, but every caller compares the result
+	 against a name that arrived as a String from the client, and on 3.6.x that comparison
+	 can silently answer false (the Unicode-comparison trap). Normalising to Strings is what
+	 makes those comparisons hold, so it is asserted rather than assumed."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	(env ownInstVarNamesOf: self subFixture) do: [:each |
+		self assert: each isString.
+		self deny: each isSymbol].
+	(env allInstVarNamesOf: self subFixture) do: [:each |
+		self assert: each isString.
+		self deny: each isSymbol].
+	self assert: ((env ownInstVarNamesOf: self superFixture) includes: 'alpha')
+]
+
+{ #category : 'tests' }
+GsRefactoringEnvironmentTest >> testOwnInstVarNamesExcludesInheritedOnes [
+	"Own means declared here: the subclass answers its own two and not the inherited 'alpha'."
+	| own |
+	own := GsRefactoringEnvironment new ownInstVarNamesOf: self subFixture.
+
+	self assert: own asArray equals: #('beta' 'gamma').
+	self deny: (own includes: 'alpha')
+]
+
+{ #category : 'tests' }
+GsRefactoringEnvironmentTest >> testOwnInstVarNamesIsEmptyForASubclassThatDeclaresNone [
+	"The sibling declares nothing of its own, yet still inherits 'alpha'."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: (env ownInstVarNamesOf: self noAccessFixture) isEmpty.
+	self assert: ((env allInstVarNamesOf: self noAccessFixture) includes: 'alpha')
+]
+
+{ #category : 'tests' }
 GsRefactoringEnvironmentTest >> testReadOnlyQueriesDoNotChangeCommitState [
 	| env before |
 	env := GsRefactoringEnvironment new.
@@ -151,8 +224,27 @@ GsRefactoringEnvironmentTest >> testReadOnlyQueriesDoNotChangeCommitState [
 	env classNamed: #Object.
 	env instanceMethodsAccessing: #alpha inClass: self superFixture.
 	env classesAndSelectorsAccessing: #alpha inHierarchyOf: self superFixture.
+	env ownInstVarNamesOf: self subFixture.
+	env allInstVarNamesOf: self subFixture.
+	env descendantsOf: self superFixture declaringInstVar: 'beta'.
 
 	self assert: System needsCommit equals: before
+]
+
+{ #category : 'tests' }
+GsRefactoringEnvironmentTest >> testTheInstVarNameQueriesHaveExactlyOneImplementationEach [
+	"Issue #401: these one-liners used to be copy-pasted into four engine classes, which is
+	 how they could drift apart. Each now has a single implementation, on the environment --
+	 assert that, so a re-introduced copy (or a revived #ownInstVarsOf: / #allInstVarsOf:)
+	 fails here instead of silently diverging again."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	#(#ownInstVarNamesOf: #allInstVarNamesOf:) do: [:sel |
+		self assert: ((env implementorsOf: sel) collect: [:m | m inClass])
+			equals: (Array with: GsRefactoringEnvironment)].
+	#(#ownInstVarsOf: #allInstVarsOf:) do: [:sel |
+		self assert: (env implementorsOf: sel) isEmpty]
 ]
 
 { #category : 'tests' }

--- a/gs-src/refactoring/tests/GsRefactoringEnvironmentTest.class.st
+++ b/gs-src/refactoring/tests/GsRefactoringEnvironmentTest.class.st
@@ -126,6 +126,18 @@ GsRefactoringEnvironmentTest >> testDescendantsDeclaringInstVarFindsOnlyTheRedec
 ]
 
 { #category : 'tests' }
+GsRefactoringEnvironmentTest >> testDescendantsDeclaringInstVarAcceptsAStringOrASymbol [
+	"The name is compared against normalised Strings, so a Symbol argument must be normalised too
+	 or it would hit the 3.6.x Unicode-comparison trap on the argument side and answer empty. Match
+	 #instanceMethodsAccessing:inClass:, which already accepts either."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: (env descendantsOf: self superFixture declaringInstVar: #beta)
+		equals: (env descendantsOf: self superFixture declaringInstVar: 'beta')
+]
+
+{ #category : 'tests' }
 GsRefactoringEnvironmentTest >> testDictionariesDefiningNameReflectWhereTheClassLives [
 	| env |
 	env := GsRefactoringEnvironment new.
@@ -185,6 +197,11 @@ GsRefactoringEnvironmentTest >> testInstVarNameQueriesAnswerStringsNotSymbols [
 	| env |
 	env := GsRefactoringEnvironment new.
 
+	"Pin the precondition: the loops below prove nothing if the query ever answers empty, so
+	 assert non-empty first -- otherwise a regression to #() would pass this test vacuously."
+	self deny: (env ownInstVarNamesOf: self subFixture) isEmpty.
+	self deny: (env allInstVarNamesOf: self subFixture) isEmpty.
+
 	(env ownInstVarNamesOf: self subFixture) do: [:each |
 		self assert: each isString.
 		self deny: each isSymbol].
@@ -236,15 +253,32 @@ GsRefactoringEnvironmentTest >> testTheInstVarNameQueriesHaveExactlyOneImplement
 	"Issue #401: these one-liners used to be copy-pasted into four engine classes, which is
 	 how they could drift apart. Each now has a single implementation, on the environment --
 	 assert that, so a re-introduced copy (or a revived #ownInstVarsOf: / #allInstVarsOf:)
-	 fails here instead of silently diverging again."
-	| env |
+	 fails here instead of silently diverging again.
+
+	 #implementorsOf: asks the RUNNING stone, so this asserts the state of the INSTALLED engine,
+	 not the source on this branch. A failure right after editing source usually means the stone's
+	 engine is stale -- reinstall it (npm run test:server:install-plugin) before reading it as a
+	 real regression.
+
+	 The revived-copy check is scoped to the four engine classes that once held the copies, not the
+	 whole image: #ownInstVarsOf: / #allInstVarsOf: are generic enough that an unrelated class
+	 adopting one should not fail a test guarding THIS drift."
+	| env engineClasses |
 	env := GsRefactoringEnvironment new.
+	engineClasses := Array
+		with: GsExtractSuperclassRefactoring
+		with: GsInstVarRefactoring
+		with: GsInstVarStructureRefactoring
+		with: GsSplitClassRefactoring.
 
 	#(#ownInstVarNamesOf: #allInstVarNamesOf:) do: [:sel |
 		self assert: ((env implementorsOf: sel) collect: [:m | m inClass])
 			equals: (Array with: GsRefactoringEnvironment)].
 	#(#ownInstVarsOf: #allInstVarsOf:) do: [:sel |
-		self assert: (env implementorsOf: sel) isEmpty]
+		| implementorClasses |
+		implementorClasses := (env implementorsOf: sel) collect: [:m | m inClass].
+		engineClasses do: [:cls |
+			self deny: (implementorClasses includes: cls)]]
 ]
 
 { #category : 'tests' }

--- a/resources/refactoring/engine-tests.gs
+++ b/resources/refactoring/engine-tests.gs
@@ -7560,6 +7560,19 @@ testDescendantsDeclaringInstVarFindsOnlyTheRedeclaringSubclasses
 
 category: 'tests'
 method: GsRefactoringEnvironmentTest
+testDescendantsDeclaringInstVarAcceptsAStringOrASymbol
+	"The name is compared against normalised Strings, so a Symbol argument must be normalised too
+	 or it would hit the 3.6.x Unicode-comparison trap on the argument side and answer empty. Match
+	 #instanceMethodsAccessing:inClass:, which already accepts either."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: (env descendantsOf: self superFixture declaringInstVar: #beta)
+		equals: (env descendantsOf: self superFixture declaringInstVar: 'beta')
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
 testDictionariesDefiningNameReflectWhereTheClassLives
 	| env |
 	env := GsRefactoringEnvironment new.
@@ -7624,6 +7637,11 @@ testInstVarNameQueriesAnswerStringsNotSymbols
 	| env |
 	env := GsRefactoringEnvironment new.
 
+	"Pin the precondition: the loops below prove nothing if the query ever answers empty, so
+	 assert non-empty first -- otherwise a regression to #() would pass this test vacuously."
+	self deny: (env ownInstVarNamesOf: self subFixture) isEmpty.
+	self deny: (env allInstVarNamesOf: self subFixture) isEmpty.
+
 	(env ownInstVarNamesOf: self subFixture) do: [:each |
 		self assert: each isString.
 		self deny: each isSymbol].
@@ -7679,15 +7697,32 @@ testTheInstVarNameQueriesHaveExactlyOneImplementationEach
 	"Issue #401: these one-liners used to be copy-pasted into four engine classes, which is
 	 how they could drift apart. Each now has a single implementation, on the environment --
 	 assert that, so a re-introduced copy (or a revived #ownInstVarsOf: / #allInstVarsOf:)
-	 fails here instead of silently diverging again."
-	| env |
+	 fails here instead of silently diverging again.
+
+	 #implementorsOf: asks the RUNNING stone, so this asserts the state of the INSTALLED engine,
+	 not the source on this branch. A failure right after editing source usually means the stone's
+	 engine is stale -- reinstall it (npm run test:server:install-plugin) before reading it as a
+	 real regression.
+
+	 The revived-copy check is scoped to the four engine classes that once held the copies, not the
+	 whole image: #ownInstVarsOf: / #allInstVarsOf: are generic enough that an unrelated class
+	 adopting one should not fail a test guarding THIS drift."
+	| env engineClasses |
 	env := GsRefactoringEnvironment new.
+	engineClasses := Array
+		with: GsExtractSuperclassRefactoring
+		with: GsInstVarRefactoring
+		with: GsInstVarStructureRefactoring
+		with: GsSplitClassRefactoring.
 
 	#(#ownInstVarNamesOf: #allInstVarNamesOf:) do: [:sel |
 		self assert: ((env implementorsOf: sel) collect: [:m | m inClass])
 			equals: (Array with: GsRefactoringEnvironment)].
 	#(#ownInstVarsOf: #allInstVarsOf:) do: [:sel |
-		self assert: (env implementorsOf: sel) isEmpty]
+		| implementorClasses |
+		implementorClasses := (env implementorsOf: sel) collect: [:m | m inClass].
+		engineClasses do: [:cls |
+			self deny: (implementorClasses includes: cls)]]
 %
 
 category: 'tests'

--- a/resources/refactoring/engine-tests.gs
+++ b/resources/refactoring/engine-tests.gs
@@ -563,10 +563,13 @@ Correctness of the read-only all-dictionaries environment: class resolution
 and enumeration span every dictionary (not just UserGlobals); instance-variable
 access is found for reads and writes across a class hierarchy and excludes
 methods that never touch the variable; the instance-variable name argument
-accepts a String or a Symbol; and the queries never dirty the transaction.
+accepts a String or a Symbol; the own/all instance-variable-name queries answer
+Strings in declaration order and separate a class''s own slots from its inherited
+ones; and the queries never dirty the transaction.
 
 setUp builds a throwaway three-class hierarchy in UserGlobals and tearDown
-removes it, so the assertions have known, self-contained answers.
+removes it, so the assertions have known, self-contained answers. The subclass
+declares its own instance variable so own-vs-inherited is distinguishable.
 '.
 true.
 %
@@ -7448,8 +7451,9 @@ method: GsRefactoringEnvironmentTest
 setUp
 	"A tiny throwaway hierarchy so the instance-variable queries have known,
 	 self-contained answers: a superclass defining 'alpha' with a reader, a
-	 writer and a non-accessing method; a subclass that reads the inherited
-	 'alpha'; and a sibling subclass that never touches it."
+	 writer and a non-accessing method; a subclass declaring its own 'beta' and
+	 'gamma' that reads the inherited 'alpha'; and a sibling subclass that declares
+	 nothing and never touches it."
 	| supr sl |
 	sl := System myUserProfile symbolList.
 	supr := Object
@@ -7464,7 +7468,7 @@ setUp
 	supr compileMethod: 'noTouch ^42' dictionaries: sl category: 'tests'.
 	(supr
 		subclass: 'GsRefEnvFixtureSub'
-		instVarNames: #()
+		instVarNames: #('beta' 'gamma')
 		classVars: #()
 		classInstVars: #()
 		poolDictionaries: #()
@@ -7512,12 +7516,46 @@ testAllClassesSpansEveryDictionaryWithoutDuplicates
 
 category: 'tests'
 method: GsRefactoringEnvironmentTest
+testAllInstVarNamesListsInheritedNamesBeforeOwnOnes
+	"Inherited first, then the class's own -- the slot order of an instance, which a
+	 class-creation change has to reproduce."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: (env allInstVarNamesOf: self superFixture) asArray
+		equals: #('alpha').
+	self assert: (env allInstVarNamesOf: self subFixture) asArray
+		equals: #('alpha' 'beta' 'gamma')
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
+testAllInstVarNamesOfAClassWithNoInstVarsIsEmpty
+	self assert: (GsRefactoringEnvironment new allInstVarNamesOf: Object) isEmpty
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
 testClassNamedResolvesClassesFromAnyDictionary
 	| env |
 	env := GsRefactoringEnvironment new.
 
 	self assert: (env classNamed: #Object) == Object.
 	self assert: (env classNamed: #GsRefEnvFixtureSuper) == self superFixture
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
+testDescendantsDeclaringInstVarFindsOnlyTheRedeclaringSubclasses
+	"The V1-add / V8-split collision check: only a descendant that declares the name as its
+	 OWN instance variable counts. 'beta' is declared by the subclass; 'alpha' is declared by
+	 the superclass itself and merely inherited, so no descendant answers for it."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: ((env descendantsOf: self superFixture declaringInstVar: 'beta')
+		collect: [:c | c name asString]) asArray equals: #('GsRefEnvFixtureSub').
+	self assert: (env descendantsOf: self superFixture declaringInstVar: 'alpha') isEmpty
 %
 
 category: 'tests'
@@ -7578,6 +7616,47 @@ testInstVarNameArgumentAcceptsAStringOrASymbol
 
 category: 'tests'
 method: GsRefactoringEnvironmentTest
+testInstVarNameQueriesAnswerStringsNotSymbols
+	"#instVarNames / #allInstVarNames answer Symbols, but every caller compares the result
+	 against a name that arrived as a String from the client, and on 3.6.x that comparison
+	 can silently answer false (the Unicode-comparison trap). Normalising to Strings is what
+	 makes those comparisons hold, so it is asserted rather than assumed."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	(env ownInstVarNamesOf: self subFixture) do: [:each |
+		self assert: each isString.
+		self deny: each isSymbol].
+	(env allInstVarNamesOf: self subFixture) do: [:each |
+		self assert: each isString.
+		self deny: each isSymbol].
+	self assert: ((env ownInstVarNamesOf: self superFixture) includes: 'alpha')
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
+testOwnInstVarNamesExcludesInheritedOnes
+	"Own means declared here: the subclass answers its own two and not the inherited 'alpha'."
+	| own |
+	own := GsRefactoringEnvironment new ownInstVarNamesOf: self subFixture.
+
+	self assert: own asArray equals: #('beta' 'gamma').
+	self deny: (own includes: 'alpha')
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
+testOwnInstVarNamesIsEmptyForASubclassThatDeclaresNone
+	"The sibling declares nothing of its own, yet still inherits 'alpha'."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	self assert: (env ownInstVarNamesOf: self noAccessFixture) isEmpty.
+	self assert: ((env allInstVarNamesOf: self noAccessFixture) includes: 'alpha')
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
 testReadOnlyQueriesDoNotChangeCommitState
 	| env before |
 	env := GsRefactoringEnvironment new.
@@ -7587,8 +7666,28 @@ testReadOnlyQueriesDoNotChangeCommitState
 	env classNamed: #Object.
 	env instanceMethodsAccessing: #alpha inClass: self superFixture.
 	env classesAndSelectorsAccessing: #alpha inHierarchyOf: self superFixture.
+	env ownInstVarNamesOf: self subFixture.
+	env allInstVarNamesOf: self subFixture.
+	env descendantsOf: self superFixture declaringInstVar: 'beta'.
 
 	self assert: System needsCommit equals: before
+%
+
+category: 'tests'
+method: GsRefactoringEnvironmentTest
+testTheInstVarNameQueriesHaveExactlyOneImplementationEach
+	"Issue #401: these one-liners used to be copy-pasted into four engine classes, which is
+	 how they could drift apart. Each now has a single implementation, on the environment --
+	 assert that, so a re-introduced copy (or a revived #ownInstVarsOf: / #allInstVarsOf:)
+	 fails here instead of silently diverging again."
+	| env |
+	env := GsRefactoringEnvironment new.
+
+	#(#ownInstVarNamesOf: #allInstVarNamesOf:) do: [:sel |
+		self assert: ((env implementorsOf: sel) collect: [:m | m inClass])
+			equals: (Array with: GsRefactoringEnvironment)].
+	#(#ownInstVarsOf: #allInstVarsOf:) do: [:sel |
+		self assert: (env implementorsOf: sel) isEmpty]
 %
 
 category: 'tests'

--- a/resources/refactoring/engine.gs
+++ b/resources/refactoring/engine.gs
@@ -5589,15 +5589,6 @@ optionsOf: aClass
 
 category: 'private'
 method: GsInstVarRefactoring
-allClassVarsOf: aClass
-	"aClass's own and inherited class-variable names, as a Set of Strings. Used to decline an
-	 #add whose name would shadow a class variable inside method bodies. Shared with V8 split --
-	 the walk itself lives on the environment so both refactorings ask the same question."
-	^environment classVarNamesVisibleTo: aClass
-%
-
-category: 'private'
-method: GsInstVarRefactoring
 isValidIvarName: aString
 	"A syntactically valid Smalltalk instance-variable name: a LOWERCASE letter or an underscore,
 	 followed by letters, digits, or underscores.
@@ -5648,7 +5639,7 @@ analyzeAdd
 		^decline := 'Cannot add ', varName printString, ': an instance-variable name must start with a lowercase letter or an underscore, followed by letters, digits, or underscores.'].
 	((environment allInstVarNamesOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': ', definingClass name asString, ' already has an instance variable of that name.'].
-	((self allClassVarsOf: definingClass) includes: varName) ifTrue: [
+	((environment classVarNamesVisibleTo: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': a class variable of that name is visible to ', definingClass name asString, ', which it would shadow.'].
 	"A subclass that already declares varName as its OWN instance variable would end up with two
 	 of that name once the new one is inherited. That fails mid-apply (error 2271), so decline up
@@ -9367,9 +9358,15 @@ descendantsOf: aClass declaringInstVar: aName
 	 classes have already been versioned. Callers decline up front and name the offenders instead.
 
 	 Shared by every refactoring that introduces an instance variable on an existing class (V1 add,
-	 V8 split), so the check and its cross-version behaviour live in one place. Read-only."
+	 V8 split), so the check and its cross-version behaviour live in one place. Read-only.
+
+	 aName is normalised to a String because #ownInstVarNamesOf: answers Strings; a caller passing a
+	 Symbol would otherwise hit the same 3.6.x Unicode-comparison trap on the argument side and get a
+	 silently empty answer. Both #instVarNameArgument callers already accept either, so we match that."
+	| name |
+	name := aName asString.
 	^(self descendantsOf: aClass)
-		select: [:d | (self ownInstVarNamesOf: d) includes: aName]
+		select: [:d | (self ownInstVarNamesOf: d) includes: name]
 %
 
 category: 'enumerating'
@@ -9400,7 +9397,11 @@ ownInstVarNamesOf: aClass
 
 	 Shared by every refactoring that reasons about instance-variable structure --
 	 add/remove, push up/down/move, extract superclass, split class -- so the
-	 normalisation lives in one place. Read-only."
+	 normalisation lives in one place. Read-only.
+
+	 The ifNil: guard is defensive only: a live class always answers an Array from #instVarNames, so
+	 nil is not expected to be reachable here. It mirrors the guard #descendantsOf:declaringInstVar:
+	 already carried and keeps the answer an empty Array rather than raising if that ever changes."
 	^(aClass instVarNames ifNil: [#()]) collect: [:e | e asString]
 %
 

--- a/resources/refactoring/engine.gs
+++ b/resources/refactoring/engine.gs
@@ -2858,18 +2858,6 @@ sharedParent
 
 category: 'private'
 method: GsExtractSuperclassRefactoring
-ownInstVarsOf: aClass
-	^aClass instVarNames collect: [:e | e asString]
-%
-
-category: 'private'
-method: GsExtractSuperclassRefactoring
-allInstVarsOf: aClass
-	^aClass allInstVarNames collect: [:e | e asString]
-%
-
-category: 'private'
-method: GsExtractSuperclassRefactoring
 sourceOf: aSelector in: aClass
 	| m |
 	m := aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
@@ -2941,8 +2929,8 @@ validateHoistInstVars
 	 created and some reparents done -- the half-applied state the user then has to abort. The
 	 class comment sells these as global declines that empty the change set, so it belongs here."
 	| own supAll |
-	own := self ownInstVarsOf: anchorClass.
-	supAll := self allInstVarsOf: sharedParent.
+	own := environment ownInstVarNamesOf: anchorClass.
+	supAll := environment allInstVarNamesOf: sharedParent.
 	hoistInstVars do: [:v |
 		(own includes: v) ifFalse: [
 			^decline := 'Cannot hoist instance variable ', v, ': it is not declared in ', anchorClass name asString, '.'].
@@ -2961,7 +2949,7 @@ descendantDeclaring: anIvarName
 	extractedClasses do: [:cls |
 		(environment descendantsOf: cls) do: [:d |
 			((extractedClasses includes: d) not
-				and: [(self ownInstVarsOf: d) includes: anIvarName])
+				and: [(environment ownInstVarNamesOf: d) includes: anIvarName])
 					ifTrue: [^d]]].
 	^nil
 %
@@ -2988,7 +2976,7 @@ visibleIvarSymbolsWith: anIvarList
 	| visible |
 	visible := Set new.
 	anIvarList do: [:v | visible add: v asSymbol].
-	(self allInstVarsOf: sharedParent) do: [:v | visible add: v asSymbol].
+	(environment allInstVarNamesOf: sharedParent) do: [:v | visible add: v asSymbol].
 	^visible
 %
 
@@ -3113,11 +3101,11 @@ candidateInstVars
 	self ensureAnalysis.
 	result := OrderedCollection new.
 	decline notNil ifTrue: [^result].
-	(self ownInstVarsOf: anchorClass) do: [:v | | all |
-		((self allInstVarsOf: sharedParent) includes: v)
+	(environment ownInstVarNamesOf: anchorClass) do: [:v | | all |
+		((environment allInstVarNamesOf: sharedParent) includes: v)
 			ifTrue: [result add: (Array with: v with: #unhoistable)]
 			ifFalse: [
-				all := extractedClasses allSatisfy: [:c | (self ownInstVarsOf: c) includes: v].
+				all := extractedClasses allSatisfy: [:c | (environment ownInstVarNamesOf: c) includes: v].
 				result add: (Array with: v with: (all ifTrue: [#identical] ifFalse: [#partial]))]].
 	^result
 %
@@ -3127,9 +3115,9 @@ method: GsExtractSuperclassRefactoring
 identicalCandidateIvarNames
 	"The own ivars of the anchor that every extracted class also owns -- the ones hoisted by
 	 default -- as an Array of Strings. Used to classify method hoistability optimistically."
-	^(self ownInstVarsOf: anchorClass) select: [:v |
-		((self allInstVarsOf: sharedParent) includes: v) not
-			and: [extractedClasses allSatisfy: [:c | (self ownInstVarsOf: c) includes: v]]]
+	^(environment ownInstVarNamesOf: anchorClass) select: [:v |
+		((environment allInstVarNamesOf: sharedParent) includes: v) not
+			and: [extractedClasses allSatisfy: [:c | (environment ownInstVarNamesOf: c) includes: v]]]
 %
 
 category: 'classification'
@@ -3179,7 +3167,7 @@ stageExtractedEdit: aClass into: cs
 	 dropped from its own list."
 	| oldDef newList |
 	oldDef := aClass definition.
-	newList := (self ownInstVarsOf: aClass) reject: [:n | hoistInstVars includes: n].
+	newList := (environment ownInstVarNamesOf: aClass) reject: [:n | hoistInstVars includes: n].
 	cs
 		addClassDefinitionEditInDictionary: (self dictNameForClass: aClass)
 		className: aClass name asString
@@ -3471,8 +3459,8 @@ applyClassChange: aChange
 		ifTrue: [newClass]
 		ifFalse: [oldToNew at: old superclass ifAbsent: [old superclass]].
 	list := isExtracted
-		ifTrue: [(self ownInstVarsOf: old) reject: [:n | hoistInstVars includes: n]]
-		ifFalse: [self ownInstVarsOf: old].
+		ifTrue: [(environment ownInstVarNamesOf: old) reject: [:n | hoistInstVars includes: n]]
+		ifFalse: [environment ownInstVarNamesOf: old].
 	skip := isExtracted ifTrue: [hoistMethods] ifFalse: [#()].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list.
 	self copyMethodsFrom: old to: new skipping: skip.
@@ -5594,19 +5582,6 @@ varName
 
 category: 'private'
 method: GsInstVarRefactoring
-ownInstVarsOf: aClass
-	"aClass's OWN instance-variable names (not inherited), as an Array of Strings."
-	^aClass instVarNames collect: [:e | e asString]
-%
-
-category: 'private'
-method: GsInstVarRefactoring
-allInstVarsOf: aClass
-	^aClass allInstVarNames collect: [:e | e asString]
-%
-
-category: 'private'
-method: GsInstVarRefactoring
 optionsOf: aClass
 	"aClass's own class-creation options, as an Array of Strings (e.g. #('selfCanBeSpecial'))."
 	^(aClass _optionsArray ifNil: [#()]) collect: [:e | e asString]
@@ -5671,7 +5646,7 @@ analyzeAdd
 	| conflicts names |
 	(self isValidIvarName: varName) ifFalse: [
 		^decline := 'Cannot add ', varName printString, ': an instance-variable name must start with a lowercase letter or an underscore, followed by letters, digits, or underscores.'].
-	((self allInstVarsOf: definingClass) includes: varName) ifTrue: [
+	((environment allInstVarNamesOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': ', definingClass name asString, ' already has an instance variable of that name.'].
 	((self allClassVarsOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot add ', varName, ': a class variable of that name is visible to ', definingClass name asString, ', which it would shadow.'].
@@ -5687,7 +5662,7 @@ analyzeAdd
 			(conflicts size = 1 ifTrue: [' already declares'] ifFalse: [' already declare']),
 			' an instance variable of that name; adding it to ', definingClass name asString,
 			' would duplicate that variable.'].
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) copyWith: varName).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) copyWith: varName).
 	self computeAffectedFrom: (Array with: definingClass).
 	self recordWillNotRecompileShadowedBy: definingClass
 %
@@ -5697,9 +5672,9 @@ method: GsInstVarRefactoring
 analyzeRemove
 	"V1 remove: varName must be an OWN instance variable of definingClass. Every method (defining
 	 class and descendants) that accesses it will lose it -- those are the willNotRecompile set."
-	((self ownInstVarsOf: definingClass) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: definingClass) includes: varName) ifFalse: [
 		^decline := 'Cannot remove ', varName, ': it is not an instance variable declared in ', definingClass name asString, '.'].
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) reject: [:n | n = varName]).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) reject: [:n | n = varName]).
 	self computeAffectedFrom: (Array with: definingClass).
 	self recordWillNotRecompileLosing: definingClass
 %
@@ -5836,7 +5811,7 @@ previewDefinitionFor: aClass oldDef: defString
 	 are not surfaced for editing in the panel."
 	^self replaceListClause: 'instVarNames:'
 		in: defString
-		with: (newIvarLists at: aClass name asString ifAbsent: [self ownInstVarsOf: aClass])
+		with: (newIvarLists at: aClass name asString ifAbsent: [environment ownInstVarNamesOf: aClass])
 %
 
 category: 'building'
@@ -6112,7 +6087,7 @@ applyClassChange: aChange
 	old := environment classNamed: aChange className.
 	old isNil ifTrue: [^self error: 'Class not found: ', aChange className].
 	parentNew := oldToNew at: old superclass ifAbsent: [old superclass].
-	list := newIvarLists at: aChange className ifAbsent: [self ownInstVarsOf: old].
+	list := newIvarLists at: aChange className ifAbsent: [environment ownInstVarNamesOf: old].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list options: (self optionsForApply: old).
 	"Count it as applied HERE, the moment the version is staged -- before copyMethodsFrom:, which
 	 could raise. If it does, this class's new version is already a real staged mutation, so the
@@ -6354,19 +6329,6 @@ topClass
 	^topClass
 %
 
-category: 'private'
-method: GsInstVarStructureRefactoring
-ownInstVarsOf: aClass
-	"aClass's OWN instance-variable names (not inherited), as an Array of Strings."
-	^aClass instVarNames collect: [:e | e asString]
-%
-
-category: 'private'
-method: GsInstVarStructureRefactoring
-allInstVarsOf: aClass
-	^aClass allInstVarNames collect: [:e | e asString]
-%
-
 category: 'private - analysis'
 method: GsInstVarStructureRefactoring
 ensureAnalysis
@@ -6404,7 +6366,7 @@ analyzeConvertTemp
 		 method can't reference it), and this engine only edits instance-side ivar lists. Decline
 		 rather than corrupt (add an unreachable ivar + recompile the class method against it)."
 		^decline := 'Cannot convert #', varName, ': converting a temporary in a class-side method to an instance variable is not supported.'].
-	((self allInstVarsOf: definingClass) includes: varName) ifTrue: [
+	((environment allInstVarNamesOf: definingClass) includes: varName) ifTrue: [
 		^decline := 'Cannot convert #', varName, ': it is already an instance variable of ', definingClass name asString, '.'].
 	behavior := methodMeta ifTrue: [definingClass class] ifFalse: [definingClass].
 	method := behavior compiledMethodAt: methodSelector environmentId: 0 otherwise: nil.
@@ -6425,7 +6387,7 @@ analyzeConvertTemp
 		newDecl,
 		(src copyFrom: tree body rightBar + 1 to: src size).
 	methodRewrite := Array with: definingClass name asString with: methodSelector with: methodMeta with: src with: newSrc.
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) copyWith: varName)
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) copyWith: varName)
 %
 
 category: 'private - analysis'
@@ -6435,18 +6397,18 @@ analyzePushUp
 	 ancestors) must not already define it; and no OTHER descendant of that superclass may
 	 own a same-named ivar (it would collide with the newly inherited one)."
 	| sup |
-	((self ownInstVarsOf: definingClass) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: definingClass) includes: varName) ifFalse: [
 		^decline := 'Cannot push up ', varName, ': it is not an instance variable declared in ', definingClass name asString, '.'].
 	sup := definingClass superclass.
 	sup isNil ifTrue: [
 		^decline := 'Cannot push up ', varName, ': ', definingClass name asString, ' has no superclass.'].
-	((self allInstVarsOf: sup) includes: varName) ifTrue: [
+	((environment allInstVarNamesOf: sup) includes: varName) ifTrue: [
 		^decline := 'Cannot push up ', varName, ': ', sup name asString, ' already defines an instance variable of that name.'].
 	(self otherDescendant: definingClass ofTop: sup ownsIvar: varName) ifNotNil: [:cls |
 		^decline := 'Cannot push up ', varName, ': ', cls, ' also declares an instance variable of that name, which would collide once it is inherited.'].
 	topClass := sup.
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) reject: [:n | n = varName]).
-	newIvarLists at: sup name asString put: ((self ownInstVarsOf: sup) copyWith: varName).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) reject: [:n | n = varName]).
+	newIvarLists at: sup name asString put: ((environment ownInstVarNamesOf: sup) copyWith: varName).
 	self moveAccessors ifTrue: [self planAccessorMovesFrom: definingClass to: (Array with: sup)]
 %
 
@@ -6457,7 +6419,7 @@ analyzePushDown
 	 access it (removing it would leave them undeclared); it must have subclasses; and no
 	 proper descendant may already own a same-named ivar (it would collide once inherited)."
 	| subs users |
-	((self ownInstVarsOf: definingClass) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: definingClass) includes: varName) ifFalse: [
 		^decline := 'Cannot push down ', varName, ': it is not an instance variable declared in ', definingClass name asString, '.'].
 	subs := (definingClass subclasses ifNil: [#()]) asArray.
 	subs isEmpty ifTrue: [
@@ -6476,9 +6438,9 @@ analyzePushDown
 	(self anyDescendantOf: definingClass ownsIvar: varName) ifNotNil: [:cls |
 		^decline := 'Cannot push down ', varName, ': ', cls, ' already declares an instance variable of that name.'].
 	topClass := definingClass.
-	newIvarLists at: definingClass name asString put: ((self ownInstVarsOf: definingClass) reject: [:n | n = varName]).
+	newIvarLists at: definingClass name asString put: ((environment ownInstVarNamesOf: definingClass) reject: [:n | n = varName]).
 	subs do: [:sub |
-		newIvarLists at: sub name asString put: ((self ownInstVarsOf: sub) copyWith: varName)].
+		newIvarLists at: sub name asString put: ((environment ownInstVarNamesOf: sub) copyWith: varName)].
 	self moveAccessors ifTrue: [self planAccessorMovesFrom: definingClass to: subs]
 %
 
@@ -6497,7 +6459,7 @@ analyzeMove
 	| def dir sup losing |
 	def := definingClass.
 	dir := moveDirection.
-	((self ownInstVarsOf: def) includes: varName) ifFalse: [
+	((environment ownInstVarNamesOf: def) includes: varName) ifFalse: [
 		^decline := 'Cannot move ', varName, ': it is not an instance variable declared in ', def name asString, '.'].
 	(targetClasses isNil or: [targetClasses isEmpty]) ifTrue: [
 		^decline := 'Cannot move ', varName, ': no destination class was chosen.'].
@@ -6512,7 +6474,7 @@ analyzeMove
 			sup := targetClasses first.
 			(self isAncestor: sup of: def) ifFalse: [
 				^decline := 'Cannot move ', varName, ' up: ', sup name asString, ' is not a superclass of ', def name asString, '.'].
-			((self allInstVarsOf: sup) includes: varName) ifTrue: [
+			((environment allInstVarNamesOf: sup) includes: varName) ifTrue: [
 				^decline := 'Cannot move ', varName, ' up: ', sup name asString, ' already defines an instance variable of that name.'].
 			(self otherDescendant: def ofTop: sup ownsIvar: varName) ifNotNil: [:cls |
 				^decline := 'Cannot move ', varName, ' up: ', cls, ' also declares an instance variable of that name, which would collide once it is inherited.'].
@@ -6553,9 +6515,9 @@ analyzeMove
 			^decline := 'Cannot move ', varName, ': ', cls name asString,
 				' still uses it in ', users size printString, ' of its own method(s): ',
 				(self selectorListString: users), '.']].
-	newIvarLists at: def name asString put: ((self ownInstVarsOf: def) reject: [:n | n = varName]).
+	newIvarLists at: def name asString put: ((environment ownInstVarNamesOf: def) reject: [:n | n = varName]).
 	targetClasses do: [:t |
-		newIvarLists at: t name asString put: ((self ownInstVarsOf: t) copyWith: varName)].
+		newIvarLists at: t name asString put: ((environment ownInstVarNamesOf: t) copyWith: varName)].
 	self moveAccessors ifTrue: [self planAccessorMovesFrom: def to: targetClasses]
 %
 
@@ -6594,7 +6556,7 @@ otherDescendant: aSkip ofTop: aTop ownsIvar: aName
 	"The name of a descendant of aTop (other than aSkip) that owns an ivar named aName, or
 	 nil."
 	(environment descendantsOf: aTop) do: [:cls |
-		(cls ~~ aSkip and: [(self ownInstVarsOf: cls) includes: aName])
+		(cls ~~ aSkip and: [(environment ownInstVarNamesOf: cls) includes: aName])
 			ifTrue: [^cls name asString]].
 	^nil
 %
@@ -6604,7 +6566,7 @@ method: GsInstVarStructureRefactoring
 anyDescendantOf: aTop ownsIvar: aName
 	"The name of any descendant of aTop that owns an ivar named aName, or nil."
 	(environment descendantsOf: aTop) do: [:cls |
-		((self ownInstVarsOf: cls) includes: aName) ifTrue: [^cls name asString]].
+		((environment ownInstVarNamesOf: cls) includes: aName) ifTrue: [^cls name asString]].
 	^nil
 %
 
@@ -7054,7 +7016,7 @@ applyClassChange: aChange
 	old := environment classNamed: aChange className.
 	old isNil ifTrue: [^self error: 'Class not found: ', aChange className].
 	parentNew := oldToNew at: old superclass ifAbsent: [old superclass].
-	list := newIvarLists at: aChange className ifAbsent: [self ownInstVarsOf: old].
+	list := newIvarLists at: aChange className ifAbsent: [environment ownInstVarNamesOf: old].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list.
 	self copyMethodsFrom: old to: new.
 	oldToNew at: old put: new
@@ -9407,7 +9369,7 @@ descendantsOf: aClass declaringInstVar: aName
 	 Shared by every refactoring that introduces an instance variable on an existing class (V1 add,
 	 V8 split), so the check and its cross-version behaviour live in one place. Read-only."
 	^(self descendantsOf: aClass)
-		select: [:d | ((d instVarNames ifNil: [#()]) collect: [:e | e asString]) includes: aName]
+		select: [:d | (self ownInstVarNamesOf: d) includes: aName]
 %
 
 category: 'enumerating'
@@ -9423,6 +9385,33 @@ classVarNamesVisibleTo: aClass
 		(cls classVarNames ifNil: [#()]) do: [:n | result add: n asString].
 		cls := cls superclass].
 	^result
+%
+
+category: 'instance variables'
+method: GsRefactoringEnvironment
+ownInstVarNamesOf: aClass
+	"aClass's OWN instance-variable names (not inherited), as an Array of Strings, in
+	 declaration order -- which is the order a class-creation change must preserve.
+
+	 Strings, not the Symbols #instVarNames answers, because every caller compares them
+	 against a name that arrived as a String from the client. Comparing a Symbol against
+	 such a String can silently answer false on 3.6.x (the Unicode-comparison trap), so
+	 normalising here is what makes those comparisons hold across releases.
+
+	 Shared by every refactoring that reasons about instance-variable structure --
+	 add/remove, push up/down/move, extract superclass, split class -- so the
+	 normalisation lives in one place. Read-only."
+	^(aClass instVarNames ifNil: [#()]) collect: [:e | e asString]
+%
+
+category: 'instance variables'
+method: GsRefactoringEnvironment
+allInstVarNamesOf: aClass
+	"aClass's own AND inherited instance-variable names, as an Array of Strings, inherited
+	 first -- the slot order of an instance. Callers use it to ask whether a name is already
+	 visible to aClass (its own or any superclass's). See #ownInstVarNamesOf: for why these
+	 are Strings. Read-only."
+	^(aClass allInstVarNames ifNil: [#()]) collect: [:e | e asString]
 %
 
 category: 'accessing'
@@ -12322,18 +12311,6 @@ movableSelectors
 
 category: 'private'
 method: GsSplitClassRefactoring
-ownInstVarsOf: aClass
-	^aClass instVarNames collect: [:e | e asString]
-%
-
-category: 'private'
-method: GsSplitClassRefactoring
-allInstVarsOf: aClass
-	^aClass allInstVarNames collect: [:e | e asString]
-%
-
-category: 'private'
-method: GsSplitClassRefactoring
 sourceOf: aSelector in: aClass
 	| m |
 	m := aClass compiledMethodAt: aSelector environmentId: 0 otherwise: nil.
@@ -12504,12 +12481,12 @@ computeAnalysis
 		^decline := 'Cannot split: a class named ', newName, ' already exists.'].
 	extractIvars isEmpty ifTrue: [
 		^decline := 'Cannot split: no instance variables were chosen to extract.'].
-	own := self ownInstVarsOf: sourceClass.
+	own := environment ownInstVarNamesOf: sourceClass.
 	extractIvars do: [:v |
 		(own includes: v) ifFalse: [
 			^decline := 'Cannot split: ', v, ' is not an instance variable of ', sourceClass name asString, '.']].
 	componentIvarName := self decapitalize: newName.
-	((self allInstVarsOf: sourceClass) includes: componentIvarName) ifTrue: [
+	((environment allInstVarNamesOf: sourceClass) includes: componentIvarName) ifTrue: [
 		^decline := 'Cannot split: the source already has an instance variable named ', componentIvarName, '.'].
 	"The component ivar is a NEW instance variable on the source, so it faces the same two
 	 collisions V1 add declines -- a class variable it would shadow, and a subclass that already
@@ -12648,7 +12625,7 @@ buildChangeSet
 category: 'building'
 method: GsSplitClassRefactoring
 retainedOwnIvars
-	^(self ownInstVarsOf: sourceClass) reject: [:n | extractIvars includes: n]
+	^(environment ownInstVarNamesOf: sourceClass) reject: [:n | extractIvars includes: n]
 %
 
 category: 'building'
@@ -12799,7 +12776,7 @@ candidatesJsonString
 	ws nextPutAll: '{"sourceClass":'; nextPutAll: (self jsonQuote: sourceClass name asString).
 	ws nextPutAll: ',"instVars":['.
 	first := true.
-	(self ownInstVarsOf: sourceClass) do: [:v |
+	(environment ownInstVarNamesOf: sourceClass) do: [:v |
 		first ifFalse: [ws nextPut: $,]. first := false.
 		ws nextPutAll: '{"name":'; nextPutAll: (self jsonQuote: v); nextPut: $}].
 	ws nextPutAll: ']}'.
@@ -12920,7 +12897,7 @@ applyClassChange: aChange
 		ifFalse: [oldToNew at: old superclass ifAbsent: [old superclass]].
 	list := isSource
 		ifTrue: [self sourceIvarsAfterSplit]
-		ifFalse: [self ownInstVarsOf: old].
+		ifFalse: [environment ownInstVarNamesOf: old].
 	skip := isSource ifTrue: [movableSelectors] ifFalse: [#()].
 	new := self makeNewVersionOf: old superclass: parentNew instVarNames: list.
 	self copyMethodsFrom: old to: new skipping: skip.

--- a/resources/refactoring/manifest.gs
+++ b/resources/refactoring/manifest.gs
@@ -64,25 +64,25 @@ m add: (Array with: 'RBWorkspaceNode' with: 15).
 m add: (Array with: 'GsChangeSignatureRefactoring' with: 44).
 m add: (Array with: 'GsClassHistory' with: 13).
 m add: (Array with: 'GsExtractMethodRefactoring' with: 71).
-m add: (Array with: 'GsExtractSuperclassRefactoring' with: 64).
+m add: (Array with: 'GsExtractSuperclassRefactoring' with: 62).
 m add: (Array with: 'GsExtractTemporaryRefactoring' with: 50).
 m add: (Array with: 'GsInlineMethodRefactoring' with: 59).
 m add: (Array with: 'GsInlineTemporaryRefactoring' with: 46).
-m add: (Array with: 'GsInstVarRefactoring' with: 54).
-m add: (Array with: 'GsInstVarStructureRefactoring' with: 71).
+m add: (Array with: 'GsInstVarRefactoring' with: 52).
+m add: (Array with: 'GsInstVarStructureRefactoring' with: 69).
 m add: (Array with: 'GsMoveMethodRefactoring' with: 38).
 m add: (Array with: 'GsPushDownMethodRefactoring' with: 40).
 m add: (Array with: 'GsPushUpMethodRefactoring' with: 43).
 m add: (Array with: 'GsRefactoringChange' with: 29).
 m add: (Array with: 'GsRefactoringChangeSet' with: 19).
-m add: (Array with: 'GsRefactoringEnvironment' with: 21).
+m add: (Array with: 'GsRefactoringEnvironment' with: 23).
 m add: (Array with: 'GsRefactoringJson' with: 3).
 m add: (Array with: 'GsRenameClassRefactoring' with: 54).
 m add: (Array with: 'GsRenameClassVariableRefactoring' with: 37).
 m add: (Array with: 'GsRenameInstanceVariableRefactoring' with: 34).
 m add: (Array with: 'GsRenameMethodRefactoring' with: 36).
 m add: (Array with: 'GsRenameTemporaryRefactoring' with: 40).
-m add: (Array with: 'GsSplitClassRefactoring' with: 60).
+m add: (Array with: 'GsSplitClassRefactoring' with: 58).
 GsRefactoring at: #GsRefactoringManifest put: m.
 true.
 %

--- a/resources/refactoring/manifest.gs
+++ b/resources/refactoring/manifest.gs
@@ -68,7 +68,7 @@ m add: (Array with: 'GsExtractSuperclassRefactoring' with: 62).
 m add: (Array with: 'GsExtractTemporaryRefactoring' with: 50).
 m add: (Array with: 'GsInlineMethodRefactoring' with: 59).
 m add: (Array with: 'GsInlineTemporaryRefactoring' with: 46).
-m add: (Array with: 'GsInstVarRefactoring' with: 52).
+m add: (Array with: 'GsInstVarRefactoring' with: 51).
 m add: (Array with: 'GsInstVarStructureRefactoring' with: 69).
 m add: (Array with: 'GsMoveMethodRefactoring' with: 38).
 m add: (Array with: 'GsPushDownMethodRefactoring' with: 40).


### PR DESCRIPTION
Closes #401.

`ownInstVarsOf:` and `allInstVarsOf:` were byte-identical one-liners copy-pasted into four
engine classes — `GsExtractSuperclassRefactoring`, `GsInstVarRefactoring`,
`GsInstVarStructureRefactoring`, `GsSplitClassRefactoring` — which is how they could quietly
drift apart. This consolidates them.

## What changed

| | |
|---|---|
| **Added** | `GsRefactoringEnvironment >> ownInstVarNamesOf:` / `allInstVarNamesOf:`, next to the sibling structural queries (`descendantsOf:`, `descendantsOf:declaringInstVar:`, `classVarNamesVisibleTo:`) |
| **Removed** | all 8 copies from the four refactorings |
| **Rewired** | 40 call sites, `self ownInstVarsOf:` → `environment ownInstVarNamesOf:` |
| **Bonus dedup** | `descendantsOf:declaringInstVar:` had the same one-liner inlined in its `select:` block; it now calls `ownInstVarNamesOf:` too |
| **Regenerated** | `engine.gs`, `engine-tests.gs`, `manifest.gs` (920 methods: −2 on each of the four classes, +2 on the environment) |

No behaviour change — these are pure read-only queries with no state.

### Two things worth a reviewer's eye

**Why the call sites talk to `environment` rather than keeping a thin local forwarder.** The
`allClassVarsOf:` precedent from #394 kept a one-line delegator on the refactoring. Going that
route here would still leave four byte-identical one-liners in four classes, just shallower
ones — which is the thing the issue asks to remove. Deleting them outright is a wider diff but
leaves nothing to drift. All 40 sites are instance-side, and `environment` is assigned at
instance creation and lives on the instance the preview token holds in `SessionTemps`, so it is
never nil on any path — including the resumed `applyForToken:` path.

**Why they were renamed instead of moved verbatim.** The environment's own convention is
`...NamesOf...` (`classVarNamesVisibleTo:`), and these answer *names*, not variables. The doc
comments now also record why the names are normalised to Strings, which none of the four copies
said: callers compare them against a name that arrived as a String from the client, and on 3.6.x
a Symbol/String comparison can silently answer false (the Unicode-comparison trap).

## Tests — [GS SUnit], `GsRefactoringEnvironmentTest` 9 → 16

The fixture subclass now declares its own `'beta'` and `'gamma'` so own-vs-inherited is
distinguishable.

- own excludes inherited and preserves declaration order; all lists inherited-then-own
- own is empty for a subclass that declares none, while all still sees the inherited name;
  empty for a class with no instance variables
- results are **Strings, not Symbols** — load-bearing, and verified as such against a live
  stone: raw `#instVarNames` elements answer `isSymbol` true and normalised ones false, so
  dropping the `asString` fails this test
- `descendantsOf:declaringInstVar:` — which had **no coverage at all** before this PR — finds
  only redeclaring subclasses, not merely-inherited names
- the read-only/commit-state test now exercises all three queries
- a **drift guard**: each query has exactly one implementor, and `#ownInstVarsOf:` /
  `#allInstVarsOf:` have none — so a re-introduced copy fails loudly instead of diverging again

> Note on the drift guard: it asks the *running stone* for implementors, so it fails against a
> stale installed engine. That is deliberate (a stale engine has masked a test before), but it
> does mean a local run wants `npm run test:server:install-plugin` first. CI installs from the
> branch, so it is always consistent there.

## Verification

| Layer | Result |
|---|---|
| RB engine SUnit — **3.6.2** (topaz, stage + run + abort) | **578 run, 0 failures+errors** |
| RB engine SUnit — **3.7.5** | **578 run, 0 failures+errors** |
| `GsRefactoringEnvironmentTest` alone | 16 run (was 9), 0 bad |
| lint / format:check / compile | clean |
| client (`--project default`) | 336 files, 5225 passed, 12 skipped |
| server / mcp-server | 322 passed / 92 passed |
| refactoring integration, serial | 126 files, 1209 passed, 1 skipped |

The engine was reinstalled on the `.env.test` stone from this branch before the client runs, so
nothing was measured against a stale engine.

**Not run:** the full CI matrix (`test-ci-local.sh 3.6.2 3.7.5` + the on-demand GCI suite). Both
RB SUnit boundaries and the whole fast gate are green above; happy to run the matrix on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
