### PR TITLE
GemStone Search: reference/pivot ordering, camelCase matching, and keystroke debounce

### DIFF
--- a/client/src/omniSearch/__tests__/omniEngine.test.ts
+++ b/client/src/omniSearch/__tests__/omniEngine.test.ts
@@ -817,6 +817,32 @@ describe('createOmniEngine — out-of-order reference and pivot results', () => 
     expect(engine.referenceResultFor(fastB!.rows[0].id)!.label).toBe('Y>>usesBeta');
   });
 
+  it('a new search supersedes a reference load the previous term left in flight', async () => {
+    let releaseRefs: (() => void) | undefined;
+    const gate = new Promise<void>((res) => (releaseRefs = res));
+    const engine = createOmniEngine({
+      providers: [fakeProvider('classes', [classResult('Alpha'), classResult('Beta')])],
+      config: cfg(),
+      resolveReferences: async () => {
+        await gate; // still resolving when the next search lands
+        return {
+          title: 'References to Alpha',
+          target: 'Alpha',
+          results: [methodResult('X>>usesAlpha', 'usesAlpha')],
+        };
+      },
+    });
+    const search = await engine.search('a');
+    const idA = search!.rows.find((r) => r.label === 'Alpha')!.id;
+
+    const slowRefs = engine.referencesFor(idA);
+    const next = await engine.search('al'); // a new term starts while the reference load is mid-flight
+    releaseRefs!();
+
+    expect(await slowRefs).toBeNull(); // superseded by the search — its rows never overwrite the list
+    expect(next!.rows.map((r) => r.label).sort()).toEqual(['Alpha', 'Beta']); // the search landed intact
+  });
+
   it('a reference load neither cancels nor is cancelled by an in-flight search', async () => {
     let releaseSearch: (() => void) | undefined;
     const gate = new Promise<void>((res) => (releaseSearch = res));
@@ -846,7 +872,9 @@ describe('createOmniEngine — out-of-order reference and pivot results', () => 
     releaseSearch!();
 
     expect(preview!.rows.map((r) => r.label)).toEqual(['A>>useFoo']); // not cancelled by the search
-    expect(await searchP).not.toBeNull(); // and it did not cancel the search either
+    // ...and it did not cancel the search either: the search's own rows land intact, not clobbered by
+    // the reference load's row.
+    expect((await searchP)!.rows.map((r) => r.label)).toEqual(['Foo']);
   });
 
   it('supersedes an earlier pivot when a second pivot is started', async () => {

--- a/client/src/omniSearch/__tests__/omniEngine.test.ts
+++ b/client/src/omniSearch/__tests__/omniEngine.test.ts
@@ -774,3 +774,134 @@ describe('createOmniEngine — scope vs. the references pivot', () => {
     expect(back!.rows.map((r) => r.label).sort()).toEqual(['Bar>>foo', 'Foo']);
   });
 });
+
+describe('createOmniEngine — out-of-order reference and pivot results', () => {
+  it("supersedes a slow reference load so its rows cannot overwrite a newer row's", async () => {
+    const rowA = classResult('Alpha');
+    const rowB = classResult('Beta');
+    const refsForA: ReferenceView = {
+      title: 'References to Alpha',
+      target: 'Alpha',
+      results: [methodResult('X>>usesAlpha', 'usesAlpha')],
+    };
+    const refsForB: ReferenceView = {
+      title: 'References to Beta',
+      target: 'Beta',
+      results: [methodResult('Y>>usesBeta', 'usesBeta')],
+    };
+    let releaseA: (() => void) | undefined;
+    const gate = new Promise<void>((res) => (releaseA = res));
+    const engine = createOmniEngine({
+      providers: [fakeProvider('classes', [rowA, rowB])],
+      config: cfg(),
+      // Alpha is the slow one and resolves LAST, exactly the order that used to corrupt the list.
+      resolveReferences: async (r) => {
+        if (r.label === 'Alpha') {
+          await gate;
+          return refsForA;
+        }
+        return refsForB;
+      },
+    });
+    const search = await engine.search('a');
+    const idA = search!.rows.find((r) => r.label === 'Alpha')!.id;
+    const idB = search!.rows.find((r) => r.label === 'Beta')!.id;
+
+    const slowA = engine.referencesFor(idA);
+    const fastB = await engine.referencesFor(idB); // arrowed on to Beta while Alpha still resolves
+    releaseA!();
+
+    expect(await slowA).toBeNull(); // stale load discarded rather than written
+    expect(fastB!.rows.map((r) => r.label)).toEqual(['Y>>usesBeta']);
+    // The rows behind the ids the UI is showing are still Beta's — opening one cannot land in Alpha's.
+    expect(engine.referenceResultFor(fastB!.rows[0].id)!.label).toBe('Y>>usesBeta');
+  });
+
+  it('a reference load neither cancels nor is cancelled by an in-flight search', async () => {
+    let releaseSearch: (() => void) | undefined;
+    const gate = new Promise<void>((res) => (releaseSearch = res));
+    let call = 0;
+    const slow: OmniProvider = {
+      category: CATEGORY_BY_ID.classes,
+      async search() {
+        call++;
+        if (call === 2) await gate; // the SECOND search blocks, with a reference load landing meanwhile
+        return [classResult('Foo')];
+      },
+    };
+    const refView: ReferenceView = {
+      title: 'References to Foo',
+      target: 'Foo',
+      results: [methodResult('A>>useFoo', 'useFoo')],
+    };
+    const engine = createOmniEngine({
+      providers: [slow],
+      config: cfg(),
+      resolveReferences: () => refView,
+    });
+    const first = await engine.search('fo');
+
+    const searchP = engine.search('foo');
+    const preview = await engine.referencesFor(first!.rows[0].id);
+    releaseSearch!();
+
+    expect(preview!.rows.map((r) => r.label)).toEqual(['A>>useFoo']); // not cancelled by the search
+    expect(await searchP).not.toBeNull(); // and it did not cancel the search either
+  });
+
+  it('supersedes an earlier pivot when a second pivot is started', async () => {
+    let releaseAlpha: (() => void) | undefined;
+    const gate = new Promise<void>((res) => (releaseAlpha = res));
+    const engine = createOmniEngine({
+      providers: [fakeProvider('classes', [classResult('Alpha'), classResult('Beta')])],
+      config: cfg(),
+      // Alpha resolves LAST — the ordering that used to let the abandoned pivot win.
+      resolveReferences: async (r) => {
+        if (r.label === 'Alpha') {
+          await gate;
+          return {
+            title: 'References to Alpha',
+            results: [methodResult('X>>usesAlpha', 'usesAlpha')],
+          };
+        }
+        return { title: 'References to Beta', results: [methodResult('Y>>usesBeta', 'usesBeta')] };
+      },
+    });
+    const search = await engine.search('a');
+    const idAlpha = search!.rows.find((r) => r.label === 'Alpha')!.id;
+    const idBeta = search!.rows.find((r) => r.label === 'Beta')!.id;
+
+    const slowPivot = engine.pivot(idAlpha);
+    const fastPivot = await engine.pivot(idBeta); // pivoted somewhere else before Alpha came back
+    releaseAlpha!();
+
+    expect(await slowPivot).toBeNull(); // stale pivot discarded
+    expect(fastPivot!.pivotTitle).toBe('References to Beta');
+    // The live list is still Beta's, so activating a row cannot open one of Alpha's references.
+    expect(engine.resultFor(fastPivot!.rows[0].id)!.label).toBe('Y>>usesBeta');
+    expect(engine.state().pivot).toBe(true);
+  });
+
+  it('supersedes a slow pivot so it cannot snap the view back to an abandoned reference view', async () => {
+    let releasePivot: (() => void) | undefined;
+    const gate = new Promise<void>((res) => (releasePivot = res));
+    const engine = createOmniEngine({
+      providers: [fakeProvider('classes', [classResult('Foo')])],
+      config: cfg(),
+      resolveReferences: async () => {
+        await gate;
+        return { title: 'References to Foo', results: [methodResult('A>>useFoo', 'useFoo')] };
+      },
+    });
+    const search = await engine.search('foo');
+
+    const pivotP = engine.pivot(search!.rows[0].id);
+    const retyped = await engine.search('fo'); // a new term while the pivot is still resolving
+    releasePivot!();
+
+    expect(await pivotP).toBeNull(); // stale pivot discarded
+    expect(retyped!.pivot).toBe(false);
+    expect(engine.state().pivot).toBe(false); // the view stayed on the search the user asked for
+    expect(engine.resultFor(retyped!.rows[0].id)!.label).toBe('Foo');
+  });
+});

--- a/client/src/omniSearch/__tests__/omniMatch.test.ts
+++ b/client/src/omniSearch/__tests__/omniMatch.test.ts
@@ -118,6 +118,36 @@ describe('omniMatch — empty query is a neutral match-all', () => {
   });
 });
 
