### PR TITLE
Add cross-platform native socket poller

### DIFF
--- a/client/src/__tests__/platformGates.ts
+++ b/client/src/__tests__/platformGates.ts
@@ -1,4 +1,5 @@
 import { describe, it } from 'vitest';
+import { isWindows } from '../wslBridge';
 
 const isSupportedPosixPlatform = process.platform === 'linux' || process.platform === 'darwin';
 
@@ -17,3 +18,12 @@ export const onSupportedPosixDescribe: ReturnType<typeof describe.runIf> =
 
 /** Same as {@link onSupportedPosixDescribe}, for a single `it` rather than a whole block. */
 export const onSupportedPosixIt: ReturnType<typeof it.runIf> = it.runIf(isSupportedPosixPlatform);
+
+/**
+ * Wraps a `describe` block that only makes sense on Windows: behavior backed
+ * by Win32-specific primitives (e.g. a raw `SOCKET` opened via `ws2_32.dll`)
+ * that have no POSIX equivalent. Runs the block's tests normally on Windows;
+ * reports them as skipped elsewhere.
+ */
+export const onSupportedWindowsDescribe: ReturnType<typeof describe.runIf> =
+  describe.runIf(isWindows());

--- a/client/src/__tests__/support/process.ts
+++ b/client/src/__tests__/support/process.ts
@@ -1,0 +1,25 @@
+import { SyncThunk } from '../../syncTypes';
+
+/**
+ * Runs `callback` with `process.platform` temporarily set to `newPlatform`,
+ * restoring the original value afterward even if `callback` throws.
+ *
+ * @param newPlatform - The platform value to report while `callback` runs.
+ * @param callback - Runs while `process.platform` reports `newPlatform`.
+ */
+export function changeProcessPlatformDuring<T>(
+  newPlatform: NodeJS.Platform,
+  callback: SyncThunk<T>,
+) {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', {
+    value: newPlatform,
+    configurable: true,
+  });
+
+  try {
+    callback();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  }
+}

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { GCI_LOGIN_QUIET, OOP_FALSE, OOP_ILLEGAL, OOP_NIL, OOP_TRUE } from './gciConstants';
 import { GciLibraryError } from './gciLibraryError';
 import { escapeString } from './queries/util';
-import type { NotPromise } from './types';
+import type { NotPromise } from './syncTypes';
 
 // OopType is uint64_t in C; koffi maps this to BigInt in JS
 const OopType = 'uint64';

--- a/client/src/gciLibrary.ts
+++ b/client/src/gciLibrary.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { GCI_LOGIN_QUIET, OOP_FALSE, OOP_ILLEGAL, OOP_NIL, OOP_TRUE } from './gciConstants';
 import { GciLibraryError } from './gciLibraryError';
 import { escapeString } from './queries/util';
+import type { NotPromise } from './types';
 
 // OopType is uint64_t in C; koffi maps this to BigInt in JS
 const OopType = 'uint64';
