### PR TITLE
Fix Windows path-separator assertions in tests

### DIFF
--- a/client/src/__tests__/databaseManager.test.ts
+++ b/client/src/__tests__/databaseManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as path from 'path';
 
 vi.mock('vscode', () => import('../__mocks__/vscode.js'));
 vi.mock('../wslFs');
@@ -20,6 +21,8 @@ import { SysadminStorage } from '../sysadminStorage';
 import { ProcessManager } from '../processManager';
 
 // ── Helpers ────────────────────────────────────────────────
+
+const DB_DATA_DIR = path.join('/root/db-1', 'data');
 
 function makeDb(overrides?: Partial<GemStoneDatabase['config']>): GemStoneDatabase {
   return {
@@ -56,6 +59,29 @@ function pickItem(index: number): void {
   vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items) => (await items)[index]);
 }
 
+/**
+ * Mirrors `vscode.Uri#fsPath`'s platform-dependent output, for building the
+ * "expected" side of an assertion against a path that came from a
+ * `vscode.Uri`'s `fsPath` getter rather than from `path.join`.
+ *
+ * @remarks
+ * `Uri#fsPath` is a separate implementation from `path.join`. Both swap `/`
+ * for `\` on Windows, but they are not interchangeable in general:
+ * `fsPath` lowercases a leading drive letter and treats a leading `//` as
+ * a network-share authority, neither of which `path.join`/`normalize`
+ * does. Asserting against `path.join`'s output instead of this helper
+ * would happen to match for simple inputs, recreating the same "two
+ * different functions, hope they agree" risk this helper exists to
+ * eliminate — call the exact getter production reads, not a lookalike, so
+ * expected tracks actual by construction, not by luck.
+ *
+ * @param rawPath - The POSIX-style path passed to `vscode.Uri.file(...)` when building the mocked value.
+ * @returns The value `.fsPath` returns for that URI on this platform.
+ */
+function uriFsPath(rawPath: string): string {
+  return vscode.Uri.file(rawPath).fsPath;
+}
+
 describe('DatabaseManager.replaceExtent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -77,14 +103,14 @@ describe('DatabaseManager.replaceExtent', () => {
     expect(ok).toBe(true);
     expect(vscode.window.showOpenDialog).toHaveBeenCalledTimes(1);
     expect(wslImportFileSync).toHaveBeenCalledWith(
-      '/seed/mydata.dbf',
-      '/root/db-1/data/extent0.dbf',
+      uriFsPath('/seed/mydata.dbf'),
+      path.join(DB_DATA_DIR, 'extent0.dbf'),
     );
-    expect(wslChmodSync).toHaveBeenCalledWith('/root/db-1/data/extent0.dbf', 0o644);
+    expect(wslChmodSync).toHaveBeenCalledWith(path.join(DB_DATA_DIR, 'extent0.dbf'), 0o644);
     // Only .dbf files are removed; README.txt is left alone.
-    expect(wslUnlinkSync).toHaveBeenCalledWith('/root/db-1/data/extent0.dbf');
-    expect(wslUnlinkSync).toHaveBeenCalledWith('/root/db-1/data/tranlog1.dbf');
-    expect(wslUnlinkSync).not.toHaveBeenCalledWith('/root/db-1/data/README.txt');
+    expect(wslUnlinkSync).toHaveBeenCalledWith(path.join(DB_DATA_DIR, 'extent0.dbf'));
+    expect(wslUnlinkSync).toHaveBeenCalledWith(path.join(DB_DATA_DIR, 'tranlog1.dbf'));
+    expect(wslUnlinkSync).not.toHaveBeenCalledWith(path.join(DB_DATA_DIR, 'README.txt'));
     const yaml = vi.mocked(wslWriteFileSync).mock.calls[0][1];
     expect(yaml).toContain('baseExtent: "mydata.dbf"');
   });
