### PR TITLE
Fix Windows CI failures in VersionManager catalog tests

### DIFF
--- a/client/src/__tests__/localVersion.test.ts
+++ b/client/src/__tests__/localVersion.test.ts
@@ -360,7 +360,11 @@ describe('VersionManager.fetchAvailableVersions', () => {
   it('excludes remote versions older than the minimum supported gemstone version', async () => {
     const storage = new SysadminStorage();
     const manager = new VersionManager(storage);
-    const platformKey = storage.getPlatformKey();
+    // getCatalogPlatformKey, not getPlatformKey: production matches the
+    // catalog against the former, which falls back to 'x86_64.Linux' when
+    // there's no local server platform (e.g. Windows without WSL). Building
+    // the fixture with getPlatformKey would diverge from that on such hosts.
+    const platformKey = storage.getCatalogPlatformKey();
     const ext = storage.getDownloadExtension();
 
     const html = [
@@ -376,7 +380,11 @@ describe('VersionManager.fetchAvailableVersions', () => {
     expect(versions.map((v) => v.version)).toEqual(['3.7.0', '3.6.2']);
   });
 
-  it('keeps a local version even when it is older than 3.6.2', async () => {
+  // Gated on POSIX not for symlinks but because it needs hasLocalServer to be
+  // true, and this file's wslBridge mock makes getPlatformKey() undefined
+  // (so hasLocalServer is false) on Windows. Real Windows+WSL coverage is
+  // tracked in #413.
+  onSupportedPosixIt('keeps a local version even when it is older than 3.6.2', async () => {
     const storage = new SysadminStorage();
     const manager = new VersionManager(storage);
     const suffix = storage.getPlatformSuffix();

--- a/client/src/__tests__/sysadminStorage.test.ts
+++ b/client/src/__tests__/sysadminStorage.test.ts
@@ -49,4 +49,11 @@ describe('SysadminStorage.getPlatformKey on Darwin', () => {
       expect(new SysadminStorage().getCatalogPlatformKey()).toBe('i386.Darwin');
     });
   });
+
+  it('falls back to x86_64.Linux when there is no local server platform', () => {
+    withPlatform('win32', 'x64', () => {
+      expect(new SysadminStorage().getPlatformKey()).toBeUndefined();
+      expect(new SysadminStorage().getCatalogPlatformKey()).toBe('x86_64.Linux');
+    });
+  });
 });


### PR DESCRIPTION
## What

Two tests in `VersionManager.fetchAvailableVersions`'s describe block failed on Windows without WSL.

`excludes remote versions older than the minimum supported gemstone version` built its mock catalog HTML with `storage.getPlatformKey()`, which is `undefined` on Windows without WSL. Production (`versionManager.ts:22`) matches the catalog against `storage.getCatalogPlatformKey()` instead, which falls back to `x86_64.Linux` for exactly that case. Switching the test to the same method fixes it on every platform, with no gating needed.

`keeps a local version even when it is older than 3.6.2` genuinely needs a local server platform to exist (`hasLocalServer`), which this test file's `wslBridge` mock rules out on Windows. Gated it to POSIX with `onSupportedPosixIt`, matching its siblings in the same describe block. Real Windows+WSL coverage for that scenario is tracked in #413.

## Why

These were the last two Windows-only test failures found while validating Windows CI on top of #407.

## Test plan

- [x] `npm run lint && npm run format:check && npm run compile` pass
- [x] `localVersion.test.ts` passes locally (25/25)
- [x] Verified against a real Windows run of this exact diff, via the `windows-health-check.yml` workflow on a separate validation branch (that workflow isn't part of this PR): these were the only 2 failures remaining after #407's fixes, and both are now green there
