### PR TITLE
Add a Windows leg to the Health Check matrix

### DIFF
--- a/.github/actions/setup-gemstone-in-windows/action.yml
+++ b/.github/actions/setup-gemstone-in-windows/action.yml
@@ -1,0 +1,64 @@
+name: Setup GemStone in Windows
+description: >-
+  Provisions WSL, downloads the native Windows GCI client, and installs and
+  starts GemStone inside the WSL guest, so a native Windows test run can
+  connect into it remotely. Only ever meant to be called when
+  runner.os == 'Windows'; the caller is responsible for that `if:` guard.
+inputs:
+  gemstone-version:
+    description: GemStone version to install and start (e.g. 3.7.5)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup WSL
+      # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+      # not a mutable tag like @v6
+      uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
+      with:
+        distribution: Ubuntu-22.04
+        additional-packages: curl unzip
+    - name: Cache GemStone Windows client download
+      # The client build is always native Windows (this action only ever
+      # runs on windows-latest), so there's only ever one platform's archive
+      # to cache here, and no runner.os is needed in the key.
+      # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
+      # not a mutable tag like @v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}\gemstone-windows-client
+        key: gemstone-windows-client-${{ inputs.gemstone-version }}
+    - name: Install GCI Windows client
+      id: windows-gci-client
+      # zizmor(template-injection): bind the untrusted matrix value to an
+      # env var instead of interpolating ${{ }} directly into the script
+      env:
+        GEMSTONE_VERSION: ${{ inputs.gemstone-version }}
+      # Composite action steps have no `runs-on`, so nothing here lets
+      # actionlint infer this is a Windows job; the shell has to be made
+      # explicit instead.
+      shell: pwsh
+      run: client/bin/gs-download-windows-gci-client.ps1 "$env:GEMSTONE_VERSION"
+    - name: Setup test environment
+      # This needs to run inside WSL, where gs-config.sh's `uname -s`
+      # resolves to Linux, native windows-latest has no GemStone server
+      # build at all, only the WSL-hosted one does. gs-test-setup-wsl.sh
+      # covers everything else this leg needs from inside WSL: creating
+      # the unprivileged user GemStone runs as, installing and starting
+      # it, and writing a .env.test the native Windows test run below can
+      # connect into remotely.
+      # zizmor(template-injection): bind the untrusted matrix value to an
+      # env var instead of interpolating ${{ }} directly into the script
+      env:
+        GEMSTONE_VERSION: ${{ inputs.gemstone-version }}
+        GCI_LIBRARY_PATH: ${{ steps.windows-gci-client.outputs.dll-path }}
+        GEMSTONE_GLOBAL_DIR: ${{ steps.windows-gci-client.outputs.global-dir }}
+        # The server download cache (health-check.yml's "Cache GemStone
+        # server download" step) restores onto this native Windows
+        # checkout, at a path WSL can't see without translation. WSLENV's
+        # /p flag converts it to the equivalent /mnt/... path crossing
+        # into the wsl-bash process below.
+        WINDOWS_DOWNLOAD_CACHE_DIR: ${{ github.workspace }}\client\tmp\downloads
+        WSLENV: GEMSTONE_VERSION:GCI_LIBRARY_PATH:GEMSTONE_GLOBAL_DIR:WINDOWS_DOWNLOAD_CACHE_DIR/p
+      shell: wsl-bash {0}
+      run: client/bin/gs-test-setup-wsl.sh "$GEMSTONE_VERSION" 'windows-ci' "$GCI_LIBRARY_PATH" "$GEMSTONE_GLOBAL_DIR" "$WINDOWS_DOWNLOAD_CACHE_DIR"

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/workflows
+            .github/actions
           sparse-checkout-cone-mode: false
           # zizmor(artipacked): checkout must not persist the token past
           # this job
@@ -121,12 +122,42 @@ jobs:
         run: npm audit signatures
 
   health-check:
