### PR TITLE
Make integration test sessions refuse commits outright

### DIFF
--- a/.claude/rules/client/tests.md
+++ b/.claude/rules/client/tests.md
@@ -44,6 +44,8 @@ Tests run in random order; the seed is printed at the top of the output. Reprodu
 
 Tests using `useIntegrationTest` require a live GemStone instance so plain `npm test` needs a running stone. Run `npm run test:server:start` once to provision one; it writes connection details to `.env.test` (which the user may override with `.env.test.local`). CI runs these as a matrix over `client/.gemstone-integration-releases.json`.
 
+See [integration-test-harness.md](../../../docs/reference/integration-test-harness.md) for the harness contract (hook order, `GciTestContext`, the commit invariant) and [integration-test-isolation.md](../../../docs/explanation/integration-test-isolation.md) for why it's built this way.
+
 GCI session/oop values are koffi `External` pointer wrappers with no enumerable properties, so vitest's deep equality (`toEqual`, and therefore `expect(spy).toHaveBeenCalledWith(someSession, ...)`) cannot tell two *different* sessions or oops apart — it treats any two of them as equal regardless of the underlying native pointer. To assert *which* session/oop a call received, pull the argument out of `spy.mock.calls` and compare with `toBe` (reference equality) instead.
 
 ### Choosing where a stone-dependent test lives
@@ -52,7 +54,7 @@ The **default home** is a `*.integration.test.ts` using `useIntegrationTest`, co
 
 The on-demand `client/src/__tests__/gci/` project **never runs in CI** (see `.claude/rules/client/gci.md`) and is being migrated away. Add a test there only when the harness genuinely cannot host it:
 
-- it must **commit** — the harness aborts every test, and an abort cannot undo a commit;
+- it must **commit** — every harness session is armed to refuse commits outright (`TransactionError 2249`), with no opt-out;
 - it needs **exclusive access to the stone**, or destroys and restores the whole repository;
 - it drives a **session lifecycle** beyond `login` / `logout` / `withTransientSession` (e.g. many logins with varying flags), or installs process-wide state once for a whole file;
 - it makes a **single blocking GCI call** that can outlast the CI budget and that vitest cannot interrupt, so a hang takes out the whole job;

--- a/.claude/rules/refactoring-tests.md
+++ b/.claude/rules/refactoring-tests.md
@@ -16,7 +16,8 @@ has an apply-path test.
 - **[GCI integration]** in `client/src/refactoring/__tests__/*.integration.test.ts` — drive apply
   through the client path end to end, gated with `requireServerPluginFeature`. This is the default
   home: it runs in CI over the whole release matrix. Only a scenario that must COMMIT belongs in the
-  on-demand `client/src/__tests__/gci/` project, since the integration harness aborts every test.
+  on-demand `client/src/__tests__/gci/` project, since every harness session is armed to refuse
+  commits outright (`TransactionError 2249`), with no opt-out.
 - Both boundaries: 3.6.2 **and** 3.7.5.
 
 ## What an apply test must assert

--- a/client/src/__tests__/gci/gciInstVar.e2e.test.ts
+++ b/client/src/__tests__/gci/gciInstVar.e2e.test.ts
@@ -31,12 +31,13 @@ import { parseStartPreview, parseApplyResult } from '../../refactoring/instVarRe
  * `GsInstVarRefactoring>>applyDeselected:options:migrate:deleteHistory:` calls
  * `commitStructuralThenMigrate:` once the structural apply has succeeded, whenever `migrate` or
  * `deleteHistory` is requested, because `migrateInstancesTo:` needs a clean transaction.
- * `useIntegrationTest` aborts after every test
- * to keep tests isolated, and an abort cannot undo a commit, so these can only move once the CI
- * migration settles a commit-and-compensate story for the harness (a transient session, or a
- * test that commits its own cleanup). That is a policy call about the harness's "never commit"
- * invariant, not a technical blocker. Note the discriminator is what the PRODUCTION code does,
- * not what the test does: a test that merely commits its own fixture belongs in the harness.
+ * `useIntegrationTest` arms GemStone's commit guard on every session it hands out, so a commit
+ * fails at the commit site with `TransactionError 2249`, with no opt-out. These can only move once
+ * the harness grows an opt-in commit strategy for tests that genuinely need to commit. That is a
+ * policy call about the harness's "never commit" invariant, not a technical blocker. Note the
+ * discriminator is what the PRODUCTION code does, not what the test does: a test that merely needs
+ * its own fixture belongs in the harness — the auto-abort rolls the fixture back, so it never
+ * needs to commit.
  *
  * Guarded on the refactoring engine being installed (the queries reference the in-stone
  * `GsInstVarRefactoring`); the tests skip, with a reason, otherwise. Each test is self-cleaning

--- a/client/src/__tests__/useIntegrationTest.integration.test.ts
+++ b/client/src/__tests__/useIntegrationTest.integration.test.ts
@@ -24,10 +24,7 @@ describe('integration test harness commit guard (integration)', () => {
     withTransientSession = testContext.withTransientSession;
   });
 
