### PR TITLE
Silence libgcits' per-login stdout banner (87% less test output)

### DIFF
--- a/client/src/__mocks__/koffi.ts
+++ b/client/src/__mocks__/koffi.ts
@@ -1,0 +1,28 @@
+import { vi } from 'vitest';
+
+/** Resolves a koffi signature string (e.g. `GciSessionPtr GciTsLogin(const char *, ...)`)
+ * to the native stub `GciLibrary` should bind for it. */
+export type KoffiFuncMock = (signature: string) => unknown;
+
+/**
+ * Builds the `{ default: ... }` module shape `vi.mock('koffi', ...)` needs to
+ * stand in for the real koffi module. `struct`/`array`/`opaque`/`pointer`/`union`/`load`
+ * are identical for every caller — only how `func` resolves a signature string
+ * to a native stub varies, so that's the one piece callers supply.
+ */
+export function mockKoffiModule(func: KoffiFuncMock) {
+  const mockLib = {
+    func: vi.fn(func),
+    unload: vi.fn(),
+  };
+  return {
+    default: {
+      struct: vi.fn(() => 'MockStruct'),
+      array: vi.fn(() => 'MockArray'),
+      opaque: vi.fn(() => 'MockOpaque'),
+      pointer: vi.fn(() => 'MockPointer'),
+      union: vi.fn(() => 'MockUnion'),
+      load: vi.fn(() => mockLib),
+    },
+  };
+}

--- a/client/src/__tests__/gci/gciLogin.test.ts
+++ b/client/src/__tests__/gci/gciLogin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterAll } from 'vitest';
 import { GciLibrary } from '../../gciLibrary';