-    timeout-minutes: 5
-    name: GemStone S/64 ${{ matrix.gemstone-version }}${{ matrix.node-version && format(' (Node {0})', matrix.node-version) || '' }}
+    # The Windows leg needs extra headroom (WSL provisioning + GCI client
+    # download); the Linux legs still fit in 5. Scoped per-platform so a
+    # Linux-side regression that doubles the runtime still trips the guard
+    # instead of quietly passing under the Windows leg's larger budget.
+    timeout-minutes: ${{ matrix.platform == 'windows-latest' && 10 || 5 }}
+    name: ${{ matrix.platform }} ${{ matrix.gemstone-version }}${{ matrix.node-version && format(' (Node {0})', matrix.node-version) || '' }}
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
+    # zizmor(template-injection): bind the untrusted matrix values to an env
+    # var instead of interpolating ${{ }} directly into a script
+    env:
+      # One name (for upload-artifact's `name`) and one path (for
+      # VITEST_JSON_OUTPUT and upload-artifact's `path`) per skip-report
+      # file. Both include matrix.platform, gemstone-version and
+      # node-version so the Linux and Windows legs of the same
+      # version/node combo don't produce same-named files — upload-artifact
+      # rejects duplicate names within a run, and report-skips'
+      # merge-multiple download would clobber same-named files. Paths are
+      # absolute (github.workspace-rooted): VITEST_JSON_OUTPUT is read by
+      # each npm workspace's vitest run, which cwds into client/, server/,
+      # or mcp-server/, so a relative path would land inside whichever
+      # workspace ran last instead of one shared test-results/ at the repo
+      # root.
+      #
+      # Each var spells out the matrix expression on its own rather than
+      # building on a shared base var: GitHub Actions' env context can't
+      # see sibling keys from the same env mapping (they'd silently
+      # resolve empty), so there's no legal way to factor this out further
+      # short of an extra step writing to $GITHUB_ENV.
+      SKIP_REPORT_BARE_NAME: skips-${{ matrix.platform }}-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare
+      SKIP_REPORT_BARE_PATH: ${{ github.workspace }}/test-results/skips-${{ matrix.platform }}-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare.json
+      SKIP_REPORT_PLUGIN_NAME: skips-${{ matrix.platform }}-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin
+      SKIP_REPORT_PLUGIN_PATH: ${{ github.workspace }}/test-results/skips-${{ matrix.platform }}-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin.json
     strategy:
       matrix:
+        platform: [ubuntu-latest, windows-latest]
         gemstone-version: ${{ fromJson(needs.prepare.outputs.versions) }}
         node-version: ['']            # empty ⇒ dev jobs resolve Node from .nvmrc (node-version-file); floor include overrides
         # node-version's declared axis value is only '' (which falls back to
@@ -136,7 +167,8 @@ jobs:
         # and the Node floor, as a smoke test to verify tests run on the
         # Node floor too. This is to support older VS Code versions.
         include:
-          - gemstone-version: ${{ needs.prepare.outputs.oldest-version }}
+          - platform: ubuntu-latest # smoke test only cares about the Node floor, not the OS-specific WSL/GCI-DLL path
+            gemstone-version: ${{ needs.prepare.outputs.oldest-version }}
             node-version: '22.15.1'   # pin the floor for the smoke-test
 
     steps:
@@ -215,50 +247,84 @@ jobs:
         run: npm ci
       - name: Compile
         run: npm run compile
-      - name: Cache GemStone installation
+      - name: Cache GemStone server download
         # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
         # not a mutable tag like @v6
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: client/tmp/downloads
-          key: gemstone-download-${{ runner.os }}-${{ matrix.gemstone-version }}
-      - name: Setup test environment
+          # The Windows leg's server install also runs as Linux (inside WSL,
+          # see setup-gemstone-in-windows), so every current matrix platform
+          # downloads the same archive for a given version: one shared key,
+          # no runner.os, lets either leg warm the cache for the other.
+          # IMPORTANT: this assumes every platform downloads the Linux archive, which
+          # is only true today. gs-config.sh also has a Darwin branch that
+          # resolves a different filename (a .dmg, not this .zip); if a
+          # macos-latest leg ever joins the matrix, it needs its own key
+          # instead of reusing this one, or it'll silently stop caching.
+          key: gemstone-server-download-linux-${{ matrix.gemstone-version }}
+          # enableCrossOsArchive is required for that sharing to actually
+          # happen: actions/cache scopes its restore lookup by key *and* a
+          # version hash that silently appends a windows-only tag on
+          # Windows runners unless this is set, so without it the two
+          # platforms would never satisfy each other's cache despite using
+          # the same key string.
+          enableCrossOsArchive: true
+      - name: Setup GemStone in Windows
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/setup-gemstone-in-windows
+        with:
+          gemstone-version: ${{ matrix.gemstone-version }}
+      - name: Setup GemStone in Linux
+        if: runner.os != 'Windows'
         # zizmor(template-injection): bind the untrusted matrix value to an
         # env var instead of interpolating ${{ }} directly into the script
         env:
           GEMSTONE_VERSION: ${{ matrix.gemstone-version }}
         run: npm run test:server:start -- "$GEMSTONE_VERSION"
       - name: Run tests (without server plugin)
