### PR TITLE
Stop grouping unrelated install-script bumps, pin @types/node and @types/vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,13 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    ignore:
+      # Part of the coordinated VS Code/Node/TypeScript version floor — see
+      # .claude/rules/version-pins.md and docs/how-to/raising-the-version-floor.md.
+      # Only bumped by hand, together with the rest of that file list.
+      - dependency-name: '@types/node'
+      - dependency-name: '@types/vscode'
     groups:
-      # Listed first so it wins the match: keeps every ESTRICTALLOWSCRIPTS-
-      # triggering bump in one recognizable PR per cycle. @vscode/vsce-sign
-      # and keytar are deliberately excluded — they're transitive, and
-      # Dependabot never names them directly.
-      install-scripts:
-        patterns:
-          - 'esbuild'
-          - 'koffi'
-          - 'lefthook'
-          - '@vscode/vsce'
-          - 'ovsx'
       dev-dependencies:
         dependency-type: 'development'
         update-types:

--- a/docs/how-to/add-a-dependency-with-install-scripts.md
+++ b/docs/how-to/add-a-dependency-with-install-scripts.md
@@ -34,4 +34,4 @@ Approvals are version-pinned (`allow-scripts-pin=true`), so a Dependabot PR that
 2. `npm rebuild`.
 3. Commit the updated `package.json` on the branch and push.
 
-Packages that receive this treatment regularly are grouped into Dependabot's `install-scripts` group (see [docs/reference/supply-chain-controls.md](../reference/supply-chain-controls.md)) so they arrive together, in one recognizable PR per cycle.
+A bump of an approved package arrives in the ordinary `dev-dependencies` or `prod-dependencies` group PR, and fails that PR's install until it's re-approved.


### PR DESCRIPTION
## Summary
- Remove the `install-scripts` dependabot group. It mixed low-risk patch bumps (esbuild, koffi, lefthook, @vscode/vsce, ovsx) with unrelated major-version jumps in one PR; those packages now fall through to the standard `dev-dependencies`/`prod-dependencies` grouping like everything else — minor/patch batched, majors reviewed individually.
- Add an `ignore` rule for `@types/node` and `@types/vscode`. Both are part of the coordinated VS Code/Node/TypeScript version floor documented in `docs/how-to/raising-the-version-floor.md` and should only move by hand, together with the rest of that file list — not via an automated bump.

## Related (not in this diff)
- Created `major`/`minor`/`patch` labels on the repo so Dependabot's built-in semver-label feature auto-tags future PRs by update type. No `dependabot.yml` config needed for that — GitHub applies it automatically once matching labels exist.