@@ -159,10 +160,6 @@ function toBigInt(value: number | bigint): bigint {
 function quietedLoginFlags(loginFlags: number): number {
   return loginFlags | GCI_LOGIN_QUIET;
 }
-
-// Rejects a Promise-returning (async) callback at the type level -- see
-// GciLibrary.executeAndRelease's doc comment for why that matters.
-type NotPromise<T> = T extends Promise<unknown> ? never : T;
 
 /**
  * FFI bindings to GemStone's native `libgcits` shared library, loaded via koffi.

--- a/client/src/sockets/__tests__/nativeSocketLibrary.test.ts
+++ b/client/src/sockets/__tests__/nativeSocketLibrary.test.ts
@@ -1,0 +1,126 @@
+import koffi from 'koffi';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NativeSocketLibrary } from '../nativeSocketLibrary';
+import { NativePOSIXSocketLibrary } from '../nativePOSIXSocketLibrary';
+import { PosixSocketLibrary } from '../bindings/posixSocketLibrary';
+import { createNativeSocketLibrary } from '../factory';
+import { changeProcessPlatformDuring } from '../../__tests__/support/process';
+import {
+  onSupportedPosixDescribe,
+  onSupportedWindowsDescribe,
+} from '../../__tests__/platformGates';
+import { LoopbackConnection, openLoopbackConnection } from './support/loopbackConnection';
+
+describe('Native socket library', () => {
+  describe('Creating instances', () => {
+    it('throws an error when a platform is not supported', () => {
+      changeProcessPlatformDuring('aix', () => {
+        expect(() => createNativeSocketLibrary()).toThrow('Unsupported platform: aix');
+      });
+    });
+  });
+
+  describe('Checking whether a socket is readable', () => {
+    let fd: bigint;
+    let loopbackConnection: LoopbackConnection;
+    let library: NativeSocketLibrary;
+
+    beforeEach(async () => {
+      loopbackConnection = await openLoopbackConnection();
+      fd = loopbackConnection.fd;
+      library = createNativeSocketLibrary();
+    });
+
+    afterEach(async () => {
+      await loopbackConnection.close();
+    });
+
+    it('reports a socket readable when data is actually waiting on it', async () => {
+      await loopbackConnection.writeFromServer('hi');
+
+      expect(library.isReadable(fd)).toBe(true);
+    });
+
+    it('reports a socket not readable when nothing has arrived yet', async () => {
+      expect(library.isReadable(fd)).toBe(false);
+    });
+
+    it('throws an error when polling an invalid file descriptor', () => {
+      expect(() => library.isReadable(library.invalidSocketDescriptor())).toThrow(
+        library.invalidFileDescriptorErrorMessage(),
+      );
+    });
+
+    onSupportedWindowsDescribe('Error handling on Windows', () => {
+      // A stale-but-non-negative closed handle makes WSAPoll return
+      // SOCKET_ERROR outright (see the "cannot be polled" test below), a
+      // different code path than the one this test means to exercise.
+      // Resetting the peer's connection is this suite's one way to produce a
+      // dead-but-open handle through a real socket: it leaves the handle
+      // itself open but errored, which reliably clears POLLRDNORM from
+      // `revents` (the same as WSAPoll would for POLLHUP/POLLERR/POLLNVAL)
+      // without touching the handle's validity. On POSIX, resolving
+      // `resetFromServer()` only guarantees the peer has torn down its own
+      // socket, not that the RST has reached and been processed by the
+      // client fd's kernel state by the time `poll()` runs, so the same
+      // assertion is flaky there.
+      it('reports the socket as unusable when it has been reset by its peer', async () => {
+        await loopbackConnection.resetFromServer();
+
+        // POLLERR|POLLHUP (0x0001|0x0002 = 0x0003): the revents WSAPoll sets
+        // for a reset connection, verified live via WSAPoll on Windows.
+        expect(() => library.isReadable(fd)).toThrow(
+          library.socketUnusableErrorMessage(fd, 0x0003),
+        );
+      });
+
+      // Unlike the reset case above, this closes the handle itself rather
+      // than merely erroring the connection behind it. This is the one
+      // real-socket way to exercise a genuine WSAPoll() syscall failure (it
+      // returns SOCKET_ERROR outright for an already-closed handle) rather
+      // than a mere unready/errored result.
+      it('reports the WSA diagnostic when the socket cannot be polled', async () => {
+        await loopbackConnection.close();
+
+        // WSAENOTSOCK (10038): what WSAPoll fails with for an already-closed
+        // handle, verified live via WSAPoll on Windows.
+        expect(() => library.isReadable(fd)).toThrow(
+          library.pollFailedErrorMessage(fd, 'WSAGetLastError 10038'),
+        );
+      });
+    });
+
+    onSupportedPosixDescribe('Error handling on POSIX', () => {
+      // Closing the handle doesn't fail poll() itself: POLLNVAL comes back
+      // through revents on an otherwise-successful call, same as the
+      // Windows reset case reports POLLHUP/POLLERR.
+      it('reports the socket as unusable once its file descriptor has been closed', async () => {
+        await loopbackConnection.close();
+
+        // POLLNVAL (0x0020, standard across POSIX libc's <poll.h>), the one
+        // revents bit a closed fd sets; verified live via poll() on macOS.
+        expect(() => library.isReadable(fd)).toThrow(
+          library.socketUnusableErrorMessage(fd, 0x0020),
+        );
+      });
+
+      // No real socket condition reliably makes poll() itself fail (EFAULT/
+      // EINTR/ENOMEM aren't safely triggerable), so this fakes the binding
+      // directly rather than going through a real fd. koffi.errno() is the
+      // real function, primed with a real POSIX error code, to check that
+      // the thrown message reflects whatever poll() actually left there.
+      it('reports the diagnostic when the poll syscall itself fails', () => {
+        koffi.errno(koffi.os.errno.EBADF);
+        const fakeLibrary = new NativePOSIXSocketLibrary({
+          name: 'fake',
+          poll: () => -1,
+          POLLIN: 0x0001,
+        } as unknown as PosixSocketLibrary);
+
+        expect(() => fakeLibrary.isReadable(3n)).toThrow(
+          fakeLibrary.pollFailedErrorMessage(3n, `errno ${koffi.os.errno.EBADF}`),
+        );
+      });
+    });
+  });
+});

--- a/client/src/sockets/__tests__/support/loopbackConnection.ts
+++ b/client/src/sockets/__tests__/support/loopbackConnection.ts
@@ -1,0 +1,133 @@
+import { createServer, Socket } from 'net';
+import { createNativeSocketLibrary } from '../../factory';
+import { RawSocketConnection } from '../../nativeSocketLibrary';
+
+export type LoopbackConnection = {
+  fd: bigint;
+  writeFromServer: (data: string) => Promise<void>;
+  resetFromServer: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+export type ConnectLoopbackClient = (port: number) => Promise<RawSocketConnection>;
+
+/**
+ * Opens a real TCP loopback connection and resolves with the client's raw
+ * fd/handle (obtained from `connectClient`, which supplies the
+ * platform-specific way to get one), a `writeFromServer` callback to send bytes from
+ * the server side, a `resetFromServer` callback to have the server side reset the
+ * connection, and a `close` callback to close both ends. The client side is
+ * never read from, so any bytes sent stay at the OS level rather than being
+ * drained, leaving the handle's readiness exactly as a real `poll`/`WSAPoll`
+ * caller would see it.
+ *
+ * `writeFromServer`, `resetFromServer`, and `close` resolve once their effect has actually
+ * happened at the OS level (the write has flushed; the reset/closed socket
+ * has closed) rather than after a guessed delay: on loopback there's no real
+ * wire transfer, so by the time the local op completes, the client side has
+ * already seen it.
+ *
+ * @param connectClient - supplies the platform-specific way to obtain the
+ * client's raw fd/handle for a given port.
+ * @returns the connected client's raw fd/handle, a `writeFromServer` callback
+ * to send bytes from the server side, a `resetFromServer` callback to have
+ * the server side reset the connection, and a `close` callback to close both
+ * ends.
+ */
+export async function openLoopbackConnectionWith(
+  connectClient: ConnectLoopbackClient,
+): Promise<LoopbackConnection> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+
+    server.once('error', reject);
+
+    let peer: Socket | undefined;
+    let client: RawSocketConnection | undefined;
+    let closed = false;
+
+    const resolveOnceBothEndsAreUp = () => {
+      if (peer && client) {
+        resolve({
+          fd: client.fd,
+          writeFromServer: (data) =>
+            new Promise((writeResolve, writeReject) =>
+              peer!.write(data, (error) => (error ? writeReject(error) : writeResolve())),
+            ),
+          resetFromServer: () =>
+            new Promise((resetResolve) => {
+              peer!.once('close', resetResolve);
+              peer!.resetAndDestroy();
+            }),
+          close: () =>
+            new Promise((closeResolve) => {
+              // Idempotent: a test may close the connection itself and the
+              // shared `afterEach` closes it again. `client!.disconnect()`
+              // isn't guaranteed idempotent on every platform (e.g. it's a
+              // bare `closesocket()` FFI call on Windows), so calling it
+              // twice on the same handle must be avoided here rather than
+              // relied on there.
+              if (closed) {
+                closeResolve();
+                return;
+              }
+              closed = true;
+
+              const finish = () => server.close(() => closeResolve());
+              // The peer may already be closed (e.g. after `resetFromServer`), in which
+              // case its one-time 'close' event has already fired and
+              // registering a new listener for it would wait forever.
+              if (peer!.destroyed) {
+                client!.disconnect();
+                finish();
+              } else {
+                peer!.once('close', finish);
+                client!.disconnect();
+              }
+            }),
+        });
+      }
+    };
+
+    server.on('connection', (socket) => {
+      peer = socket;
+      // Disconnecting the client can send an RST if it still has unread data
+      // waiting (see `close`/`disconnect` above), which surfaces here as an
+      // 'error' on the peer. Node rethrows an un-listened-for socket 'error'
+      // as an uncaught exception that would otherwise crash the whole test
+      // run.
+      peer.on('error', () => undefined);
+      resolveOnceBothEndsAreUp();
+    });
+
+    const onListening = async () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('Expected the loopback server to report a network address'));
+        return;
+      }
+
+      client = await connectClient(address.port);
+      resolveOnceBothEndsAreUp();
+    };
+
+    // `server.listen`'s callback type is `() => void`; it doesn't await a
+    // returned promise, so a rejection from `connectClient` would otherwise
+    // become an unhandled rejection instead of failing this Promise.
+    server.listen(0, '127.0.0.1', () => onListening().catch(reject));
+  });
+}
+
+/**
+ * Opens a real TCP loopback connection using the current platform's native
+ * socket library to obtain the client's handle.
+ *
+ * @returns the connected client's raw fd/handle, a `writeFromServer` callback to send
+ * bytes from the server side, a `resetFromServer` callback to have the server side
+ * reset the connection, and a `close` callback to close both ends.
+ */
+export async function openLoopbackConnection() {
+  const library = createNativeSocketLibrary();
+
+  return await openLoopbackConnectionWith((port) => library.connectRawSocket(port));
+}

