### PR TITLE
GemStone Search: bind reveals/searches to the result's session, sweep all method environments

### DIFF
--- a/client/src/__tests__/explorerOmniReveal.test.ts
+++ b/client/src/__tests__/explorerOmniReveal.test.ts
@@ -193,6 +193,16 @@ describe('reveal targets the result’s own session, not whatever is selected no
     expect(dict.reveal).toHaveBeenCalledTimes(1); // and actually revealed
   });
 
+  it('does not re-select when the result already came from the active session', async () => {
+    const { ctl, selectSession } = makeTwoSessionController(1); // active session is 1…
+    const { dict } = withViews(ctl);
+
+    await ctl.revealDictionaryByName('UserGlobals', 1); // …and the result also came from session 1
+
+    expect(selectSession).not.toHaveBeenCalled(); // no needless switch → no downstream refresh cycle
+    expect(dict.reveal).toHaveBeenCalledTimes(1); // still reveals
+  });
+
   it('warns and does not reveal when the result’s session is gone', async () => {
     const { ctl, selectSession } = makeTwoSessionController(2);
     const { dict } = withViews(ctl);

--- a/client/src/__tests__/explorerOmniReveal.test.ts
+++ b/client/src/__tests__/explorerOmniReveal.test.ts
@@ -158,3 +158,72 @@ describe('revealCategoryByPath checks existence before mutating the panes', () =
     expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
   });
 });