-        # zizmor(template-injection): bind the untrusted matrix values to an
-        # env var instead of interpolating ${{ }} directly into the script
         env:
-          VITEST_JSON_OUTPUT: ${{ github.workspace }}/test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare.json
+          VITEST_JSON_OUTPUT: ${{ env.SKIP_REPORT_BARE_PATH }}
         run: npm test
+      - name: Relativize skip report paths (without server plugin)
+        env:
+          SKIP_REPORT_PATH: ${{ env.SKIP_REPORT_BARE_PATH }}
+        # windows-latest defaults to pwsh, which doesn't understand bash's
+        # $VAR syntax — force bash (present on both runner images) so this
+        # one shell script works unchanged on either platform.
+        shell: bash
+        run: node scripts/relativize-skip-report.mjs "$SKIP_REPORT_PATH" "$GITHUB_WORKSPACE"
       - name: Upload skip report (without server plugin)
         if: always()
         # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
         # not a mutable tag like @v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare
-          path: test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-bare.json
+          name: ${{ env.SKIP_REPORT_BARE_NAME }}
+          path: ${{ env.SKIP_REPORT_BARE_PATH }}
           if-no-files-found: ignore
       - name: Install server plugin
         run: npm run test:server:install-plugin
       - name: Run tests (with server plugin)
-        # zizmor(template-injection): bind the untrusted matrix values to an
-        # env var instead of interpolating ${{ }} directly into the script
         env:
-          VITEST_JSON_OUTPUT: ${{ github.workspace }}/test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin.json
+          VITEST_JSON_OUTPUT: ${{ env.SKIP_REPORT_PLUGIN_PATH }}
         run: npm test
+      - name: Relativize skip report paths (with server plugin)
+        env:
+          SKIP_REPORT_PATH: ${{ env.SKIP_REPORT_PLUGIN_PATH }}
+        # windows-latest defaults to pwsh, which doesn't understand bash's
+        # $VAR syntax — force bash (present on both runner images) so this
+        # one shell script works unchanged on either platform.
+        shell: bash
+        run: node scripts/relativize-skip-report.mjs "$SKIP_REPORT_PATH" "$GITHUB_WORKSPACE"
       - name: Upload skip report (with server plugin)
         if: always()
         # zizmor(unpinned-uses): actions must be pinned to a commit SHA,
         # not a mutable tag like @v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin
-          path: test-results/skips-${{ matrix.gemstone-version }}-${{ matrix.node-version || 'nvmrc' }}-plugin.json
+          name: ${{ env.SKIP_REPORT_PLUGIN_NAME }}
+          path: ${{ env.SKIP_REPORT_PLUGIN_PATH }}
           if-no-files-found: ignore
 
   package-check:

--- a/client/bin/gs-create-test-env-file.sh
+++ b/client/bin/gs-create-test-env-file.sh
@@ -1,25 +1,85 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./gs-create-test-env-file.sh <version> <name>
+# Usage: ./gs-create-test-env-file.sh <version> <name> [--remote]
+#          [--gci-library-path <path>] [--global-dir <path>]
 #
 # Writes .env.test with the connection details for the running GemStone
 # instance. Vite loads this file automatically when running tests, making
 # the variables available to the test suite as process.env.VITE_GEMSTONE_*.
 #
 # Arguments:
