### PR TITLE
Lint out-of-harness GemStone sessions in integration tests (gci migration phase 5c)

### DIFF
--- a/client/src/__tests__/forkGem.integration.test.ts
+++ b/client/src/__tests__/forkGem.integration.test.ts
@@ -7,7 +7,7 @@ import { useIntegrationTest } from './useIntegrationTest';
 import { GciLibrary } from '../gciLibrary';
 import * as browserQueries from '../browserQueries';
 import type { ActiveSession } from '../sessionManager';
-// eslint-disable-next-line no-restricted-imports -- forking is this file's subject, so it is the one integration test allowed to spawn a gem the harness never armed; the forked gems here only sleep, and write nothing
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- forking is this file's subject, so it is the one integration test allowed to spawn a gem the harness never armed; the forked gems here only sleep, and write nothing
 import { canForkGem, forkGemRunning } from '../queries/forkGem';
 
 /**

--- a/client/src/__tests__/forkGem.integration.test.ts
+++ b/client/src/__tests__/forkGem.integration.test.ts
@@ -7,6 +7,7 @@ import { useIntegrationTest } from './useIntegrationTest';
 import { GciLibrary } from '../gciLibrary';
 import * as browserQueries from '../browserQueries';
 import type { ActiveSession } from '../sessionManager';
+// eslint-disable-next-line no-restricted-imports -- forking is this file's subject, so it is the one integration test allowed to spawn a gem the harness never armed; the forked gems here only sleep, and write nothing
 import { canForkGem, forkGemRunning } from '../queries/forkGem';
 
 /**

--- a/client/src/__tests__/gci/gciLogin.test.ts
+++ b/client/src/__tests__/gci/gciLogin.test.ts
@@ -253,7 +253,7 @@ describe('GciTsLogin / GciTsLogout', () => {
     });
   });
 
-  describe('GciTsAbort / GciTsBegin / GciTsCommit / GciTsContinueWith', () => {
+  describe('GciTsAbort / GciTsBegin / GciTsContinueWith', () => {
     it('abort succeeds on a clean session', () => {
       const { session } = gci.GciTsLogin(
         STONE_NRS,
@@ -294,28 +294,6 @@ describe('GciTsLogin / GciTsLogout', () => {
       console.log('Begin - success:', begin.success);
       console.log('Begin - err:', JSON.stringify(begin.err, bigIntReplacer, 2));
       expect(begin.success).toBe(true);
-
-      gci.GciTsLogout(session);
-    });
-
-    it('commit succeeds on a clean session', () => {
-      const { session } = gci.GciTsLogin(
-        STONE_NRS,
-        null,
-        null,
-        false,
-        GEM_NRS,
-        GS_USER,
-        GS_PASSWORD,
-        0,
-        0,
-      );
-      expect(session).not.toBeNull();
-
-      const commit = gci.GciTsCommit(session);
-      console.log('Commit - success:', commit.success);
-      console.log('Commit - err:', JSON.stringify(commit.err, bigIntReplacer, 2));
-      expect(commit.success).toBe(true);
 
       gci.GciTsLogout(session);
     });

--- a/client/src/gciLibrary/__tests__/gciCommit.committing.integration.test.ts
+++ b/client/src/gciLibrary/__tests__/gciCommit.committing.integration.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { GciLibrary, GciError } from '../../gciLibrary';
+import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
+
+/**
+ * The `.committing.` infix comes from `commitEmptyTransaction` below, not
+ * from this suite's own tests (`allowedCommits` stays at 0 — none of them
+ * commit on the harness session).
+ */
+describe('GciTsCommit (integration)', () => {
+  let gci: GciLibrary;
+  let handle: unknown;
+
+  useIntegrationTest((testContext) => {
+    gci = testContext.gciLibrary;
+    handle = testContext.session;
+  });
+
+  /** Throws unless `session`'s transaction is provably empty. Never commits. */
+  function assertTransactionIsEmpty(gciLibrary: GciLibrary, session: unknown): void {
+    const needsCommit = gciLibrary.executeAndFetchString(session, 'System needsCommit printString');
+    if (needsCommit !== 'false') {
+      throw new Error(
+        `assertTransactionIsEmpty: expected System needsCommit to be false, got ${needsCommit}`,
+      );
+    }
+  }
+
+  /**
+   * Logs in a session of its own, outside the harness and never armed with
+   * its commit guard, proves the transaction empty, commits it, and logs
+   * out. Safe only because the transaction is proven empty first — this
+   * is not a pattern to copy for a test that needs to commit real changes.
+   */
+  function commitEmptyTransaction(gciLibrary: GciLibrary): { success: boolean; err: GciError } {
+    const session = gciLibrary.login(
+      process.env.VITE_GEMSTONE_STONE_NRS!,
+      process.env.VITE_GEMSTONE_GEM_NRS!,
+      process.env.VITE_GEMSTONE_USER!,
+      process.env.VITE_GEMSTONE_PASSWORD!,
+    );
+
+    try {
+      assertTransactionIsEmpty(gciLibrary, session);
+
+      // The empty commit below is still a real commit at the stone level —
+      // it writes a commit record and advances the sequence. Harmless, but
+      // not a no-op: never call this in a loop.
+      return gciLibrary.GciTsCommit(session);
+    } finally {
+      gciLibrary.logout(session);
+    }
+  }
+
+  it('commit succeeds on a clean session', () => {
+    const commit = commitEmptyTransaction(gci);
+
+    expect(commit.success).toBe(true);
+    expect(commit.err.number).toBe(0);
+  });
+
+  it('the emptiness proof passes on a clean harness session', () => {
+    expect(() => assertTransactionIsEmpty(gci, handle)).not.toThrow();
+  });
+
+  it('the emptiness proof has discriminating power', () => {
+    gci.executeDiscardingResult(handle, 'UserGlobals at: #JasperEmptyCommitProbe put: 42');
+
+    expect(() => assertTransactionIsEmpty(gci, handle)).toThrow();
+  });
+});