--- a/client/src/sockets/bindings/posixSocketLibrary.ts
+++ b/client/src/sockets/bindings/posixSocketLibrary.ts
@@ -1,0 +1,60 @@
+import koffi, { KoffiFunction } from 'koffi';
+
+export type PosixSocketLibrary = {
+  name: string;
+  poll: KoffiFunction;
+  POLLIN: number;
+};
+
+let instance: PosixSocketLibrary | undefined;
+
+/**
+ * Returns the shared POSIX polling library loaded from `libraryName`,
+ * loading it on first use.
+ *
+ * @param libraryName - the shared library to load the polling primitive from.
+ * @param nfdsType - the C type of `poll()`'s `nfds` parameter on this
+ * platform, since it isn't uniform across POSIX libc implementations.
+ * @returns the loaded library's bindings.
+ * @throws {Error} If already loaded under a different library name, or if
+ * the library itself can't be loaded on this machine.
+ */
+export function posixSocketLibrary(
+  libraryName: string,
+  nfdsType: 'unsigned int' | 'unsigned long',
+): PosixSocketLibrary {
+  if (instance && instance.name !== libraryName) {
+    throw new Error(
+      `posixSocketLibrary already loaded as '${instance.name}', cannot reload as '${libraryName}'`,
+    );
+  }
+
+  return (instance ??= loadPosixSocketLibrary(libraryName, nfdsType));
+}
+
+/**
+ * Loads `libraryName` and builds the polling primitive it exposes.
+ *
+ * @param libraryName - the shared library to load.
+ * @param nfdsType - the C type of `poll()`'s `nfds` parameter on this platform.
+ * @returns the loaded library's bindings.
+ * @throws {Error} If the library can't be loaded on this machine.
+ */
+function loadPosixSocketLibrary(
+  libraryName: string,
+  nfdsType: 'unsigned int' | 'unsigned long',
+): PosixSocketLibrary {
+  const libc = koffi.load(libraryName);
+
+  koffi.struct('libc_PollFd', {
+    fd: 'int',
+    events: 'int16',
+    revents: 'int16',
+  });
+
+  return {
+    name: libraryName,
+    poll: libc.func(`int poll(_Inout_ libc_PollFd *fds, ${nfdsType} nfds, int timeout)`),
+    POLLIN: 0x0001,
+  };
+}

