### PR TITLE
Run npm config get through a shell on Windows

### DIFF
--- a/scripts/lint-supply-chain.mjs
+++ b/scripts/lint-supply-chain.mjs
@@ -25,7 +25,7 @@
 //
 //   node scripts/lint-supply-chain.mjs
 
-import { execFileSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 // package.json's `allowScripts` is the single source of truth for the install-script
@@ -68,7 +68,7 @@ const REGISTRY_PREFIX = 'https://registry.npmjs.org/';
 // true/7/[] instead of 'true'/'7'/'' — which every comparison and message below would have to
 // re-stringify.) npm's own warnings go to stderr, so only key=value lines reach here.
 function getConfigs(keys) {
-  const output = execFileSync('npm', ['config', 'get', ...keys], { encoding: 'utf8' });
+  const output = execSync(`npm config get ${keys.join(' ')}`, { encoding: 'utf8' });
   const values = new Map();
 
   for (const line of output.split('\n')) {


### PR DESCRIPTION
## Summary
- `lint-supply-chain.mjs` called `execFileSync('npm', ...)` directly. On Windows, `npm` resolves to the `npm.cmd` shim, and `CreateProcess` (used without a shell) doesn't consult `PATHEXT`, so the call failed with `ENOENT` and took down all 25 tests in `lintSupplyChain.test.ts` on Windows CI.
- Routes the call through a shell instead, folding the config keys into a single command string (rather than a `shell: true` + args array) to avoid Node's `DEP0190` deprecation warning landing on stderr and breaking the "stderr is empty" assertions.

Verified against the [Windows Health Check workflow](https://github.com/GemTalk/Jasper/actions/runs/31515193946/job/93858478218): `lintSupplyChain.test.ts` now passes fully (25/25) on Windows. The two remaining failures in that run (`localVersion.test.ts`) are pre-existing and unrelated to this change.

## Test plan
- [x] `npx vitest run src/__tests__/lintSupplyChain.test.ts` — 25/25 passing locally
- [x] `npm run lint && npm run format:check && npm run compile && npm test` — all green
- [x] Confirmed fix on Windows via the Windows Health Check CI workflow