--- a/client/src/gciLibrary/__tests__/gciCommit.committing.integration.test.ts
+++ b/client/src/gciLibrary/__tests__/gciCommit.committing.integration.test.ts
@@ -33,10 +33,12 @@ describe('GciTsCommit (integration)', () => {
    * is not a pattern to copy for a test that needs to commit real changes.
    */
   function commitEmptyTransaction(gciLibrary: GciLibrary): { success: boolean; err: GciError } {
+    // eslint-disable-next-line no-restricted-syntax -- the one sanctioned unarmed login in this repo; safe only because assertTransactionIsEmpty runs before the commit below. If you are reading this comment in a second file, that is the bug.
     const session = gciLibrary.login(
       process.env.VITE_GEMSTONE_STONE_NRS!,
       process.env.VITE_GEMSTONE_GEM_NRS!,
       process.env.VITE_GEMSTONE_USER!,
+      // eslint-disable-next-line no-restricted-syntax -- credentials for the sanctioned unarmed login above; see that comment before copying either line
       process.env.VITE_GEMSTONE_PASSWORD!,
     );
 

--- a/client/src/gciLibrary/__tests__/gciCommit.committing.integration.test.ts
+++ b/client/src/gciLibrary/__tests__/gciCommit.committing.integration.test.ts
@@ -1,73 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { GciLibrary, GciError } from '../../gciLibrary';
+import { GciLibrary } from '../../gciLibrary';
 import { useIntegrationTest } from '../../__tests__/useIntegrationTest';
 
 /**
- * The `.committing.` infix comes from `commitEmptyTransaction` below, not
- * from this suite's own tests (`allowedCommits` stays at 0 — none of them
- * commit on the harness session).
+ * Covers the binding's success branch: the koffi signature, the session
+ * pointer round-trip, and reading `number` back out of the `GciErrSType`
+ * out-param. The refusal branch — where that struct's `number` and `message`
+ * carry the values production reads on a failed commit — is covered by
+ * "refuses a commit issued through the GCI commit call directly" in
+ * `client/src/__tests__/useIntegrationTest.integration.test.ts`.
  */
 describe('GciTsCommit (integration)', () => {
   let gci: GciLibrary;
   let handle: unknown;
 
-  useIntegrationTest((testContext) => {
-    gci = testContext.gciLibrary;
-    handle = testContext.session;
-  });
-
-  /** Throws unless `session`'s transaction is provably empty. Never commits. */
-  function assertTransactionIsEmpty(gciLibrary: GciLibrary, session: unknown): void {
-    const needsCommit = gciLibrary.executeAndFetchString(session, 'System needsCommit printString');
-    if (needsCommit !== 'false') {
-      throw new Error(
-        `assertTransactionIsEmpty: expected System needsCommit to be false, got ${needsCommit}`,
-      );
-    }
-  }
-
-  /**
-   * Logs in a session of its own, outside the harness and never armed with
-   * its commit guard, proves the transaction empty, commits it, and logs
-   * out. Safe only because the transaction is proven empty first — this
-   * is not a pattern to copy for a test that needs to commit real changes.
-   */
-  function commitEmptyTransaction(gciLibrary: GciLibrary): { success: boolean; err: GciError } {
-    // eslint-disable-next-line no-restricted-syntax -- the one sanctioned unarmed login in this repo; safe only because assertTransactionIsEmpty runs before the commit below. If you are reading this comment in a second file, that is the bug.
-    const session = gciLibrary.login(
-      process.env.VITE_GEMSTONE_STONE_NRS!,
-      process.env.VITE_GEMSTONE_GEM_NRS!,
-      process.env.VITE_GEMSTONE_USER!,
-      // eslint-disable-next-line no-restricted-syntax -- credentials for the sanctioned unarmed login above; see that comment before copying either line
-      process.env.VITE_GEMSTONE_PASSWORD!,
-    );
-
-    try {
-      assertTransactionIsEmpty(gciLibrary, session);
-
-      // The empty commit below is still a real commit at the stone level —
-      // it writes a commit record and advances the sequence. Harmless, but
-      // not a no-op: never call this in a loop.
-      return gciLibrary.GciTsCommit(session);
-    } finally {
-      gciLibrary.logout(session);
-    }
-  }
+  useIntegrationTest(
+    (testContext) => {
+      gci = testContext.gciLibrary;
+      handle = testContext.session;
+    },
+    { allowedCommits: 1 },
+  );
 
   it('commit succeeds on a clean session', () => {
-    const commit = commitEmptyTransaction(gci);
+    const commit = gci.GciTsCommit(handle);
 
     expect(commit.success).toBe(true);
     expect(commit.err.number).toBe(0);
-  });
-
-  it('the emptiness proof passes on a clean harness session', () => {
-    expect(() => assertTransactionIsEmpty(gci, handle)).not.toThrow();
-  });
-
-  it('the emptiness proof has discriminating power', () => {
-    gci.executeDiscardingResult(handle, 'UserGlobals at: #JasperEmptyCommitProbe put: 42');
-
-    expect(() => assertTransactionIsEmpty(gci, handle)).toThrow();
   });
 });

--- a/docs/reference/integration-test-harness.md
+++ b/docs/reference/integration-test-harness.md
@@ -47,7 +47,7 @@ Use `withTransientSession` when a test needs a second, independent session (e.g.
 
 Every session the harness creates — the shared one and any `withTransientSession` one — is armed with GemStone's own commit guard before it is handed to a test. A commit attempted by a test, or by the production code it exercises, fails at the commit site with `TransactionError 2249`, naming the harness in the error. There is currently **no opt-out** for those sessions: a test cannot commit on a session the harness handed it.
 
-The guard is session-scoped, so it binds only the sessions the harness creates. Anything that reaches the stone through a session of its own is unarmed and _can_ commit to the shared stone. A test that spawns one owns the cleanup itself; the harness's transaction-abort cannot reach it.
+The guard is session-scoped, so it binds only the sessions the harness creates. Anything that reaches the stone through a session of its own is unarmed and _can_ commit to the shared stone. This is enforced using linter rules, but in case a test that spawns one is required, it owns the cleanup itself; the harness's transaction-abort cannot reach it.
 
 Arming must be the harness's own doing. GemStone reports whether the call was the one that disabled commits, and the harness treats "they were already disabled" as a hard failure — by that point the invariant technically holds, but for a reason the harness did not establish (a `UserProfile` with `disableCommits`, a stone mid-restore). That is intentional: a whole matrix pass running under a guard the harness didn't arm is worse than a loud stop that makes the environment explain itself.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,6 +57,10 @@ const LOGIN_CREDENTIALS =
 // Every name the connection helpers give the password. Shared by the two
 // selectors below, which differ only in the syntax they read it with.
 const PASSWORD_NAMES = '/^(VITE_GEMSTONE_PASSWORD|gsPassword|GS_PASSWORD)$/';
+// Every raw login wrapper on `GciLibrary`, including the non-blocking
+// completion call: a test holding a socket from a non-blocking start finishes
+// its login through `GciTsNbLoginFinished`, and that session is unarmed too.
+const RAW_LOGIN_NAMES = '/^GciTsN?b?Login(_|Finished)?$/';
 const FORKED_GEM =
   'Prefer running the expression on the test context session. A forked gem runs in a session of its own that the harness never armed, and it outlives the test.';
 
@@ -266,10 +270,11 @@ export default tseslint.config(
           // libraries are *named* in assertions all over the unit tests
           // (`expect(gci.GciTsLogin).not.toHaveBeenCalled()`), and flagging
           // those would flag the tests that prove a path does not log in. A
-          // call is the thing that acquires a session. Pulling the wrapper into
-          // a local first would slip past this selector, but not past the
-          // `new GciLibrary` and password bans either side of it.
-          selector: 'CallExpression[callee.property.name=/^GciTsN?b?Login_?$/]',
+          // call is the thing that acquires a session. Matched by `.name` and
+          // `.value` both, as the password selectors below are: in
+          // `gci['GciTsLogin'](...)` the property is a `Literal`, which carries
+          // `.value` and no `.name`.
+          selector: `CallExpression:matches([callee.property.name=${RAW_LOGIN_NAMES}], [callee.property.value=${RAW_LOGIN_NAMES}])`,
           message: RAW_GCI_LOGIN,
         },
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,30 @@ const banChain = (matcher, message, negatedMessage) =>
     ]),
   );
 
+// An integration test never acquires a session; it receives one. Every session
+// `useIntegrationTest` hands out is armed with GemStone's session-level commit
+// guard, so nothing the test does can outlive its automatic abort. A test that
+// logs in on its own gets an *unarmed* session -- and unlike a refused commit,
+// which fails loudly with GemStone error 2249, that succeeds silently and
+// writes to the shared stone. Nothing detects it at runtime, which is why the
+// rules below catch it at lint time instead.
+//
+// Building a session outside the harness takes three things: a library
+// instance, a login call, and credentials. Each is banned separately, so
+// working around one selector (by renaming the receiver, say) still trips
+// another. Committing is deliberately *not* banned -- the harness already
+// refuses it, in the stone, with a message naming itself.
+const OWN_GCI_LIBRARY =
+  'Prefer the loaded library on the test context (`testContext.gciLibrary`). A second GciLibrary instance is the first half of a session the harness never armed.';
+const RAW_GCI_LOGIN =
+  'Prefer the session on the test context (`testContext.session`), or `withTransientSession(...)` for a second one. The raw GciTs*Login* wrappers return a session the harness never armed with the commit guard.';
+const GCI_LIBRARY_LOGIN =
+  'Prefer the session on the test context (`testContext.session`), or `withTransientSession(...)` for a second one. `GciLibrary.login` returns a session the harness never armed with the commit guard.';
+const LOGIN_CREDENTIALS =
+  'Prefer letting `useIntegrationTest` read the connection environment. A test reaching for the password is assembling its own login, and that session is not armed with the commit guard.';
+const FORKED_GEM =
+  'Prefer running the expression on the test context session. A forked gem runs in a session of its own that the harness never armed, and it outlives the test.';
+
 export default tseslint.config(
   // Keep lint ignores in sync with every `.gitignore` in the repo, instead of
   // a hand-maintained duplicate list that drifts (e.g. missed `.vscode-test/`
@@ -187,6 +211,70 @@ export default tseslint.config(
     // not fixed in place.
     files: ['client/src/__tests__/gci/**/*.test.ts'],
     rules: { 'vitest/no-conditional-expect': 'off' },
+  },
+  {
+    // Confines every test to the harness's session (see the message constants
+    // above for why).
+    //
+    // Three exemptions, for two different reasons:
+    //
+    // `client/src/__tests__/gci/**` is being deleted, not fixed. Every file
+    // there logs in for itself, so the rule would only collect disables that
+    // leave with the files.
+    //
+    // The other two are the unit tests *of* the login bindings, and they are
+    // exempt as whole files because naming those bindings is the whole point of
+    // each: `gciLoginQuiet` calls all four raw wrappers to assert the quiet bit
+    // reaches the native layer, and `gciOptionalFunctions` calls the ones an
+    // older library lacks to assert each throws. Both mock `koffi`, so a call
+    // reaches a `vi.fn()` and never a stone -- there is no session to arm, and
+    // so nothing for this rule to protect. Matched by basename rather than
+    // path, so moving either file keeps its exemption.
+    files: ['**/*.test.ts', '**/*.spec.ts', '**/*.test.tsx'],
+    ignores: [
+      'client/src/__tests__/gci/**',
+      '**/gciLoginQuiet.test.ts',
+      '**/gciOptionalFunctions.test.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        { selector: "NewExpression[callee.name='GciLibrary']", message: OWN_GCI_LIBRARY },
+        {
+          // Shaped as a call, not a bare member access: `vi.fn()`-mocked
+          // libraries are *named* in assertions all over the unit tests
+          // (`expect(gci.GciTsLogin).not.toHaveBeenCalled()`), and flagging
+          // those would flag the tests that prove a path does not log in. A
+          // call is the thing that acquires a session. Pulling the wrapper into
+          // a local first would slip past this selector, but not past the
+          // `new GciLibrary` and password bans either side of it.
+          selector: 'CallExpression[callee.property.name=/^GciTsN?b?Login_?$/]',
+          message: RAW_GCI_LOGIN,
+        },
+        {
+          // Keyed on the receiver, not the bare name: `login` is also the
+          // harness's own re-login on the test context, and `testContext.login`
+          // / `testContext.login()` / a destructured `login()` are all
+          // legitimate. Only a `login` sent to the GciLibrary itself is the
+          // escape hatch.
+          selector:
+            "CallExpression[callee.object.name=/^gci(Library)?$/][callee.property.name='login']",
+          message: GCI_LIBRARY_LOGIN,
+        },
+        {
+          // The sharpest of the four and the hardest to work around: there is
+          // no login without a password, whatever the receiver is called. The
+          // other VITE_GEMSTONE_* values stay allowed -- tests read the gem NRS
+          // and library path for reasons that have nothing to do with logging in.
+          selector: "MemberExpression[property.name='VITE_GEMSTONE_PASSWORD']",
+          message: LOGIN_CREDENTIALS,
+        },
+      ],
+      'no-restricted-imports': [
+        'error',
+        { patterns: [{ group: ['**/queries/forkGem'], message: FORKED_GEM }] },
+      ],
+    },
   },
   // Disables stylistic ESLint rules that would conflict with Prettier; must stay last.
   eslintConfigPrettier,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -269,10 +269,25 @@ export default tseslint.config(
           selector: "MemberExpression[property.name='VITE_GEMSTONE_PASSWORD']",
           message: LOGIN_CREDENTIALS,
         },
+        {
+          // The import ban below only sees the module specifier, so a call
+          // that reaches the fork query through a re-export slips past it.
+          // Keyed on a call through a receiver: the direct-import form stays
+          // the import rule's job, and the fork query's own unit test (bare
+          // calls on a mocked executor, no stone) is left alone.
+          selector: 'CallExpression[callee.property.name=/^(canForkGem|forkGemRunning)$/]',
+          message: FORKED_GEM,
+        },
       ],