-  const commitGuardIsArmedOn = (aSession: unknown) =>
-    gci.executeAndRelease(aSession, 'System commitsDisabledUntilLogout', (oop) =>
-      gci.isTrueOop(oop),
-    );
+  const commitGuardIsArmedOn = (aSession: unknown) => gci.areCommitsDisabledUntilLogout(aSession);
 
   const commitOn = (aSession: unknown) => () =>
     gci.executeAndRelease(aSession, 'System commitTransaction', (oop) => gci.isTrueOop(oop));

--- a/client/src/__tests__/useIntegrationTest.integration.test.ts
+++ b/client/src/__tests__/useIntegrationTest.integration.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { GciLibrary } from '../gciLibrary';
+import { GciLibraryError } from '../gciLibraryError';
+import { COMMIT_GUARD_REASON, GciTestContext, useIntegrationTest } from './useIntegrationTest';
+
+/**
+ * The harness's own commit invariant: every session it hands out has GemStone's
+ * session-level commit guard armed, so nothing a test does can persist past the
+ * automatic abort. These tests exercise the guard the only way it can be
+ * exercised — by attempting a real commit and asserting GemStone refuses it.
+ */
+describe('integration test harness commit guard (integration)', () => {
+  let gci: GciLibrary;
+  let session: unknown;
+  let login: GciTestContext['login'];
+  let logout: GciTestContext['logout'];
+  let withTransientSession: GciTestContext['withTransientSession'];
+
+  useIntegrationTest((testContext) => {
+    gci = testContext.gciLibrary;
+    session = testContext.session;
+    login = testContext.login;
+    logout = testContext.logout;
+    withTransientSession = testContext.withTransientSession;
+  });
+
+  const commitGuardIsArmedOn = (aSession: unknown) =>
+    gci.executeAndRelease(aSession, 'System commitsDisabledUntilLogout', (oop) =>
+      gci.isTrueOop(oop),
+    );
+
+  const commitOn = (aSession: unknown) => () =>
+    gci.executeAndRelease(aSession, 'System commitTransaction', (oop) => gci.isTrueOop(oop));
+
+  // Asserts on GemStone's error number and on the harness's own reason, never on
+  // the prose around them: that wording is GemStone's and differs across the
+  // releases the integration matrix covers.
+  const expectRefusedByCommitGuard = (attemptCommit: () => unknown) => {
+    let refusal: unknown;
+    try {
+      attemptCommit();
+    } catch (error) {
+      refusal = error;
+    }
+
+    expect(refusal).toBeInstanceOf(GciLibraryError);
+    expect((refusal as Error).message).toMatch(/error 2249/);
+    expect((refusal as Error).message).toContain(COMMIT_GUARD_REASON);
+  };
+
+  it('reports commits as disabled for the rest of the session', () => {
+    expect(commitGuardIsArmedOn(session)).toBe(true);
+  });
+
+  it('refuses a commit attempted on the session handed to a test', () => {
+    expectRefusedByCommitGuard(commitOn(session));
+  });
+
+  it('refuses a commit issued through the GCI commit call directly', () => {
+    const { success, err } = gci.GciTsCommit(session);
+
+    expect(success).toBe(false);
+    expect(err.number).toBe(2249);
+    expect(err.message).toContain(COMMIT_GUARD_REASON);
+  });
+
+  it('refuses a commit attempted on a second, independent session', () => {
+    withTransientSession((transientSession) => {
+      expect(commitGuardIsArmedOn(transientSession)).toBe(true);
+      expectRefusedByCommitGuard(commitOn(transientSession));
+    });
+  });
+
+  it('refuses a commit on a session re-established part way through a test file', () => {
+    logout();
+    login();
+
+    expect(commitGuardIsArmedOn(session)).toBe(true);
+    expectRefusedByCommitGuard(commitOn(session));
+  });
+
+  it('leaves the session usable after a refused commit', () => {
+    expect(commitOn(session)).toThrow();
+
+    expect(gci.executeAndRelease(session, '3 + 4 = 7', (oop) => gci.isTrueOop(oop))).toBe(true);
+  });
+});

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -119,11 +119,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     try {
       // Checked before the cleanup below on purpose: if the commit guard is no longer armed, that means a test
       // committed and left the session dirty, so the cleanup below is not guaranteed to succeed. Bail out early
-      const commitGuardStillArmed = gciLibrary.executeAndRelease(
-        session,
-        'System commitsDisabledUntilLogout',
-        (oop) => gciLibrary.isTrueOop(oop),
-      );
+      const commitGuardStillArmed = gciLibrary.areCommitsDisabledUntilLogout(session);
 
       if (!commitGuardStillArmed) {
         throw new Error(
@@ -225,11 +221,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
   function armCommitGuard(aSession: unknown) {
     let armedNewly: boolean;
     try {
-      armedNewly = gciLibrary.executeAndRelease(
-        aSession,
-        `System disableCommitsWithReason: '${COMMIT_GUARD_REASON}'`,
-        (oop) => gciLibrary.isTrueOop(oop),
-      );
+      armedNewly = gciLibrary.disableCommitsUntilLogout(aSession, COMMIT_GUARD_REASON);
     } catch (error) {
       // `cause` keeps the original error — stack included — linked to this one, which
       // vitest prints under a "Caused by:" heading. Its message is also inlined here so

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -109,6 +109,20 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     if (!session) return;
 
     try {
+      // Checked before the cleanup below on purpose: if the commit guard is no longer armed, that means a test
+      // committed and left the session dirty, so the cleanup below is not guaranteed to succeed. Bail out early
+      const commitGuardStillArmed = gciLibrary.executeAndRelease(
+        session,
+        'System commitsDisabledUntilLogout',
+        (oop) => gciLibrary.isTrueOop(oop),
+      );
+
+      if (!commitGuardStillArmed) {
+        throw new Error(
+          `useIntegrationTest: the commit guard was no longer armed at the end of "${expect.getState().currentTestName}" — this is a harness bug, not a mid-test abort (the guard cannot be dropped). Failing the rest of this file since every remaining test would run against an unguarded session.`,
+        );
+      }
+
       gciLibrary.abortTransaction(session);
       gciLibrary.resetNonTransactionalSessionState(session);
     } catch (error) {
@@ -131,6 +145,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
       options?.user ?? process.env.VITE_GEMSTONE_USER!,
       process.env.VITE_GEMSTONE_PASSWORD!,
     );
+    armCommitGuard(session);
 
     callback({
       gciLibrary,
@@ -176,10 +191,65 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     );
 
     try {
+      armCommitGuard(transientSession);
       callback(transientSession);
     } finally {
       gciLibrary.logout(transientSession);
     }
+  }
+
+  /**
+   * Arms GemStone's own session-level commit guard, so any commit attempted by a
+   * test — or by the production code it exercises — fails at the commit site
+   * with TransactionError 2249 instead of leaking state past the harness's abort.
+   *
+   * Session-scoped and irreversible: there is no `enableCommits`, and the only
+   * exit is logout. That is why it is armed once per session here rather than
+   * per test, and why every session the harness creates must go through it.
+   *
+   * Deliberately strict: arming is required to be *this* harness's doing. If
+   * GemStone reports commits were already disabled -- by this user's profile,
+   * or by a stone that is mid-restore -- the commit invariant happens to hold,
+   * but it holds for a reason the harness did not establish and cannot vouch
+   * for. Rather than run a whole matrix pass under a guard it did not arm, the
+   * harness fails loudly so the environment gets explained.
+   */
+  function armCommitGuard(aSession: unknown) {
+    let armedNewly: boolean;
+    try {
+      armedNewly = gciLibrary.executeAndRelease(
+        aSession,
+        `System disableCommitsWithReason: 'jasper-test-harness: integration tests must not commit'`,
+        (oop) => gciLibrary.isTrueOop(oop),
+      );
+    } catch (error) {
+      // `cause` keeps the original error — stack included — linked to this one, which
+      // vitest prints under a "Caused by:" heading. Its message is also inlined here so
+      // the failure reads completely even through reporters that only show the message.
+      // A non-Error throw has no message, so it gets described by type and value rather
+      // than through JSON.stringify, which renders `undefined` for several such values.
+      const cause =
+        error instanceof Error
+          ? error.message
+          : `a non-Error value of type ${typeof error} was thrown (${String(error)})`;
+
+      throw new Error(
+        `useIntegrationTest: could not arm the "no commits allowed" guard on this session. Cause: ${cause}`,
+        { cause: error },
+      );
+    }
+
+    if (!armedNewly) {
+      throw new Error(
+        `useIntegrationTest: GemStone reports commits were already disabled on this fresh session, so the "no commits allowed" guard is not this harness's doing. This is an unexpected environment, and the harness refuses to run under a guard it did not arm. Usual causes: this user's UserProfile has "disableCommits" set, or the stone is mid-restore. Check the stone and the credentials in .env.test (or .env.test.local).`,
+      );
+    }
+
+    // Arming is a doit, so it caches the Utf8 class oop and leaves oops in the
+    // PureExportSet: a session would reach its first test already dirty, and
+    // arming would be observable by tests that assert otherwise. Resetting here
+    // hands every session over in the state a bare login leaves behind.
+    gciLibrary.resetNonTransactionalSessionState(aSession);
   }
 
   /**
@@ -203,7 +273,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
 
             If the environment is already set up, refer to the original error below for more details.
             -----------------------------------------------------------------------------------------
-           
+
             `;
 
       if (error instanceof Error) {

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -119,13 +119,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     try {
       // Checked before the cleanup below on purpose: if the commit guard is no longer armed, that means a test
       // committed and left the session dirty, so the cleanup below is not guaranteed to succeed. Bail out early
-      const commitGuardStillArmed = gciLibrary.areCommitsDisabledUntilLogout(session);
-
-      if (!commitGuardStillArmed) {
-        throw new Error(
-          `useIntegrationTest: the commit guard was no longer armed at the end of "${expect.getState().currentTestName}" — this is a harness bug, not a mid-test abort (the guard cannot be dropped). Failing the rest of this file since every remaining test would run against an unguarded session.`,
-        );
-      }
+      assertCommitGuardIsStillArmed(session);
 
       gciLibrary.abortTransaction(session);
       gciLibrary.resetNonTransactionalSessionState(session);
@@ -250,6 +244,19 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     // arming would be observable by tests that assert otherwise. Resetting here
     // hands every session over in the state a bare login leaves behind.
     gciLibrary.resetNonTransactionalSessionState(aSession);
+  }
+
+  /**
+   * Fails if the session's commit guard is no longer armed. GemStone gives no way
+   * to drop it short of logout, so a session that comes back unguarded means the
+   * harness itself misplaced the guard.
+   */
+  function assertCommitGuardIsStillArmed(aSession: unknown) {
+    if (gciLibrary.areCommitsDisabledUntilLogout(aSession)) return;
+
+    throw new Error(
+      `useIntegrationTest: the commit guard was no longer armed at the end of "${expect.getState().currentTestName}" — this is a harness bug, not a mid-test abort (the guard cannot be dropped). Failing the rest of this file since every remaining test would run against an unguarded session.`,
+    );
   }
 
   /**

--- a/client/src/__tests__/useIntegrationTest.ts
+++ b/client/src/__tests__/useIntegrationTest.ts
@@ -12,6 +12,14 @@ export type GciTestContext = {
 
 type UseIntegrationTestCallback = (testContext: GciTestContext) => void;
 
+/**
+ * Reason GemStone reports when it refuses a commit from a harness session. It
+ * names the harness so a refusal is traceable back to here rather than reading
+ * as an unrelated transaction error — assert against this constant instead of
+ * the surrounding message, whose wording varies by GemStone release.
+ */
+export const COMMIT_GUARD_REASON = 'jasper-test-harness: integration tests must not commit';
+
 /** Options accepted by a `GciTestContext`'s `login`. */
 type LoginOptions = {
   /** GemStone user to log in as. Defaults to `VITE_GEMSTONE_USER`; override to test login with different (e.g. invalid) credentials. */
@@ -219,7 +227,7 @@ export function useIntegrationTest(callback: UseIntegrationTestCallback) {
     try {
       armedNewly = gciLibrary.executeAndRelease(
         aSession,
-        `System disableCommitsWithReason: 'jasper-test-harness: integration tests must not commit'`,
+        `System disableCommitsWithReason: '${COMMIT_GUARD_REASON}'`,
         (oop) => gciLibrary.isTrueOop(oop),
       );
     } catch (error) {

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -2,6 +2,7 @@ import koffi from 'koffi';
 import * as path from 'path';
 import { OOP_FALSE, OOP_ILLEGAL, OOP_NIL, OOP_TRUE } from './gciConstants';
 import { GciLibraryError } from './gciLibraryError';
+import { escapeString } from './queries/util';
 
 // OopType is uint64_t in C; koffi maps this to BigInt in JS
 const OopType = 'uint64';
@@ -2146,6 +2147,40 @@ export class GciLibrary {
     const { success, err } = this.GciTsAbort(session);
 
     this.throwUnless(success, err);
+  }
+
+  /**
+   * Disables commits on `session` for the remainder of its lifetime, recording
+   * `reason` as the explanation GemStone reports when it refuses a commit
+   * (`TransactionError 2249`). Session-scoped and irreversible: there is no
+   * counterpart that re-enables commits, and the only exit is logout.
+   *
+   * @param session - The GemStone session to operate in.
+   * @param reason - Why commits are being disabled; surfaced in the refusal message.
+   * @returns Whether this call is the one that disabled commits — `false` means
+   *   they were already disabled.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public disableCommitsUntilLogout(session: unknown, reason: string) {
+    return this.executeAndRelease(
+      session,
+      `System disableCommitsWithReason: '${escapeString(reason)}'`,
+      (oop) => this.isTrueOop(oop),
+    );
+  }
+
+  /**
+   * Returns whether commits have been disabled on `session` for the remainder
+   * of its lifetime (see `System class >> disableCommitsWithReason:`). The flag
+   * is session-scoped and irreversible: the only exit is logout.
+   *
+   * @param session - The GemStone session to operate in.
+   * @throws {GciLibraryError} If the underlying GCI call fails.
+   */
+  public areCommitsDisabledUntilLogout(session: unknown) {
+    return this.executeAndRelease(session, 'System commitsDisabledUntilLogout', (oop) =>
+      this.isTrueOop(oop),
+    );
   }
 
   // ---------------------------------------------------------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,9 @@ New docs are organized by [Diátaxis](https://diataxis.fr/) category — `how-to
 
 - [npm supply-chain threat model](explanation/npm-supply-chain-threat-model.md) — the install-time execution threat these controls defend against, and why each is shaped the way it is.
 - [Why there are two browsers, and which one gets the work](explanation/system-browser-and-explorer.md) — the System Browser is frozen, the Explorer is where new features land; why "frozen" rather than deprecated or maintained, and the one gap still browser-only.
+- [Integration test isolation](explanation/integration-test-isolation.md) — why transaction-abort is the isolation mechanism for `useIntegrationTest`, and why the commit guard is armed per-session and irreversible.
 
 ## Reference
 
 - [npm supply-chain controls](reference/supply-chain-controls.md) — this repo's `.npmrc` keys, `allowScripts` verdicts, CI-only checks, and sunset conditions.
+- [Integration test harness](reference/integration-test-harness.md) — the `useIntegrationTest` `GciTestContext`, hook order, and the commit invariant.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ New docs are organized by [Diátaxis](https://diataxis.fr/) category — `how-to
 
 - [npm supply-chain threat model](explanation/npm-supply-chain-threat-model.md) — the install-time execution threat these controls defend against, and why each is shaped the way it is.
 - [Why there are two browsers, and which one gets the work](explanation/system-browser-and-explorer.md) — the System Browser is frozen, the Explorer is where new features land; why "frozen" rather than deprecated or maintained, and the one gap still browser-only.
+- [The four kinds of tests](explanation/test-tiers.md) — unit, integration, GCI, and acceptance: what each proves, what it needs, and the names that mislead.
 - [Integration test isolation](explanation/integration-test-isolation.md) — why transaction-abort is the isolation mechanism for `useIntegrationTest`, and why the commit guard is armed per-session and irreversible.
 
 ## Reference

--- a/docs/explanation/integration-test-isolation.md
+++ b/docs/explanation/integration-test-isolation.md
@@ -1,0 +1,19 @@
+# Integration test isolation
+
+Background for [the harness reference](../reference/integration-test-harness.md): why `useIntegrationTest` is shaped the way it is. Worth reading before touching the commit guard or adding a new escape hatch.
+
+## The setting
+
+Integration tests run against one shared GemStone stone. Test _files_ run in parallel Vitest workers, each with its own login. CI runs the suite twice per matrix cell — bare, then with the Jasper Server Plugin installed — resetting the extent between matrix _cells_, but **not** between those two passes within a cell. Anything that survives the bare pass is still there for the plugin pass.
+
+## Why transaction-abort is the isolation mechanism, and where it's weaker than it reads
+
+`useIntegrationTest` wraps every test in a transaction that is always aborted, so a test's database changes never leak into the next one — as long as nothing commits. Three things make that promise weaker than it sounds:
+
+1. **A commit promotes the session's entire transaction**, not just the change under test. One committing line inside an otherwise-unrelated test call promotes everything staged in that transaction.
+2. **Committed data is global and durable.** It's visible to every other worker against the shared stone, and to the second CI pass, until something explicitly cleans it up.
+3. **The invariant binds a session, not a test.** "Every test aborts" only holds if nothing in that test's session ever commits — including production code the test merely exercises. A single committing call anywhere in the session's lifetime breaks the guarantee for every test that shares it.
+
+## Why the guard is armed at the session level, and why it's irreversible
+
+The commit guard (`System disableCommitsWithReason:`) is armed once per session — in `login()` and in `withTransientSession()` — rather than per test, because the property it enforces ("this session never commits") is a session-level property, not a per-test one. There is no `enableCommits`; the only way out is `logout`. That's deliberate: a reversible guard would need to be re-armed after every operation that might have cleared it, which is exactly the kind of per-test bookkeeping the harness is trying to make unnecessary. Arming once, unconditionally, for the life of the session removes the whole category of "did we forget to re-arm" bugs.

--- a/docs/explanation/test-tiers.md
+++ b/docs/explanation/test-tiers.md
@@ -1,0 +1,90 @@
+# The four kinds of tests
+
+Jasper has four test tiers. They differ in what they can prove, what they need to run, and whether CI runs them at all. This page is the shared vocabulary: what each tier is called, what it means, and which one a new test belongs in.
+
+## At a glance
+
+| Tier            | What makes it one                                 | Run with                  | Needs a live stone? | Runs in CI?       |
+| --------------- | ------------------------------------------------- | ------------------------- | ------------------- | ----------------- |
+| **Unit**        | A Vitest test that needs no stone                 | `npm test`                | No                  | Yes               |
+| **Integration** | A client test that calls `useIntegrationTest`     | `npm test`                | **Yes**             | Yes — full matrix |
+| **GCI**         | Any test under `client/src/__tests__/gci/`        | `npm run test:gci`        | **Yes**             | **No** — legacy   |
+| **Acceptance**  | A `*.spec.ts` under `acceptance/tests/`           | `npm run test:acceptance` | Only some specs     | Not yet           |
+
+`npm test` runs the first two, in all three workspaces. Everything else is opt-in.
+
+## Unit tests
+
+Plain Vitest over `client/`, `server/`, and `mcp-server/`. They exercise TypeScript decisions in isolation: parser and formatter behavior in the LSP server, tree providers and command handlers in the client, tool registration in the MCP server.
+
+They never talk to GemStone. The `vscode` module is supplied by a manual mock (`client/src/__mocks__/vscode.ts`) that Vitest picks up automatically, and query builders are driven by a fake `QueryExecutor` returning canned strings. A unit test that would need a stone is, by definition, an integration test.
+
+This is the default tier: if a behavior can be proven without a stone, prove it here — it's the fastest feedback and the only tier with no external prerequisites.
+
+## Integration tests
+
+A test is an integration test because it calls `useIntegrationTest` — that's the whole definition. Such tests log into a **real GemStone stone** over the real GCI shared library — no mocks anywhere in the GCI path — and assert that our Smalltalk snippets, GCI calls, and refactorings actually do what we think against a live database.
+
+The harness wraps each test in a transaction it always aborts, and arms GemStone's commit guard on every session, so a test cannot leave anything behind. See [integration test isolation](integration-test-isolation.md) for why, and [the harness reference](../reference/integration-test-harness.md) for the contract.
+
+They are part of `npm test`. This is deliberate and has a consequence worth internalizing: **`npm test` fails, rather than skips, when no stone is reachable.** Provision one with `npm run test:server:start`.
+
+CI runs this tier the widest: a matrix over every GemStone release in `client/.gemstone-integration-releases.json`, and within each cell, twice — once against a bare stone, once after installing the Jasper Server Plugin.
+
+The convention is to name the file `*.integration.test.ts` and co-locate it in the `__tests__/` dir next to the code it exercises. Two separate things ride on that, and only one is a convention:
+
+- **The `__tests__/` dir is load-bearing.** The `default` project's glob is `src/**/__tests__/**/*.test.ts`, so a test placed anywhere else under `src/` is never collected — it doesn't fail, it silently never runs.
+- **The `.integration.` suffix is the courtesy.** Nothing enforces it; the harness works from any collected file. It makes the tier visible from a directory listing, so follow it — but read the name as a hint, not a guarantee.
+
+Grep for `useIntegrationTest` when you need the real list, and note it over-reports: a handful of files in the CI-excluded `gci/` directory call the harness too, so filter those out.
+
+## GCI tests
+
+The on-demand suite under `client/src/__tests__/gci/`, run with `npm run test:gci`. Historically this was where anything touching a live stone went, before the integration harness existed.
+
+**It is legacy and being retired.** It never runs in CI, so nothing it covers is actually protected on a push. The directory is closed: tests move out of it, not into it. The narrow set of cases that still genuinely belong there is enumerated in `.claude/rules/client/tests.md`.
+
+## Acceptance tests
+
+Playwright driving a **real VS Code window** with the extension loaded, under `acceptance/`. Where the other tiers call our API, these click the UI: the GemStone activity-bar item, the tree views, the command palette. They answer "does the feature work for a user", not "does this function return the right value".
+
+Slow and GUI-bound. macOS cannot run them headless — a local run flashes a window and steals focus — so the container path (`npm run test:acceptance:docker`) is the recommended one. A run also produces a storyboard: the suite rendered as an illustrated manual, screenshots paired with the steps that produced them. See [acceptance/README.md](../../acceptance/README.md).
+
+They are experimental and a work in progress. They are not wired into CI.
+
+## What the tests run inside
+
+The first three tiers run under **plain Node**, driven by Vitest. The extension they test does not: it runs inside **Electron's** Node, in a VS Code extension host, with the real `vscode` API supplied by the editor. That difference is the ceiling on what those tiers can prove.
+
+Three environments, then:
+
+- **Node** — the default for every Vitest test, unit through GCI. The `vscode` module doesn't exist here; a manual mock (`client/src/__mocks__/vscode.ts`) stands in for it. Integration and GCI tests do load the real native GCI library via koffi, so the GemStone side is genuine — but it's Node's process loading it, not Electron's.
+- **Node + jsdom** — opted into per file with a `// @vitest-environment jsdom` docblock, for the webview scripts that run in a real DOM in production. jsdom is not a browser and not Electron's renderer; it's a good enough DOM to unit-test script behavior.
+- **Electron + real VS Code** — acceptance specs only. The actual editor binary, the actual extension host, the actual `vscode` API.
+
+So a passing unit or integration suite says nothing about whether the extension **activates**, whether a command is registered where VS Code can find it, or whether the native library loads under Electron's ABI. Only the acceptance tier exercises the runtime users get, which is why "all green" and "it works when I launch it" are separate claims.
+
+## Names that mislead
+
+Four collisions that cost people time:
+
+- **`npm run test:server` vs `npm run test:server:start`.** The first runs the **LSP server workspace's** unit tests (no stone involved). The second starts the **GemStone test stone**. Two unrelated meanings of "server" that happen to share a prefix.
+- **"Integration" doesn't mean "several modules together."** Here it means exactly one thing: *runs against a live stone*. A test that wires up five client modules with no stone is still a unit test.
+- **"GCI test" is ambiguous — prefer "the `gci` suite" for the legacy one.** Plenty of *integration* tests exercise the GCI bindings (`client/src/gciLibrary/__tests__/*.integration.test.ts`), and those are the ones that run in CI. "The GCI suite" / `npm run test:gci` refers only to the legacy on-demand directory.
+- **`.test.ts` vs `.spec.ts`.** Vitest tiers use `.test.ts`; acceptance specs use `.spec.ts`. The suffix is what keeps Playwright's files out of Vitest's globs — and it's also why the repo-wide test conventions in `.claude/rules/tests.md` don't apply to acceptance specs, which follow Playwright's own idioms.
+
+One more piece of vocabulary: `client/vitest.config.ts` defines two Vitest **projects**, `default` and `gci`. `npm test` pins `--project default` (unit + integration); `npm run test:gci` pins `--project gci`. Both show up in the VS Code Testing panel, which is why they live in one config file.
+
+## Choosing a tier for a new test
+
+1. Can it be proven without a stone? → **unit test**.
+2. Does it need a live stone? → **integration test**, using `useIntegrationTest`, co-located with the code. This is the default for stone-dependent work, and a case that *can* be written this way MUST be. The detailed decision guide — including the reasons that look like justifications for the `gci` suite but aren't — is in `.claude/rules/client/tests.md`.
+3. Does it need to verify UI/DOM behavior? → **unit jsdom test**.
+4. **GCI suite**: no. Add nothing here without checking the closed-directory rules first.
+
+## See also
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — provisioning a test stone, pointing tests at your own stone, reproducing a shuffled run via `VITEST_SEED`.
+- [Integration test harness](../reference/integration-test-harness.md) — `GciTestContext`, hook order, the commit invariant.
+- [Integration test isolation](integration-test-isolation.md) — why transaction-abort, and why the commit guard is irreversible.
+- [acceptance/README.md](../../acceptance/README.md) — running acceptance specs locally vs. containerised.

--- a/docs/reference/integration-test-harness.md
+++ b/docs/reference/integration-test-harness.md
@@ -1,0 +1,60 @@
+# Integration test harness (`useIntegrationTest`)
+
+Lookup for someone about to write a stone-dependent test. See [integration test isolation](../explanation/integration-test-isolation.md) for why the harness is shaped this way.
+
+## What it provides
+
+Call `useIntegrationTest(callback)` at the top of a `describe` block. The `callback` receives a `GciTestContext`:
+
+| Field                            | What it is                                                                                                              |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `gciLibrary`                     | The loaded `GciLibrary` instance for this suite.                                                                        |
+| `session`                        | The current session — an opaque koffi handle. Do not compare it with `toEqual` (see "Failure modes" below); use `toBe`. |
+| `login(options?)`                | Logs in again, optionally as a different `user`. Re-invokes `callback` with the fresh context.                          |
+| `logout()`                       | Logs out the current session and clears it. Returns the now-invalid session handle.                                     |
+| `withTransientSession(callback)` | Runs `callback` against a second, independent session, then always logs it out.                                         |
+
+The `callback` fires once **per login**, not once per file: at the end of `beforeAll`, and again any time a test calls `login()` (including the automatic re-login after a test calls `logout()`). Capture the fields you need into variables your tests read, and expect those variables to be reassigned across a file that logs in more than once.
+
+## Hook order
+
+| Hook         | Does, in order                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `beforeAll`  | Set `GEMSTONE_GLOBAL_DIR` → load the GCI library → login → **arm the commit guard** → `resetNonTransactionalSessionState` → fire `callback` |
+| `beforeEach` | Poison check (fail fast if a previous test's cleanup failed) → auto re-login if a prior test called `logout()` → `beginTransaction`         |
+| `afterEach`  | **assert the commit guard is still armed** → `abortTransaction` → `resetNonTransactionalSessionState`                                       |
+| `afterAll`   | logout → close the library → restore `GEMSTONE_GLOBAL_DIR`                                                                                  |
+
+## `login({ user })` and `withTransientSession`
+
+Use `login({ user: 'SystemUser' })` to re-authenticate as a different identity on the _same_ shared session — this re-fires `callback`.
+
+Use `withTransientSession` when a test needs a second, independent session (e.g. to verify one session's cache doesn't leak into another's). It does **not**:
+
+- accept a `user` override — it always logs in as the harness's default user;
+- touch the shared `session` the harness manages;
+- re-fire `callback`.
+
+## The commit invariant
+
+Every session the harness creates — the shared one and any `withTransientSession` one — is armed with GemStone's own commit guard before it is handed to a test. A commit attempted by a test, or by the production code it exercises, fails at the commit site with `TransactionError 2249`, naming the harness in the error. There is currently **no opt-out** for those sessions: a test cannot commit on a session the harness handed it.
+
+The guard is session-scoped, so it binds only the sessions the harness creates. Anything that reaches the stone through a session of its own is unarmed and _can_ commit to the shared stone. A test that spawns one owns the cleanup itself; the harness's transaction-abort cannot reach it.
+
+Arming must be the harness's own doing. GemStone reports whether the call was the one that disabled commits, and the harness treats "they were already disabled" as a hard failure — by that point the invariant technically holds, but for a reason the harness did not establish (a `UserProfile` with `disableCommits`, a stone mid-restore). That is intentional: a whole matrix pass running under a guard the harness didn't arm is worse than a loud stop that makes the environment explain itself.
+
+### Escape hatches
+
+Not yet available. A future phase adds an opt-in mechanism (`commitStrategy`) for tests that genuinely need to commit; this section will describe it once it exists.
+
+## Failure modes you'll actually hit
+
+- **The setup banner**: if no stone is reachable, `beforeAll` fails with a banner pointing at `npm run test:server:start`, prepended to the underlying login/library-load error.
+- **`sessionCleanupFailed` poisoning the file**: if `afterEach` cleanup fails — including the commit-guard-still-armed check — every remaining test in that file fails fast in `beforeEach` rather than running against a session in an unknown state. Look at the _first_ failure in the file; it's the real one.
+- **Session/oop identity**: `session` and any oop values are koffi pointer wrappers with no enumerable properties. `toEqual` treats any two of them as equal regardless of the underlying native pointer — compare with `toBe` when the assertion is about _which_ session or oop a call received.
+
+## Running it
+
+- `npm run test:server:start` / `:list` / `:stop` — provision, inspect, and tear down the test stone.
+- `npx vitest run <file>` from `client/` — run a single integration test file.
+- CI runs the suite twice per matrix cell: once against a bare stone, once after installing the Jasper Server Plugin. See `.claude/rules/client/tests.md` for gating a test to one pass.


### PR DESCRIPTION
## What

Groundwork for the next slice of the GCI-suite migration: making the integration harness's isolation promise real, and writing down the test tiers it belongs to.

**The guard.** `useIntegrationTest` wraps every test in a transaction it always aborts — but an abort cannot undo a commit, so the promise only held as long as nothing (test, or production code the test exercises) committed. Every session the harness creates now arms GemStone's own session-level commit guard (`System disableCommitsWithReason:`) before handing it to a test, so a commit fails at the commit site with `TransactionError 2249` naming the harness, instead of silently leaking state into the next test, the parallel workers sharing the stone, and the second CI pass within a matrix cell.

- Armed in `login()` **and** in `withTransientSession()` — the latter previously went straight through `gciLibrary.login` without arming anything.
- Session-scoped and irreversible: there is no `enableCommits`, the only exit is `logout`. That's why it's armed once per session rather than per test.
- Arming is required to be *this harness's* doing. GemStone reports whether the call is what disabled commits; "they were already disabled" is a hard failure, because at that point the invariant holds for a reason the harness didn't establish and can't vouch for (a `UserProfile` with `disableCommits`, a stone mid-restore). A loud stop beats a whole matrix pass under a guard we didn't arm.
- `afterEach` asserts the guard is still armed *before* cleaning up, and treats a dropped guard as a harness bug that poisons the rest of the file — cleanup isn't trustworthy on a session that managed to commit.
- Arming is a doit, so it caches an oop and dirties the `PureExportSet`; `resetNonTransactionalSessionState` runs right after, so every session is handed over in the state a bare login leaves behind.

**The tests.** A new `useIntegrationTest.integration.test.ts` covers the invariant the only way it can be covered — by attempting real commits and asserting GemStone refuses them: on the shared session, through `GciTsCommit` directly, on a `withTransientSession` session, on a session re-established mid-file via `logout()`/`login()`, and that the session stays usable after a refusal. Assertions are on error number `2249` and the exported `COMMIT_GUARD_REASON`, never on GemStone's prose, which varies across the releases in the integration matrix.

**The docs.** Three new pages, indexed in `docs/README.md`:

- `reference/integration-test-harness.md` — the `GciTestContext`, hook order, the commit invariant, the failure modes you'll actually hit.
- `explanation/integration-test-isolation.md` — why transaction-abort is the isolation mechanism, where it's weaker than it reads, why the guard is session-level and irreversible.
- `explanation/test-tiers.md` — unit / integration / GCI / acceptance: what each proves, what it needs, what CI runs, what each runs *inside* (Node vs jsdom vs Electron), and the four name collisions that keep costing people time (`test:server` vs `test:server:start`, "integration" ≠ "several modules", "GCI test" vs the legacy `gci` suite, `.test.ts` vs `.spec.ts`).

`.claude/rules/client/tests.md` now points at those pages, and its "must commit" escape-to-the-`gci`-suite reason is restated as what it now is: harness sessions refuse commits outright, with no opt-out.

## Why

Tests keep moving out of the on-demand `gci/` suite (#326, #334, #344) into the CI integration suite. That's only safe if the integration harness actually isolates — and its central promise had a hole big enough that "it must commit" was a legitimate reason to leave a test behind in a directory CI never runs. Closing the hole first, before the next batch of migrations, makes the remaining escape hatches genuinely narrow. The opt-in `commitStrategy` for tests that truly need to commit lands in a later phase; the reference doc marks the spot.

## Test plan

- [x] `npm run lint && npm run format:check && npm run compile` pass
- [x] `npm test` passes against a live stone, including the new harness suite
- [x] Guard verified positively, not just by "tests still pass": each commit path is asserted to be refused with `2249` + the harness reason