-#   version   GemStone version (e.g. 3.7.5)
-#   name      Instance name used when the stone was started
+#   version              GemStone version (e.g. 3.7.5)
+#   name                 Instance name used when the stone was started
+#   --remote             Write a stone/gem NRS reachable from outside this
+#                        machine's own network stack: this machine's own IP
+#                        instead of 'localhost', and NetLDI's actual bound
+#                        port instead of its symbolic name. Needed when the
+#                        test runner connects from across a network boundary
+#                        (e.g. native Windows reaching into the WSL guest
+#                        this script ran in), where neither 'localhost' nor
+#                        NetLDI's name-based lookup (via /etc/services)
+#                        resolves.
+#   --gci-library-path   Write this instead of the (WSL-native) GCI DLL path
+#                        gs-config.sh would otherwise compute -- e.g. the
+#                        native Windows path for that same cross-boundary
+#                        test runner, which this script has no way to know.
+#   --global-dir         Write this instead of the (WSL-native) lock/log
+#                        directory gs-config.sh would otherwise compute, for
+#                        the same reason.
 
+USAGE_MESSAGE="Usage: $0 <version> <name> [--remote] [--gci-library-path <path>] [--global-dir <path>]"
 # shellcheck disable=SC2034
 # This variable is read by gs-config.sh when sourced below
-VERSION="${1:?Usage: $0 <version> <name>}"
+VERSION="${1:?$USAGE_MESSAGE}"
 # shellcheck disable=SC2034
 # This variable is read by gs-config.sh when sourced below
-NAME="${2:?Usage: $0 <version> <name>}"
+NAME="${2:?$USAGE_MESSAGE}"
+shift 2
+
+remote_flag=""
+gci_library_path_override=""
+gemstone_global_dir_override=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote)
+      remote_flag=1
+      shift
+      ;;
+    --gci-library-path)
+      gci_library_path_override="${2:?$USAGE_MESSAGE}"
+      shift 2
+      ;;
+    --global-dir)
+      gemstone_global_dir_override="${2:?$USAGE_MESSAGE}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "$USAGE_MESSAGE" >&2
+      exit 1
+      ;;
+  esac
+done
 
 # shellcheck source=gs-config.sh
 source "$(dirname "$0")/gs-config.sh"
+
+if [[ -n "$remote_flag" ]]; then
+  # gs-info.py prints "<ip> <port>" on one line: this machine's own address
+  # and NetLDI's actual bound port, both reachable from outside this
+  # machine's own network stack (unlike 'localhost' and NetLDI's name).
+  info=$("$GS_SCRIPTS_DIR/gs-info.py" "$LDI_NAME")
+  read -r host netldi_locator <<< "$info"
+else
+  host="localhost"
+  netldi_locator="$LDI_NAME"
+fi
+
+# Default to gs-config.sh's real values when --gci-library-path/--global-dir
+# weren't given.
+gci_library_path_override="${gci_library_path_override:-$GCI_LIBRARY_PATH}"
+gemstone_global_dir_override="${gemstone_global_dir_override:-$GEMSTONE_GLOBAL_DIR}"
 
 # Values are single-quoted so the .env parser preserves special characters in
 # NRS strings (e.g. '!' and '#' which shells and some parsers treat as special).
@@ -28,11 +88,11 @@ source "$(dirname "$0")/gs-config.sh"
 # .env.test relative to the project root (client/), so the path must be fixed
 # regardless of where the caller runs this script from.
 cat << EOF > "$(dirname "$0")/../.env.test"
-VITE_GEMSTONE_STONE_NRS='!tcp@localhost#server!${STONE_NAME}'
-VITE_GEMSTONE_GEM_NRS='!tcp@localhost#netldi:${LDI_NAME}#task!gemnetobject'
+VITE_GEMSTONE_STONE_NRS='!tcp@${host}#server!${STONE_NAME}'
+VITE_GEMSTONE_GEM_NRS='!tcp@${host}#netldi:${netldi_locator}#task!gemnetobject'
 VITE_GEMSTONE_USER='${GS_USERNAME}'
 VITE_GEMSTONE_PASSWORD='${GS_PASSWORD}'