-      'no-restricted-imports': [
+      // The typescript-eslint drop-in, for `allowTypeImports`: naming a type
+      // from the fork query forks nothing.
+      '@typescript-eslint/no-restricted-imports': [
         'error',
-        { patterns: [{ group: ['**/queries/forkGem'], message: FORKED_GEM }] },
+        {
+          patterns: [
+            { group: ['**/queries/forkGem'], message: FORKED_GEM, allowTypeImports: true },
+          ],
+        },
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,6 +54,9 @@ const GCI_LIBRARY_LOGIN =
   'Prefer the session on the test context (`testContext.session`), or `withTransientSession(...)` for a second one. `GciLibrary.login` returns a session the harness never armed with the commit guard.';
 const LOGIN_CREDENTIALS =
   'Prefer letting `useIntegrationTest` read the connection environment. A test reaching for the password is assembling its own login, and that session is not armed with the commit guard.';
+// Every name the connection helpers give the password. Shared by the two
+// selectors below, which differ only in the syntax they read it with.
+const PASSWORD_NAMES = '/^(VITE_GEMSTONE_PASSWORD|gsPassword|GS_PASSWORD)$/';
 const FORKED_GEM =
   'Prefer running the expression on the test context session. A forked gem runs in a session of its own that the harness never armed, and it outlives the test.';
 
@@ -271,16 +274,27 @@ export default tseslint.config(
           message: GCI_LIBRARY_LOGIN,
         },
         {
-          // The password by its env-var name, for a test that reads the
-          // environment directly instead of going through the helper. The
-          // other VITE_GEMSTONE_* values stay allowed -- tests read the gem NRS
-          // and library path for reasons that have nothing to do with logging in.
-          selector: "MemberExpression[property.name='VITE_GEMSTONE_PASSWORD']",
+          // The password read off something, for a test that goes to the
+          // environment (or a config object) instead of through the helper. A
+          // property selector, so the receiver is irrelevant -- but a `.name`
+          // one alone matches only a *non-computed* access: in
+          // `process.env['VITE_GEMSTONE_PASSWORD']` the property is a
+          // `Literal`, which carries `.value` and no `.name`, so both are
+          // matched. The other VITE_GEMSTONE_* values stay allowed -- tests
+          // read the gem NRS and library path for reasons that have nothing to
+          // do with logging in.
+          selector: `MemberExpression:matches([property.name=${PASSWORD_NAMES}], [property.value=${PASSWORD_NAMES}])`,
           message: LOGIN_CREDENTIALS,
         },
         {
-          // The password by its other two names. Property-name selectors, so the receiver is irrelevant.
-          selector: 'MemberExpression[property.name=/^(gsPassword|GS_PASSWORD)$/]',
+          // `const { VITE_GEMSTONE_PASSWORD } = process.env` is not a
+          // `MemberExpression` at all, and destructuring the environment is
+          // ordinary enough in test setup to be the next thing reached for once
+          // the selector above stops the direct read. Anchored on
+          // `ObjectPattern` so it only reads the binding side: the mock-env
+          // object literal in testConnection.test.ts is an `ObjectExpression`
+          // and stays legal.
+          selector: `ObjectPattern > Property:matches([key.name=${PASSWORD_NAMES}], [key.value=${PASSWORD_NAMES}])`,
           message: LOGIN_CREDENTIALS,
         },
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -244,6 +244,23 @@ export default tseslint.config(
       'no-restricted-syntax': [
         'error',
         { selector: "NewExpression[callee.name='GciLibrary']", message: OWN_GCI_LIBRARY },
+        // `callee.name` reads a bare identifier only, so a namespace import
+        // (`new gciLib.GciLibrary(...)`) walks past it. The three selectors
+        // here close the aliasing routes at their narrowest point -- the
+        // namespaced construction, the renaming import itself, and the
+        // assignment to a local -- rather than banning the import outright,
+        // which would also hit the many tests that name `GciLibrary` purely as
+        // a type annotation and the few that use its statics.
+        { selector: "NewExpression[callee.property.name='GciLibrary']", message: OWN_GCI_LIBRARY },
+        {
+          selector: "ImportSpecifier[imported.name='GciLibrary'][local.name!='GciLibrary']",
+          message: OWN_GCI_LIBRARY,
+        },
+        {
+          selector:
+            "VariableDeclarator:matches([init.name='GciLibrary'], [init.property.name='GciLibrary'])",
+          message: OWN_GCI_LIBRARY,
+        },
         {
           // Shaped as a call, not a bare member access: `vi.fn()`-mocked
           // libraries are *named* in assertions all over the unit tests

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,9 +41,10 @@ const banChain = (matcher, message, negatedMessage) =>
 // rules below catch it at lint time instead.
 //
 // Building a session outside the harness takes three things: a library
-// instance, a login call, and credentials. Each is banned separately, so
-// working around one selector (by renaming the receiver, say) still trips
-// another. Committing is deliberately *not* banned -- the harness already
+// instance, a login call, and credentials. Each is banned separately, and none
+// of the selectors keys on a receiver's name, so renaming or re-routing the
+// receiver does not shake any of them off -- and working around one still
+// trips another. Committing is deliberately *not* banned -- the harness already
 // refuses it, in the stone, with a message naming itself.
 const OWN_GCI_LIBRARY =
   'Prefer the loaded library on the test context (`testContext.gciLibrary`). A second GciLibrary instance is the first half of a session the harness never armed.';
@@ -252,21 +253,34 @@ export default tseslint.config(
           message: RAW_GCI_LOGIN,
         },
         {
-          // Keyed on the receiver, not the bare name: `login` is also the
-          // harness's own re-login on the test context, and `testContext.login`
-          // / `testContext.login()` / a destructured `login()` are all
-          // legitimate. Only a `login` sent to the GciLibrary itself is the
-          // escape hatch.
-          selector:
-            "CallExpression[callee.object.name=/^gci(Library)?$/][callee.property.name='login']",
+          // Keyed on the method and its arity, not the receiver's name: a
+          // receiver-name selector only reads `callee.object.name`, which does
+          // not exist on a `MemberExpression` receiver, so it would miss
+          // `testContext.gciLibrary.login(...)` -- the most natural spelling
+          // inside a `useIntegrationTest` callback -- along with every receiver
+          // not spelled `gci`/`gciLibrary`. Arity is what actually identifies
+          // it: `GciLibrary.login` takes exactly four arguments, while the
+          // logins a test may legitimately call take other counts. Both member and bare
+          // call forms, so pulling `login` out of the library into a local
+          // first does not slip past.
+          selector: "CallExpression[callee.property.name='login'][arguments.length=4]",
           message: GCI_LIBRARY_LOGIN,
         },
         {
-          // The sharpest of the four and the hardest to work around: there is
-          // no login without a password, whatever the receiver is called. The
+          selector: "CallExpression[callee.name='login'][arguments.length=4]",
+          message: GCI_LIBRARY_LOGIN,
+        },
+        {
+          // The password by its env-var name, for a test that reads the
+          // environment directly instead of going through the helper. The
           // other VITE_GEMSTONE_* values stay allowed -- tests read the gem NRS
           // and library path for reasons that have nothing to do with logging in.
           selector: "MemberExpression[property.name='VITE_GEMSTONE_PASSWORD']",
+          message: LOGIN_CREDENTIALS,
+        },
+        {
+          // The password by its other two names. Property-name selectors, so the receiver is irrelevant.
+          selector: 'MemberExpression[property.name=/^(gsPassword|GS_PASSWORD)$/]',
           message: LOGIN_CREDENTIALS,
         },
         {

--- a/mcp-server/src/__tests__/mcpSession.test.ts
+++ b/mcp-server/src/__tests__/mcpSession.test.ts
@@ -80,6 +80,7 @@ describe('McpSession', () => {
         false,
         config.gemNrs,
         config.gsUser,
+        // eslint-disable-next-line no-restricted-syntax -- asserting the password reaches the login is this test's whole point; `mockGci` is a `vi.fn()` mock, so no session and no stone are involved
         config.gsPassword,
         0,
         0,
@@ -97,6 +98,7 @@ describe('McpSession', () => {
         false,
         config.gemNrs,
         config.gsUser,
+        // eslint-disable-next-line no-restricted-syntax -- asserting the password reaches the login is this test's whole point; `mockGci` is a `vi.fn()` mock, so no session and no stone are involved
         config.gsPassword,
         0,
         0,


### PR DESCRIPTION
## Summary

- Migrates the `commit succeeds on a clean session` test off the legacy `gci` e2e suite (`gciLogin.test.ts`) into a new `gciCommit.committing.integration.test.ts`. The old version asserted on a session it logged in itself, outside the harness; the new version proves the harness session's transaction is empty via `System needsCommit`, then exercises a real login/commit/logout cycle it owns explicitly (with an `assertTransactionIsEmpty` self-check test to prove the emptiness check has discriminating power).
- Adds an ESLint rule (`no-restricted-syntax`/`no-restricted-imports`) that bans integration tests from assembling their own out-of-harness GemStone session: a bare `new GciLibrary()`, raw `GciTs*Login*` calls, `gci(Library).login(...)`, reading `VITE_GEMSTONE_PASSWORD`, or importing `queries/forkGem`. Every session `useIntegrationTest` hands out is armed with GemStone's commit guard (refused commits fail loudly with error 2249); a self-assembled session isn't, so a stray commit would succeed silently against the shared CI stone with nothing to catch it at runtime — hence a lint-time rule instead.
- The rule ignores `client/src/__tests__/gci/**` (being deleted, not fixed) and the login-binding unit tests (`gciLoginQuiet.test.ts`, `gciOptionalFunctions.test.ts`), which mock `koffi` and exist specifically to call those raw wrappers.
- The two remaining legitimate exceptions (the new commit test's `commitEmptyTransaction` helper, and `forkGem.integration.test.ts`, which tests forking itself) take scoped inline `eslint-disable-next-line` comments rather than a file-level carve-out.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:client` (gci commit + forkGem integration tests, against a running test stone)