### PR TITLE
Fix installer and refactoring-test paths on Windows+WSL

### DIFF
--- a/client/src/enhancedInspector/__tests__/enhancedInspectorInstall.test.ts
+++ b/client/src/enhancedInspector/__tests__/enhancedInspectorInstall.test.ts
@@ -8,8 +8,13 @@ vi.mock('../../browserQueries', () => ({
   executeFetchString: vi.fn(),
 }));
 
+vi.mock('../../wslBridge', () => ({
+  needsWsl: vi.fn(() => false),
+}));
+
 import { ActiveSession } from '../../sessionManager';
 import { executeFetchString } from '../../browserQueries';
+import { needsWsl } from '../../wslBridge';
 import {
   installEnhancedInspectorSupport,
   isEnhancedInspectorInstalled,
@@ -180,6 +185,24 @@ describe('installEnhancedInspectorSupport', () => {
     expect(result.message).toContain('GsEnhancedInspector');
     expect(commit).not.toHaveBeenCalled();
     expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('translates a Windows-style payload path to its WSL mount before it reaches the gem', async () => {
+    vi.mocked(needsWsl).mockReturnValueOnce(true);
+    const { session } = createMockSession();
+
+    await installEnhancedInspectorSupport(
+      session,
+      'D:\\a\\Jasper\\Jasper\\resources\\enhancedInspector',
+    );
+
+    const fileInCode = String(
+      executeFetchStringMock.mock.calls.find((c) =>
+        String(c[1]).includes('GsFileIn fromPath'),
+      )?.[1],
+    );
+    expect(fileInCode).toContain('/mnt/d/a/Jasper/Jasper/resources/enhancedInspector');
+    expect(fileInCode).not.toContain('D:\\');
   });
 
   it('files the payload in the loader dependency order', async () => {

--- a/client/src/enhancedInspector/enhancedInspectorInstall.ts
+++ b/client/src/enhancedInspector/enhancedInspectorInstall.ts
@@ -33,6 +33,7 @@ import {
   gsStringLiteral,
   messageOf,
   safeAbort,
+  toLocalGemPath,
   yieldToEventLoop,
 } from '../serverPlugin/installHelpers';
 
@@ -208,8 +209,10 @@ export function isEnhancedInspectorInstalled(session: ActiveSession): boolean {
  * partial is committed. On success the work is committed and verified.
  *
  * @param session     a session with write access to kernel classes (SystemUser).
- * @param payloadDir  absolute path to the directory holding the `.gs` files,
- *                    readable by the gem (a local stone).
+ * @param payloadDir  absolute client-side path to the directory holding the
+ *                    `.gs` files; translated to the gem's local path (see
+ *                    `toLocalGemPath`) before use, so callers must pass it
+ *                    untranslated.
  * @param onProgress  optional incremental progress callback.
  */
 export async function installEnhancedInspectorSupport(
@@ -217,8 +220,9 @@ export async function installEnhancedInspectorSupport(
   payloadDir: string,
   onProgress: ProgressReporter = () => {},
 ): Promise<InstallResult> {
-  const sep = payloadDir.endsWith('/') ? '' : '/';
-  const serverPath = (file: string): string => `${payloadDir}${sep}${file}`;
+  const gemPayloadDir = toLocalGemPath(payloadDir);
+  const sep = gemPayloadDir.endsWith('/') ? '' : '/';
+  const serverPath = (file: string): string => `${gemPayloadDir}${sep}${file}`;
   // The prepare-dictionary step + 7 files + the commit step.
   const stepIncrement = 100 / (ENHANCED_INSPECTOR_FILES.length + 2);
 
@@ -233,7 +237,7 @@ export async function installEnhancedInspectorSupport(
       filedIn: [],
       message:
         `The database's gem cannot read the payload files (${unreadable.join(', ')}) under ` +
-        `${payloadDir}. Server-side install requires a local stone whose gem shares this ` +
+        `${gemPayloadDir}. Server-side install requires a local stone whose gem shares this ` +
         'filesystem.',
     };
   }

--- a/client/src/refactoring/__tests__/refactoringChangeSignature.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringChangeSignature.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeChangeSignature,
   startChangeSignaturePreview,
@@ -16,6 +14,7 @@ import { parseAnalysis, parseStartPreview, parseApplyResult } from '../changeSig
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the change-method-signature (M5) refactoring —
@@ -54,14 +53,6 @@ describe('change method signature (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsChangeSignatureRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const BASE = 'CSigItBase';
   const WHOLE = { kind: 'wholeSystem' } as const;
@@ -109,7 +100,7 @@ describe('change method signature (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsChangeSignatureRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringClass.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringClass.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import { startRenameClassPreview, applyRenameClass } from '../queries/previewRenameClass';
 import { PREVIEW_PAGE_BYTES } from '../queries/previewRenameMethod';
 import { parseStartPreview, parseApplyResult } from '../renameClassPreview';
@@ -14,6 +12,7 @@ import type { ActiveSession } from '../../sessionManager';
 import { testActiveSession } from '../../__tests__/testActiveSession';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration tests for the rename-class (R3) refactoring and the
@@ -49,14 +48,6 @@ describe('rename class + class history (integration)', () => {
       "(System myUserProfile symbolList objectNamed: 'GsRenameClassRefactoring') notNil printString",
     ).trim() === 'true';
 
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
-
   it('reports rename-class engine availability matching the shared refactoring probe', () => {
     expect(rbEnginePresent()).toBe(q.checkRefactoringSupportAvailable(session()));
   });
@@ -65,7 +56,7 @@ describe('rename class + class history (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| failuresAndErrors |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 failuresAndErrors := 0.
 #(#GsRenameClassRefactoringTest #GsClassHistoryTest)
   do: [:nm | | r |

--- a/client/src/refactoring/__tests__/refactoringClassVariable.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringClassVariable.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import { startRenameClassVarPreview, applyRenameClassVar } from '../queries/previewRenameClassVar';
 import { PREVIEW_PAGE_BYTES } from '../queries/previewRenameMethod';
 import { parseStartPreview, parseApplyResult } from '../renameClassVarPreview';
@@ -13,6 +11,7 @@ import type { ActiveSession } from '../../sessionManager';
 import { testActiveSession } from '../../__tests__/testActiveSession';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the rename-class-variable (R4) refactoring,
@@ -46,14 +45,6 @@ describe('rename class variable (integration)', () => {
     exec(
       "(System myUserProfile symbolList objectNamed: 'GsRenameClassVariableRefactoring') notNil printString",
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const dictIndexOf = (name: string): number =>
     parseInt(
@@ -123,7 +114,7 @@ describe('rename class variable (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsRenameClassVariableRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringExtractMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringExtractMethod.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeExtractSelection,
   startExtractMethodPreview,
@@ -15,6 +13,7 @@ import { PREVIEW_PAGE_BYTES } from '../queries/previewRenameMethod';
 import { parseAnalysis, parseStartPreview, parseApplyResult } from '../extractMethodPreview';
 import type { ActiveSession } from '../../sessionManager';
 import { testActiveSession } from '../../__tests__/testActiveSession';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the extract-method (M1) refactoring, over the
@@ -46,14 +45,6 @@ describe('extract method (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsExtractMethodRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const dictIndexOf = (name: string): number =>
     parseInt(
@@ -96,7 +87,7 @@ describe('extract method (integration)', () => {
     if (!enginePresent()) ctx.skip('refactoring engine not loaded in this stone');
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsExtractMethodRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringExtractSuperclass.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringExtractSuperclass.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeExtractSuperclass,
   candidatesForExtractSuperclass,
@@ -22,6 +20,7 @@ import {
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the insert-superclass (V6) / extract-superclass (V7)
@@ -56,14 +55,6 @@ describe('extract superclass (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsExtractSuperclassRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const ANIMAL = 'EsItAnimal';
   const DOG = 'EsItDog';
@@ -110,7 +101,7 @@ describe('extract superclass (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsExtractSuperclassRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringExtractTemporary.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringExtractTemporary.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeExtractTemporary,
   startExtractTemporaryPreview,
@@ -16,6 +14,7 @@ import { parseAnalysis, parseStartPreview, parseApplyResult } from '../extractTe
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the extract-temporary (M3) refactoring, over the
@@ -49,14 +48,6 @@ describe('extract temporary (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsExtractTemporaryRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const dictIndexOf = (name: string): number =>
     parseInt(
@@ -99,7 +90,7 @@ describe('extract temporary (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsExtractTemporaryRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringInlineMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInlineMethod.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeInlineSend,
   startInlineMethodPreview,
@@ -15,6 +13,7 @@ import { PREVIEW_PAGE_BYTES } from '../queries/previewRenameMethod';
 import { parseAnalysis, parseStartPreview, parseApplyResult } from '../inlineMethodPreview';
 import type { ActiveSession } from '../../sessionManager';
 import { testActiveSession } from '../../__tests__/testActiveSession';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the inline-method (M2) refactoring, over the
@@ -47,14 +46,6 @@ describe('inline method (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsInlineMethodRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const dictIndexOf = (name: string): number =>
     parseInt(
@@ -100,7 +91,7 @@ describe('inline method (integration)', () => {
     if (!enginePresent()) ctx.skip('refactoring engine not loaded in this stone');
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsInlineMethodRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringInlineTemporary.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInlineTemporary.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeInlineTemporary,
   startInlineTemporaryPreview,
@@ -16,6 +14,7 @@ import { parseAnalysis, parseStartPreview, parseApplyResult } from '../inlineTem
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the inline-temporary (M4) refactoring, over the
@@ -49,14 +48,6 @@ describe('inline temporary (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsInlineTemporaryRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const dictIndexOf = (name: string): number =>
     parseInt(
@@ -96,7 +87,7 @@ describe('inline temporary (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsInlineTemporaryRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInstVar.integration.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import { analyzeInstVar, startInstVarPreview, applyInstVar } from '../queries/previewInstVar';
 import { PREVIEW_PAGE_BYTES } from '../queries/previewRenameMethod';
 import { parseAnalysis, parseStartPreview, parseApplyResult } from '../instVarRefactorPreview';
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the add / remove instance-variable (V1) refactoring,
@@ -50,14 +49,6 @@ describe('add / remove instance variable (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsInstVarRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const userIndex = (): number =>
     parseInt(
@@ -103,7 +94,7 @@ describe('add / remove instance variable (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsInstVarRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringInstVarStructure.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInstVarStructure.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeInstVarStructure,
   startInstVarStructurePreview,
@@ -17,6 +15,7 @@ import { parseAnalysis, parseStartPreview, parseApplyResult } from '../instVarSt
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the instance-variable structure refactorings (V2
@@ -49,14 +48,6 @@ describe('instance-variable structure (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsInstVarStructureRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const BASE = 'VsItBase';
   const MID = 'VsItMid';
@@ -143,7 +134,7 @@ describe('instance-variable structure (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsInstVarStructureRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringInstall.test.ts
+++ b/client/src/refactoring/__tests__/refactoringInstall.test.ts
@@ -5,8 +5,13 @@ vi.mock('../../browserQueries', () => ({
   checkRefactoringSupportAvailable: vi.fn(),
 }));
 
+vi.mock('../../wslBridge', () => ({
+  needsWsl: vi.fn(() => false),
+}));
+
 import { ActiveSession } from '../../sessionManager';
 import { executeFetchString, checkRefactoringSupportAvailable } from '../../browserQueries';
+import { needsWsl } from '../../wslBridge';
 import {
   installRefactoringSupport,
   isRefactoringSupportInstalled,
@@ -149,6 +154,29 @@ describe('installRefactoringSupport', () => {
       String(c[1]).includes('loadFromServerDir'),
     );
     expect(ranLoader).toBe(false);
+  });
+
+  it('translates a Windows-style payload path to its WSL mount before it reaches the gem', async () => {
+    vi.mocked(needsWsl).mockReturnValueOnce(true);
+    const { session } = createMockSession();
+
+    await installRefactoringSupport(session, 'D:\\a\\Jasper\\Jasper\\resources\\refactoring');
+
+    const loaderCode = String(
+      executeFetchStringMock.mock.calls.find((c) =>
+        String(c[1]).includes('loadFromServerDir'),
+      )?.[1],
+    );
+    expect(loaderCode).toContain('/mnt/d/a/Jasper/Jasper/resources/refactoring');
+    expect(loaderCode).not.toContain('D:\\');
+
+    const fileInCode = String(
+      executeFetchStringMock.mock.calls.find((c) => String(c[1]).includes('GsFileIn'))?.[1],
+    );
+    expect(fileInCode).toContain(
+      '/mnt/d/a/Jasper/Jasper/resources/refactoring/refactoring-loader.gs',
+    );
+    expect(fileInCode).not.toContain('D:\\');
   });
 
   it('rolls back and reports failure when the loader file-in raises', async () => {

--- a/client/src/refactoring/__tests__/refactoringMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringMethod.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   startRenameMethodPreview,
   pageRenameMethodPreview,
@@ -17,6 +15,7 @@ import type { ActiveSession } from '../../sessionManager';
 import { testActiveSession } from '../../__tests__/testActiveSession';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration tests for the rename-method (R2) refactoring, over
@@ -55,9 +54,6 @@ describe('rename method (integration)', () => {
       "(System myUserProfile symbolList objectNamed: 'GsRenameMethodRefactoring') notNil printString",
     ).trim() === 'true';
 
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
   it('reports rename-method engine availability matching the ivar engine probe', () => {
     expect(rbEnginePresent()).toBe(q.checkRefactoringSupportAvailable(session()));
   });
@@ -67,10 +63,8 @@ describe('rename method (integration)', () => {
 
     // File in the test classes (in-image compile — robust) then run every engine
     // suite, answering the total failure+error count across all of them.
-    const p = escapeString(engineTestsPayload());
-    const code = `| p failuresAndErrors |
-p := '${p}'.
-[GsFileIn fromServerPath: p] on: Error do: [:e | GsFileIn fromPath: p on: #serverUtf8File to: nil].
+    const code = `| failuresAndErrors |
+${fileInEngineTestsExpr()}
 failuresAndErrors := 0.
 #(#GsRenameMethodRefactoringTest #GsRenameInstanceVariableRefactoringTest #GsRefactoringEnvironmentTest #GsRefactoringChangeSetTest)
   do: [:nm | | r |
@@ -84,12 +78,10 @@ failuresAndErrors printString`;
   it('runs the rename-method suite alone and reports its test count', (ctx) => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
-    const p = escapeString(engineTestsPayload());
     // The class isn't defined at this doit's compile time (it is filed in at run
     // time), so resolve it via objectNamed: rather than as a bareword.
-    const code = `| p r |
-p := '${p}'.
-[GsFileIn fromServerPath: p] on: Error do: [:e | GsFileIn fromPath: p on: #serverUtf8File to: nil].
+    const code = `| r |
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsRenameMethodRefactoringTest) suite run.
 r runCount printString, ' ', (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringMoveMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringMoveMethod.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzeMoveMethod,
   startMoveMethodPreview,
@@ -16,6 +14,7 @@ import { parseAnalysis, parseStartPreview, parseApplyResult } from '../moveMetho
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the move-method (M6) refactoring, over the real
@@ -50,14 +49,6 @@ describe('move method (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsMoveMethodRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const dictIndexOf = (name: string): number =>
     parseInt(
@@ -100,7 +91,7 @@ describe('move method (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsMoveMethodRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringPushMethod.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringPushMethod.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   analyzePushMethod,
   startPushMethodPreview,
@@ -16,6 +14,7 @@ import { parseAnalysis, parseStartPreview, parseApplyResult } from '../pushMetho
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the push-up / push-down method (M7 / M8)
@@ -51,14 +50,6 @@ describe('push method up/down (integration)', () => {
       '((System myUserProfile symbolList objectNamed: #GsPushUpMethodRefactoring) notNil and: ' +
         '[(System myUserProfile symbolList objectNamed: #GsPushDownMethodRefactoring) notNil]) printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const BASE = 'PumItBase';
   const SUBA = 'PumItA';
@@ -114,7 +105,7 @@ describe('push method up/down (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsPushUpMethodRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 
@@ -125,7 +116,7 @@ r := (System myUserProfile symbolList objectNamed: #GsPushUpMethodRefactoringTes
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsPushDownMethodRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringSplitClass.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringSplitClass.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   candidatesForSplitClass,
   analyzeSplitClass,
@@ -24,6 +22,7 @@ import {
 import type { ActiveSession } from '../../sessionManager';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the split-class (V8 / extract class) refactoring, over the real
@@ -59,14 +58,6 @@ describe('split class (integration)', () => {
     exec(
       '(System myUserProfile symbolList objectNamed: #GsSplitClassRefactoring) notNil printString',
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   // A cohesive Contact whose address ivars (street/city/zip) and the methods that use them are a
   // clean extract set; name/email + their readers stay behind, and a subclass adds `tier` without
@@ -125,7 +116,7 @@ describe('split class (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsSplitClassRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/refactoringTemporary.integration.test.ts
+++ b/client/src/refactoring/__tests__/refactoringTemporary.integration.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as path from 'path';
 vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
 
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 import { GciLibrary } from '../../gciLibrary';
 import * as q from '../../browserQueries';
-import { escapeString } from '../../queries/util';
 import {
   startRenameTemporaryPreview,
   applyRenameTemporary,
@@ -16,6 +14,7 @@ import type { ActiveSession } from '../../sessionManager';
 import { testActiveSession } from '../../__tests__/testActiveSession';
 import { requireServerPluginFeature } from '../../__tests__/requireServerPluginFeature';
 import { pluginFeatures } from '../../serverPlugin/pluginFeatures';
+import { fileInEngineTestsExpr } from './support/refactoring';
 
 /**
  * Automatic GCI integration test for the rename-temporary/argument (R5)
@@ -50,14 +49,6 @@ describe('rename temporary/argument (integration)', () => {
     exec(
       "(System myUserProfile symbolList objectNamed: 'GsRenameTemporaryRefactoring') notNil printString",
     ).trim() === 'true';
-
-  const engineTestsPayload = (): string =>
-    path.resolve(__dirname, '../../../../resources/refactoring/engine-tests.gs');
-
-  const fileInTests = (): string => {
-    const p = escapeString(engineTestsPayload());
-    return `[GsFileIn fromServerPath: '${p}'] on: Error do: [:e | GsFileIn fromPath: '${p}' on: #serverUtf8File to: nil].`;
-  };
 
   const dictIndexOf = (name: string): number =>
     parseInt(
@@ -102,7 +93,7 @@ describe('rename temporary/argument (integration)', () => {
     requireServerPluginFeature(pluginFeatures.refactoring, ctx, session());
 
     const code = `| r |
-${fileInTests()}
+${fileInEngineTestsExpr()}
 r := (System myUserProfile symbolList objectNamed: #GsRenameTemporaryRefactoringTest) suite run.
 (r failures size + r errors size) printString`;
 

--- a/client/src/refactoring/__tests__/support/refactoring.ts
+++ b/client/src/refactoring/__tests__/support/refactoring.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+import { escapeString } from '../../../queries/util';
+import { toLocalGemPath } from '../../../serverPlugin/installHelpers';
+
+/**
+ * Absolute path to the built GS SUnit payload every refactoring engine
+ * integration test files in before running its suite in-stone.
+ */
+const engineTestsPayloadPath = (): string =>
+  path.resolve(__dirname, '../../../../../resources/refactoring/engine-tests.gs');
+
+/**
+ * The `GsFileIn` statement to file `engineTestsPayloadPath()` into the stone.
+ *
+ * `fromServerPath:` alone reads the (ASCII-only) payload correctly on every
+ * supported release — see gs-src/refactoring/LOADING.md's file-in-signature
+ * note — so there is no need for the `#serverUtf8File` form the production
+ * loader reserves for 3.7+, nor for a fallback to it. A fallback used to sit
+ * here, triggered by any `Error` from the first attempt; on a pre-3.7 stone
+ * that signature's `to:` argument is a required Boolean, so passing it `nil`
+ * raised `ImproperOperation (error 2085)` — invisible whenever the CI client
+ * and gem shared a filesystem (the first attempt always succeeded), but hit
+ * as soon as one didn't, because the raw client path wasn't gem-visible
+ * either (the Windows-client + WSL-server topology).
+ *
+ * `toLocalGemPath` is the same path translation the production installers use
+ * (`serverPlugin/installHelpers.ts`): on Windows it rewrites a client
+ * checkout path to its WSL-visible form, since the gem always runs inside
+ * WSL there; a no-op everywhere else.
+ */
+export const fileInEngineTestsExpr = (): string =>
+  `GsFileIn fromServerPath: '${escapeString(toLocalGemPath(engineTestsPayloadPath()))}'.`;

--- a/client/src/refactoring/refactoringInstall.ts
+++ b/client/src/refactoring/refactoringInstall.ts
@@ -39,6 +39,7 @@ import {
   gsStringLiteral,
   messageOf,
   safeAbort,
+  toLocalGemPath,
   yieldToEventLoop,
 } from '../serverPlugin/installHelpers';
 
@@ -106,8 +107,9 @@ export function isRefactoringSupportInstalled(session: ActiveSession): boolean {
  * engine is committed and the loader's completeness check has already passed.
  *
  * @param session     a session with write access to kernel classes (SystemUser).
- * @param payloadDir  absolute path to `resources/refactoring/`, readable by the
- *                    gem (a local stone).
+ * @param payloadDir  absolute client-side path to `resources/refactoring/`;
+ *                    translated to the gem's local path (see `toLocalGemPath`)
+ *                    before use, so callers must pass it untranslated.
  * @param onProgress  optional incremental progress callback.
  */
 export async function installRefactoringSupport(
@@ -115,8 +117,9 @@ export async function installRefactoringSupport(
   payloadDir: string,
   onProgress: ProgressReporter = () => {},
 ): Promise<RefactoringInstallResult> {
-  const sep = payloadDir.endsWith('/') ? '' : '/';
-  const serverPath = (file: string): string => `${payloadDir}${sep}${file}`;
+  const gemPayloadDir = toLocalGemPath(payloadDir);
+  const sep = gemPayloadDir.endsWith('/') ? '' : '/';
+  const serverPath = (file: string): string => `${gemPayloadDir}${sep}${file}`;
 
   // Fail fast (and clearly) if the gem can't read the payload — e.g. a remote
   // stone whose gem doesn't share this machine's filesystem.
@@ -127,7 +130,7 @@ export async function installRefactoringSupport(
       report: '',
       message:
         `The database's gem cannot read the payload files (${unreadable.join(', ')}) under ` +
-        `${payloadDir}. Server-side install requires a local stone whose gem shares this ` +
+        `${gemPayloadDir}. Server-side install requires a local stone whose gem shares this ` +
         'filesystem.',
     };
   }
@@ -163,7 +166,7 @@ export async function installRefactoringSupport(
     raw = executeFetchString(
       session,
       '| ldr | ' +
-        `ldr := GsRefactoringLoader loadFromServerDir: ${gsStringLiteral(payloadDir)}. ` +
+        `ldr := GsRefactoringLoader loadFromServerDir: ${gsStringLiteral(gemPayloadDir)}. ` +
         "(ldr allOk ifTrue: ['OK'] ifFalse: ['FAIL']), (String with: Character lf), ldr reportString",
     );
   } catch (e: unknown) {

--- a/client/src/serverPlugin/__tests__/installHelpers.test.ts
+++ b/client/src/serverPlugin/__tests__/installHelpers.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../wslBridge', () => ({
+  needsWsl: vi.fn(),
+  windowsPathToWsl: vi.fn((p: string) => {
+    const m = p.match(/^\\\\wsl(?:\$|\.localhost)\\[^\\]+(.*)$/i);
+    return m ? m[1].replace(/\\/g, '/') : p;
+  }),
+}));
+
+vi.mock('../../browserQueries', () => ({
+  executeFetchString: vi.fn(),
+}));
+
+import { needsWsl } from '../../wslBridge';
+import { toLocalGemPath } from '../installHelpers';
+
+describe('toGemPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('translates a Windows drive path to its WSL mount when the gem runs inside WSL', () => {
+    vi.mocked(needsWsl).mockReturnValue(true);
+
+    expect(toLocalGemPath('D:\\a\\Jasper\\Jasper\\resources\\refactoring')).toBe(
+      '/mnt/d/a/Jasper/Jasper/resources/refactoring',
+    );
+  });
+
+  it('translates a WSL UNC path to its Linux-side form when the gem runs inside WSL', () => {
+    vi.mocked(needsWsl).mockReturnValue(true);
+
+    expect(toLocalGemPath('\\\\wsl$\\Ubuntu\\home\\x')).toBe('/home/x');
+  });
+
+  it('leaves the path unchanged when the gem does not run inside WSL', () => {
+    vi.mocked(needsWsl).mockReturnValue(false);
+
+    expect(toLocalGemPath('/home/runner/work/Jasper/Jasper/resources/refactoring')).toBe(
+      '/home/runner/work/Jasper/Jasper/resources/refactoring',
+    );
+  });
+});

--- a/client/src/serverPlugin/__tests__/installHelpers.test.ts
+++ b/client/src/serverPlugin/__tests__/installHelpers.test.ts
@@ -15,7 +15,7 @@ vi.mock('../../browserQueries', () => ({
 import { needsWsl } from '../../wslBridge';
 import { toLocalGemPath } from '../installHelpers';
 
-describe('toGemPath', () => {
+describe('toLocalGemPath', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/client/src/serverPlugin/installHelpers.ts
+++ b/client/src/serverPlugin/installHelpers.ts
@@ -13,6 +13,8 @@
 import { ActiveSession } from '../sessionManager';
 import { executeFetchString } from '../browserQueries';
 import { gemNrsFor, stoneNrsFor, DEFAULT_GS_PW } from '../loginTypes';
+import { needsWsl } from '../wslBridge';
+import { toWslPath } from '../wslFs';
 
 // GemStone's default SystemUser password on a fresh stone. Tried first so a
 // stock stone installs in one step; on failure the caller falls back to a
@@ -30,6 +32,18 @@ export const DEFAULT_SYSTEMUSER_PW = DEFAULT_GS_PW;
  *  the whole value wrapped in quotes. */
 export function gsStringLiteral(s: string): string {
   return `'${s.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Translate an absolute path into the form the gem process must open it as. On
+ * Windows the gem always runs inside WSL (see docs/windows-wsl.md) — a checkout
+ * path like `D:\...` is only visible to it via WSL's DrvFs automount at
+ * `/mnt/d/...`, so payload paths must be translated before crossing the GCI
+ * connection. No-op on every other platform, and harmless when the stone really
+ * is remote: the translated path is just as unreadable to a truly remote gem.
+ */
+export function toLocalGemPath(path: string): string {
+  return needsWsl() ? toWslPath(path) : path;
 }
 
 /** Whether the gem process can read the file at `serverPath`. */


### PR DESCRIPTION
## Summary
- On Windows the gem always runs inside WSL, so it only sees a Windows-drive checkout through WSL's DrvFs mount (`/mnt/<drive>/...`), never the raw `D:\...` path the client resolves. Add `toLocalGemPath()` and use it in the refactoring and enhanced-inspector installers before payload paths cross the GCI connection.
- Every refactoring integration test built its own `GsFileIn` call with a fallback to a GemStone 3.7-only signature. That fallback never fired when client and gem shared a filesystem, but on the Windows client + WSL server topology the first attempt fails (unresolvable path) and the fallback's `to:` argument raises `ImproperOperation 2085` on our 3.6.2 CI stone. Extract one shared helper (`fileInEngineTestsExpr`) that translates the path the same way the production installers do and drops the broken fallback, since `fromServerPath:` alone works on every supported release.

## Test plan
- [x] `npm run lint && npm run format:check && npm run compile && npm test` (against a local 3.6.2 stone)
- [x] New unit tests for `toLocalGemPath`, and WSL-path-translation cases added to the refactoring/enhanced-inspector installer test suites