-VITE_GEMSTONE_GCI_LIBRARY_PATH='${GCI_LIBRARY_PATH}'
-VITE_GEMSTONE_GLOBAL_DIR='${GEMSTONE_GLOBAL_DIR}'
+VITE_GEMSTONE_GCI_LIBRARY_PATH='${gci_library_path_override}'
+VITE_GEMSTONE_GLOBAL_DIR='${gemstone_global_dir_override}'
 VITE_GEMSTONE_VERSION='${VERSION}'
 EOF

--- a/client/bin/gs-download-windows-gci-client.ps1
+++ b/client/bin/gs-download-windows-gci-client.ps1
@@ -1,0 +1,46 @@
+# Usage: ./gs-download-windows-gci-client.ps1 <version>
+#
+# Downloads and extracts the native Windows GemStone GCI client for
+# <version>, and creates a native Windows lock/log directory for the GCI
+# library. Writes "dll-path" and "global-dir" to $env:GITHUB_OUTPUT: values
+# only the native Windows side can produce, needed by the "Setup test
+# environment" step in setup-gemstone-in-windows/action.yml, which runs
+# inside a WSL guest with no way to compute either itself.
+#
+# Arguments:
+#   version   GemStone version (e.g. 3.7.5)
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+# The client distribution's name: also its zip's filename stem, and its own
+# top-level folder once extracted (Expand-Archive has no flag to flatten
+# that away, so $dllPath below still has to walk into it).
+$clientFilename = "GemStone64BitClient${Version}-x86.Windows_NT"
+$clientZipFile = "$clientFilename.zip"
+$downloadUrl = "https://downloads.gemtalksystems.com/pub/GemStone64/${Version}/$clientZipFile"
+$clientZipFilePath = Join-Path $env:RUNNER_TEMP $clientZipFile
+$extractPath = Join-Path $env:RUNNER_TEMP 'gemstone-windows-client'
+$dllPath = Join-Path $extractPath "$clientFilename\bin\libgcits-${Version}-64.dll"
+
+# $extractPath is restored by the caller's "Cache GemStone Windows client
+# download" actions/cache step, keyed on $Version; a hit means both the
+# download and extraction below are a no-op, same as gs-install.sh's cache
+# check for the server archive.
+if (Test-Path $dllPath) {
+    Write-Host "GCI client already extracted at $dllPath, skipping download."
+} else {
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $clientZipFilePath
+    Expand-Archive -Path $clientZipFilePath -DestinationPath $extractPath
+}
+
+if (-not (Test-Path $dllPath)) { throw "Expected GCI DLL not found at $dllPath" }
+echo "dll-path=$dllPath" >> $env:GITHUB_OUTPUT
+
+$globalDir = Join-Path $env:RUNNER_TEMP 'gemstone-global'
+New-Item -ItemType Directory -Force -Path $globalDir | Out-Null
+echo "global-dir=$globalDir" >> $env:GITHUB_OUTPUT