+import { GCI_LOGIN_PW_ENCRYPTED } from '../../gciConstants';
 import {
   GCI_LIBRARY_PATH,
   STONE_NRS,
@@ -167,7 +168,6 @@ describe('GciTsLogin / GciTsLogout', () => {
       const encrypted = gci.GciTsEncrypt(GS_PASSWORD);
       expect(encrypted).not.toBeNull();
 
-      const GCI_LOGIN_PW_ENCRYPTED = 1;
       const { session, err } = gci.GciTsLogin(
         STONE_NRS,
         null,

--- a/client/src/__tests__/gciOptionalFunctions.test.ts
+++ b/client/src/__tests__/gciOptionalFunctions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockKoffiModule } from '../__mocks__/koffi';
 
 // Functions that older / client GCI libraries do NOT export.
 // The GciTs* functions below (per a gcits.hf diff of 3.6.2 vs 3.7.5) were added
@@ -31,27 +32,14 @@ const OPTIONAL_FUNCTIONS = [
 // Mock koffi before importing GciLibrary
 vi.mock('koffi', () => {
   const stubFn = vi.fn();
-  const mockLib = {
-    func: vi.fn((signature: string) => {
-      for (const name of OPTIONAL_FUNCTIONS) {
-        if (signature.includes(name)) {
-          throw new Error(`Cannot find function '${name}' in shared library`);
-        }
+  return mockKoffiModule((signature: string) => {
+    for (const name of OPTIONAL_FUNCTIONS) {
+      if (signature.includes(name)) {
+        throw new Error(`Cannot find function '${name}' in shared library`);
       }
-      return stubFn;
-    }),
-    unload: vi.fn(),
-  };
-  return {
-    default: {
-      struct: vi.fn(() => 'MockStruct'),
-      array: vi.fn(() => 'MockArray'),
-      opaque: vi.fn(() => 'MockOpaque'),
-      pointer: vi.fn(() => 'MockPointer'),
-      union: vi.fn(() => 'MockUnion'),
-      load: vi.fn(() => mockLib),
-    },
-  };
+    }
+    return stubFn;
+  });
 });
 
 import { GciLibrary } from '../gciLibrary';

--- a/client/src/gciConstants.ts
+++ b/client/src/gciConstants.ts
@@ -30,6 +30,17 @@ export const GCI_PERFORM_FLAG_SINGLE_STEP = 4;
 // No effect where native code is unavailable anyway (e.g. Darwin/ARM builds).
 export const GCI_PERFORM_FLAG_INTERPRETED = 0x20;
 
+// Login flags (from gci.ht)
+// Tells GciTsLogin the `gemstonePassword` argument is already ciphertext, as produced by
+// GciTsEncrypt, rather than plaintext.
+export const GCI_LOGIN_PW_ENCRYPTED = 0x1;
+
+// Suppresses libgcits' unsolicited ` gcits login:` / ` gcits logout:` printf()s
+// to stdout, which are the majority of the test suite's output and bypass the
+// JS console entirely. Present with this value since 3.6.2, so no version
+// gating is needed.
+export const GCI_LOGIN_QUIET = 0x10;
+
 // Class OOPs (from gcioop.ht)
 export const OOP_CLASS_STRING = 74753n;
 export const OOP_CLASS_UTF8 = 154113n;

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -1,6 +1,6 @@
 import koffi from 'koffi';
 import * as path from 'path';
-import { OOP_FALSE, OOP_ILLEGAL, OOP_NIL, OOP_TRUE } from './gciConstants';
+import { GCI_LOGIN_QUIET, OOP_FALSE, OOP_ILLEGAL, OOP_NIL, OOP_TRUE } from './gciConstants';
 import { GciLibraryError } from './gciLibraryError';
 import { escapeString } from './queries/util';
 
@@ -151,6 +151,15 @@ function toBigInt(value: number | bigint): bigint {
   return typeof value === 'bigint' ? value : BigInt(value);
 }
 
+// Forces GCI_LOGIN_QUIET on top of a caller's loginFlags. Jasper never wants
+// libgcits' ` gcits login:` / ` gcits logout:` banner on stdout, so every login
+// wrapper ORs the bit in rather than making all ~6 call sites remember it. This
+// is the one deliberate deviation from the raw wrappers' 1:1 contract; all
+// other caller-supplied bits pass through untouched.
+function quietedLoginFlags(loginFlags: number): number {
+  return loginFlags | GCI_LOGIN_QUIET;
+}
+
 // Rejects a Promise-returning (async) callback at the type level -- see
 // GciLibrary.executeAndRelease's doc comment for why that matters.
 type NotPromise<T> = T extends Promise<unknown> ? never : T;
@@ -163,6 +172,8 @@ type NotPromise<T> = T extends Promise<unknown> ? never : T;
  * - Raw `GciTsXxx` methods (e.g. `GciTsExecute`, `GciTsLogin`) are thin 1:1
  *   wrappers around the C functions of the same name — one per exported
  *   symbol, following the struct/pointer patterns already established below.
+ *   The one deliberate exception: the login wrappers force `GCI_LOGIN_QUIET`
+ *   into `loginFlags` — see the `quietedLoginFlags` helper above for why.
  * - The remaining methods (grouped into labeled sections further down: Session
  *   lifecycle, Code execution, Symbol resolution & Utf8 caching, Object
  *   lifecycle & PureExportSet, UserGlobals management, SessionTemps
@@ -409,10 +420,11 @@ export class GciLibrary {
     this._GciTsNbLogout = this.lib.func(`int GciTsNbLogout(GciSessionPtr, _Out_ GciErrSType *)`);
     this._GciTsSessionIsRemote = this.lib.func(`int GciTsSessionIsRemote(GciSessionPtr)`);
     // Optional: not exported by some libraries (e.g. GemStone 4.0). Jasper's
-    // login path passes the password in the clear (GciTsLogin with loginFlags
-    // 0), so GciTsEncrypt is never called during connect — binding it eagerly
-    // would abort library load for a library that lacks it. Only the ergonomic
-    // GciTsEncrypt() wrapper (used by tests) would throw if it were absent.
+    // login path passes the password in the clear (GciTsLogin without
+    // GCI_LOGIN_PW_ENCRYPTED), so GciTsEncrypt is never called during connect —
+    // binding it eagerly would abort library load for a library that lacks it.
+    // Only the ergonomic GciTsEncrypt() wrapper (used by tests) would throw if
+    // it were absent.
     this._GciTsEncrypt = this.optionalFunc(
       'GciTsEncrypt',
       `char* GciTsEncrypt(const char *, _Out_ char *, size_t)`,
@@ -769,7 +781,7 @@ export class GciLibrary {
       gemServiceNrs,
       gemstoneUsername,
       gemstonePassword,
-      loginFlags,
+      quietedLoginFlags(loginFlags),
       haltOnErrNum,
       executedSessionInit,
       err,
@@ -804,7 +816,7 @@ export class GciLibrary {
       gemstoneUsername,
       gemstonePassword,
       netldiName,
-      loginFlags,
+      quietedLoginFlags(loginFlags),
       haltOnErrNum,
       executedSessionInit,
       err,
@@ -837,7 +849,7 @@ export class GciLibrary {
       gemServiceNrs,
       gemstoneUsername,
       gemstonePassword,
-      loginFlags,
+      quietedLoginFlags(loginFlags),
       haltOnErrNum,
       loginPollSocket,
     );
@@ -866,7 +878,7 @@ export class GciLibrary {
       gemstoneUsername,
       gemstonePassword,
       netldiName,
-      loginFlags,
+      quietedLoginFlags(loginFlags),
       haltOnErrNum,
       loginPollSocket,
     );
@@ -2069,9 +2081,10 @@ export class GciLibrary {
    * Logs into a GemStone stone and returns the resulting session.
    *
    * `HostUserId`/`HostPassword` are not exposed by this overload — the gem
-   * process runs as the netldi process's user. Login flags and
-   * `haltOnErrNum` are left at their defaults (see `GciTsLogin` in
-   * `gcits.hf` for what they control).
+   * process runs as the netldi process's user. Login flags are
+   * `GCI_LOGIN_QUIET` (forced by the `GciTsLogin` wrapper) and `haltOnErrNum`
+   * is left at its default (see `GciTsLogin` in `gcits.hf` for what they
+   * control).
    *
    * @param stoneNrs - The NRS of the stone to log into.
    * @param gemServiceNrs - The NRS of the gem service to use.

--- a/client/src/gciLibrary/README.md
+++ b/client/src/gciLibrary/README.md
@@ -11,7 +11,9 @@ moves another slice.
 ## What is here, and why only this
 
 `__tests__/` holds integration tests for the **raw bindings** only — the wrappers that are
-1:1 with a GCI C entry point (`GciTs*`, plus the session-free `Gci*` host utilities).
+1:1 with a GCI C entry point (`GciTs*`, plus the session-free `Gci*` host utilities), with one
+deliberate exception: the login wrappers force `GCI_LOGIN_QUIET` into `loginFlags` — see
+`quietedLoginFlags` in `client/src/gciLibrary.ts`.
 
 The narrow scope is deliberate. Raw-binding tests can move without touching the wrapper
 code, which keeps this first step reviewable. The ergonomic layer on top of the bindings,

--- a/client/src/gciLibrary/__tests__/gciLoginQuiet.test.ts
+++ b/client/src/gciLibrary/__tests__/gciLoginQuiet.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GCI_LOGIN_PW_ENCRYPTED, GCI_LOGIN_QUIET } from '../../gciConstants';
+
+// One stub per native function, so each login binding's arguments can be
+// inspected independently. Keyed by the function name parsed out of the koffi
+// signature string. vi.hoisted because the vi.mock factory below is hoisted
+// above this module's imports.
+const nativeStubs = vi.hoisted(() => new Map<string, ReturnType<typeof vi.fn>>());
+
+vi.mock('koffi', () => {
+  const mockLib = {
+    func: vi.fn((signature: string) => {
+      // `GciSessionPtr GciTsLogin(const char *, ...)` -> `GciTsLogin`
+      const name = /(\w+)\s*\(/.exec(signature)?.[1] ?? signature;
+      let stub = nativeStubs.get(name);
+      if (!stub) {
+        stub = vi.fn();
+        nativeStubs.set(name, stub);
+      }
+      return stub;
+    }),
+    unload: vi.fn(),
+  };
+  return {
+    default: {
+      struct: vi.fn(() => 'MockStruct'),
+      array: vi.fn(() => 'MockArray'),
+      opaque: vi.fn(() => 'MockOpaque'),
+      pointer: vi.fn(() => 'MockPointer'),
+      union: vi.fn(() => 'MockUnion'),
+      load: vi.fn(() => mockLib),
+    },
+  };
+});
+
+import { GciLibrary } from '../../gciLibrary';
+
+// Fixed inputs shared by every wrapper below. Their actual values don't
+// matter — only whether `loginFlags` gets the quiet bit ORed in — so a
+// single constant keeps that irrelevance obvious at the call site.
+const NO_LOGIN_FLAGS = 0;
+const NETLDI_NAME = 'netldi';
+
+/**
+ * Builds the full positional argument list a login wrapper's native stub is
+ * expected to receive. `netldiArg` is the netldi name for wrappers that take
+ * one (the `_` variants); omit it for wrappers that don't.
+ */
+function expectedLoginCall({
+  netldiArg,
+  loginFlags,
+  outParams,
+}: {
+  netldiArg?: string;
+  loginFlags: number;
+  outParams: unknown[];
+}): unknown[] {
+  const netldiArgs = netldiArg === undefined ? [] : [netldiArg];
+  return [
+    null,
+    null,
+    null,
+    0,
+    null,
+    'user',
+    'password',
+    ...netldiArgs,
+    loginFlags,
+    0,
+    ...outParams,
+  ];
+}
+
+// GciTsLogin/GciTsLogin_ report executedSessionInit and err; the Nb variants
+// report only a loginPollSocket.
+const BLOCKING_OUT_PARAMS = [[0], {}];
+const NON_BLOCKING_OUT_PARAMS = [[0]];
+
+function lastCallTo(name: string): unknown[] {
+  const stub = nativeStubs.get(name);
+  expect(stub, `no native stub recorded for ${name}`).toBeDefined();
+  expect(stub!).toHaveBeenCalledTimes(1);
+  return stub!.mock.calls[0];
+}
+
+interface LoginWrapperFixture {
+  name: string;
+  netldiArg?: string;
+  outParams: unknown[];
+  invoke: (gci: GciLibrary, loginFlags: number) => void;
+}
+
+// One entry per raw login wrapper, so both scenarios below (no flags,
+// caller-supplied flags) run identically across all four — the plain vs.
+// netldi and blocking vs. non-blocking distinctions are declared once here
+// instead of duplicated per test.
+const WRAPPERS: LoginWrapperFixture[] = [
+  {
+    name: 'GciTsLogin',
+    outParams: BLOCKING_OUT_PARAMS,
+    invoke: (gci, loginFlags) =>
+      gci.GciTsLogin(null, null, null, false, null, 'user', 'password', loginFlags, 0),
+  },
+  {
+    name: 'GciTsLogin_',
+    netldiArg: NETLDI_NAME,
+    outParams: BLOCKING_OUT_PARAMS,
+    invoke: (gci, loginFlags) =>
+      gci.GciTsLogin_(
+        null,
+        null,
+        null,
+        false,
+        null,
+        'user',
+        'password',
+        NETLDI_NAME,
+        loginFlags,
+        0,
+      ),
+  },
+  {
+    name: 'GciTsNbLogin',
+    outParams: NON_BLOCKING_OUT_PARAMS,
+    invoke: (gci, loginFlags) =>
+      gci.GciTsNbLogin(null, null, null, false, null, 'user', 'password', loginFlags, 0),
+  },
+  {
+    name: 'GciTsNbLogin_',
+    netldiArg: NETLDI_NAME,
+    outParams: NON_BLOCKING_OUT_PARAMS,
+    invoke: (gci, loginFlags) =>
+      gci.GciTsNbLogin_(
+        null,
+        null,
+        null,
+        false,
+        null,
+        'user',
+        'password',
+        NETLDI_NAME,
+        loginFlags,
+        0,
+      ),
+  },
+];
+
+describe('login wrappers force GCI_LOGIN_QUIET', () => {
+  let gci: GciLibrary;
+
+  beforeEach(() => {
+    nativeStubs.clear();
+    gci = new GciLibrary('/fake/libgcits.dylib');
+  });
+
+  describe.each(WRAPPERS)('$name', ({ name, netldiArg, outParams, invoke }) => {
+    it('passes the quiet bit when the caller asks for no flags', () => {
+      invoke(gci, NO_LOGIN_FLAGS);
+
+      expect(lastCallTo(name)).toEqual(
+        expectedLoginCall({ netldiArg, loginFlags: GCI_LOGIN_QUIET, outParams }),
+      );
+    });
+
+    it('adds the quiet bit to caller-supplied flags instead of replacing them', () => {
+      invoke(gci, GCI_LOGIN_PW_ENCRYPTED);
+
+      expect(lastCallTo(name)).toEqual(
+        expectedLoginCall({
+          netldiArg,
+          loginFlags: GCI_LOGIN_QUIET | GCI_LOGIN_PW_ENCRYPTED,
+          outParams,
+        }),
+      );
+    });
+  });
+});

--- a/client/src/gciLibrary/__tests__/gciLoginQuiet.test.ts
+++ b/client/src/gciLibrary/__tests__/gciLoginQuiet.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GCI_LOGIN_PW_ENCRYPTED, GCI_LOGIN_QUIET } from '../../gciConstants';
+import { mockKoffiModule } from '../../__mocks__/koffi';
 
 // One stub per native function, so each login binding's arguments can be
 // inspected independently. Keyed by the function name parsed out of the koffi
@@ -7,31 +8,18 @@ import { GCI_LOGIN_PW_ENCRYPTED, GCI_LOGIN_QUIET } from '../../gciConstants';
 // above this module's imports.
 const nativeStubs = vi.hoisted(() => new Map<string, ReturnType<typeof vi.fn>>());
 
-vi.mock('koffi', () => {
-  const mockLib = {
-    func: vi.fn((signature: string) => {
-      // `GciSessionPtr GciTsLogin(const char *, ...)` -> `GciTsLogin`
-      const name = /(\w+)\s*\(/.exec(signature)?.[1] ?? signature;
-      let stub = nativeStubs.get(name);
-      if (!stub) {
-        stub = vi.fn();
-        nativeStubs.set(name, stub);
-      }
-      return stub;
-    }),
-    unload: vi.fn(),
-  };
-  return {
-    default: {
-      struct: vi.fn(() => 'MockStruct'),
-      array: vi.fn(() => 'MockArray'),
-      opaque: vi.fn(() => 'MockOpaque'),
-      pointer: vi.fn(() => 'MockPointer'),
-      union: vi.fn(() => 'MockUnion'),
-      load: vi.fn(() => mockLib),
-    },
-  };
-});
+vi.mock('koffi', () =>
+  mockKoffiModule((signature: string) => {
+    // `GciSessionPtr GciTsLogin(const char *, ...)` -> `GciTsLogin`
+    const name = /(\w+)\s*\(/.exec(signature)?.[1] ?? signature;
+    let stub = nativeStubs.get(name);
+    if (!stub) {
+      stub = vi.fn();
+      nativeStubs.set(name, stub);
+    }
+    return stub;
+  }),
+);
 
 import { GciLibrary } from '../../gciLibrary';
 


### PR DESCRIPTION
## Why

Every GemStone login and logout makes `libgcits` `printf` a line straight to the process's stdout:

```
 gcits login: session 0x88140c000 lgc 0x88140c008 rpc gem processId 24917
 gcits logout: nbExecInProg 0x0 session 0x88140c000 rpc gem processId 24917
```

It bypasses the JS `console` entirely — it comes from native code, not from JS — so **no vitest reporter, `--silent`, or `onConsoleLog` hook can suppress it**. Every test run, in CI and locally, carries one pair of these lines per session. Nobody reads them, and nothing in Jasper depends on them.

The cost is real and it is paid three times over: CI log noise, humans scrolling past it, and — the motivating case — AI coding agents, which pay for the whole test transcript in context tokens on every single run. Wasted context is wasted budget and wasted attention.

The fix is already in our hands: bit 4 of the `loginFlags` argument we pass on every login — `GCI_LOGIN_QUIET = 0x10` — gates every one of those stdout writes. Jasper hardcoded `loginFlags = 0` at all six production call sites, so we were opting into the noise by omission.

## What changed

- **`gciConstants.ts`** — new `GCI_LOGIN_QUIET = 0x10`, documented alongside the existing `GCI_PERFORM_FLAG_*` block.
- **`gciLibrary.ts`** — a private `quietedLoginFlags()` helper ORs the bit over whatever the caller passed, applied in all four raw login wrappers (`GciTsLogin`, `GciTsLogin_`, `GciTsNbLogin`, `GciTsNbLogin_`). They all share `doLogin` inside the library, so blocking, netldi and non-blocking paths behave identically.
- **No call site changes.** `sessionManager.ts`, `installHelpers.ts`, `mcp-server/src/mcpSession.ts`, `GciLibrary.login()` and every test keep passing `0`; the OR happens one level below them. Doing it in the wrapper rather than at each call site means future callers get it for free and cannot forget it.
- **Docs** — the class-level "thin 1:1 wrappers" claim now records this as its single deliberate exception, and `login()`'s doc no longer says flags are left at zero.
- **New test** — `client/src/gciLibrary/__tests__/gciLoginQuiet.test.ts` mocks koffi with a distinct stub per native function and asserts against the recorded native arguments: the quiet bit reaches all four wrappers, and a caller passing `GCI_LOGIN_PW_ENCRYPTED` (`1`) arrives as `0x11` — the bit is **added**, never substituted.

## The wins (measured, not estimated)

Full `npm test`, before vs after, `VITEST_SEED` pinned so runs are comparable:

| run | lines | bytes | tokens | `gcits` lines |
|---|---|---|---|---|
| all passing, before | 159 | 9,567 | **3,491** | 110 |
| all passing, after | 49 | 1,427 | **461** | 0 |
| one failing test, before | 147 | 9,785 | **3,590** | 110 |
| one failing test, after | 37 | 1,643 | **538** | 0 |

**~87% fewer tokens per test run** (85% when a test fails). 110 of the 159 baseline lines were the banner — it was the *majority* of our test output. The on-demand `npm run test:gci` suite, which performs ~20 real logins, went from 45 banner lines to 0.

Two things worth calling out:

- **Output filtering cannot fix this.** Running the same suite through a token-optimizing output filter saved 0.5% before this change (3,491 → 3,472 tokens), and on a failing run came out 3 tokens *larger*. Interleaved native stdout is invisible to line-based filters. This had to be fixed at the source.
- **Nothing diagnostic is lost.** `GCI_LOGIN_QUIET` does not affect the client trace file, so `GS_LGC_DEBUG` tracing still works if anyone ever needs the session details. Verified by deliberately breaking a live-login integration test: the `FAIL` header, assertion diff, `file:line:col` and code frame all still come through intact, and the received value was real data fetched from the stone — proof the login itself succeeded with the flag set.

## Compatibility

`GCI_LOGIN_QUIET` carries the value `0x10` in every version from 3.6.2 through 3.7.5, so **no version gating is needed** and `gciVersionGated.test.ts` is unaffected. Verified empirically against a live stone: login still succeeds, and the logout banner goes quiet too.

## Verification

- `npm run lint && npm run format:check && npm run compile` — clean.
- `npm test` — 377 client files / 5,642 tests, server 322, mcp-server 92, all passing; zero `gcits` lines.
- `npm run test:gci` — comes back quiet (45 → 0 banner lines)
- Existing tests that assert `GciTsLogin` was called with `..., 0, 0` (`mcpSession.test.ts`, `sessionManager.test.ts`) mock the *wrapper*, which still receives `0` — they stay green and keep asserting what the caller intends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
