### PR TITLE
Move the release instructions to docs/, and correct them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,19 +131,4 @@ CI runs on **GitHub Actions**. The [Health Check workflow](.github/workflows/hea
 
 ## Publishing a release
 
-1. `npm version <X.Y.Z> --no-git-tag-version` — bumps `package.json`'s `version` and `package-lock.json`'s two root fields (`version` and `packages."".version`) atomically. Don't hand-edit these or find-and-replace the version string across the lockfile: the version can collide with an unrelated dependency's own version elsewhere in `package-lock.json` (e.g. `1.8.11` matches `typed-rest-client@1.8.11`), corrupting that entry. `--no-git-tag-version` skips npm's own commit/tag, since steps 3-4 below handle that. Then promote the `[Unreleased]` section in `CHANGELOG.md` to a new dated `[X.Y.Z]` heading. Sweep `main` since the last release for merged PRs that didn't add their own changelog entries.
-2. `npm run compile && npm test`
-3. Commit the version + changelog changes (e.g. `Release X.Y.Z: <one-line summary>`).
-4. `git tag -a vX.Y.Z -m "Release X.Y.Z"` — annotated tag, on the release commit.
-5. `npx @vscode/vsce package` — produces `gemstone-ide-X.Y.Z.vsix` in the repo root. The previous version's `.vsix` is gitignored but stays on disk; delete it to keep the root tidy.
-6. `npm run publish` — runs `vsce publish` then `ovsx publish` for the VS Code Marketplace and Open VSX. If `vsce publish` times out on the Azure DevOps Gallery API (it happens), re-run `npx @vscode/vsce publish` directly — don't re-run `npm run publish`, since the ovsx step will then double-publish and fail with "already exists."
-7. `git push origin main && git push origin vX.Y.Z` — push the commit and the tag (the tag does not piggyback on the branch push).
-
-You must be logged in with Personal Access Tokens for both publishers. To set up credentials:
-
-```sh
-npx @vscode/vsce login gemtalksystems   # VS Code Marketplace
-npx ovsx create-namespace gemtalksystems -p <token>   # Open VSX (one-time)
-```
-
-`ovsx publish` reads `OVSX_PAT` from the environment (or a stored token).
+Publishing to the VS Code Marketplace and Open VSX needs a personal access token for the `gemtalksystems` publisher on each registry, so it falls to a maintainer rather than to contributors. The procedure — pre-flight token checks, the version-bump and changelog sweep, packaging, and what the registries do after a publish reports success — is in [docs/how-to/publishing-a-release.md](docs/how-to/publishing-a-release.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ New docs are organized by [Diátaxis](https://diataxis.fr/) category — `how-to
 - [Adding a dependency with an install script](how-to/add-a-dependency-with-install-scripts.md) — the `strict-allow-scripts` bootstrap sequence when a new dependency has a `pre`/`post`/`install` script.
 - [Using `overrides` in root `package.json`](how-to/npm-overrides.md) — an override may only narrow; violating that silently breaks packaging.
 - [Raising the VS Code / Node version floor](how-to/raising-the-version-floor.md) — the coordinated set of files that must move together.
+- [Publishing a release](how-to/publishing-a-release.md) — the maintainer-only token pre-flight, version bump, changelog sweep, and dual-registry publish, and why a success message is not yet a live release.
 
 ## Explanation
 

--- a/docs/how-to/publishing-a-release.md
+++ b/docs/how-to/publishing-a-release.md
@@ -1,0 +1,64 @@
+# Publishing a release
+
+Releasing Jasper to the marketplaces is a maintainer task: it needs a personal access token for the `gemtalksystems` publisher on each of the two registries. Outside contributors need none of it — [CONTRIBUTING.md](../../CONTRIBUTING.md) covers the ordinary build-and-test loop.
+
+## Pre-flight
+
+Verify both tokens resolve before you build anything — a missing or expired one is far cheaper to find now than after the commit and tag exist:
+
+```sh
+npx @vscode/vsce verify-pat gemtalksystems
+npx ovsx verify-pat gemtalksystems
+```
+
+## Steps
+
+1. `npm version <X.Y.Z> --no-git-tag-version` — bumps `package.json`'s `version` and `package-lock.json`'s two root fields (`version` and `packages."".version`) atomically. Don't hand-edit these or find-and-replace the version string across the lockfile: the version can collide with an unrelated dependency's own version elsewhere in `package-lock.json` (e.g. `1.8.11` matches `typed-rest-client@1.8.11`), corrupting that entry. `--no-git-tag-version` skips npm's own commit/tag, since steps 3-4 below handle that.
+
+   npm owns `package.json`'s formatting, and the file is currently in npm's own style, so this rewrites only the version line. Confirm that with `git diff package.json` before committing — `npm run format` globs only `*.{ts,mts,cts,js,mjs,cjs}`, so `format:check` will not catch stray churn here.
+
+   Then promote the `[Unreleased]` section in `CHANGELOG.md` to a new dated `[X.Y.Z]` heading. Sweep `main` since the last release for changes that didn't add their own changelog entries — `git log --oneline --first-parent vX.Y.Z..HEAD` lists them, one line per landing on `main`. Use `--first-parent` rather than filtering for merge commits: it also catches a squash-merged PR and anything committed straight to `main`, which are exactly the changes least likely to have written their own entry. **Check the previous release's section too:** a branch cut before the last `[Unreleased]` → `[X.Y.Z]` rename merges its bullet into that now-released section, so the entry claims to have shipped in a version that never contained it. Move any such entry into the new section.
+
+2. `npm run lint && npm run format:check && npm run compile && npm test` — the full gate, matching the one every PR is held to.
+3. Commit the version + changelog changes (e.g. `Release X.Y.Z: <one-line summary>`).
+4. `git tag -a vX.Y.Z -m "Release X.Y.Z"` — annotated tag, on the release commit.
+5. `npm run package` — runs `vsce package`, producing `gemstone-ide-X.Y.Z.vsix` in the repo root. The previous version's `.vsix` is gitignored but stays on disk; delete it to keep the root tidy. Note this file is **not** what gets uploaded: both commands in step 6 repackage into their own temp `.vsix`. It is for local inspection and archival.
+6. `npm run publish` — runs `vsce publish` then `ovsx publish` for the VS Code Marketplace and Open VSX. If `vsce publish` times out on the Azure DevOps Gallery API (it happens), re-run just that half with `npm run publish:vsce` rather than `npm run publish`, so the ovsx half doesn't run twice. If it does run twice it is harmless — `ovsx` refuses a duplicate rather than publishing one — but re-running the whole script obscures which half actually succeeded.
+7. `git push origin main && git push origin vX.Y.Z` — push the commit and the tag (the tag does not piggyback on the branch push).
+
+## A success message is not a live release
+
+Both CLIs print success as soon as the **upload** is accepted. The version then takes anywhere from ~2 to ~22 minutes to become publicly queryable, and the two registries are independent — either can be first. During that window:
+
+- Open VSX answers `Extension not found` for the new version, and `ovsx publish` run again reports `already published, but currently isn't active and therefore not visible`. That message means *wait*, not *retry* — it has always resolved on its own. It is also proof the upload landed.
+- The Marketplace omits the version from gallery queries, so `vsce show` still reports the previous one.
+
+Verify against each registry rather than trusting the CLI output:
+
+```sh
+# Open VSX
+curl -s https://open-vsx.org/api/gemtalksystems/gemstone-ide | jq -r .version
+
+# VS Code Marketplace
+npx @vscode/vsce show gemtalksystems.gemstone-ide
+```
+
+## Credentials
+
+Each registry takes a personal access token, tied to your own account rather than to the publisher. Store both once and neither publish step needs anything in the environment:
+
+```sh
+npx @vscode/vsce login gemtalksystems   # VS Code Marketplace
+npx ovsx login gemtalksystems           # Open VSX
+```
+
+`vsce` reads `VSCE_PAT` from the environment or its stored login; `ovsx` reads `OVSX_PAT` or its stored token. `npx @vscode/vsce ls-publishers` shows what is stored locally — an empty list means no credentials **on this machine**, not that the publisher is unregistered.
+
+The **VS Code Marketplace** token comes from Azure DevOps (`dev.azure.com` → User settings → Personal Access Tokens). Two settings matter, and both are easy to get wrong:
+
+- **Organization: All accessible organizations** — a token scoped to a single organization fails with a 401 that reads like a bad token.
+- **Scopes: Marketplace → Manage** (under "Show all scopes").
+
+Your account must also be a member of the `gemtalksystems` publisher; <https://marketplace.visualstudio.com/manage/publishers/gemtalksystems> loads if it is and 404s if it isn't. Azure DevOps shows a PAT once, at creation, and stores it hashed — a lost token is replaced, never recovered.
+
+The **Open VSX** token comes from <https://open-vsx.org> (sign in with GitHub → user settings → Access Tokens), and your account must belong to the `gemtalksystems` namespace. The namespace itself already exists; `npx ovsx create-namespace gemtalksystems -p <token>` is a one-time step that does not need repeating.

--- a/docs/how-to/publishing-a-release.md
+++ b/docs/how-to/publishing-a-release.md
@@ -23,7 +23,9 @@ npx ovsx verify-pat gemtalksystems
 3. Commit the version + changelog changes (e.g. `Release X.Y.Z: <one-line summary>`).
 4. `git tag -a vX.Y.Z -m "Release X.Y.Z"` — annotated tag, on the release commit.
 5. `npm run package` — runs `vsce package`, producing `gemstone-ide-X.Y.Z.vsix` in the repo root. The previous version's `.vsix` is gitignored but stays on disk; delete it to keep the root tidy. Note this file is **not** what gets uploaded: both commands in step 6 repackage into their own temp `.vsix`. It is for local inspection and archival.
-6. `npm run publish` — runs `vsce publish` then `ovsx publish` for the VS Code Marketplace and Open VSX. If `vsce publish` times out on the Azure DevOps Gallery API (it happens), re-run just that half with `npm run publish:vsce` rather than `npm run publish`, so the ovsx half doesn't run twice. If it does run twice it is harmless — `ovsx` refuses a duplicate rather than publishing one — but re-running the whole script obscures which half actually succeeded.
+6. `npm run publish` — the two registries, in sequence. **The script is `publish:vsce && publish:ovsx`, so the halves are not independent:** if `vsce publish` exits non-zero, `ovsx publish` never runs at all, and the release is live on the Marketplace and absent from Open VSX.
+
+   `vsce publish` does time out on the Azure DevOps Gallery API, and a timeout tells you nothing about whether the upload landed. So don't reason about which halves ran — ask the registries, and publish whatever is missing with `npm run publish:vsce` or `npm run publish:ovsx`. **A release is not done until both registries report the new version.** See [A success message is not a live release](#a-success-message-is-not-a-live-release) below for how to tell a missing publish from one that is merely still propagating; the two look identical from the outside and the difference decides whether you publish again or wait.
 7. `git push origin main && git push origin vX.Y.Z` — push the commit and the tag (the tag does not piggyback on the branch push).
 
 ## A success message is not a live release
@@ -42,6 +44,13 @@ curl -s https://open-vsx.org/api/gemtalksystems/gemstone-ide | jq -r .version
 # VS Code Marketplace
 npx @vscode/vsce show gemtalksystems.gemstone-ide
 ```
+
+**A registry that doesn't show the version is not proof the upload failed** — and this cuts both ways, so establish which case you are in before acting:
+
+- **The publish command reported success.** The upload landed; this is propagation. Wait. Re-publishing is not the fix.
+- **The publish command never ran, or exited non-zero.** Nothing is propagating. Publish that half — `npm run publish:vsce` or `npm run publish:ovsx`.
+
+`npm run publish`'s `&&` makes the second case easy to hit: a failed `vsce publish` means `ovsx publish` was never reached, so Open VSX's `Extension not found` means *not published*, not *not yet visible*. If you are unsure which happened, re-running a publish is safe enough to settle it: `vsce` reports `already exists` and `ovsx` reports `already published, but currently isn't active and therefore not visible` rather than creating a duplicate — and either message is itself proof the upload had landed.
 
 ## Credentials
 


### PR DESCRIPTION
Publishing is a maintainer task — it needs a personal access token for the `gemtalksystems` publisher on each of the two registries — so the procedure is of no use to the public contributors `CONTRIBUTING.md` is written for. This moves it to `docs/how-to/publishing-a-release.md`, per that directory's [Diátaxis](https://diataxis.fr/) layout, and leaves a short pointer behind for the maintainer who looks in the old place.

It also carries the corrections and additions from cutting 1.8.11 through 1.8.14 in one session. The mechanics were right — steps 1, 3, 4, 5 and 7 behaved as written — but several things were wrong or missing.

## Corrections

- **The changelog sweep now uses `git log --first-parent`**, one line per landing on `main`. Filtering for merge commits sees only PRs that landed as merge commits: a squash-merged PR and anything committed straight to `main` are both invisible to it, and those are the changes least likely to have written their own entry. Measured over `v1.8.14..main`, `--first-parent` misses none of the 26 the merge filter found and adds the 2 direct-to-`main` commits it did not.
- **A changelog entry can land in an already-released section.** A branch cut before the previous `[Unreleased]` → `[X.Y.Z]` rename merges its bullet into that released section, claiming it shipped in a version that never contained it. #442 did exactly this into `[1.8.11]`; caught and moved during 1.8.13.
- **Step 2 was narrower than the gate every PR is held to** — `compile && test` rather than `lint && format:check && compile && test`.
- **The double-publish warning had the wrong reason.** It said re-running `npm run publish` makes `ovsx` "double-publish and fail with 'already exists.'" Re-running it twice (1.8.11 and 1.8.13) showed `ovsx` refuses a duplicate rather than creating one, reporting `already published, but currently isn't active and therefore not visible`. Re-running only the `vsce` half still stands as the advice; the stated reason did not.
- **Step 5's `.vsix` is not the artifact that gets uploaded.** Both publish commands repackage into their own temp file — `ovsx publish` self-describes as "packaging it first if necessary." Reading 5 → 6 in sequence implies otherwise.
- **`npm run package` and `npm run publish:vsce`** replace the spelled-out `npx` invocations, so the instructions cannot drift from the scripts.

## Additions

- **A new "A success message is not a live release" section.** Both CLIs print success when the *upload* is accepted; the version then takes ~2–22 minutes to become publicly queryable, and either registry can lead. Open VSX's `already published, but currently isn't active` means wait, not retry — it resolved on its own both times. This cost a misdiagnosis during 1.8.11, where the `ovsx` step was wrongly assumed not to have run. Includes commands to verify against each registry's API rather than trusting CLI output.
- **`ovsx login`**, previously undocumented — the Open VSX half can be stored the same way `vsce login` stores the Marketplace half, so neither publish step needs anything in the environment.
- **`verify-pat` as a pre-flight** for both registries, at the top of the document.
- **The Azure DevOps PAT requirements**: `All accessible organizations` (a single-org token fails with a 401 that reads like a bad token) and scope `Marketplace → Manage`. This is what stalled the first release of the session. Also notes that a lost PAT is replaced rather than recovered, and that an empty `vsce ls-publishers` means no credentials *on this machine* rather than an unregistered publisher.

## Note on history

An earlier revision of this went in as 7dc5233c straight to `main`, skipping review, and was reverted in cc666da8. It was then re-opened as #516, which is where the `--first-parent` sweep, the `npm run package` / `npm run publish:vsce` consistency fix, and one removal came from: #516 also claimed `npm version` reformats `package.json` and gave a `git checkout package.json` recipe to undo it. That claim does not hold — `package.json` is in npm's own style on `main`, so `npm version` rewrites only the version line (verified: a 2-line diff), and all four of the `v1.8.11`–`v1.8.14` release commits touch exactly 2 lines of it. Only the durable part is kept: confirm with `git diff package.json`, since `format:check` globs no JSON. #516 and its branch have been deleted in favour of this PR.

Docs-only — no build, extension, or CI surface. `lint`, `format:check`, `compile` and `npm test` all pass (client 452 files / 7294 tests, server 322, mcp-server 92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