--- a/client/src/sockets/bindings/windowsSocketLibrary.ts
+++ b/client/src/sockets/bindings/windowsSocketLibrary.ts
@@ -1,0 +1,77 @@
+import koffi, { KoffiFunction } from 'koffi';
+
+export type WindowsSocketLibrary = {
+  WSAPoll: KoffiFunction;
+  socket: KoffiFunction;
+  connect: KoffiFunction;
+  closesocket: KoffiFunction;
+  WSAGetLastError: KoffiFunction;
+  POLLRDNORM: number;
+  AF_INET: number;
+  SOCK_STREAM: number;
+  IPPROTO_TCP: number;
+  INVALID_SOCKET: bigint;
+  SOCKET_ERROR: number;
+  SOCKADDR_IN_SIZE: number;
+};
+
+let instance: WindowsSocketLibrary | undefined;
+
+/**
+ * Returns the shared Windows polling library, loading it on first use.
+ *
+ * @returns the loaded library's bindings.
+ * @throws {Error} If the library can't be loaded on this machine.
+ */
+export function windowsSocket2Library(): WindowsSocketLibrary {
+  return (instance ??= loadWindowsSocket2Library());
+}
+
+/**
+ * Loads the Windows polling library and builds its bindings.
+ *
+ * @returns the loaded library's bindings.
+ * @throws {Error} If the library can't be loaded on this machine.
+ */
+function loadWindowsSocket2Library(): WindowsSocketLibrary {
+  const ws2 = koffi.load('ws2_32.dll');
+
+  // Registered once at module scope, rather than per instance: koffi's struct
+  // registry is process-wide, and re-declaring an already-registered name
+  // throws, which a second `NativeWindowsSocketLibrary` instance would hit
+  // if these lived inside the constructor.
+  koffi.struct('WS2_WsaPollFd', {
+    fd: 'uint64',
+    events: 'int16',
+    revents: 'int16',
+  });
+
+  // A minimal `sockaddr_in`: 2-byte family, 2-byte port, 4-byte address, 8
+  // bytes of zero padding (16 bytes total, matching the real struct's layout
+  // exactly). Port and address are declared as raw byte arrays rather than
+  // `uint16`/`uint32` so the network-byte-order bytes written are exactly the
+  // bytes koffi puts in memory, regardless of the host's own endianness.
+  koffi.struct('WS2_RawSockAddrIn', {
+    family: 'uint16',
+    portBytes: 'uint8[2]',
+    addrBytes: 'uint8[4]',
+    zero: 'uint8[8]',
+  });
+
+  return {
+    WSAPoll: ws2.func(
+      'int __stdcall WSAPoll(_Inout_ WS2_WsaPollFd *fdArray, unsigned long fds, int timeout)',
+    ),
+    socket: ws2.func('uint64 __stdcall socket(int af, int type, int protocol)'),
+    connect: ws2.func('int __stdcall connect(uint64 s, WS2_RawSockAddrIn *name, int namelen)'),
+    closesocket: ws2.func('int __stdcall closesocket(uint64 s)'),
+    WSAGetLastError: ws2.func('int __stdcall WSAGetLastError()'),
+    POLLRDNORM: 0x0100,
+    AF_INET: 2,
+    SOCK_STREAM: 1,
+    IPPROTO_TCP: 6,
+    INVALID_SOCKET: 0xffffffffffffffffn,
+    SOCKET_ERROR: -1,
+    SOCKADDR_IN_SIZE: koffi.sizeof('WS2_RawSockAddrIn'),
+  };
+}