--- a/client/bin/gs-info.py
+++ b/client/bin/gs-info.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Usage: ./gs-info.py <netldi-name>
+#
+# Prints "<ip> <port>" so a caller outside this machine's own network stack
+# (e.g. a native Windows host reaching into the WSL guest this runs in) can
+# connect to the NetLDI process named <netldi-name>. Neither 'localhost' nor
+# NetLDI's name resolve from outside, so this reports this machine's real
+# address and NetLDI's actual bound port instead.
+#
+# Exits 1 with an error on stderr (echoing gslist's own output) if no such
+# server is running. Requires gslist on PATH.
+#
+# Python, not bash like the other gs-*.sh scripts: finding "this machine's
+# own address" portably needs a real socket API. Bash has no built-in way to
+# do that, and the OS-level fallback isn't portable either: `hostname -I`
+# only exists on Linux (including the WSL guest this actually runs in), not
+# on macOS, where a dev testing this locally would need something else
+# entirely (e.g. `ipconfig getifaddr en0`). Python's socket module gives one
+# implementation that works the same everywhere.
+
+import json
+import socket
+import subprocess
+import sys
+
+def local_outbound_ip():
+    # Doesn't actually send any packets (UDP connect() just picks a route):
+    # this reads back whichever local address the OS would use to reach the
+    # outside world, i.e. this machine's own address as seen from beyond its
+    # network stack -- the same thing `hostname -I` plus IPv4/IPv6 filtering
+    # was after.
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe_socket:
+            probe_socket.connect(("8.8.8.8", 80))
+            return probe_socket.getsockname()[0]
+    except OSError as e:
+        print(f"Could not determine this machine's outbound IP: {e}", file=sys.stderr)
+        sys.exit(1)
+
+def netldi_port(name):
+    result = subprocess.run(
+        [
+          "gslist",
+          # -j: JSON output, so the Port field is read by name instead of by
+          # counting columns in gslist's fixed-width table
+          "-j",
+          # -c: clean up stale locks left by a killed server
+          "-c",
+          # -v: verify the server actually responds, not just that its lock file exists
+          "-v",
+          # -n: filter to this exact name, server-side
+          "-n",
+          # the NetLDI name -n is filtering on
+          name
+        ],
+        capture_output=True,
+        text=True
+    )
+
+    entries = None
+    if result.returncode == 0:
+        try:
+            entries = json.loads(result.stdout)["GemStoneServers"]
+        except (json.JSONDecodeError, KeyError):
+            entries = None
+
+    if not entries:
+        print(f"Could not find a running Netldi named {name} in gslist output:", file=sys.stderr)
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    return entries[0]["Port"]
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(f"Usage: {sys.argv[0]} <netldi-name>")
+    name = sys.argv[1]
+    print(local_outbound_ip(), netldi_port(name))
+
+main()

--- a/client/bin/gs-test-setup-wsl.sh
+++ b/client/bin/gs-test-setup-wsl.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./gs-test-setup-wsl.sh <version> <name> <gci-library-path> <global-dir> <shared-download-dir>
+#
+# Installs and starts GemStone inside this WSL guest, and writes a
+# .env.test the native Windows test run can connect into remotely
+# (gs-test-setup.sh's `--remote` flag). Must run as root (the distro's
+# default user): GemStone itself can't, so this creates an unprivileged
+# user first and does everything else as that user.
+#
+# Arguments:
+#   version              GemStone version to install and start (e.g. 3.7.5)
+#   name                 Instance name; Stone and NetLDI names are derived from it
+#   gci-library-path     Native Windows GCI DLL path for .env.test; this WSL
+#                        guest has no way to know it
+#   global-dir           Native Windows lock/log directory for .env.test, for
+#                        the same reason
+#   shared-download-dir  Native checkout's client/tmp/downloads, translated to
+#                        its /mnt/... path; the server download is symlinked
+#                        in from here so this leg shares the same
+#                        actions/cache entry as the Linux legs instead of
+#                        re-downloading every run
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+USAGE_MESSAGE="Usage: $0 <version> <name> <gci-library-path> <global-dir> <shared-download-dir>"
+VERSION="${1:?$USAGE_MESSAGE}"
+NAME="${2:?$USAGE_MESSAGE}"
+GCI_LIBRARY_PATH_OVERRIDE="${3:?$USAGE_MESSAGE}"
+GEMSTONE_GLOBAL_DIR_OVERRIDE="${4:?$USAGE_MESSAGE}"
+SHARED_DOWNLOAD_DIR="${5:?$USAGE_MESSAGE}"
+
+# startnetldi's guest mode (used by gs-start.sh) refuses to run as root.
+id -u gsuser >/dev/null 2>&1 || useradd -m -s /bin/bash gsuser
+gsuser_home=$(getent passwd gsuser | cut -d: -f6)
+
+# gs-install.sh extracts into $(pwd)/tmp/gemstone/, and GemStone's stone
+# process needs real POSIX locks/shared memory: run from gsuser's own
+# filesystem, not wherever this script itself was invoked from (the
+# checkout's DrvFs mount), which was slow enough over thousands of small
+# files to look hung.
+work_dir="$gsuser_home/gemstone-ci"
+mkdir -p "$work_dir"
+chown gsuser "$work_dir"
+
+# Only the download itself is symlinked back onto the DrvFs-mounted
+# checkout, not the extraction target above: it's a single archive file, a
+# sequential copy across the DrvFs bridge rather than the many-small-files
+# pattern that made extracting there slow. This lets gs-install.sh's
+# existing archive-already-exists check share the actions/cache entry the
+# Linux legs populate (or populate it, on a cache miss), instead of
+# downloading fresh into this guest on every run.
+mkdir -p "$SHARED_DOWNLOAD_DIR" "$work_dir/tmp"
+ln -sfn "$SHARED_DOWNLOAD_DIR" "$work_dir/tmp/downloads"
+chown -R gsuser "$work_dir/tmp"
+
+# No Node is installed in this distro, so a plain `npm` would resolve
+# through WSL's Windows-PATH interop to the *Windows* npm, which can't run
+# "./bin/*.sh" -- call gs-test-setup.sh directly instead. --gci-library-path
+# and --global-dir are just forwarded on through it to
+# gs-create-test-env-file.sh, unread by anything in between; see that
+# script's own usage comment for what they're for.
+su gsuser -c "cd '$work_dir' && '$SCRIPT_DIR/gs-test-setup.sh' '$VERSION' '$NAME' --remote --gci-library-path '$GCI_LIBRARY_PATH_OVERRIDE' --global-dir '$GEMSTONE_GLOBAL_DIR_OVERRIDE'"

