### PR TITLE
Fix Unicode7 doit-literal comparisons on GemStone 3.6.x (#399, #400)

### DIFF
--- a/client/src/__tests__/exportManager.test.ts
+++ b/client/src/__tests__/exportManager.test.ts
@@ -68,7 +68,7 @@ const h = vi.hoisted(() => {
 
   // syncClassBuildExpr: resolve dict by name, return `idx \t hash \n source`.
   const classPayload = (img: FakeImage, code: string): string => {
-    const dn = code.match(/name asString = '((?:[^']|'')*)'/);
+    const dn = code.match(/name asSymbol == #'((?:[^']|'')*)'/);
     const cn = code.match(/at: #'((?:[^']|'')*)'/);
     if (!dn || !cn) return '';
     const dictName = dn[1].replace(/''/g, "'");

--- a/client/src/__tests__/exportManager.test.ts
+++ b/client/src/__tests__/exportManager.test.ts
@@ -68,9 +68,17 @@ const h = vi.hoisted(() => {
 
   // syncClassBuildExpr: resolve dict by name, return `idx \t hash \n source`.
   const classPayload = (img: FakeImage, code: string): string => {
-    const dn = code.match(/name asSymbol == #'((?:[^']|'')*)'/);
+    const dn = code.match(/name asString asSymbol == #'((?:[^']|'')*)'/);
     const cn = code.match(/at: #'((?:[^']|'')*)'/);
-    if (!dn || !cn) return '';
+    // This fake tracks the generated class-build idiom by hand. If it drifts (e.g. syncClassBuildExpr
+    // changes how it names the dictionary or class), fail loudly HERE rather than returning '' — an
+    // empty payload silently reads as "class not found" and surfaces as a puzzling sync result several
+    // assertions later. classPayload is only called for 'class'-labeled codes, so a miss is a harness
+    // bug, not a valid input.
+    if (!dn || !cn)
+      throw new Error(
+        `exportManager test fake: class-build idiom not recognized — retarget classPayload's regex to match syncClassBuildExpr. Code was:\n${code}`,
+      );
     const dictName = dn[1].replace(/''/g, "'");
     const className = cn[1].replace(/''/g, "'");
     const c = img.classes.find(

--- a/client/src/__tests__/rowanQueries.test.ts
+++ b/client/src/__tests__/rowanQueries.test.ts
@@ -149,6 +149,19 @@ describe('diffRowanProject', () => {
       error: 'could not read disk',
     });
   });
+
+  // `op class name` is a Symbol; on 3.6.x a string literal inside a GCI doit is
+  // Unicode7, and `Symbol = Unicode7` answers false silently — so both add/remove
+  // branches fell through to 'M'. The classifier must compare interned Symbols.
+  // Regression guard for issue #400 (diff mislabelled every row 'M' on 3.6.x).
+  it('classifies operations by interned Symbol, not string (3.6.x Unicode7 safety)', () => {
+    const exec = executor('');
+    diffRowanProject(exec, 'STON');
+    const code = exec.mock.calls[0][0];
+    expect(code).toContain('op class name asSymbol == #CypressAddition');
+    expect(code).toContain('op class name asSymbol == #CypressRemoval');
+    expect(code).not.toMatch(/class name = '/);
+  });
 });
 
 describe('formatRowanDiff', () => {

--- a/client/src/queries/rowan/diffRowanProject.ts
+++ b/client/src/queries/rowan/diffRowanProject.ts
@@ -37,6 +37,9 @@ ws := WriteStream on: Unicode7 new.
 patches do: [:assoc | | pkg |
   pkg := assoc key.
   assoc value operations do: [:op | | c |
+    "Unicode7 idiom (see escapeString in queries/util.ts): a string literal inside a GCI doit is
+     Unicode7 on 3.6.x, so compare the image-derived class name as an interned Symbol via asSymbol
+     == #Lit -- a plain = against a string literal raises ArgumentError 2718 on a 3.6.x client."
     c := op class name asSymbol == #CypressAddition
       ifTrue: ['I']
       ifFalse: [op class name asSymbol == #CypressRemoval ifTrue: ['D'] ifFalse: ['M']].

--- a/client/src/queries/rowan/diffRowanProject.ts
+++ b/client/src/queries/rowan/diffRowanProject.ts
@@ -37,9 +37,9 @@ ws := WriteStream on: Unicode7 new.
 patches do: [:assoc | | pkg |
   pkg := assoc key.
   assoc value operations do: [:op | | c |
-    c := op class name = 'CypressAddition'
+    c := op class name asSymbol == #CypressAddition
       ifTrue: ['I']
-      ifFalse: [op class name = 'CypressRemoval' ifTrue: ['D'] ifFalse: ['M']].
+      ifFalse: [op class name asSymbol == #CypressRemoval ifTrue: ['D'] ifFalse: ['M']].
     ws nextPutAll: c; tab; nextPutAll: pkg asString; tab;
        nextPutAll: ([op definition printString] on: Error do: [:e | '?']); lf]].
 ws contents`;

--- a/client/src/queries/util.ts
+++ b/client/src/queries/util.ts
@@ -2,6 +2,16 @@ export function escapeString(s: string): string {
   return s.replace(/'/g, "''");
 }
 
+// Unicode7 gotcha for generated Smalltalk (GemStone 3.6.x). Every string literal inside a
+// GCI-executed doit compiles to Unicode7, and comparing an image-derived value against one
+// misbehaves: `Symbol = 'lit'` silently answers false, and `String = 'lit'` raises ArgumentError
+// 2718 — so class/method/dictionary sync and export failed outright on 3.6.x clients (issues #399,
+// #400). The safe idiom is to compare interned Symbols: `someName asSymbol == #Lit`. When the
+// image value may be nil (e.g. an unnamed SymbolDictionary — `SymbolDictionary new name` is nil),
+// go through asString first: `name asString asSymbol == #Lit`, so nil answers #nil instead of a
+// `nil asSymbol` doesNotUnderstand. Never write a plain `= 'literal'` against an image-derived
+// value in a doit; 3.7.x tolerates it, so a reverted idiom only breaks at a 3.6.x client site.
+
 // A Smalltalk expression for the class (or its metaclass) that receives a
 // method-level operation. `dict` (a 1-based SymbolList index, or a name) scopes
 // the resolution to a specific dictionary so the same key in two dictionaries

--- a/client/src/sync/__tests__/syncProtocol.test.ts
+++ b/client/src/sync/__tests__/syncProtocol.test.ts
@@ -8,12 +8,23 @@ describe('syncClassBuildExpr', () => {
   // Regression guard for issue #399 (class sync/export failed outright on 3.6.x).
   it('resolves the dictionary by interned Symbol, not string (3.6.x Unicode7 safety)', () => {
     const code = syncClassBuildExpr('UserGlobals', 'Object');
-    expect(code).toContain("name asSymbol == #'UserGlobals'");
+    expect(code).toContain("name asString asSymbol == #'UserGlobals'");
     expect(code).not.toMatch(/name asString = '/);
   });
 
   it('doubles a quote in the dictionary name inside the Symbol literal', () => {
     const code = syncClassBuildExpr("Od'd", 'Object');
-    expect(code).toContain("name asSymbol == #'Od''d'");
+    expect(code).toContain("name asString asSymbol == #'Od''d'");
+  });
+
+  // A dictionary in the symbol list can have a nil name — `SymbolDictionary new` produces one, and
+  // the loop scans every dictionary until it matches, so one unnamed dictionary ahead of the target
+  // is enough. Verified in-stone: `nil asSymbol` is a doesNotUnderstand (2010) that would kill the
+  // whole scan, while `nil asString asSymbol` answers #nil and simply doesn't match. So the idiom
+  // must be `name asString asSymbol`, never a bare `name asSymbol`. Regression guard for that.
+  it('goes through asString so a nil-named dictionary does not doesNotUnderstand the scan', () => {
+    const code = syncClassBuildExpr('UserGlobals', 'Object');
+    expect(code).toContain('name asString asSymbol ==');
+    expect(code).not.toMatch(/name asSymbol ==/);
   });
 });

--- a/client/src/sync/__tests__/syncProtocol.test.ts
+++ b/client/src/sync/__tests__/syncProtocol.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { syncClassBuildExpr } from '../syncProtocol';
+
+describe('syncClassBuildExpr', () => {
+  // On GemStone 3.6.x every string literal inside a GCI-executed doit compiles to
+  // Unicode7, and `String = Unicode7` raises ArgumentError 2718 — so the symbol-list
+  // lookup this expression depends on must compare interned Symbols, not strings.
+  // Regression guard for issue #399 (class sync/export failed outright on 3.6.x).
+  it('resolves the dictionary by interned Symbol, not string (3.6.x Unicode7 safety)', () => {
+    const code = syncClassBuildExpr('UserGlobals', 'Object');
+    expect(code).toContain("name asSymbol == #'UserGlobals'");
+    expect(code).not.toMatch(/name asString = '/);
+  });
+
+  it('doubles a quote in the dictionary name inside the Symbol literal', () => {
+    const code = syncClassBuildExpr("Od'd", 'Object');
+    expect(code).toContain("name asSymbol == #'Od''d'");
+  });
+});

--- a/client/src/sync/syncProtocol.ts
+++ b/client/src/sync/syncProtocol.ts
@@ -112,7 +112,7 @@ export function syncClassBuildExpr(dictName: string, className: string): string 
   | sl idx |
   sl := System myUserProfile symbolList.
   idx := 0.
-  1 to: sl size do: [:i | (idx = 0 and: [(sl at: i) name asString = '${escapeString(dictName)}']) ifTrue: [idx := i]].
+  1 to: sl size do: [:i | (idx = 0 and: [(sl at: i) name asSymbol == #'${escapeString(dictName)}']) ifTrue: [idx := i]].
   idx = 0
     ifTrue: ['']
     ifFalse: [

--- a/client/src/sync/syncProtocol.ts
+++ b/client/src/sync/syncProtocol.ts
@@ -108,11 +108,16 @@ export function contentBuildExpr(refs: ClassRef[]): string {
 // manifest's per-index keying), then returns `dictIndex \t md5 \n file-out`,
 // or '' if the dictionary or class is not found.
 export function syncClassBuildExpr(dictName: string, className: string): string {
+  // Unicode7 idiom (see escapeString in queries/util.ts): a string literal inside a GCI doit is
+  // Unicode7 on 3.6.x, so compare an image-derived name as an interned Symbol, never a String.
+  // `name asString asSymbol` (not bare `name asSymbol`) so a dictionary with a nil name — which
+  // `SymbolDictionary new` produces, and one sitting ahead of the target in the scan is enough —
+  // answers #nil and moves on, rather than a `nil asSymbol` doesNotUnderstand that kills the scan.
   return blockExpr(`
   | sl idx |
   sl := System myUserProfile symbolList.
   idx := 0.
-  1 to: sl size do: [:i | (idx = 0 and: [(sl at: i) name asSymbol == #'${escapeString(dictName)}']) ifTrue: [idx := i]].
+  1 to: sl size do: [:i | (idx = 0 and: [(sl at: i) name asString asSymbol == #'${escapeString(dictName)}']) ifTrue: [idx := i]].
   idx = 0
     ifTrue: ['']
     ifFalse: [


### PR DESCRIPTION
## Summary

On GemStone 3.6.x, every string literal inside a GCI-executed doit compiles to `Unicode7`, so comparing an image-derived value against a **string literal** misbehaves in one of two ways:

- `String = 'literal'` → **raises** `ArgumentError` 2718 ("Unicode argument disallowed in String comparison")
- `Symbol = 'literal'` → silently answers **false**

Both hazards had a live client site. 3.7.x is unaffected either way.

## Fixes

**#399 — class sync/export failed outright on 3.6.x.** `syncClassBuildExpr` resolved the target dictionary with `(sl at: i) name asString = '<dict>'`, which raised 2718, so the whole sync/export path died. Now compares interned Symbols: `(sl at: i) name asSymbol == #'<dict>'`.

**#400 — Rowan project diff labelled every row `M` on 3.6.x.** `diffRowanProject` classified operations with `op class name = 'CypressAddition'`. Since `op class name` is a `Symbol`, `Symbol = Unicode7` answered `false` and both the add/remove branches fell through to `'M'` — silently wrong, no error. Now compares `op class name asSymbol == #CypressAddition` / `== #CypressRemoval`.

Both changes are no-ops on 3.7.x (worked before and after) and correct on 3.6.x.

## Tests

- **Unit guards** on the generated Smalltalk assert the Symbol idiom for both sites (`client/src/sync/__tests__/syncProtocol.test.ts` for #399; a new case in `rowanQueries.test.ts` for #400). Each was confirmed to **fail on the pre-fix source and pass on the fix**, so they genuinely bite.
- The `exportManager` fake-executor regex is retargeted to the new idiom.
- **Verified end-to-end against a live 3.6.2 stone by hand:** the pre-fix `syncClassBuildExpr` raised exactly `ArgumentError (error 2718) ... UserGlobals`; the fix returns the class payload.

A committed live integration test was deliberately omitted — it destabilized the parallel RB-SUnit integration tests by adding a concurrent GCI session to the shared stone (variable victims, always the in-stone SUnit suites). The deterministic unit guards plus the manual live proof cover the fix without making the suite flaky.

## Scope

Client-only (two query-builder strings + tests); no engine `.gs` changes. Gate: lint / format:check / compile clean, full client suite 337/337.

Fixes #399
Fixes #400