--- a/client/src/sockets/factory.ts
+++ b/client/src/sockets/factory.ts
@@ -1,0 +1,22 @@
+import { NativeSocketLibrary } from './nativeSocketLibrary';
+import { NativeWindowsSocketLibrary } from './nativeWindowsSocketLibrary';
+import { NativePOSIXSocketLibrary } from './nativePOSIXSocketLibrary';
+
+/**
+ * Creates the native socket library for the current platform.
+ *
+ * @returns a library instance for polling sockets and opening test-only raw connections.
+ * @throws {Error} If the current platform isn't supported.
+ */
+export function createNativeSocketLibrary(): NativeSocketLibrary {
+  switch (process.platform) {
+    case 'win32':
+      return new NativeWindowsSocketLibrary();
+    case 'darwin':
+      return NativePOSIXSocketLibrary.forDarwin();
+    case 'linux':
+      return NativePOSIXSocketLibrary.forLinux();
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}

--- a/client/src/sockets/nativePOSIXSocketLibrary.ts
+++ b/client/src/sockets/nativePOSIXSocketLibrary.ts
@@ -1,0 +1,118 @@
+import koffi from 'koffi';
+import { connect, Socket } from 'net';
+import { PosixSocketLibrary, posixSocketLibrary } from './bindings/posixSocketLibrary';
+import { NativeSocketLibrary, RawSocketConnection } from './nativeSocketLibrary';
+
+export class NativePOSIXSocketLibrary extends NativeSocketLibrary {
+  public invalidSocketDescriptor(): bigint {
+    return -1n;
+  }
+  /**
+   * Creates an instance for polling sockets on Linux.
+   *
+   * @throws {Error} If the native polling primitive can't be loaded on this machine.
+   */
+  public static forLinux() {
+    return new NativePOSIXSocketLibrary(posixSocketLibrary('libc.so.6', 'unsigned long'));
+  }
+
+  /**
+   * Creates an instance for polling sockets on macOS.
+   *
+   * @throws {Error} If the native polling primitive can't be loaded on this machine.
+   */
+  public static forDarwin() {
+    return new NativePOSIXSocketLibrary(posixSocketLibrary('libSystem.dylib', 'unsigned int'));
+  }
+
+  /**
+   * Creates an instance backed by the given POSIX polling bindings.
+   *
+   * @param posixSocketLibrary - the polling bindings to use.
+   */
+  constructor(private posixSocketLibrary: PosixSocketLibrary) {
+    super();
+  }
+
+  public isReadable(fd: bigint): boolean {
+    this.assertIsValidFileDescriptor(fd);
+
+    // `pollFd` must stay in a variable, not an inline literal: koffi writes
+    // poll()'s output back into this same object, and we need to read the
+    // resulting `revents` below. POSIX fds are always small ints by OS
+    // design, so narrowing to `Number` here is safe even though `fd` is a
+    // `bigint` at the API boundary (matching Windows' 64-bit handles).
+    const pollFd = { fd: Number(fd), events: this.posixSocketLibrary.POLLIN, revents: 0 };
+    const status = this.posixSocketLibrary.poll(pollFd, 1, 0);
+
+    // A negative status means poll() itself failed. Capture the reason
+    // immediately, via koffi.errno(), before any other native call can
+    // overwrite it.
+    if (status < 0) {
+      this.throwPollFailedError(fd, `errno ${koffi.errno()}`);
+    }
+
+    // 0 means it timed out with nothing to report; there's no meaningful
+    // revents to check.
+    if (status === 0) {
+      return false;
+    }
+
+    // POSIX counts the fd as having an event (status > 0) for POLLERR/
+    // POLLHUP/POLLNVAL too, not just POLLIN, so a positive status alone
+    // doesn't mean the socket is readable. Only report readable when POLLIN
+    // is actually set; otherwise treat it as a failed check rather than a
+    // false positive on a dead or errored socket.
+    if (!(pollFd.revents & this.posixSocketLibrary.POLLIN)) {
+      this.throwUnusableSocketError(fd, pollFd.revents);
+    }
+
+    return true;
+  }
+
+  /**
+   * Opens a real client socket to 127.0.0.1:`port` and reads back its
+   * underlying OS file descriptor: the same kind of fd production code
+   * checks for readiness, so this is the only way to test that check
+   * against a genuine socket rather than a fake result.
+   *
+   * @param port - TCP port on the loopback interface to connect to.
+   * @returns The connected socket's raw fd, and a way to close it.
+   * @throws {Error} If the connection can't be established.
+   */
+  public connectRawSocket(port: number): Promise<RawSocketConnection> {
+    return new Promise((resolve, reject) => {
+      const clientSocket = connect(port, '127.0.0.1');
+      // Without this, libuv still drains bytes off the fd into Node's
+      // internal buffer in the background even though nothing here ever
+      // calls `.on('data', ...)`, which clears the OS-level readiness a
+      // moment after data arrives. Pausing stops that background read so
+      // the fd's readiness reflects only what a real `poll`/`WSAPoll`
+      // caller would see, matching the doc comment above.
+      clientSocket.pause();
+      // The client under test is never read from, so a peer reset (used to
+      // exercise the POLLHUP/POLLERR case) arrives as an ECONNRESET here,
+      // after 'connect' already resolved the promise; rejecting at that
+      // point is a no-op. Node rethrows an un-listened-for socket 'error' as
+      // an uncaught exception that would otherwise crash the whole test run.
+      clientSocket.on('error', (error) => reject(error));
+      clientSocket.on('connect', () =>
+        resolve({
+          fd: BigInt(this.rawFdOf(clientSocket)),
+          disconnect: () => clientSocket.destroy(),
+        }),
+      );
+    });
+  }
+
+  /**
+   * Returns `socket`'s underlying OS file descriptor, reached through an
+   * internal Node property since there's no public API for it.
+   *
+   * @param socket - the connected socket to read the descriptor from.
+   * @returns the socket's raw file descriptor.
+   */
+  private rawFdOf(socket: Socket): number {
+    return (socket as unknown as { _handle: { fd: number } })._handle.fd;
+  }
+}

--- a/client/src/sockets/nativeSocketLibrary.ts
+++ b/client/src/sockets/nativeSocketLibrary.ts
@@ -1,0 +1,125 @@
+/** A raw, poll-able socket handle, and a way to close it. */
+export type RawSocketConnection = {
+  fd: bigint;
+  disconnect: () => void;
+};
+
+/**
+ * Cross-platform way to check whether a socket has data ready to read right
+ * now, backed by libc's `poll()` on POSIX and `ws2_32`'s `WSAPoll()` on
+ * Windows. It only ever answers "is this readable right now?"; it never
+ * waits. It exists as a fallback for `GciLibrary` to add non-blocking
+ * support on GCI versions where `GciTsNbPoll` isn't available.
+ *
+ * `fd` is a `bigint` everywhere in this API so the same signature can carry
+ * either a POSIX file descriptor (a small int, narrowed back down in the
+ * POSIX subclass since kernel fds are always small) or a Windows `SOCKET`
+ * handle (a 64-bit value that doesn't fit in a `number`).
+ */
+export abstract class NativeSocketLibrary {
+  /**
+   * Reports whether the given socket currently has data ready to read,
+   * without waiting.
+   *
+   * @param fd - OS-level file descriptor for an open socket.
+   * @returns `true` if the socket has data ready, `false` if it doesn't yet.
+   * @throws {Error} If `fd` is this platform's invalid file descriptor
+   *   sentinel, if the poll syscall itself fails, or if it succeeds but
+   *   reports the socket as errored, hung up, or otherwise unusable.
+   */
+  public abstract isReadable(fd: bigint): boolean;
+
+  /**
+   * The platform-specific sentinel value that marks a file descriptor as
+   * never valid: POSIX's `-1`, or Windows' `INVALID_SOCKET`.
+   *
+   * @returns The invalid file descriptor sentinel for this platform.
+   */
+  public abstract invalidSocketDescriptor(): bigint;
+
+  /**
+   * Builds the message reported when a readiness check is given an invalid
+   * file descriptor.
+   *
+   * @returns The error message text.
+   */
+  public invalidFileDescriptorErrorMessage() {
+    return `Cannot check whether socket is readable: the file descriptor is not valid.`;
+  }
+
+  /**
+   * Builds the message reported when the underlying readiness check itself
+   * fails, as opposed to succeeding but reporting the socket unusable.
+   *
+   * @param fd - OS-level file descriptor the check was performed on.
+   * @param diagnostic - platform-specific detail about the failure, e.g. an
+   *   errno or a `WSAGetLastError` code.
+   * @returns The error message text.
+   */
+  public pollFailedErrorMessage(fd: bigint, diagnostic: string) {
+    return `Checking whether socket ${fd} is readable failed: the poll syscall itself failed (${diagnostic}).`;
+  }
+
+  /**
+   * Builds the message reported when the readiness check succeeds but
+   * reports the socket as errored, hung up, or otherwise unusable rather
+   * than readable.
+   *
+   * @param fd - OS-level file descriptor the check was performed on.
+   * @param revents - the `revents` bitmask the check reported.
+   * @returns The error message text.
+   */
+  public socketUnusableErrorMessage(fd: bigint, revents: number) {
+    return `Checking whether socket ${fd} is readable failed: the socket is in an unusable state (revents=0x${revents.toString(16).padStart(4, '0')}).`;
+  }
+
+  /**
+   * Opens a real, poll-able client connection to 127.0.0.1:`port`. Production
+   * code never opens its own sockets through this method; it exists for test
+   * fixtures that need a genuine handle to check readiness against, rather
+   * than a fake result.
+   *
+   * @param port - TCP port on the loopback interface to connect to.
+   * @returns The connected handle, and a way to close it.
+   * @throws {Error} If the connection can't be established.
+   */
+  public abstract connectRawSocket(port: number): Promise<RawSocketConnection>;
+
+  /**
+   * Throws the error for when the underlying readiness check itself fails,
+   * as opposed to succeeding but reporting the socket unusable.
+   *
+   * @param fd - OS-level file descriptor the check was performed on.
+   * @param diagnostic - platform-specific detail about the failure, e.g. an
+   *   errno or a `WSAGetLastError` code.
+   * @throws {Error} Always.
+   */
+  protected throwPollFailedError(fd: bigint, diagnostic: string): never {
+    throw new Error(this.pollFailedErrorMessage(fd, diagnostic));
+  }
+
+  /**
+   * Throws the error for when the readiness check succeeds but reports the
+   * socket as errored, hung up, or otherwise unusable rather than readable.
+   *
+   * @param fd - OS-level file descriptor the check was performed on.
+   * @param revents - the `revents` bitmask the check reported.
+   * @throws {Error} Always.
+   */
+  protected throwUnusableSocketError(fd: bigint, revents: number): never {
+    throw new Error(this.socketUnusableErrorMessage(fd, revents));
+  }
+
+  /**
+   * Throws if `fd` is this platform's invalid file descriptor sentinel (see
+   * {@link invalidSocketDescriptor}).
+   *
+   * @param fd - the file descriptor to validate.
+   * @throws {Error} If `fd` is the invalid file descriptor sentinel.
+   */
+  protected assertIsValidFileDescriptor(fd: bigint): void {
+    if (fd === this.invalidSocketDescriptor()) {
+      throw new Error(this.invalidFileDescriptorErrorMessage());
+    }
+  }
+}

--- a/client/src/sockets/nativeWindowsSocketLibrary.ts
+++ b/client/src/sockets/nativeWindowsSocketLibrary.ts
@@ -1,0 +1,109 @@
+import { NativeSocketLibrary, RawSocketConnection } from './nativeSocketLibrary';
+import { windowsSocket2Library } from './bindings/windowsSocketLibrary';
+
+/**
+ * All `ws2_32.dll` bindings the extension needs live here: the `WSAPoll`
+ * primitive {@link isReadable} polls production sockets through, plus the
+ * raw `socket`/`connect`/`closesocket` calls test fixtures use to obtain a
+ * genuine, `WSAPoll`-able handle (see {@link connectRawSocket}).
+ */
+export class NativeWindowsSocketLibrary extends NativeSocketLibrary {
+  /**
+   * Creates an instance backed by the given Windows polling bindings.
+   *
+   * @param ws2 - the polling bindings to use; defaults to the shared,
+   *   lazily-loaded `ws2_32.dll` bindings.
+   * @throws {Error} If the native bindings can't be loaded on this machine.
+   */
+  constructor(private readonly ws2 = windowsSocket2Library()) {
+    super();
+  }
+
+  public invalidSocketDescriptor() {
+    return this.ws2.INVALID_SOCKET;
+  }
+
+  public isReadable(fd: bigint): boolean {
+    this.assertIsValidFileDescriptor(fd);
+
+    // `pollFd` must stay in a variable, not an inline literal: koffi writes
+    // WSAPoll's output back into this same object, and we need to read the
+    // resulting `revents` below.
+    const pollFd = { fd, events: this.ws2.POLLRDNORM, revents: 0 };
+    const status = this.ws2.WSAPoll(pollFd, 1, 0);
+
+    // A negative status means WSAPoll itself failed. Capture the reason
+    // immediately, via WSAGetLastError(), before any other ws2_32.dll call
+    // can overwrite it.
+    if (status < 0) {
+      this.throwPollFailedError(fd, `WSAGetLastError ${this.ws2.WSAGetLastError()}`);
+    }
+
+    // 0 means it timed out with nothing to report; there's no meaningful
+    // revents to check.
+    if (status === 0) {
+      return false;
+    }
+
+    // WSAPoll counts the fd as having an event (status > 0) for POLLERR/
+    // POLLHUP/POLLNVAL too, not just POLLRDNORM, so a positive status alone
+    // doesn't mean the socket is readable. Only report readable when
+    // POLLRDNORM is actually set; otherwise treat it as a failed check
+    // rather than a false positive on a dead or errored socket.
+    if (!(pollFd.revents & this.ws2.POLLRDNORM)) {
+      this.throwUnusableSocketError(fd, pollFd.revents);
+    }
+
+    return true;
+  }
+
+  /**
+   * Opens a real client `SOCKET` to 127.0.0.1:`port`, bypassing Node's `net`
+   * module entirely.
+   *
+   * This is the only way to get a real, `WSAPoll`-able socket handle on
+   * Windows: Node's `net.Socket` doesn't expose one (`.fd`/`_handle.fd` is
+   * known to return `-1` there, since Windows sockets aren't in the same
+   * handle namespace as POSIX fds/CRT descriptors), so a `net.Socket` can't
+   * stand in for the kind of handle production code actually polls for
+   * readiness. Production code never opens its own sockets through this
+   * method; it exists for test fixtures that need such a handle.
+   *
+   * Relies on Winsock already being initialized: libuv calls `WSAStartup`
+   * while setting up Node's own event loop on Windows, before any user code
+   * runs, so no separate `WSAStartup` call is needed here.
+   *
+   * @param port - TCP port on the loopback interface to connect to.
+   * @returns The connected socket's raw handle, and a way to close it.
+   * @throws {Error} If the native `socket()` or `connect()` call fails.
+   */
+  public async connectRawSocket(port: number): Promise<RawSocketConnection> {
+    // Koffi only returns a BigInt for a `uint64` when the value actually
+    // needs one; a small handle value comes back as a plain Number, so it
+    // must be normalized here to match `RawSocketConnection.fd`'s `bigint`
+    // type (and the `INVALID_SOCKET` comparison below).
+    const handle = BigInt(
+      this.ws2.socket(this.ws2.AF_INET, this.ws2.SOCK_STREAM, this.ws2.IPPROTO_TCP) as
+        number | bigint,
+    );
+    if (handle === this.ws2.INVALID_SOCKET) {
+      throw new Error(`socket() failed (WSAGetLastError ${this.ws2.WSAGetLastError()})`);
+    }
+
+    const address = {
+      family: this.ws2.AF_INET,
+      portBytes: [(port >> 8) & 0xff, port & 0xff],
+      addrBytes: [127, 0, 0, 1],
+      zero: [0, 0, 0, 0, 0, 0, 0, 0],
+    };
+
+    const status = this.ws2.connect(handle, address, this.ws2.SOCKADDR_IN_SIZE) as number;
+    if (status === this.ws2.SOCKET_ERROR) {
+      const error = this.ws2.WSAGetLastError();
+      this.ws2.closesocket(handle);
+      throw new Error(`connect() failed (WSAGetLastError ${error})`);
+    }
+
+    return { fd: handle, disconnect: () => this.ws2.closesocket(handle) };
+  }
+}

--- a/client/src/syncTypes.ts
+++ b/client/src/syncTypes.ts
@@ -1,2 +1,5 @@
 /** Rejects a Promise-returning (async) type at the type level, resolving to `never` instead. */
 export type NotPromise<T> = T extends Promise<unknown> ? never : T;
+
+/** A callback that takes no arguments and cannot be a promise-returning (async) function. */
+export type SyncThunk<T> = () => NotPromise<T>;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,0 +1,2 @@
+/** Rejects a Promise-returning (async) type at the type level, resolving to `never` instead. */
+export type NotPromise<T> = T extends Promise<unknown> ? never : T;


### PR DESCRIPTION
## Summary
- Adds `NativeSocketLibrary`, a cross-platform way to check whether a socket has data ready to read right now: backed by libc's `poll()` on POSIX and `ws2_32`'s `WSAPoll()` on Windows through koffi FFI bindings, since Node's `net.Socket` never exposes a real, pollable handle on Windows.
- `createNativeSocketLibrary()` selects the right implementation for the current platform.
- Adds test infrastructure to exercise this against genuine loopback sockets (closed/reset connections) rather than mocking the native calls: a `process.platform` stub, Windows/POSIX `describe` gates, and a loopback-connection fixture.
- Nothing uses this yet. The next PRs will use it to add non-blocking support to `GciLibrary`, as a fallback for GCI versions where `GciTsNbPoll` isn't available.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run compile`
- [ ] `npm test` (run on CI matrix — POSIX and Windows paths both need coverage)