--- a/client/bin/gs-test-setup.sh
+++ b/client/bin/gs-test-setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./gs-test-setup.sh <version> <name>
+# Usage: ./gs-test-setup.sh <version> <name> [gs-create-test-env-file.sh flags]
 #
 # Prepares a local GemStone instance for integration tests:
 #   1. Installs GemStone if not already present.
@@ -13,13 +13,17 @@ set -euo pipefail
 # Arguments:
 #   version   GemStone version to install and start (e.g. 3.7.5)
 #   name      Instance name; Stone and NetLDI names are derived from it
+#   (any remaining arguments are forwarded as-is to gs-create-test-env-file.sh;
+#   see its own usage comment)
 
 SCRIPT_DIR="$(dirname "$0")"
-VERSION="${1:?Usage: $0 <version> <name>}"
-NAME="${2:?Usage: $0 <version> <name>}"
+USAGE_MESSAGE="Usage: $0 <version> <name> [gs-create-test-env-file.sh flags]"
+VERSION="${1:?$USAGE_MESSAGE}"
+NAME="${2:?$USAGE_MESSAGE}"
+shift 2
 
 "$SCRIPT_DIR/gs-install.sh" "$VERSION"
 "$SCRIPT_DIR/gs-stop.sh" "$VERSION" "$NAME"
 "$SCRIPT_DIR/gs-reset-extent.sh" "$VERSION"
 "$SCRIPT_DIR/gs-start.sh" "$VERSION" "$NAME"
-"$SCRIPT_DIR/gs-create-test-env-file.sh" "$VERSION" "$NAME"
+"$SCRIPT_DIR/gs-create-test-env-file.sh" "$VERSION" "$NAME" "$@"

--- a/client/src/__tests__/rowanLoad.test.ts
+++ b/client/src/__tests__/rowanLoad.test.ts
@@ -27,7 +27,9 @@ function write(rel: string, content: string): void {
   fs.writeFileSync(full, content);
 }
 
