### PR TITLE
Move senders/implementors counts into the selector hover (#432)

### DIFF
--- a/client/src/__mocks__/vscode.ts
+++ b/client/src/__mocks__/vscode.ts
@@ -714,6 +714,10 @@ export const InputBoxValidationSeverity = {
 // ── MarkdownString mock ──────────────────────────────────
 
 export class MarkdownString {
+  // Mirror the real MarkdownString flags the extension sets: `isTrusted` enables
+  // command: links, `supportThemeIcons` enables $(codicon) rendering.
+  isTrusted?: boolean;
+  supportThemeIcons?: boolean;
   constructor(public value: string = '') {}
   appendMarkdown(value: string): MarkdownString {
     this.value += value;

--- a/client/src/__tests__/gemstoneCodeLensProvider.test.ts
+++ b/client/src/__tests__/gemstoneCodeLensProvider.test.ts
@@ -90,10 +90,14 @@ name: aString
       expect(lenses).toHaveLength(4); // 2 methods × 2 lenses
     });
 
-    it('returns a senders+implementors lens pair for gemstone:// method URIs', () => {
+    it('returns no lenses for gemstone:// method URIs (#432: the selector hover owns those)', () => {
+      // The editable gemstone:// method editor no longer carries a
+      // senders/implementors CodeLens (it jiggled the source on open). Those counts
+      // now live in the selector hover (GemStoneHoverProvider) as clickable links,
+      // so the CodeLens provider emits nothing there.
       const doc = createMockDocument('name\n  ^ name', 'gemstone');
       const lenses = provider.provideCodeLenses(doc);
-      expect(lenses).toHaveLength(2); // 1 method × 2 lenses
+      expect(lenses).toHaveLength(0);
     });
 
     it('returns no lenses for an unsaved new-method template', () => {

--- a/client/src/__tests__/gemstoneHoverProvider.test.ts
+++ b/client/src/__tests__/gemstoneHoverProvider.test.ts
@@ -4,6 +4,7 @@ vi.mock('vscode', () => import('../__mocks__/vscode.js'));
 
 vi.mock('../browserQueries', () => ({
   implementorsOf: vi.fn(() => []),
+  sendersOf: vi.fn(() => []),
   getAllClassNames: vi.fn(() => []),
   getClassComment: vi.fn(() => ''),
 }));
@@ -13,9 +14,10 @@ import type * as vscode from 'vscode';
 import { GemStoneHoverProvider } from '../gemstoneHoverProvider';
 import { SelectorResolver } from '../gemstoneDefinitionProvider';
 import { SessionManager } from '../sessionManager';
-import { implementorsOf, getAllClassNames, getClassComment } from '../browserQueries';
+import { implementorsOf, sendersOf, getAllClassNames, getClassComment } from '../browserQueries';
 
 const mockImplementorsOf = vi.mocked(implementorsOf);
+const mockSendersOf = vi.mocked(sendersOf);
 const mockGetAllClassNames = vi.mocked(getAllClassNames);
 const mockGetClassComment = vi.mocked(getClassComment);
 
@@ -56,9 +58,11 @@ describe('GemStoneHoverProvider', () => {
   beforeEach(() => {
     __resetConfig();
     mockImplementorsOf.mockReset();
+    mockSendersOf.mockReset();
     mockGetAllClassNames.mockReset();
     mockGetClassComment.mockReset();
     mockImplementorsOf.mockReturnValue([]);
+    mockSendersOf.mockReturnValue([]);
     mockGetAllClassNames.mockReturnValue([]);
     mockGetClassComment.mockReturnValue('');
   });
@@ -72,7 +76,7 @@ describe('GemStoneHoverProvider', () => {
   });
 
   describe('selector hover', () => {
-    it('shows implementors with categories', async () => {
+    it('shows implementors with categories, plus clickable senders/implementors links', async () => {
       mockImplementorsOf.mockReturnValue([
         {
           dictName: 'Globals',
@@ -89,6 +93,7 @@ describe('GemStoneHoverProvider', () => {
           category: 'accessing',
         },
       ]);
+      mockSendersOf.mockReturnValue(Array.from({ length: 7 }, () => ({}) as never));
       const resolver: SelectorResolver = { getSelector: vi.fn(async () => 'size') };
       const provider = new GemStoneHoverProvider(makeSessionManager(true), resolver);
       const result = await provider.provideHover(makeDocument('self size'), pos(0, 5));
@@ -96,9 +101,25 @@ describe('GemStoneHoverProvider', () => {
       expect(result).not.toBeNull();
       const md = result!.contents as unknown as MarkdownString;
       expect(md.value).toContain('**#size**');
-      expect(md.value).toContain('*2* implementors');
+      // #432: counts are clickable command links, not plain text.
+      expect(md.value).toContain('7 senders](command:gemstone.sendersOfSelector?');
+      expect(md.value).toContain('2 implementors](command:gemstone.implementorsOfSelector?');
+      expect(md.isTrusted).toBe(true); // command: links only fire from a trusted hover
       expect(md.value).toContain('`Array` (accessing)');
       expect(md.value).toContain('`String` (accessing)');
+    });
+
+    it('shows a hover with just a senders link when the selector has no implementors', async () => {
+      mockImplementorsOf.mockReturnValue([]);
+      mockSendersOf.mockReturnValue(Array.from({ length: 3 }, () => ({}) as never));
+      const resolver: SelectorResolver = { getSelector: vi.fn(async () => 'onlySent') };
+      const provider = new GemStoneHoverProvider(makeSessionManager(true), resolver);
+      const result = await provider.provideHover(makeDocument('self onlySent'), pos(0, 5));
+
+      expect(result).not.toBeNull();
+      const md = result!.contents as unknown as MarkdownString;
+      expect(md.value).toContain('3 senders](command:gemstone.sendersOfSelector?');
+      expect(md.value).toContain('0 implementors](command:gemstone.implementorsOfSelector?');
     });
 
     it('shows singular "implementor" for one result', async () => {
@@ -116,7 +137,7 @@ describe('GemStoneHoverProvider', () => {
       const result = await provider.provideHover(makeDocument('self size'), pos(0, 5));
 
       const md = result!.contents as unknown as MarkdownString;
-      expect(md.value).toContain('*1* implementor\n');
+      expect(md.value).toContain('1 implementor](command:gemstone.implementorsOfSelector?');
     });
 
     it('shows "class" suffix for class-side implementors', async () => {
@@ -151,7 +172,7 @@ describe('GemStoneHoverProvider', () => {
       const result = await provider.provideHover(makeDocument('self size'), pos(0, 5));
 
       const md = result!.contents as unknown as MarkdownString;
-      expect(md.value).toContain('*15* implementors');
+      expect(md.value).toContain('15 implementors](command:gemstone.implementorsOfSelector?');
       expect(md.value).toContain('Class9');
       expect(md.value).not.toContain('Class10');
       expect(md.value).toContain('...and 5 more');

--- a/client/src/gemstoneCodeLensProvider.ts
+++ b/client/src/gemstoneCodeLensProvider.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { SessionManager, ActiveSession } from './sessionManager';
 import { parseTopazDocument } from './topazFileIn';
 import { extractSelector } from './systemBrowser';
-import { parseMethodUri } from './gemstoneFileSystemProvider';
 import * as queries from './browserQueries';
 
 interface CodeLensData {
@@ -90,12 +89,13 @@ export class GemStoneCodeLensProvider implements vscode.CodeLensProvider, vscode
     return lenses;
   }
 
-  private provideGemstoneCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
-    const method = parseMethodUri(document.uri);
-    if (!method) return [];
-
-    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
-    return this.makeMethodLenses(range, method.selector, method.className, method.isMeta);
+  private provideGemstoneCodeLenses(_document: vscode.TextDocument): vscode.CodeLens[] {
+    // #432: the editable gemstone:// method editor no longer carries a
+    // senders/implementors CodeLens (it appeared after first paint and shoved the
+    // source down — the "jiggle"). Those counts now live in the selector hover
+    // (GemStoneHoverProvider) as clickable links, which is out of the document flow
+    // and can't move the source. The topaz/file paths above keep their lenses.
+    return [];
   }
 
   // Emit the senders + implementors pair on the same range, in that order.

--- a/client/src/gemstoneHoverProvider.ts
+++ b/client/src/gemstoneHoverProvider.ts
@@ -9,6 +9,34 @@ export class GemStoneHoverProvider implements vscode.HoverProvider {
     private selectorResolver?: SelectorResolver,
   ) {}
 
+  /**
+   * Senders counts, keyed by `selector|sessionId|maxEnv`. `sendersOf` blocks the
+   * host and can be costly for a popular selector, and a hover fires on every mouse
+   * rest — so once counted, a re-hover of the same selector is instant. (The
+   * implementors count is free: the hover already runs `implementorsOf` to list
+   * the classes.)
+   */
+  private sendersCountCache = new Map<string, number>();
+
+  /**
+   * A trusted markdown line of clickable senders/implementors links (#432). This
+   * is where those counts live now — the source-editor CodeLens jiggled the code on
+   * open, so the counts moved into this hover, out of the document flow. Each link
+   * fires the same command the old lens did, opening the results panel.
+   */
+  private navLinks(selector: string, sessionId: number, sendersCount: number, implCount: number) {
+    const arg = encodeURIComponent(JSON.stringify([{ selector, sessionId }]));
+    // The quoted title after the URL is the link's tooltip; without it VS Code
+    // shows the raw `command:…?%5B…` URI on hover (#432).
+    const senders =
+      `[$(references) ${sendersCount} sender${sendersCount === 1 ? '' : 's'}]` +
+      `(command:gemstone.sendersOfSelector?${arg} "Browse senders of #${selector}")`;
+    const impl =
+      `[$(symbol-method) ${implCount} implementor${implCount === 1 ? '' : 's'}]` +
+      `(command:gemstone.implementorsOfSelector?${arg} "Browse implementors of #${selector}")`;
+    return `${senders}  ·  ${impl}`;
+  }
+
   async provideHover(
     document: vscode.TextDocument,
     position: vscode.Position,
@@ -29,12 +57,28 @@ export class GemStoneHoverProvider implements vscode.HoverProvider {
     if (selector) {
       const env = vscode.workspace.getConfiguration('gemstone').get<number>('maxEnvironment', 0);
       const results = queries.implementorsOf(session, selector, env);
-      if (results.length === 0) return null;
+
+      // Senders count (cached — sendersOf is costly and a hover fires easily).
+      const sKey = `${selector}|${session.id}|${env}`;
+      let sendersCount = this.sendersCountCache.get(sKey);
+      if (sendersCount === undefined) {
+        try {
+          sendersCount = queries.sendersOf(session, selector, env).length;
+        } catch {
+          sendersCount = 0;
+        }
+        this.sendersCountCache.set(sKey, sendersCount);
+      }
+
+      // Nothing to say if the selector is neither sent nor implemented anywhere.
+      if (results.length === 0 && sendersCount === 0) return null;
 
       const md = new vscode.MarkdownString();
-      md.appendMarkdown(
-        `**#${selector}** — *${results.length}* implementor${results.length === 1 ? '' : 's'}\n\n`,
-      );
+      md.supportThemeIcons = true;
+      md.isTrusted = true; // required for the command: links below to be clickable
+      md.appendMarkdown(`**#${selector}**\n\n`);
+      md.appendMarkdown(this.navLinks(selector, session.id, sendersCount, results.length) + '\n\n');
+
       const show = results.slice(0, 10);
       for (const r of show) {
         const side = r.isMeta ? ' class' : '';


### PR DESCRIPTION
## What & why

Opening a method jiggled the source: the senders/implementors counts lived as CodeLens links *above* the method, so as each one resolved and appeared, the method body shifted down — right when you're trying to start reading. A CodeLens inherently occupies a line that only exists once the provider returns (after first paint), so that one shift is unavoidable while the counts live in the document flow. Previous in-place attempts couldn't remove it.

This moves the counts **out of the document entirely**, into the **selector hover** — where appearing late costs nothing visually and the source can never move.

## Changes

- **`gemstoneHoverProvider.ts`** — the selector hover now leads with clickable **senders · implementors** links (trusted markdown + codicons) with friendly tooltips (`Browse senders of #sel`), each firing the same command the old CodeLens did. The implementor preview list stays below. The senders count is cached per `selector|session|env` (`sendersOf` blocks the host and a hover fires on every mouse-rest). The hover now also appears for a selector that is *sent but not implemented*.
- **`gemstoneCodeLensProvider.ts`** — the `gemstone://` method editor no longer emits a senders/implementors CodeLens (topaz/file docs keep theirs), so the source never shifts on open.
- Tests updated/added (senders link, senders-only hover); the test `__mocks__` `MarkdownString` learns the `isTrusted` / `supportThemeIcons` flags the hover sets.

## Acceptance criteria (from #432)

- ✅ Opening a method never shifts the source text — the counts are no longer in the document flow.
- ✅ Senders and implementors are still obvious and one click each to navigate (via the hover links).
- ✅ Both counts still resolve lazily and stay cached.

## Testing

Client-only TypeScript change (no server / GemStone / RB surface). Full client gate green: `compile` / `lint` / `format:check`, and the client unit suite (**5637 passed, 111 skipped, 0 failed**). Manually exercised by @ericwinger during development (hover links + tooltips verified).

## Not in scope

A separate, pre-existing breadcrumb behavior — VS Code rebuilding the breadcrumb's symbol segment when a method opens from the bottom-panel Omni webview — can flash on a selector change. It's independent of this change (reproduces on `main`), is driven by the panel origin rather than anything the extension controls, and was confirmed unfixable from the extension via open-path/column tweaks. Left as-is here.

Closes #432