+
+// A reveal that names a session (Omni Search results carry their own sessionId) must run against THAT
+// session, not whatever session happens to be selected now — otherwise, after the user switches the
+// active session, a click resolves against the new one and lands in the wrong session's data (or, worse,
+// a same-named dictionary/category in it). No id → the old "resolve the selected session" behaviour.
+describe('reveal targets the result’s own session, not whatever is selected now', () => {
+  /** Two logged-in sessions, `selected` is the currently-active one; tracks selectSession calls. */
+  function makeTwoSessionController(selectedId: number) {
+    const sessions = new Map<number, ActiveSession>([
+      [1, { id: 1 } as ActiveSession],
+      [2, { id: 2 } as ActiveSession],
+    ]);
+    let selected = selectedId;
+    const selectSession = vi.fn((id: number) => {
+      selected = id;
+    });
+    const sessionManager = {
+      getSelectedSession: () => sessions.get(selected),
+      resolveSession: () => Promise.resolve(sessions.get(selected)),
+      getSession: (id: number) => sessions.get(id),
+      selectSession,
+    } as unknown as SessionManager;
+    return { ctl: new ExplorerController(sessionManager), selectSession };
+  }
+
+  it('switches to the result’s session before revealing a dictionary', async () => {
+    const { ctl, selectSession } = makeTwoSessionController(2); // active session is 2…
+    const { dict } = withViews(ctl);
+
+    await ctl.revealDictionaryByName('UserGlobals', 1); // …but the result came from session 1
+
+    expect(selectSession).toHaveBeenCalledWith(1); // switched to the result's session
+    expect(dict.reveal).toHaveBeenCalledTimes(1); // and actually revealed
+  });
+
+  it('warns and does not reveal when the result’s session is gone', async () => {
+    const { ctl, selectSession } = makeTwoSessionController(2);
+    const { dict } = withViews(ctl);
+
+    await ctl.revealDictionaryByName('UserGlobals', 99); // 99 was logged out
+
+    expect(selectSession).not.toHaveBeenCalled();
+    expect(dict.reveal).not.toHaveBeenCalled(); // no fallback to the selected session
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(vscode.window.showWarningMessage).mock.calls[0][0])).toContain('99');
+  });
+
+  it('does not force-select a session when no id is given (uses the selected one)', async () => {
+    const { ctl, selectSession } = makeTwoSessionController(2);
+    const { dict } = withViews(ctl);
+
+    await ctl.revealDictionaryByName('UserGlobals'); // legacy callers pass no id
+
+    expect(selectSession).not.toHaveBeenCalled();
+    expect(dict.reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches to the result’s session before revealing a category', async () => {
+    const { ctl, selectSession } = makeTwoSessionController(2);
+    const { category } = withViews(ctl);
+    classesInDict.mockReturnValue([{ className: 'Foo', category: 'Kernel' }]);
+    vi.spyOn(ctl, 'selectClassCategory').mockImplementation(() => {});
+
+    await ctl.revealCategoryByPath('UserGlobals', 'Kernel', 1);
+
+    expect(selectSession).toHaveBeenCalledWith(1);
+    expect(category.reveal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -764,7 +764,14 @@ export class ExplorerController {
       );
       return undefined;
     }
-    this.sessionManager.selectSession(sessionId);
+    // Only switch when the result came from a DIFFERENT session than the one already selected. The
+    // common case — searching and clicking a result in the session you are already in — must not fire a
+    // needless `selectSession`, which unconditionally emits onDidChangeSelection (sessionManager.ts) and
+    // drives a full downstream refresh it doesn't need: symbol-cache invalidation, admin-panel restale,
+    // sunit resync, tree refreshes. Mirrors OmniSearchPanel.show()'s session-id compare before switching.
+    if (this.sessionManager.getSelectedSession()?.id !== sessionId) {
+      this.sessionManager.selectSession(sessionId);
+    }
     return session;
   }
 

--- a/client/src/gemstoneExplorer.ts
+++ b/client/src/gemstoneExplorer.ts
@@ -750,6 +750,24 @@ export class ExplorerController {
     return this.sessionManager.getSelectedSession();
   }
 
+  // Resolve the session a reveal should run against. When a caller (Omni Search) names the session its
+  // result came from, switch the Explorer to that session first so the reveal targets the right data —
+  // otherwise, after the user switches the active session, a click would resolve against the new one
+  // and land in the wrong session (or a same-named dictionary/category). With no id, fall back to the
+  // normal "resolve the selected session (prompting if ambiguous)" path.
+  private async resolveSessionFor(sessionId?: number): Promise<ActiveSession | undefined> {
+    if (sessionId === undefined) return this.sessionManager.resolveSession();
+    const session = this.sessionManager.getSession(sessionId);
+    if (!session) {
+      void vscode.window.showWarningMessage(
+        `That result's GemStone session (${sessionId}) is no longer active.`,
+      );
+      return undefined;
+    }
+    this.sessionManager.selectSession(sessionId);
+    return session;
+  }
+
   setViews(views: ExplorerViews): void {
     this.views = views;
     this.syncTitles();
@@ -3559,10 +3577,11 @@ export class ExplorerController {
   // Browser "Find Class…"), then cascade the new panes to the chosen class:
   // select its dictionary and class-category, reveal the class row, and open its
   // definition. An explicit `name` arg (programmatic callers) skips the picker.
-  async findClass(name?: string): Promise<void> {
+  async findClass(name?: string, sessionId?: number): Promise<void> {
     // Resolve rather than require a pre-selected session: if one session is
     // logged in it's chosen automatically (a bare getSelectedSession() no-ops).
-    const session = await this.sessionManager.resolveSession();
+    // An explicit sessionId (Omni Search) pins the reveal to the result's own session.
+    const session = await this.resolveSessionFor(sessionId);
     if (!session) return;
 
     let entries: queries.ClassNameEntry[];
@@ -3607,8 +3626,8 @@ export class ExplorerController {
   // Reveal+select a dictionary row by name in the Dictionaries pane (used by Omni
   // Search). Resolves the 1-based symbol-list index from the live list, cascades
   // the panes to that dictionary, and highlights its row. Warns on an unknown name.
-  async revealDictionaryByName(name: string): Promise<void> {
-    const session = await this.sessionManager.resolveSession();
+  async revealDictionaryByName(name: string, sessionId?: number): Promise<void> {
+    const session = await this.resolveSessionFor(sessionId);
     if (!session) return;
     const names = queries.getDictionaryNames(session);
     const idx = names.indexOf(name);
@@ -3632,8 +3651,12 @@ export class ExplorerController {
   // Reveal+select a class-category node by path in the Categories pane (used by Omni Search). Selects
   // the home dictionary first (so its categories load + the classes pane filters to the category),
   // then selects and reveals the category node itself.
-  async revealCategoryByPath(dictName: string, categoryPath: string): Promise<void> {
-    const session = await this.sessionManager.resolveSession();
+  async revealCategoryByPath(
+    dictName: string,
+    categoryPath: string,
+    sessionId?: number,
+  ): Promise<void> {
+    const session = await this.resolveSessionFor(sessionId);
     if (!session) return;
     const names = queries.getDictionaryNames(session);
     const idx = names.indexOf(dictName);
@@ -5341,20 +5364,36 @@ export function registerGemStoneExplorer(
       if (node instanceof MethodItem) void ctl.openMethod(node, 'pin');
     }),
     // Find Class: cascade the panes to a class by name (from the Classes pane
-    // title button or the command palette).
-    vscode.commands.registerCommand('gemstone.explorer.findClass', (name?: string) =>
-      ctl.findClass(typeof name === 'string' ? name : undefined),
+    // title button or the command palette). The optional sessionId lets a caller (Omni Search) target
+    // the session its result came from rather than whatever session is selected now.
+    vscode.commands.registerCommand(
+      'gemstone.explorer.findClass',
+      (name?: string, sessionId?: number) =>
+        ctl.findClass(
+          typeof name === 'string' ? name : undefined,
+          typeof sessionId === 'number' ? sessionId : undefined,
+        ),
     ),
-    // Reveal+select a dictionary row by name (Omni Search dictionary results).
-    vscode.commands.registerCommand('gemstone.explorer.revealDictionary', (name?: string) =>
-      typeof name === 'string' ? ctl.revealDictionaryByName(name) : undefined,
+    // Reveal+select a dictionary row by name (Omni Search dictionary results). Optional sessionId as
+    // above — the result carries the session it was found in.
+    vscode.commands.registerCommand(
+      'gemstone.explorer.revealDictionary',
+      (name?: string, sessionId?: number) =>
+        typeof name === 'string'
+          ? ctl.revealDictionaryByName(name, typeof sessionId === 'number' ? sessionId : undefined)
+          : undefined,
     ),
-    // Reveal+select a class-category node by dict + path (Omni Search category results).
+    // Reveal+select a class-category node by dict + path (Omni Search category results). Optional
+    // sessionId as above.
     vscode.commands.registerCommand(
       'gemstone.explorer.revealCategory',
-      (dictName?: string, categoryPath?: string) =>
+      (dictName?: string, categoryPath?: string, sessionId?: number) =>
         typeof dictName === 'string' && typeof categoryPath === 'string'
-          ? ctl.revealCategoryByPath(dictName, categoryPath)
+          ? ctl.revealCategoryByPath(
+              dictName,
+              categoryPath,
+              typeof sessionId === 'number' ? sessionId : undefined,
+            )
           : undefined,
     ),
     // Open a class's definition editor (inline button / menu on the class row —

--- a/client/src/omniSearch/DESIGN.md
+++ b/client/src/omniSearch/DESIGN.md
@@ -108,7 +108,10 @@ Global "search anything browsable" for the GemStone IDE — the Jasper answer to
 
 6. **Reference Search (Wishlist Task 1).** A result can pivot to "who references it": a **method** row →
    **senders** of its selector, a **class** row → **references to** it (via the shared
-   `sendersOf` / `referencesToObject` queries). Two entry points: the per-row **↗ button** and
+   `sendersOf` / `referencesToObject` queries). The pivot sweeps every method environment
+   (`0..maxEnvironment`) and dedups by class/selector — matching the `sendersOfSelector` /
+   `implementorsOfSelector` commands — so hits in a non-zero environment aren't missed, and each opens
+   in the environment it was found in. Two entry points: the per-row **↗ button** and
    **Alt+Enter** on the highlighted row. `references.ts` is the pure glue (no `vscode`, no session).
    The setting **`referencesInPreview`** (default `true`) shows the references as a sticky list in the
    preview pane, leaving the results list in place; set it `false` for the classic pivot that replaces

--- a/client/src/omniSearch/__tests__/omniSearchCommand.test.ts
+++ b/client/src/omniSearch/__tests__/omniSearchCommand.test.ts
@@ -14,23 +14,27 @@ import { OMNI_VIEW_ID } from '../omniSearchViewProvider';
 describe('buildOmniHandlers', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('reveals a dictionary by name via the Explorer command, not a bare pane focus', () => {
+  it('reveals a dictionary by name via the Explorer command, threading the result session', () => {
     void buildOmniHandlers().revealDictionary({
       kind: 'revealDictionary',
-      sessionId: 1,
+      sessionId: 7,
       dictName: 'V8SplitDemo',
     });
 
+    // The result's own sessionId (7) must be passed so the reveal targets that session, not whatever
+    // session is selected now — the fix for the "click after switching sessions lands in the wrong
+    // session" bug. Passing a bare pane focus, or dropping the sessionId, fails here.
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
       'gemstone.explorer.revealDictionary',
       'V8SplitDemo',
+      7,
     );
   });
 
-  it('jumps a global to the class of its value, not to the dictionary', () => {
+  it('jumps a global to the class of its value, threading the result session', () => {
     void buildOmniHandlers().revealGlobal({
       kind: 'revealGlobal',
-      sessionId: 1,
+      sessionId: 7,
       dictName: 'Globals',
       name: 'Transcript',
       className: 'GsTerminalStream',
@@ -39,6 +43,7 @@ describe('buildOmniHandlers', () => {
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
       'gemstone.explorer.findClass',
       'GsTerminalStream',
+      7,
     );
   });
 
@@ -61,10 +66,10 @@ describe('buildOmniHandlers', () => {
     expect(call[2]).toEqual({ preserveFocus: true, preview: false });
   });
 
-  it('reveals a class category via dict + path, not just the dictionary', () => {
+  it('reveals a class category via dict + path, threading the result session', () => {
     void buildOmniHandlers().revealCategory({
       kind: 'revealCategory',
-      sessionId: 1,
+      sessionId: 7,
       dictName: 'Globals',
       dictIndex: 1,
       category: 'Kernel-Objects',
@@ -74,6 +79,7 @@ describe('buildOmniHandlers', () => {
       'gemstone.explorer.revealCategory',
       'Globals',
       'Kernel-Objects',
+      7,
     );
   });
 });

--- a/client/src/omniSearch/__tests__/omniSearchPanel.test.ts
+++ b/client/src/omniSearch/__tests__/omniSearchPanel.test.ts
@@ -1,0 +1,66 @@
+/**
+ * OmniSearchPanel.show() session binding.
+ *
+ * The Spotter is a singleton bound to one GemStone session: its engine (and the providers, activation
+ * and preview inside it) are built once from that session's `deps` in the constructor. So a second
+ * `show()` for the SAME session must just refocus the open panel, but a `show()` for a DIFFERENT
+ * session must REPLACE it — a bare reveal would keep searching and opening against the previous session
+ * with no sign anything is wrong (the reported two-session bug).
+ *
+ * createOmniEngine is mocked so `show()`/the constructor need no real session wiring; asserting which
+ * deps it was last built from is how we prove the live panel is bound to the right session. The whole
+ * lifecycle runs as one sequential scenario because OmniSearchPanel.current is a singleton that would
+ * otherwise leak between `it` blocks.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { OmniPanelDeps } from '../omniSearchPanel';
+
+vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
+vi.mock('../omniEngine', () => ({ createOmniEngine: vi.fn(() => ({})) }));
+
+import * as vscode from 'vscode';
+import { OmniSearchPanel } from '../omniSearchPanel';
+import { createOmniEngine } from '../omniEngine';
+
+// Minimal deps: with createOmniEngine mocked, only sessionId (the identity show() compares on) and the
+// shape matter; the rest are never touched on the show()/constructor path.
+function deps(sessionId: number): OmniPanelDeps {
+  return {
+    sessionId,
+    config: { enabledCategories: [] },
+    providers: [],
+    activate: vi.fn(),
+    previewSource: vi.fn(() => ''),
+    onError: vi.fn(),
+  } as unknown as OmniPanelDeps;
+}
+
+describe('OmniSearchPanel.show', () => {
+  it('refocuses on the same session, but replaces + rebinds the engine on a different one', () => {
+    const created = vi.mocked(vscode.window.createWebviewPanel);
+    const engine = vi.mocked(createOmniEngine);
+
+    // First open, session 1.
+    const depsA = deps(1);
+    OmniSearchPanel.show(depsA);
+    expect(created).toHaveBeenCalledTimes(1);
+    const panelA = created.mock.results[0].value;
+    expect(engine).toHaveBeenLastCalledWith(depsA);
+
+    // Second invocation, SAME session: refocus the open panel, do not open a new one.
+    OmniSearchPanel.show(deps(1));
+    expect(created).toHaveBeenCalledTimes(1); // no second panel
+    expect(panelA.reveal).toHaveBeenCalled();
+    expect(panelA.webview.postMessage).toHaveBeenCalledWith({ command: 'focusInput' });
+    expect(panelA.dispose).not.toHaveBeenCalled();
+
+    // Invocation for a DIFFERENT session: tear the old panel down and build a new one bound to it.
+    // On the buggy code show() would just reveal panelA — no dispose, no new panel, engine still bound
+    // to session 1 — so all three assertions below pin the fix.
+    const depsB = deps(2);
+    OmniSearchPanel.show(depsB);
+    expect(panelA.dispose).toHaveBeenCalledTimes(1);
+    expect(created).toHaveBeenCalledTimes(2);
+    expect(engine).toHaveBeenLastCalledWith(depsB);
+  });
+});

--- a/client/src/omniSearch/__tests__/references.test.ts
+++ b/client/src/omniSearch/__tests__/references.test.ts
@@ -50,7 +50,6 @@ describe('referenceRequestFor', () => {
       title: 'Senders of printString',
       kind: 'senders',
       selector: 'printString',
-      environmentId: 0,
     });
   });
 
@@ -59,7 +58,6 @@ describe('referenceRequestFor', () => {
       title: 'References to OrderedCollection',
       kind: 'references',
       className: 'OrderedCollection',
-      environmentId: 0,
     });
   });
 
@@ -82,7 +80,6 @@ describe('referenceRequestFor', () => {
       title: 'References to Transcript',
       kind: 'references',
       className: 'Transcript',
-      environmentId: 0,
     });
   });
 
@@ -124,6 +121,25 @@ describe('methodRowsToResults', () => {
       kind: 'openMethod',
       isMeta: true,
       selector: 'with:',
+    });
+  });
+
+  it('carries the given method environment into each open action (defaults to 0)', () => {
+    const rows: MethodSearchResult[] = [
+      {
+        dictName: 'Globals',
+        className: 'Array',
+        isMeta: false,
+        selector: 'do:',
+        category: 'enumerating',
+      },
+    ];
+
+    // Default: env 0 (the Source/Literals scopes rely on this).
+    expect(methodRowsToResults(rows, 7)[0].action).toMatchObject({ environmentId: 0 });
+    // Explicit non-zero env (a references-pivot hit found in environment 2) must open there, not env 0.
+    expect(methodRowsToResults(rows, 7, 'methods', 2)[0].action).toMatchObject({
+      environmentId: 2,
     });
   });
 });

--- a/client/src/omniSearch/__tests__/resolveReferences.test.ts
+++ b/client/src/omniSearch/__tests__/resolveReferences.test.ts
@@ -1,0 +1,130 @@
+/**
+ * resolveReferencesUsing — the references-pivot query layer.
+ *
+ * Senders and references can live in any method environment, so the pivot must sweep
+ * 0..maxEnvironment (like the gemstone.sendersOfSelector / implementorsOfSelector commands), not just
+ * environment 0. A hit found in a non-zero environment must survive AND open in that environment; a
+ * method that appears in more than one environment is shown once (lowest-environment copy kept).
+ *
+ * browserQueries is mocked so no stone is needed; each env returns a distinct row so we can prove which
+ * environments were actually queried and which env each surviving row was tagged with.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => import('../../__mocks__/vscode.js'));
+vi.mock('../../browserQueries', () => ({
+  sendersOf: vi.fn(),
+  referencesToObject: vi.fn(),
+  // Named imports the module pulls from browserQueries but this test never exercises.
+  defaultQueryExecutorUsing: vi.fn(),
+  getMethodSource: vi.fn(),
+  getClassDefinition: vi.fn(),
+}));
+
+import { __resetConfig, __setConfig } from '../../__mocks__/vscode';
+import { sendersOf, referencesToObject } from '../../browserQueries';
+import { resolveReferencesUsing } from '../omniSearchCommand';
+import type { MethodSearchResult } from '../../queries/methodSearch';
+import type { OmniResult } from '../omniTypes';
+import type { ActiveSession } from '../../sessionManager';
+
+const sendersOfMock = vi.mocked(sendersOf);
+
+const SESSION = { id: 5 } as ActiveSession;
+
+// A method OmniResult, so referenceRequestFor() asks for senders of its selector.
+const methodResult: OmniResult = {
+  categoryId: 'methods',
+  label: 'Object>>foo',
+  score: 1,
+  ranges: [],
+  action: {
+    kind: 'openMethod',
+    sessionId: 5,
+    dictName: 'Globals',
+    className: 'Object',
+    isMeta: false,
+    category: 'accessing',
+    selector: 'foo',
+    environmentId: 0,
+    dictIndex: 0,
+  },
+};
+
+function row(className: string): MethodSearchResult {
+  return { dictName: 'Globals', className, isMeta: false, selector: 'foo', category: 'accessing' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetConfig();
+});
+
+describe('resolveReferencesUsing sweeps every method environment', () => {
+  it('queries only environment 0 when maxEnvironment is 0 (the default)', () => {
+    sendersOfMock.mockReturnValue([row('CallerA')]);
+
+    const view = resolveReferencesUsing(SESSION)(methodResult);
+
+    expect(sendersOfMock).toHaveBeenCalledTimes(1);
+    expect(sendersOfMock).toHaveBeenCalledWith(SESSION, 'foo', 0);
+    expect(view?.results).toHaveLength(1);
+  });
+
+  it('queries 0..maxEnvironment and keeps hits found only in a non-zero environment', () => {
+    __setConfig('gemstone', 'maxEnvironment', 2);
+    // env 0 → CallerA, env 1 → nothing, env 2 → CallerC.
+    sendersOfMock.mockImplementation((_s, _sel, env) =>
+      env === 0 ? [row('CallerA')] : env === 2 ? [row('CallerC')] : [],
+    );
+
+    const view = resolveReferencesUsing(SESSION)(methodResult);
+
+    expect(sendersOfMock.mock.calls.map((c) => c[2])).toEqual([0, 1, 2]); // swept every env
+    const labels = view?.results.map((r) => r.label);
+    expect(labels).toEqual(['CallerA>>foo', 'CallerC>>foo']); // env-0 and env-2 hits both survive
+  });
+
+  it('tags each surviving row with the environment it was found in, so it opens there', () => {
+    __setConfig('gemstone', 'maxEnvironment', 1);
+    sendersOfMock.mockImplementation((_s, _sel, env) =>
+      env === 0 ? [row('CallerA')] : [row('CallerC')],
+    );
+
+    const view = resolveReferencesUsing(SESSION)(methodResult);
+
+    const envById = Object.fromEntries(
+      (view?.results ?? []).map((r) => [
+        r.label,
+        r.action.kind === 'openMethod' ? r.action.environmentId : -1,
+      ]),
+    );
+    expect(envById['CallerA>>foo']).toBe(0);
+    expect(envById['CallerC>>foo']).toBe(1); // NOT 0 — it opens in the env it was found in
+  });
+
+  it('shows a method that appears in several environments once, keeping the lowest-env copy', () => {
+    __setConfig('gemstone', 'maxEnvironment', 2);
+    sendersOfMock.mockReturnValue([row('CallerA')]); // same hit in every env
+
+    const view = resolveReferencesUsing(SESSION)(methodResult);
+
+    expect(view?.results).toHaveLength(1); // deduped by class/selector
+    const only = view?.results[0];
+    expect(only?.action.kind === 'openMethod' && only.action.environmentId).toBe(0); // lowest env kept
+  });
+
+  it('returns null for a non-referenceable result and never queries', () => {
+    const dictResult: OmniResult = {
+      categoryId: 'dictionaries',
+      label: 'UserGlobals',
+      score: 1,
+      ranges: [],
+      action: { kind: 'revealDictionary', sessionId: 5, dictName: 'UserGlobals' },
+    };
+
+    expect(resolveReferencesUsing(SESSION)(dictResult)).toBeNull();
+    expect(sendersOfMock).not.toHaveBeenCalled();
+    expect(vi.mocked(referencesToObject)).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/omniSearch/omniSearchCommand.ts
+++ b/client/src/omniSearch/omniSearchCommand.ts
@@ -90,20 +90,30 @@ export function buildOmniHandlers(openOptions?: OmniOpenOptions): OmniActionHand
     revealDictionary(a) {
       // Cascade the Explorer to the named dictionary and select its row (the command resolves the
       // symbol-list index and reveals it — a bare pane `.focus` would not select the dictionary).
-      void vscode.commands.executeCommand('gemstone.explorer.revealDictionary', a.dictName);
+      // Pass the result's own session so the reveal targets it, not whatever session is selected now
+      // (same as openClass/openMethod) — otherwise switching sessions after a search lands you in the
+      // wrong session's data.
+      void vscode.commands.executeCommand(
+        'gemstone.explorer.revealDictionary',
+        a.dictName,
+        a.sessionId,
+      );
     },
     revealGlobal(a) {
       // Jump to the class of the global's value (e.g. Transcript → its stream class) — more useful
       // than landing in the whole dictionary. findClass resolves the class's home dict + reveals it.
-      void vscode.commands.executeCommand('gemstone.explorer.findClass', a.className);
+      // Session-scoped for the same reason as revealDictionary above.
+      void vscode.commands.executeCommand('gemstone.explorer.findClass', a.className, a.sessionId);
     },
     revealCategory(a) {
       // Select the category's home dictionary, then select + reveal the category node (and filter the
-      // classes pane to it) — not just land in the dictionary.
+      // classes pane to it) — not just land in the dictionary. Session-scoped for the same reason as
+      // revealDictionary above.
       void vscode.commands.executeCommand(
         'gemstone.explorer.revealCategory',
         a.dictName,
         a.category,
+        a.sessionId,
       );
     },
   };
@@ -117,12 +127,30 @@ export function resolveReferencesUsing(
   return (result) => {
     const req = referenceRequestFor(result);
     if (!req) return null;
-    const rows =
-      req.kind === 'senders'
-        ? sendersOf(session, req.selector, req.environmentId)
-        : referencesToObject(session, req.className, req.environmentId);
+    // Senders and references can live in ANY method environment, so sweep 0..maxEnvironment the same
+    // way the gemstone.sendersOfSelector / implementorsOfSelector commands do — a single env-0 query
+    // silently misses every hit in environment >= 1 on a multi-environment stone. Dedup by
+    // class/selector keeping the lowest-environment copy, and carry each surviving row's environment
+    // into its open action so it opens where it was found. (maxEnvironment defaults to 0, so the common
+    // single-environment case stays exactly one round trip.)
+    const maxEnv = vscode.workspace.getConfiguration('gemstone').get<number>('maxEnvironment', 0);
+    const seen = new Set<string>();
+    const results: OmniResult[] = [];
+    for (let env = 0; env <= maxEnv; env++) {
+      const rows =
+        req.kind === 'senders'
+          ? sendersOf(session, req.selector, env)
+          : referencesToObject(session, req.className, env);
+      for (const r of methodRowsToResults(rows, session.id, 'methods', env)) {
+        const a = r.action;
+        const key = a.kind === 'openMethod' ? `${a.className}|${a.isMeta}|${a.selector}` : r.label;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        results.push(r);
+      }
+    }
     const target = req.kind === 'senders' ? req.selector : req.className;
-    return { title: req.title, target, results: methodRowsToResults(rows, session.id) };
+    return { title: req.title, target, results };
   };
 }
 

--- a/client/src/omniSearch/omniSearchPanel.ts
+++ b/client/src/omniSearch/omniSearchPanel.ts
@@ -70,12 +70,23 @@ export class OmniSearchPanel {
   // Guard so an initial "inactive" view-state event can't dispose the panel before it's ever focused.
   private hasBeenActive = false;
 
-  /** Open (or reveal) the Spotter. Only one exists at a time — a second invocation refocuses it. */
+  /** Open (or reveal) the Spotter. Only one exists at a time. A second invocation for the SAME
+   *  session just refocuses it; one for a DIFFERENT session replaces it, because a Spotter is bound
+   *  to its session (see below) and can't be re-pointed in place. */
   static show(deps: OmniPanelDeps): void {
-    if (OmniSearchPanel.current) {
-      OmniSearchPanel.current.panel.reveal(OmniSearchPanel.current.panel.viewColumn);
-      OmniSearchPanel.current.panel.webview.postMessage({ command: 'focusInput' });
-      return;
+    const existing = OmniSearchPanel.current;
+    if (existing) {
+      if (existing.deps.sessionId === deps.sessionId) {
+        // Same session: bring the open Spotter forward and refocus its field.
+        existing.panel.reveal(existing.panel.viewColumn);
+        existing.panel.webview.postMessage({ command: 'focusInput' });
+        return;
+      }
+      // Different session: the open Spotter's engine (and its providers, activation and preview) was
+      // built once from the OLD session's `deps` in the constructor and can't be re-pointed here, so a
+      // bare reveal would keep searching and opening against the previous session with no sign
+      // anything is wrong. Replace it with a Spotter bound to the new session's deps.
+      existing.dispose();
     }
     const panel = vscode.window.createWebviewPanel(
       'gemstoneOmniSearch',

--- a/client/src/omniSearch/references.ts
+++ b/client/src/omniSearch/references.ts
@@ -14,48 +14,39 @@ import { MethodSearchResult } from '../queries/methodSearch';
 import { OmniCategoryId, OmniResult } from './omniTypes';
 
 export type ReferenceRequest =
-  | { title: string; kind: 'senders'; selector: string; environmentId: number }
-  | { title: string; kind: 'references'; className: string; environmentId: number };
+  | { title: string; kind: 'senders'; selector: string }
+  | { title: string; kind: 'references'; className: string };
 
-/** What (if anything) the reference button on a result should fetch, plus its breadcrumb title. */
+/** What (if anything) the reference button on a result should fetch, plus its breadcrumb title.
+ *  No environment is carried: senders/references can live in ANY method environment, so the command
+ *  layer sweeps every environment (0..maxEnvironment) rather than the source row's own — see
+ *  `resolveReferencesUsing`. */
 export function referenceRequestFor(result: OmniResult): ReferenceRequest | null {
   const a = result.action;
   if (a.kind === 'openMethod') {
-    return {
-      title: `Senders of ${a.selector}`,
-      kind: 'senders',
-      selector: a.selector,
-      environmentId: a.environmentId,
-    };
+    return { title: `Senders of ${a.selector}`, kind: 'senders', selector: a.selector };
   }
   if (a.kind === 'openClass') {
-    return {
-      title: `References to ${a.className}`,
-      kind: 'references',
-      className: a.className,
-      environmentId: 0,
-    };
+    return { title: `References to ${a.className}`, kind: 'references', className: a.className };
   }
   if (a.kind === 'revealGlobal') {
     // A global is referenceable by its name, exactly like a class (referencesToObject takes any
     // symbol-list name), so "who uses this variable?" works from a global hit too.
-    return {
-      title: `References to ${a.name}`,
-      kind: 'references',
-      className: a.name,
-      environmentId: 0,
-    };
+    return { title: `References to ${a.name}`, kind: 'references', className: a.name };
   }
   return null;
 }
 
 /** Shape method-search rows into method OmniResults (label `Class>>selector`, opens the method).
  *  `categoryId` lets non-method sources (e.g. the Source scope) group their method hits under their
- *  own separator while still opening the method. */
+ *  own separator while still opening the method. `environmentId` is the method environment the rows
+ *  were found in — it must ride through to the open action so a hit in a non-zero environment opens
+ *  there; it defaults to 0 for the env-0 sources (Source/Literals). */
 export function methodRowsToResults(
   rows: readonly MethodSearchResult[],
   sessionId: number,
   categoryId: OmniCategoryId = 'methods',
+  environmentId = 0,
 ): OmniResult[] {
   return rows.map((r) => ({
     categoryId,
@@ -73,7 +64,7 @@ export function methodRowsToResults(
       isMeta: r.isMeta,
       category: r.category,
       selector: r.selector,
-      environmentId: 0,
+      environmentId,
       dictIndex: 0,
     },
   }));


### PR DESCRIPTION
## What & why

Three correctness fixes for GemStone Search, each a state bug that only surfaces with more than one
session or method environment. They were surfaced by a `/code-review` pass over the GemStone Search
feature (posted on #451, but outside that PR's diff), and are handled here as their own change.

### Fixes

- **The Spotter panel stayed bound to the session it was opened with.** `OmniSearchPanel.show()` used to
  reveal the existing panel and discard the incoming `deps`, so after the active session changed it kept
  searching and opening against the old session with no sign anything was wrong. It now compares the
  session: same session → reveal + refocus (unchanged); different session → replace the panel (the
  engine, providers, activation and preview are built once from `deps` in the constructor, so it can't be
  re-pointed in place). (#459)

- **The dictionary / global / class-category reveal actions ignored the result's session.** The three
  reveal handlers dropped the result's `sessionId`, and the Explorer commands resolved against whatever
  session was selected *now* — so searching in one session, switching active to another, then clicking a
  result revealed it in the wrong session (best case "not found", worst case a same-named
  dictionary/category in the other session, silently). The handlers now thread `a.sessionId` through, and
  `findClass` / `revealDictionaryByName` / `revealCategoryByPath` select that session first (warning if
  it's gone) — matching how `openClass` / `openMethod` already carry the session. (#459)

- **The references pivot only queried method environment 0.** On a stone with `maxEnvironment > 0`,
  pivoting to senders/references missed every hit in environment ≥ 1. `resolveReferencesUsing` now sweeps
  `0..maxEnvironment` and dedups by class/selector — matching the existing
  `sendersOfSelector` / `implementorsOfSelector` commands — and carries each surviving row's environment
  into its open action so it opens where it was found. `maxEnvironment` defaults to 0, so the common
  single-environment case is unchanged (one round trip). (#461)

## Testing

Client-only TypeScript change (no server / GemStone / RB surface). Fast gate green — `lint`,
`format:check`, `compile`, and the full `npm test` (client **5949 passed / 12 skipped** incl. the live
integration test, server **322**, mcp **92**), re-run after merging current `main`.

Each fix is pinned by unit tests that **fail on the old code and pass on the new** (verified by reverting
only the source): new `omniSearchPanel.test.ts` and `resolveReferences.test.ts`, plus additions to
`omniSearchCommand.test.ts`, `explorerOmniReveal.test.ts`, and `references.test.ts`.

**No F5 verification:** all three require the active session to change between a search and the action on
its result (or a `maxEnvironment > 0` stone), and there is no quick session switch to stage that by hand
— so the unit tests are the verification of record here.

Closes #459
Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