+describe('omniMatch — a camelCase boundary is preferred even with case folding on', () => {
+  // The default is caseSensitive:false, which folds the target before matching. The word-start
+  // preference must still be judged against the ORIGINAL case, or its camelCase-hump half can never
+  // fire and a mid-word occurrence wins over a later camelCase one.
+  it('picks the camelCase-hump occurrence over an earlier mid-word one (case-INSENSITIVE)', () => {
+    const r = match('co', 'xcoreFooCore', opts('fuzzy'));
+    expect(r?.ranges).toEqual([[8, 10]]); // the "Co" of "Core", not the "co" at index 1
+  });
+
+  it('agrees with the case-SENSITIVE result — folding changes equality, not the preference', () => {
+    const insensitive = match('co', 'xcoreFooCore', opts('fuzzy'));
+    const sensitive = match('Co', 'xcoreFooCore', opts('fuzzy', true));
+    expect(insensitive?.ranges).toEqual(sensitive?.ranges);
+  });
+
+  it('still prefers a separator boundary, which folding never hid', () => {
+    const r = match('core', 'xcore-core', opts('fuzzy'));
+    expect(r?.ranges).toEqual([[6, 10]]); // after the '-', not the mid-word run at 1
+  });
+
+  it('falls back to the leftmost occurrence when no occurrence is at a boundary', () => {
+    const r = match('or', 'worldform', opts('fuzzy'));
+    expect(r?.ranges).toEqual([[1, 3]]); // no boundary anywhere → leftmost, unchanged behaviour
+  });
+
+  it('ranks the camelCase-boundary target above a mid-word one for the same query', () => {
+    expect(rank('co', ['xcoreish', 'FooCore'], 'fuzzy')).toEqual(['FooCore', 'xcoreish']);
+  });
+});
+
 describe('isWordStart', () => {
   it('flags string start, post-separator, and camelCase humps', () => {
     expect(isWordStart('OrderedCollection', 0)).toBe(true); // start

--- a/client/src/omniSearch/__tests__/omniSearchView.test.ts
+++ b/client/src/omniSearch/__tests__/omniSearchView.test.ts
@@ -987,3 +987,106 @@ describe('Omni Search view — scopes skipped under All', () => {
     expect(hint().textContent).toBe('');
   });
 });
+
+describe('search field debounce', () => {
+  /** Mount, then push a host config carrying `debounceMs` (the only way the webview learns it). */
+  function mountWithDebounce(debounceMs: number) {
+    const m = mount();
+    m.handle.onMessage({
+      data: { command: 'config', categories: [], scopeId: null, debounceMs },
+    });
+    m.vscode.postMessage.mockClear();
+    return m;
+  }
+
+  function type(text: string) {
+    const input = document.getElementById('query') as HTMLInputElement;
+    input.value = text;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function queries(vscode: { postMessage: ReturnType<typeof vi.fn> }) {
+    return vscode.postMessage.mock.calls
+      .map((c) => c[0] as { command: string; value?: string })
+      .filter((m) => m.command === 'query')
+      .map((m) => m.value);
+  }
+
+  it('coalesces a burst of keystrokes into ONE search, carrying the final text', () => {
+    vi.useFakeTimers();
+    try {
+      const { vscode } = mountWithDebounce(120);
+      type('f');
+      type('fo');
+      type('foo');
+      expect(queries(vscode)).toEqual([]); // nothing sent while the user is still typing
+
+      vi.advanceTimersByTime(120);
+      expect(queries(vscode)).toEqual(['foo']); // one search, the finished term
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waits for quiet — a keystroke inside the window restarts the delay', () => {
+    vi.useFakeTimers();
+    try {
+      const { vscode } = mountWithDebounce(120);
+      type('f');
+      vi.advanceTimersByTime(100); // not yet
+      type('fo');
+      vi.advanceTimersByTime(100); // still inside the restarted window
+      expect(queries(vscode)).toEqual([]);
+
+      vi.advanceTimersByTime(20);
+      expect(queries(vscode)).toEqual(['fo']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('searches immediately when the delay is 0 (opt-out) and before any config arrives', () => {
+    const immediate = mountWithDebounce(0);
+    type('ab');
+    expect(queries(immediate.vscode)).toEqual(['ab']);
+
+    // No config message at all — the field must still work, just uncoalesced.
+    const bare = mount();
+    type('cd');
+    expect(queries(bare.vscode)).toEqual(['cd']);
+  });
+
+  it('the clear button searches at once and cancels a keystroke still pending', () => {
+    vi.useFakeTimers();
+    try {
+      const { vscode } = mountWithDebounce(120);
+      type('foo');
+      (document.getElementById('clear') as HTMLButtonElement).click();
+      expect(queries(vscode)).toEqual(['']); // immediate, not waiting out the timer
+
+      vi.advanceTimersByTime(500);
+      expect(queries(vscode)).toEqual(['']); // and 'foo' never lands after the clear
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores a nonsense debounce value, keeping the last good one in force', () => {
+    vi.useFakeTimers();
+    try {
+      const { handle, vscode } = mountWithDebounce(120);
+      // A negative value is not a valid delay; adopting it would drop the coalescing entirely.
+      handle.onMessage({
+        data: { command: 'config', categories: [], scopeId: null, debounceMs: -5 },
+      });
+      vscode.postMessage.mockClear();
+
+      type('x');
+      expect(queries(vscode)).toEqual([]); // still coalescing, so -5 was not adopted
+      vi.advanceTimersByTime(120);
+      expect(queries(vscode)).toEqual(['x']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/client/src/omniSearch/omniEngine.ts
+++ b/client/src/omniSearch/omniEngine.ts
@@ -304,7 +304,8 @@ export interface OmniEngine {
   loadMore(): Promise<OmniViewData | null>;
   /** Jump the cap to everything (bounded by the server fetch caps); re-runs the current term. */
   loadAll(): Promise<OmniViewData | null>;
-  /** Pivot the list to a row's references/senders. Returns null if not referenceable / no resolver. */
+  /** Pivot the list to a row's references/senders. Returns null if not referenceable, if there is no
+   *  resolver, or if a newer call superseded this one while it resolved. */
   pivot(rowId: number): Promise<OmniViewData | null>;
   /** Leave the reference view and restore the prior search. */
   exitPivot(): Promise<OmniViewData | null>;
@@ -312,7 +313,8 @@ export interface OmniEngine {
    *  `explicitOnly` ids are ignored (they are never in "All" anyway). */
   setExcludedFromAll(ids: readonly OmniCategoryId[]): Promise<OmniViewData | null>;
   /** Load a row's references/senders for the sticky preview-pane list WITHOUT pivoting — the search
-   *  list and all search state are left intact. Returns null if not referenceable / no resolver. */
+   *  list and all search state are left intact. Returns null if not referenceable, if there is no
+   *  resolver, or if a newer reference load superseded this one while it resolved. */
   referencesFor(rowId: number): Promise<ReferencePreview | null>;
   /** The `OmniResult` for a reference row id from the last `referencesFor` (for opening its source). */
   referenceResultFor(refId: number): OmniResult | undefined;
@@ -349,6 +351,11 @@ export function createOmniEngine(deps: OmniEngineDeps): OmniEngine {
   // The reference rows from the last `referencesFor`, indexed by the preview list's row id. Kept
   // separate from `current` so loading references never disturbs the search list or its ids.
   let referenceRows: OmniResult[] = [];
+  // Ordering token for `referencesFor`, deliberately SEPARATE from `generation`: loading the preview
+  // list leaves the search alone, so a reference load must neither cancel an in-flight search nor be
+  // cancelled by one. All it has to supersede is an earlier reference load, whose slower resolve would
+  // otherwise land in `referenceRows` after a newer row's — see the guard in `referencesFor`.
+  let referenceGeneration = 0;
 
   const effectiveConfig = (): OmniConfig => ({
     ...config,
@@ -549,8 +556,14 @@ export function createOmniEngine(deps: OmniEngineDeps): OmniEngine {
       if (!deps.resolveReferences) return null;
       const result = current[rowId];
       if (!result) return null;
-      ++generation; // supersede any in-flight search so its late result can't land over the pivot
+      // Take a token of our own as we supersede in-flight work. Bumping `generation` stops an older
+      // search from landing over this pivot, but the resolve below can be slow (senders of a common
+      // selector), and anything the user does while we wait — a new term, another pivot — bumps the
+      // generation again. Without re-checking afterwards this call would snap the view back to a pivot
+      // that has already been left behind.
+      const gen = ++generation;
       const view = await deps.resolveReferences(result);
+      if (gen !== generation) return null; // a newer call superseded this pivot
       if (!view) return null; // not referenceable — leave the current list as-is
       pivot = view;
       current = view.results;
@@ -573,7 +586,12 @@ export function createOmniEngine(deps: OmniEngineDeps): OmniEngine {
       if (!deps.resolveReferences) return null;
       const result = current[rowId];
       if (!result) return null;
+      // `referenceRows` is the single array every preview row id indexes into, so a slow load must not
+      // land after a newer one: arrowing from row A to row B while A is still resolving would leave B's
+      // list on screen over A's rows, and `referenceResultFor` would then open the wrong method.
+      const gen = ++referenceGeneration;
       const view = await deps.resolveReferences(result);
+      if (gen !== referenceGeneration) return null; // a newer reference load superseded this one
       if (!view) return null; // not referenceable
       referenceRows = view.results;
       const built = buildView(

--- a/client/src/omniSearch/omniEngine.ts
+++ b/client/src/omniSearch/omniEngine.ts
@@ -410,6 +410,12 @@ export function createOmniEngine(deps: OmniEngineDeps): OmniEngine {
       current = filterPivot(pivot.results, rawValue.trim());
       return pivotView();
     }
+    // A new search supersedes any reference load already in flight: otherwise its rows would land in
+    // this search's preview under a row id that now points at a different result (ids are array
+    // indices), and `referenceResultFor` would then open from that stale list. A reference load
+    // started AFTER this point takes a newer token and is unaffected — a search and a later reference
+    // load stay independent (see the tests in "out-of-order reference and pivot results").
+    ++referenceGeneration;
     const term = rawValue.trim();
     // A genuinely new term restarts at the base cap: load-more/load-all raise `scopeLimit` for the
     // term in the box, but that must not leak into the next search (else every keystroke fans out at
@@ -588,7 +594,9 @@ export function createOmniEngine(deps: OmniEngineDeps): OmniEngine {
       if (!result) return null;
       // `referenceRows` is the single array every preview row id indexes into, so a slow load must not
       // land after a newer one: arrowing from row A to row B while A is still resolving would leave B's
-      // list on screen over A's rows, and `referenceResultFor` would then open the wrong method.
+      // list on screen over A's rows, and `referenceResultFor` would then open the wrong method. A new
+      // search bumps `referenceGeneration` too (see `runSearch`), so a load the previous term left in
+      // flight is discarded rather than dropped over the new results.
       const gen = ++referenceGeneration;
       const view = await deps.resolveReferences(result);
       if (gen !== referenceGeneration) return null; // a newer reference load superseded this one

--- a/client/src/omniSearch/omniMatch.ts
+++ b/client/src/omniSearch/omniMatch.ts
@@ -106,27 +106,28 @@ function matchSubstring(q: string, t: string): number[] | null {
 }
 
 /**
- * A CONTIGUOUS occurrence of `q` in `t` (a real substring), preferring one that begins at a word
+ * A CONTIGUOUS occurrence of `q` in `folded` (a real substring), preferring one that begins at a word
  * boundary — returns its index run, or null if `q` isn't a substring. This runs BEFORE the greedy
  * subsequence so an exact run always wins: greedy-leftmost otherwise grabs a stray early character
  * (the `c` in "Colle**c**tions" / "Announ**c**ements") and misses a clean later "Core", letting a
  * scattered match that happens to start at index 0 outrank an exact mid-string one.
  *
- * `t` is the case-folded target (what we search in), `cased` the original (what we judge boundaries in).
- * They must be separate: half of `isWordStart` is the camelCase hump test, which needs a real uppercase
- * letter to fire, and in the DEFAULT case-insensitive mode `t` has none left. Asking `t` about word
- * starts silently reduced the preference to separators only and picked a mid-word occurrence over a
- * later camelCase one — the majority of searches, since case-insensitive is the default.
+ * `folded` is the case-folded target (what we search in), `original` the un-folded one (what we judge
+ * boundaries in). They must be separate: half of `isWordStart` is the camelCase hump test, which needs
+ * a real uppercase letter to fire, and in the DEFAULT case-insensitive mode `folded` has none left.
+ * Asking `folded` about word starts silently reduced the preference to separators only and picked a
+ * mid-word occurrence over a later camelCase one — the majority of searches, since case-insensitive is
+ * the default.
  */
-function contiguousIndices(q: string, t: string, cased: string): number[] | null {
+function contiguousIndices(q: string, folded: string, original: string): number[] | null {
   let firstAt = -1;
-  let at = t.indexOf(q);
+  let at = folded.indexOf(q);
   while (at >= 0) {
-    if (isWordStart(cased, at)) {
+    if (isWordStart(original, at)) {
       return Array.from({ length: q.length }, (_, i) => at + i); // word-start run — the best kind
     }
     if (firstAt < 0) firstAt = at;
-    at = t.indexOf(q, at + 1);
+    at = folded.indexOf(q, at + 1);
   }
   return firstAt < 0 ? null : Array.from({ length: q.length }, (_, i) => firstAt + i);
 }
@@ -136,16 +137,16 @@ function contiguousIndices(q: string, t: string, cased: string): number[] | null
  * `contiguousIndices`) so exact runs rank above scattered matches; only when `q` is not a substring
  * does it fall back to a greedy left-to-right subsequence (predictable and cheap).
  */
-function matchFuzzy(q: string, t: string, cased: string): number[] | null {
-  const contiguous = contiguousIndices(q, t, cased);
+function matchFuzzy(q: string, folded: string, original: string): number[] | null {
+  const contiguous = contiguousIndices(q, folded, original);
   if (contiguous) return contiguous;
 
   const indices: number[] = [];
   let ti = 0;
   for (const qc of q) {
     let found = -1;
-    for (let i = ti; i < t.length; i++) {
-      if (t[i] === qc) {
+    for (let i = ti; i < folded.length; i++) {
+      if (folded[i] === qc) {
         found = i;
         break;
       }

--- a/client/src/omniSearch/omniMatch.ts
+++ b/client/src/omniSearch/omniMatch.ts
@@ -111,12 +111,18 @@ function matchSubstring(q: string, t: string): number[] | null {
  * subsequence so an exact run always wins: greedy-leftmost otherwise grabs a stray early character
  * (the `c` in "Colle**c**tions" / "Announ**c**ements") and misses a clean later "Core", letting a
  * scattered match that happens to start at index 0 outrank an exact mid-string one.
+ *
+ * `t` is the case-folded target (what we search in), `cased` the original (what we judge boundaries in).
+ * They must be separate: half of `isWordStart` is the camelCase hump test, which needs a real uppercase
+ * letter to fire, and in the DEFAULT case-insensitive mode `t` has none left. Asking `t` about word
+ * starts silently reduced the preference to separators only and picked a mid-word occurrence over a
+ * later camelCase one — the majority of searches, since case-insensitive is the default.
  */
-function contiguousIndices(q: string, t: string): number[] | null {
+function contiguousIndices(q: string, t: string, cased: string): number[] | null {
   let firstAt = -1;
   let at = t.indexOf(q);
   while (at >= 0) {
-    if (isWordStart(t, at)) {
+    if (isWordStart(cased, at)) {
       return Array.from({ length: q.length }, (_, i) => at + i); // word-start run — the best kind
     }
     if (firstAt < 0) firstAt = at;
@@ -130,8 +136,8 @@ function contiguousIndices(q: string, t: string): number[] | null {
  * `contiguousIndices`) so exact runs rank above scattered matches; only when `q` is not a substring
  * does it fall back to a greedy left-to-right subsequence (predictable and cheap).
  */
-function matchFuzzy(q: string, t: string): number[] | null {
-  const contiguous = contiguousIndices(q, t);
+function matchFuzzy(q: string, t: string, cased: string): number[] | null {
+  const contiguous = contiguousIndices(q, t, cased);
   if (contiguous) return contiguous;
 
   const indices: number[] = [];
@@ -171,7 +177,7 @@ export function match(query: string, target: string, opts: MatchOptions): MatchR
       break;
     case 'fuzzy':
     default:
-      indices = matchFuzzy(q, t);
+      indices = matchFuzzy(q, t, target);
       break;
   }
   if (indices === null) return null;

--- a/client/src/omniSearch/omniSearchShared.ts
+++ b/client/src/omniSearch/omniSearchShared.ts
@@ -131,6 +131,10 @@ export function configMessage(config: OmniConfig, pinned: boolean): Record<strin
     previewPane: config.previewPane,
     excludedFromAll: config.excludedFromAll,
     matchMode: config.matchMode,
+    // How long the field waits after a keystroke before searching. The webview owns the timer (it is
+    // the only side that sees keystrokes); the host just forwards the configured value, so a settings
+    // edit takes effect on the next config push like every other field here.
+    debounceMs: config.debounceMs,
     placeholder: placeholderFor(null),
     keyHint: REFERENCES_KEY_HINT,
   };

--- a/client/src/omniSearch/omniSearchView.js
+++ b/client/src/omniSearch/omniSearchView.js
@@ -54,6 +54,12 @@
     var activeIndex = -1;
     var inPivot = false;
     var previewTimer = null;
+    // Keystroke coalescing for the search field. `debounceMs` is pushed from the host config; 0 means
+    // search on every keystroke. Without this every character fanned out a full provider search — one
+    // set of stone round-trips per keypress — and the `debounceMs` setting documented in the manifest
+    // had no consumer at all once the Quick Pick (its only reader) was removed.
+    var queryTimer = null;
+    var debounceMs = 0;
     // When true, the references/senders gesture fills the preview pane with a sticky list (instead of
     // pivoting the left list). Pushed from the host config; false = the classic pivot.
     var referencesInPreview = false;
@@ -92,6 +98,31 @@
         }
       }
       vscode.postMessage(msg);
+    }
+
+    /** Drop a keystroke search that has not fired yet (a decisive gesture supersedes typing). */
+    function cancelPendingQuery() {
+      if (queryTimer) {
+        clearTimeout(queryTimer);
+        queryTimer = null;
+      }
+    }
+
+    /**
+     * Search for `value` after `debounceMs` of quiet, replacing any keystroke search still pending.
+     * `debounceMs` of 0 (including before the host's first config message arrives) searches at once, so
+     * the field is never unresponsive — it just is not coalesced yet.
+     */
+    function sendQueryDebounced(value) {
+      cancelPendingQuery();
+      if (!debounceMs) {
+        post('query', { value: value });
+        return;
+      }
+      queryTimer = setTimeout(function () {
+        queryTimer = null;
+        post('query', { value: value });
+      }, debounceMs);
     }
 
     // ── Highlighting ────────────────────────────────────────────────
@@ -566,6 +597,8 @@
           if (typeof msg.previewPane === 'boolean') setPreviewEnabled(msg.previewPane);
           if (Array.isArray(msg.excludedFromAll)) excludedFromAll = msg.excludedFromAll.slice();
           if (typeof msg.matchMode === 'string') setMatchMode(msg.matchMode);
+          if (typeof msg.debounceMs === 'number' && msg.debounceMs >= 0)
+            debounceMs = msg.debounceMs;
           tabCategories = msg.categories || [];
           renderTabs(msg.categories, msg.scopeId);
           renderScopeFilter();
@@ -989,7 +1022,7 @@
       // debounced reply would leave it a keystroke behind.
       updateScopeHint();
       rehighlightSourcePreview(); // clear/refresh the stale blue match marks now, not on the fetch
-      post('query', { value: inputEl.value });
+      sendQueryDebounced(inputEl.value);
     });
 
     // Bound to the whole document, NOT just the search field: in a WebviewView the field's focus is
@@ -1103,6 +1136,10 @@
         scrollResetPending = true;
         updateClearVisibility();
         updateScopeHint(); // nothing typed = nothing being skipped, so drop the hint at once
+        // Deliberately NOT debounced, and it cancels any pending keystroke search: clearing is a
+        // single decisive gesture, not typing, so making the user wait for a timer would feel broken —
+        // and a keystroke queued a moment earlier must not land after the clear and refill the list.
+        cancelPendingQuery();
         post('query', { value: '' });
         inputEl.focus();
       });

--- a/client/src/omniSearch/omniSearchView.js
+++ b/client/src/omniSearch/omniSearchView.js
@@ -112,15 +112,21 @@
      * Search for `value` after `debounceMs` of quiet, replacing any keystroke search still pending.
      * `debounceMs` of 0 (including before the host's first config message arrives) searches at once, so
      * the field is never unresponsive — it just is not coalesced yet.
+     *
+     * Marks the field busy at the moment it actually dispatches, NOT on each keystroke: during the quiet
+     * window before the timer fires there is no stone work in flight, so a high `debounceMs` must not
+     * leave the panel reading as busy with nothing happening. Busy means "a query is out to the host."
      */
     function sendQueryDebounced(value) {
       cancelPendingQuery();
       if (!debounceMs) {
+        setBusy(true);
         post('query', { value: value });
         return;
       }
       queryTimer = setTimeout(function () {
         queryTimer = null;
+        setBusy(true);
         post('query', { value: value });
       }, debounceMs);
     }
@@ -1014,7 +1020,6 @@
 
     // ── Input + keyboard ────────────────────────────────────────────
     inputEl.addEventListener('input', function () {
-      setBusy(true);
       scrollResetPending = true; // a new query starts the list at the top
       previewMode = 'source'; // typing dismisses a sticky references list
       updateClearVisibility();


### PR DESCRIPTION
## What & why

Three independent defects in GemStone Search, all from @npapagna's `/code-review` pass over the
feature, recorded as a plain comment on #451 (findings 1, 2, 8 and 9 of
https://github.com/GemTalk/Jasper/pull/451#issuecomment-5345768636). None of them were in that PR's
diff, so they were filed separately and are fixed here. Findings 3, 4 and 5 from the same review are
being handled in parallel; findings 6 and 7 were already fixed by #445 and are answered on #451.

One commit per issue, so each can be read or reverted on its own.

## Changes

**`963d806e` — a stale reference load or pivot can no longer overwrite a newer one (#460)**

Two paths asked the stone for a result's references and wrote the answer into shared state without
checking whether a newer request had superseded them. `runSearch` has always had this guard; these two
never took a token.

- `referencesFor` gets its **own** counter, `referenceGeneration`. It deliberately does not share
  `generation`: capturing that read-only would not fix the bug (two successive reference loads capture
  the same value, so neither invalidates the other), and bumping it would break this call's contract of
  leaving the search intact. Before: arrowing from row A to row B while A was still resolving left B's
  list on screen over A's rows, so clicking a visible reference opened one of A's — silently.
- `pivot` already bumped `generation` but never re-checked its own token, so a slow pivot resolving
  after the user typed a new term snapped the view back to the abandoned pivot.

**`94bd5f56` — case-insensitive matching can prefer a camelCase boundary again (#462)**

`match` folds the target before picking which occurrence to match, and the picker asked the *folded*
string whether a position begins a word. Half of that test is the camelCase-hump check, which cannot
fire once every capital is gone — so with the default `caseSensitive: false` the preference silently
collapsed to separators only. `contiguousIndices`/`matchFuzzy` now judge boundaries on the original-case
target while still matching on the folded one. Searching `co` in `xcoreFooCore` now picks the `Co` of
`Core`, agreeing with what `caseSensitive: true` always did.

**`5e45ecf3` — keystrokes are coalesced, and `debounceMs` does something again (#463)**

Typing posted a query on every `input` event, so a ten-character term fanned out ten full provider
searches. `gemstone.omniSearch.debounceMs` was still parsed and clamped but read by nothing — its only
consumer was the Quick Pick controller, removed with that UI — so turning the knob up did nothing and
there was no user-side mitigation. Wired up rather than removed, because DESIGN.md asserts debounced
behaviour in three places, including the matcher benchmark whose conclusion is argued *from* a 120 ms
debounce.

- `configMessage` now carries `debounceMs` (that payload enumerates its fields, so it had to be added).
- The webview gained `sendQueryDebounced` / `cancelPendingQuery`. A delay of 0 — including before the
  first config message arrives — searches immediately, so the field is never unresponsive.
- The clear (×) button stays immediate **and** cancels a pending keystroke search, so a keystroke queued
  a moment earlier cannot land after the clear and refill the list.
- A scope change deliberately does **not** cancel a pending query: the pending value is newer than the
  host's, so letting it fire is what lands the right end state.

## Testing

Client-only TypeScript/JS change — no server, GemStone or refactoring-engine surface. Client gate green:
`lint` / `format:check` / `compile`, and the full suite (**client 5952 passed / 12 skipped, server 322,
mcp-server 92**), with the live-stone integration tests running rather than skipping.

**14 new tests.** Every one was checked against reverted source, so none of them is decorative:

| Tests | Reproduce the defect | Pin behaviour that must not change |
|---|---|---|
| #460 — 4 | 3 (stale reference load; pivot superseded by a search; pivot superseded by a second pivot) | 1 — a reference load and an in-flight search do not cancel each other, which fails if the two counters are ever collapsed |
| #462 — 5 | 2 (the camelCase occurrence is chosen; folded result agrees with the case-sensitive one) | 3 — separator boundaries, the leftmost fallback, and relative ranking |
| #463 — 5 | 4 (burst coalesces to one search; a keystroke restarts the window; clear supersedes a pending search; a nonsense value is not adopted) | 1 — the immediate/uncoalesced path for a 0 delay and a config-less field |

## DESIGN.md

No change needed, which is worth stating explicitly because it looks like it should need one. DESIGN.md
already describes debounced search in three places — the Spotlight comparison, the Methods provider, and
the matcher benchmark's "behind a 120 ms debounce" — and describes the word-start weights as tuned for
camelCase identifiers. All four were written as the intended design; it was the CODE that had drifted away
from them. These commits restore the behaviour the doc already documents, so every one of those lines is
accurate again rather than needing a rewrite.

Closes #460
Closes #462
Closes #463