@@ -101,8 +127,8 @@ describe('DatabaseManager.replaceExtent', () => {
     expect(ok).toBe(true);
     expect(vscode.window.showOpenDialog).not.toHaveBeenCalled();
     expect(wslImportFileSync).toHaveBeenCalledWith(
-      '/gs/bin/extent0.dbf',
-      '/root/db-1/data/extent0.dbf',
+      path.join('/gs', 'bin', 'extent0.dbf'),
+      path.join(DB_DATA_DIR, 'extent0.dbf'),
     );
     const yaml = vi.mocked(wslWriteFileSync).mock.calls[0][1];
     expect(yaml).toContain('baseExtent: "extent0.dbf"');
@@ -120,8 +146,8 @@ describe('DatabaseManager.replaceExtent', () => {
 
     expect(ok).toBe(true);
     expect(wslImportFileSync).toHaveBeenCalledWith(
-      '/seed/mydata.dbf',
-      '/root/db-1/data/extent0.dbf',
+      uriFsPath('/seed/mydata.dbf'),
+      path.join(DB_DATA_DIR, 'extent0.dbf'),
     );
   });
 
@@ -221,8 +247,8 @@ describe('DatabaseManager.createDatabaseDirect', () => {
     await makeCreateManager().createDatabaseDirect('3.7.4', 'extent0', 'gs64stone', 'gs64ldi');
 
     expect(wslCopyFileSync).toHaveBeenCalledWith(
-      '/gs/data/system.conf',
-      '/root/db-1/conf/default.conf',
+      path.join('/gs', 'data', 'system.conf'),
+      path.join('/root', 'db-1', 'conf', 'default.conf'),
     );
   });
 
@@ -231,7 +257,7 @@ describe('DatabaseManager.createDatabaseDirect', () => {
 
     const systemConf = vi
       .mocked(wslWriteFileSync)
-      .mock.calls.find((c) => String(c[0]).endsWith('conf/system.conf'))![1];
+      .mock.calls.find((c) => String(c[0]).endsWith(path.join('conf', 'system.conf')))![1];
     expect(systemConf).toContain('conf/default.conf');
   });
 
@@ -240,12 +266,14 @@ describe('DatabaseManager.createDatabaseDirect', () => {
 
     const gemConf = vi
       .mocked(wslWriteFileSync)
-      .mock.calls.find((c) => String(c[0]).endsWith('conf/gem.conf'))![1];
+      .mock.calls.find((c) => String(c[0]).endsWith(path.join('conf', 'gem.conf')))![1];
     expect(gemConf).toContain('GEM_TEMPOBJ_CACHE_SIZE = 500000;');
   });
 
   it('skips default.conf and still creates the database when the source is absent', async () => {
-    vi.mocked(wslExistsSync).mockImplementation((p: string) => p !== '/gs/data/system.conf');
+    vi.mocked(wslExistsSync).mockImplementation(
+      (p: string) => p !== path.join('/gs', 'data', 'system.conf'),
+    );
 
     const db = await makeCreateManager().createDatabaseDirect(
       '3.7.4',
@@ -255,8 +283,8 @@ describe('DatabaseManager.createDatabaseDirect', () => {
     );
 
     expect(wslCopyFileSync).not.toHaveBeenCalledWith(
-      '/gs/data/system.conf',
-      '/root/db-1/conf/default.conf',
+      path.join('/gs', 'data', 'system.conf'),
+      path.join('/root', 'db-1', 'conf', 'default.conf'),
     );
     expect(db.dirName).toBe('db-1');
   });

--- a/client/src/__tests__/databaseManager.test.ts
+++ b/client/src/__tests__/databaseManager.test.ts
@@ -19,6 +19,7 @@ import { DatabaseManager } from '../databaseManager';
 import { GemStoneDatabase } from '../sysadminTypes';
 import { SysadminStorage } from '../sysadminStorage';
 import { ProcessManager } from '../processManager';
+import { uriFsPath } from './support/uri';
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -57,29 +58,6 @@ function makeManager(overrides?: {
 /** Pick the QuickPick item at `index` (preserving object identity). */
 function pickItem(index: number): void {
   vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items) => (await items)[index]);
-}
-
-/**
- * Mirrors `vscode.Uri#fsPath`'s platform-dependent output, for building the
- * "expected" side of an assertion against a path that came from a
- * `vscode.Uri`'s `fsPath` getter rather than from `path.join`.
- *
- * @remarks
- * `Uri#fsPath` is a separate implementation from `path.join`. Both swap `/`
- * for `\` on Windows, but they are not interchangeable in general:
- * `fsPath` lowercases a leading drive letter and treats a leading `//` as
- * a network-share authority, neither of which `path.join`/`normalize`
- * does. Asserting against `path.join`'s output instead of this helper
- * would happen to match for simple inputs, recreating the same "two
- * different functions, hope they agree" risk this helper exists to
- * eliminate — call the exact getter production reads, not a lookalike, so
- * expected tracks actual by construction, not by luck.
- *
- * @param rawPath - The POSIX-style path passed to `vscode.Uri.file(...)` when building the mocked value.
- * @returns The value `.fsPath` returns for that URI on this platform.
- */
-function uriFsPath(rawPath: string): string {
-  return vscode.Uri.file(rawPath).fsPath;
 }
 
 describe('DatabaseManager.replaceExtent', () => {

--- a/client/src/__tests__/debuggerPanel.test.ts
+++ b/client/src/__tests__/debuggerPanel.test.ts
@@ -140,6 +140,7 @@ vi.mock('../browserQueries', () => ({
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { uriFsPath } from './support/uri';
 import * as debug from '../debugQueries';
 import * as queries from '../browserQueries';
 import {
@@ -918,7 +919,7 @@ describe('DebuggerPanel', () => {
       const opened = vi
         .mocked(vscode.workspace.openTextDocument)
         .mock.calls.at(-1)![0] as vscode.Uri;
-      expect(opened.fsPath).toBe('/Users/me/.jasper/stacks/x.txt');
+      expect(opened.fsPath).toBe(uriFsPath('/Users/me/.jasper/stacks/x.txt'));
       expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ preview: false }),

--- a/client/src/__tests__/extentBackupManager.test.ts
+++ b/client/src/__tests__/extentBackupManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
 
 vi.mock('vscode', () => import('../__mocks__/vscode.js'));
 
@@ -12,6 +13,7 @@ import {
 import type { ActiveSession } from '../sessionManager';
 import type { GemStoneSessionItem } from '../loginTreeProvider';
 import type { DatabaseNode } from '../databaseTreeProvider';
+import { uriFsPath } from './support/uri';
 
 // A fake GCI executor that answers each bracketing call by matching the emitted
 // Smalltalk. Override any response to drive a failure path.
@@ -50,16 +52,14 @@ function makeDeps(execute: QueryExecutor, over: Partial<ExtentBackupDeps> = {}):
 
 // The order index of the execute() call whose Smalltalk contains `needle`.
 function callOrder(execute: QueryExecutor, needle: string): number {
-  const spy = execute as unknown as {
-    mock: { calls: [string][]; invocationCallOrder: number[] };
-  };
+  const spy = vi.mocked(execute);
   const i = spy.mock.calls.findIndex(([code]) => code.includes(needle));
   return i === -1 ? -1 : spy.mock.invocationCallOrder[i];
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([{ fsPath: '/chosen' } as vscode.Uri]);
+  vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([vscode.Uri.file('/chosen')]);
 });
 
 describe('runOnlineExtentBackup', () => {
@@ -70,12 +70,21 @@ describe('runOnlineExtentBackup', () => {
     const ok = await runOnlineExtentBackup(deps);
 
     expect(ok).toBe(true);
-    expect(deps.copyFile).toHaveBeenCalledWith(
-      '/db/data/extent0.dbf',
-      expect.stringMatching(/\/chosen\/gs64stone_extents_[\d-]+_[\d-]+\/extent0\.dbf$/),
+    const copyFile = vi.mocked(deps.copyFile);
+    // copyFile takes exactly (src, dest) — toHaveBeenCalledWith used to
+    // enforce that implicitly; destructuring below doesn't, so check it here.
+    expect(copyFile.mock.calls[0]).toHaveLength(2);
+    const [src, dest] = copyFile.mock.calls[0];
+    expect(src).toBe(path.join('/db/data', 'extent0.dbf'));
+    // path.basename/dirname parse whatever separator path.join used to build
+    // `dest`, so decomposing it this way stays correct on every platform,
+    // unlike a regex with a hardcoded `/`, which only matches on POSIX.
+    expect(path.basename(dest)).toBe('extent0.dbf');
+    expect(path.basename(path.dirname(dest))).toMatch(
+      /^gs64stone_extents_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$/,
     );
-    const copyOrder = (deps.copyFile as unknown as { mock: { invocationCallOrder: number[] } }).mock
-      .invocationCallOrder[0];
+    expect(path.dirname(path.dirname(dest))).toBe(uriFsPath('/chosen'));
+    const copyOrder = copyFile.mock.invocationCallOrder[0];
     expect(callOrder(execute, 'suspendCheckpointsForMinutes')).toBeLessThan(copyOrder);
     expect(copyOrder).toBeLessThan(callOrder(execute, 'resumeCheckpoints'));
   });
@@ -161,10 +170,11 @@ describe('runOnlineExtentBackup', () => {
 
     expect(ok).toBe(true);
     expect(deps.copyFile).toHaveBeenCalledTimes(2);
-    const copied = (
-      deps.copyFile as unknown as { mock: { calls: [string, string][] } }
-    ).mock.calls.map(([src]) => src);
-    expect(copied).toEqual(['/db/data/extent0.dbf', '/db/data/extent1.dbf']);
+    const copied = vi.mocked(deps.copyFile).mock.calls.map(([src]) => src);
+    expect(copied).toEqual([
+      path.join('/db/data', 'extent0.dbf'),
+      path.join('/db/data', 'extent1.dbf'),
+    ]);
   });
 });
 

--- a/client/src/__tests__/rowanLoad.test.ts
+++ b/client/src/__tests__/rowanLoad.test.ts
@@ -36,7 +36,7 @@ describe('findRowanLoadSpecs', () => {
 
     expect(specs).toHaveLength(1);
     expect(specs[0].name).toBe('LoadMe');
-    expect(specs[0].path.endsWith('rowan/specs/LoadMe.ston')).toBe(true);
+    expect(specs[0].path.endsWith(path.join('rowan', 'specs', 'LoadMe.ston'))).toBe(true);
   });
 
   it('ignores .ston files that are not load specs', () => {

--- a/client/src/__tests__/rowanProjectView.test.ts
+++ b/client/src/__tests__/rowanProjectView.test.ts
@@ -13,6 +13,7 @@ import {
   RowanDependencyGroupItem,
 } from '../rowanProjectView';
 import { addProjectDependency } from '../rowanDependency';
+import { uriFsPath } from './support/uri';
 
 const dirs: string[] = [];
 
@@ -137,7 +138,9 @@ describe('RowanProjectTreeProvider', () => {
 
     const [row] = provider.getChildren(dependencyGroup(provider));
 
-    expect(row.resourceUri?.fsPath).toBe(path.join(dir, 'rowan', 'projects', 'SharedKit.ston'));
+    expect(row.resourceUri?.fsPath).toBe(
+      uriFsPath(path.join(dir, 'rowan', 'projects', 'SharedKit.ston')),
+    );
   });
 
   it('shows the revision a git dependency is pinned to', () => {

--- a/client/src/__tests__/seasideServer.test.ts
+++ b/client/src/__tests__/seasideServer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as child_process from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 
 vi.mock('vscode', () => import('../__mocks__/vscode.js'));
 import {
@@ -70,7 +71,7 @@ describe('Seaside server lifecycle', () => {
 
     expect(url).toBe(seasideUrl());
     const [cmd, args, opts] = vi.mocked(child_process.spawn).mock.calls[0];
-    expect(cmd).toBe('/gs/GemStone64Bit3.7.5-arm64.Darwin/bin/topaz');
+    expect(cmd).toBe(path.join('/gs/GemStone64Bit3.7.5-arm64.Darwin', 'bin', 'topaz'));
     expect(args).toEqual(['-l']);
     expect(opts?.detached).toBe(true);
   });

--- a/client/src/__tests__/support/uri.ts
+++ b/client/src/__tests__/support/uri.ts
@@ -1,0 +1,25 @@
+import { URI as Uri } from 'vscode-uri';
+
+/**
+ * Mirrors `vscode.Uri#fsPath`'s platform-dependent output, for building the
+ * "expected" side of an assertion against a path that came from a
+ * `vscode.Uri`'s `fsPath` getter rather than from `path.join`.
+ *
+ * @remarks
+ * `Uri#fsPath` is a separate implementation from `path.join`. Both swap `/`
+ * for `\` on Windows, but they are not interchangeable in general:
+ * `fsPath` lowercases a leading drive letter and treats a leading `//` as
+ * a network-share authority, neither of which `path.join`/`normalize`
+ * does. Asserting against `path.join`'s output instead of this helper
+ * would happen to match for simple inputs, recreating the same "two
+ * different functions, hope they agree" risk this helper exists to
+ * eliminate — call the exact getter production reads, not a lookalike, so
+ * expected tracks actual by construction, not by luck.
+ *
+ * @param rawPath - A filesystem path, in either separator style, passed to
+ * `vscode.Uri.file(...)` when building the mocked value.
+ * @returns The value `.fsPath` returns for that URI on this platform.
+ */
+export function uriFsPath(rawPath: string): string {
+  return Uri.file(rawPath).fsPath;
+}

--- a/client/src/__tests__/systemBrowser.test.ts
+++ b/client/src/__tests__/systemBrowser.test.ts
@@ -88,10 +88,29 @@ import { ClassBrowser } from '../classBrowser';
 import { CommentBrowser } from '../commentBrowser';
 import type { ActiveSession } from '../sessionManager';
 import type { ExportManager } from '../exportManager';
+import { uriFsPath } from './support/uri';
 
 // ── Helpers ──────────────────────────────────────────────────
 
 const SESSION_ROOT = path.join('/tmp', 'gemstone', 'localhost', 'gs64stone', 'DataCurator');
+
+/**
+ * The path a per-class file-out file lands at when writing "as many files",
+ * alongside the chosen loader file.
+ *
+ * @remarks
+ * `handleFileOutDictionaryMany` derives each class file's path with
+ * `path.join(path.dirname(uri.fsPath), file.fileName)` (systemBrowser.ts).
+ * Reproducing that same chain here, rather than a hardcoded literal, keeps
+ * the expected value correct on every platform's separator.
+ *
+ * @param loaderRawPath - The POSIX-style path passed to `vscode.Uri.file(...)` for the chosen loader file.
+ * @param fileName - The per-class file's name, e.g. `Object.gs`.
+ * @returns The path the per-class file is expected to be written to.
+ */
+function fileOutPath(loaderRawPath: string, fileName: string): string {
+  return path.join(path.dirname(uriFsPath(loaderRawPath)), fileName);
+}
 
 function makeSession(id = 1, label = 'test'): ActiveSession {
   return {
@@ -1516,7 +1535,11 @@ describe('SystemBrowser', () => {
       await vi.waitFor(() =>
         expect(queries.fileOutClass).toHaveBeenCalledWith(session, 'Array', 1),
       );
-      expect(fs.writeFileSync).toHaveBeenCalledWith('/out/Array.gs', '! Array file-out', 'utf8');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        uriFsPath('/out/Array.gs'),
+        '! Array file-out',
+        'utf8',
+      );
     });
 
     it('defaults a test class file name to its subject', async () => {
@@ -1555,16 +1578,24 @@ describe('SystemBrowser', () => {
 
       await vi.waitFor(() =>
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          '/out/Object.gs',
+          fileOutPath('/out/UserGlobals.gs', 'Object.gs'),
           '! Object file-out',
           'utf8',
         ),
       );
-      expect(fs.writeFileSync).toHaveBeenCalledWith('/out/Animal.gs', '! Animal file-out', 'utf8');
-      expect(fs.writeFileSync).toHaveBeenCalledWith('/out/Dog.gs', '! Dog file-out', 'utf8');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        fileOutPath('/out/UserGlobals.gs', 'Animal.gs'),
+        '! Animal file-out',
+        'utf8',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        fileOutPath('/out/UserGlobals.gs', 'Dog.gs'),
+        '! Dog file-out',
+        'utf8',
+      );
       const loader = vi
         .mocked(fs.writeFileSync)
-        .mock.calls.find((c) => c[0] === '/out/UserGlobals.gs')![1];
+        .mock.calls.find((c) => c[0] === uriFsPath('/out/UserGlobals.gs'))![1];
       expect(loader).toContain('input Object.gs\ninput Animal.gs\ninput Dog.gs\n');
     });
 
@@ -1581,14 +1612,14 @@ describe('SystemBrowser', () => {
 
       await vi.waitFor(() =>
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          '/out/UserGlobals.gs',
+          uriFsPath('/out/UserGlobals.gs'),
           expect.anything(),
           'utf8',
         ),
       );
       const loader = vi
         .mocked(fs.writeFileSync)
-        .mock.calls.find((c) => c[0] === '/out/UserGlobals.gs')![1] as string;
+        .mock.calls.find((c) => c[0] === uriFsPath('/out/UserGlobals.gs'))![1] as string;
       expect(loader).toContain("at: #'Dog' put: nil");
       expect(loader.indexOf('input Object.gs')).toBeGreaterThan(
         loader.indexOf("at: #'Dog' put: nil"),


### PR DESCRIPTION
## Summary
- Several test files compared a real `vscode.Uri#fsPath` value against a hardcoded forward-slash literal or a POSIX-only regex, which breaks on Windows: `fsPath` uses `\` separators and lowercases drive letters, neither of which `path.join`/raw string literals reproduce.
- Adds a shared `uriFsPath()` test helper (`client/src/__tests__/support/uri.ts`) that calls the real `Uri.file(...).fsPath` so expected values are built the same way production builds them, then fixes each affected assertion in `databaseManager`, `debuggerPanel`, `seasideServer`, `extentBackupManager`, `systemBrowser`, `rowanLoad`, and `rowanProjectView` tests.
- Along the way, `extentBackupManager.test.ts`'s mock-call assertions were switched from unsafe `as unknown as` casts to `vi.mocked()`, and an implicit argument-count check that got dropped when a `toHaveBeenCalledWith` was replaced by manual destructuring was restored explicitly.

## Test plan
- [x] `npx vitest run` passes for every touched test file (individually verified during review)
- [x] `npm run lint`, `npm run format:check`, and `npx tsc --noEmit` all clean on the changed files
- [x] Verified the restored arity check in `extentBackupManager.test.ts` actually fails against a deliberately broken (3-arg) `copyFile` call before confirming it passes against the real code

🤖 Generated with [Claude Code](https://claude.com/claude-code)