-describe('findRowanLoadSpecs', () => {
+// Default timeout was timing out on the Windows health-check leg: process
+// spawns and filesystem I/O both run measurably slower there than on Linux.
+describe('findRowanLoadSpecs', { timeout: 10000 }, () => {
   it('finds a load spec by its content signature, in any layout', () => {
     write('rowan/specs/LoadMe.ston', LOAD_SPEC('LoadMe'));
     write('rowan/project.ston', "RwProjectSpecificationV2 { #specName : 'project' }");
@@ -143,7 +145,10 @@ describe('deriveRepoName', () => {
   });
 });
 
-describe('updateGitRepo', () => {
+// Higher than findRowanLoadSpecs' bump above: each test here spawns several
+// git processes (clone, commit, push, pull), so the same per-process
+// Windows overhead compounds more. Same root cause, not a separate issue.
+describe('updateGitRepo', { timeout: 20000 }, () => {
   // Strip GIT_* from the env so the test's own git commands operate on its temp
   // repos, not on whatever repo the ambient environment points at — critical when
   // this suite runs inside a git hook (e.g. the pre-push hook exports GIT_DIR).

--- a/scripts/relativize-skip-report.mjs
+++ b/scripts/relativize-skip-report.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+//
+// Adds a relativePosixPath field to each testResult in a Vitest JSON report,
+// in place, alongside its existing (untouched) absolute-path name. Vitest's
+// JSON reporter always writes the producing runner's absolute path verbatim
+// (no config option to change that — see summarize-skipped-tests.mjs's
+// aggregation, which relies on these paths being comparable across the
+// health-check matrix's Linux and Windows legs). This runs immediately after
+// `vitest run`, on the same OS and checkout that produced the report, where
+// the real repo root and path separator are known outright rather than
+// needing to be guessed later during aggregation.
+//
+//   node scripts/relativize-skip-report.mjs <path-to-json-report> <repo-root>
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { posix, relative, sep } from 'node:path';
+
+function main() {
+  const [reportPath, repoRoot] = process.argv.slice(2);
+  if (!reportPath || !repoRoot) {
+    console.error('Usage: node relativize-skip-report.mjs <path-to-json-report> <repo-root>');
+    process.exit(1);
+  }
+
+  // The test step may have failed before vitest wrote a report at all.
+  if (!existsSync(reportPath)) {
+    process.exit(0);
+  }
+
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+
+  for (const testResult of report.testResults ?? []) {
+    testResult.relativePosixPath = relative(repoRoot, testResult.name).split(sep).join(posix.sep);
+  }
+
+  writeFileSync(reportPath, JSON.stringify(report));
+  process.exit(0);
+}
+
+main();

--- a/scripts/summarize-skipped-tests.mjs
+++ b/scripts/summarize-skipped-tests.mjs
@@ -29,10 +29,14 @@ function collectTestStats(reportFiles) {
     const report = JSON.parse(readFileSync(reportFile, 'utf8'));
 
     for (const testResult of report.testResults ?? []) {
+      // relativePosixPath (added by relativize-skip-report.mjs, right after
+      // `vitest run`) is repo-relative and OS-independent, so the same test
+      // collapses onto one key regardless of which health-check matrix leg
+      // produced the report.
       for (const assertion of testResult.assertionResults ?? []) {
-        const key = `${testResult.name} ${assertion.fullName}`;
+        const key = `${testResult.relativePosixPath} ${assertion.fullName}`;
         const entry = stats.get(key) ?? {
-          file: testResult.name,
+          file: testResult.relativePosixPath,
           fullName: assertion.fullName,
           seen: 0,
           skipped: 0,


### PR DESCRIPTION
## Summary
- Adds a `windows-latest` leg to the `health-check` job matrix, alongside the existing `ubuntu-latest` one, so the GemStone integration suite also runs against the native Windows GCI client.
- Windows has no native GemStone server build, so the new leg provisions WSL via a new composite action (`setup-gemstone-in-windows`), installs and starts the server inside the guest, downloads the native Windows GCI client, and points the native Windows test run at the WSL-hosted server remotely.
- `gs-create-test-env-file.sh` gains `--remote`, `--gci-library-path`, and `--global-dir` so the same script can write a `.env.test` that's reachable across that WSL/native-Windows boundary; `gs-test-setup.sh` just forwards extra args through to it.
- The server download cache is keyed on `gemstone-server-download-linux-<version>` (no `runner.os`), since the Windows leg's server install also runs as Linux under WSL and can share the same cached archive; a future macOS leg would need its own key, since `gs-config.sh` resolves a different archive there.
- The job's `timeout-minutes` is scoped per platform (5 for Linux, 10 for the Windows leg's added WSL/GCI-download overhead) instead of raised for everyone, so a Linux-side regression that doubles runtime still trips the guard.

## Test plan
- [x] `npm run lint && npm run format:check && npm run compile && npm test` locally
- [x] CI matrix green on both `ubuntu-latest` and `windows-latest` legs across the GemStone version matrix
- [x] Windows leg's WSL setup, GCI client download, and remote `.env.test` connection succeed end-to-end in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)